### PR TITLE
fix: add identity provider logo retrieval functionality and related error handling

### DIFF
--- a/backend/internal/application/auth/errs.go
+++ b/backend/internal/application/auth/errs.go
@@ -37,6 +37,8 @@ var (
 	ErrIdentityNotFound = errors.New("identity not found")
 	// ErrIdentityProviderDeleteConflict 表示删除身份源会让用户失去最后一种登录方式。
 	ErrIdentityProviderDeleteConflict = errors.New("identity provider delete conflict")
+	// ErrIdentityProviderLogoUnavailable 表示身份源图标不可用或不符合代理安全策略。
+	ErrIdentityProviderLogoUnavailable = errors.New("identity provider logo unavailable")
 	// ErrTwoFactorSetupExpired 两步验证设置已过期。
 	ErrTwoFactorSetupExpired = errors.New("two factor setup expired")
 	// ErrTwoFactorSetupNotStarted 当前没有待确认的两步验证设置。

--- a/backend/internal/application/auth/provider.go
+++ b/backend/internal/application/auth/provider.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -10,8 +11,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
+	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -71,6 +74,11 @@ type UserIdentityView struct {
 	EmailVerified       bool
 	LinkedAt            time.Time
 	LastLoginAt         *time.Time
+}
+
+type IdentityProviderLogoAsset struct {
+	ContentType string
+	Content     []byte
 }
 
 type UpsertIdentityProviderInput struct {
@@ -701,6 +709,7 @@ const (
 	providerIntentRegister = "register"
 	providerIntentBind     = "bind"
 	providerHTTPTimeout    = 10 * time.Second
+	providerLogoMaxBytes   = 2 << 20
 )
 
 func normalizeProviderSlug(value string) string {
@@ -720,6 +729,124 @@ func normalizeProviderIntent(value string) string {
 	default:
 		return providerIntentLogin
 	}
+}
+
+func (s *Service) GetIdentityProviderLogo(ctx context.Context, slug string) (*IdentityProviderLogoAsset, error) {
+	provider, err := s.repo.GetIdentityProviderBySlug(ctx, normalizeProviderSlug(slug))
+	if err != nil {
+		return nil, ErrIdentityProviderLogoUnavailable
+	}
+	logoURL := strings.TrimSpace(provider.LogoURL)
+	parsed, err := url.Parse(logoURL)
+	if err != nil || parsed == nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return nil, ErrIdentityProviderLogoUnavailable
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
+
+	response, err := s.providerHTTPClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, ErrIdentityProviderLogoUnavailable
+	}
+
+	content, err := io.ReadAll(io.LimitReader(response.Body, providerLogoMaxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(content) == 0 || len(content) > providerLogoMaxBytes {
+		return nil, ErrIdentityProviderLogoUnavailable
+	}
+	contentType := resolveIdentityProviderLogoContentType(response.Header.Get("Content-Type"), parsed.Path, content)
+	if contentType == "" {
+		return nil, ErrIdentityProviderLogoUnavailable
+	}
+	return &IdentityProviderLogoAsset{
+		ContentType: contentType,
+		Content:     content,
+	}, nil
+}
+
+func resolveIdentityProviderLogoContentType(headerValue string, requestPath string, content []byte) string {
+	contentType := normalizeIdentityProviderLogoContentType(headerValue)
+	if isAllowedIdentityProviderLogoContentType(contentType) {
+		return contentType
+	}
+	if contentType == "" || contentType == "application/octet-stream" {
+		contentType = normalizeIdentityProviderLogoContentType(http.DetectContentType(content))
+		if isAllowedIdentityProviderLogoContentType(contentType) {
+			return contentType
+		}
+		contentType = providerLogoContentTypeByExtension(requestPath)
+		if contentType == "image/svg+xml" && !looksLikeSVG(content) {
+			return ""
+		}
+		if isAllowedIdentityProviderLogoContentType(contentType) {
+			return contentType
+		}
+	}
+	return ""
+}
+
+func normalizeIdentityProviderLogoContentType(value string) string {
+	contentType, _, err := mime.ParseMediaType(strings.TrimSpace(value))
+	if err != nil {
+		contentType = strings.TrimSpace(value)
+	}
+	return strings.ToLower(contentType)
+}
+
+func isAllowedIdentityProviderLogoContentType(contentType string) bool {
+	switch contentType {
+	case "image/avif",
+		"image/gif",
+		"image/jpeg",
+		"image/png",
+		"image/svg+xml",
+		"image/vnd.microsoft.icon",
+		"image/webp",
+		"image/x-icon":
+		return true
+	default:
+		return false
+	}
+}
+
+func providerLogoContentTypeByExtension(requestPath string) string {
+	switch strings.ToLower(path.Ext(requestPath)) {
+	case ".avif":
+		return "image/avif"
+	case ".gif":
+		return "image/gif"
+	case ".ico":
+		return "image/x-icon"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".svg":
+		return "image/svg+xml"
+	case ".webp":
+		return "image/webp"
+	default:
+		return ""
+	}
+}
+
+func looksLikeSVG(content []byte) bool {
+	trimmed := bytes.TrimSpace(content)
+	if len(trimmed) == 0 {
+		return false
+	}
+	lowered := bytes.ToLower(trimmed)
+	return bytes.HasPrefix(lowered, []byte("<svg")) || (bytes.HasPrefix(lowered, []byte("<?xml")) && bytes.Contains(lowered, []byte("<svg")))
 }
 
 func firstNonEmpty(values ...string) string {

--- a/backend/internal/application/auth/provider_test.go
+++ b/backend/internal/application/auth/provider_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -228,6 +230,60 @@ func TestUnlinkCurrentUserIdentityRejectsLastPasswordlessLoginMethod(t *testing.
 	}
 }
 
+func TestGetIdentityProviderLogoFetchesConfiguredImage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") == "" {
+			t.Fatal("expected image accept header")
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte{0x89, 0x50, 0x4e, 0x47})
+	}))
+	defer server.Close()
+
+	repo := &providerLoginRepo{
+		providersBySlug: map[string]*domainuser.IdentityProvider{
+			"acme": {
+				Slug:    "acme",
+				LogoURL: server.URL + "/logo.png",
+			},
+		},
+	}
+	service := NewService(config.Config{JWTSecret: "test-secret"}, repo, nil)
+
+	asset, err := service.GetIdentityProviderLogo(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("expected logo asset, got %v", err)
+	}
+	if asset.ContentType != "image/png" {
+		t.Fatalf("expected image/png, got %q", asset.ContentType)
+	}
+	if string(asset.Content) != string([]byte{0x89, 0x50, 0x4e, 0x47}) {
+		t.Fatalf("unexpected logo content: %#v", asset.Content)
+	}
+}
+
+func TestGetIdentityProviderLogoRejectsHTML(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<script>alert(1)</script>"))
+	}))
+	defer server.Close()
+
+	repo := &providerLoginRepo{
+		providersBySlug: map[string]*domainuser.IdentityProvider{
+			"acme": {
+				Slug:    "acme",
+				LogoURL: server.URL + "/logo.html",
+			},
+		},
+	}
+	service := NewService(config.Config{JWTSecret: "test-secret"}, repo, nil)
+
+	if _, err := service.GetIdentityProviderLogo(context.Background(), "acme"); !errors.Is(err, ErrIdentityProviderLogoUnavailable) {
+		t.Fatalf("expected unavailable error, got %v", err)
+	}
+}
+
 func TestUnlinkCurrentUserIdentityAllowsLastIdentityWhenPasswordEnabled(t *testing.T) {
 	repo := &providerLoginRepo{
 		credentialsByUserID: map[uint]*domainuser.Credential{
@@ -285,6 +341,18 @@ type providerLoginRepo struct {
 	usersByEmail              map[string]*domainuser.User
 	credentialsByUserID       map[uint]*domainuser.Credential
 	identities                []domainuser.UserIdentity
+	providersBySlug           map[string]*domainuser.IdentityProvider
+}
+
+func (r *providerLoginRepo) GetIdentityProviderBySlug(ctx context.Context, slug string) (*domainuser.IdentityProvider, error) {
+	if r.providersBySlug == nil {
+		return nil, repository.ErrNotFound
+	}
+	provider, ok := r.providersBySlug[slug]
+	if !ok {
+		return nil, repository.ErrNotFound
+	}
+	return provider, nil
 }
 
 func (r *providerLoginRepo) GetUserIdentityByProviderSubject(ctx context.Context, providerID uint, subject string) (*domainuser.UserIdentity, error) {

--- a/backend/internal/transport/http/auth/handler.go
+++ b/backend/internal/transport/http/auth/handler.go
@@ -105,6 +105,22 @@ func (h *Handler) LoginOptions(c *gin.Context) {
 	response.Success(c, toLoginOptionsResponse(result))
 }
 
+func (h *Handler) IdentityProviderLogo(c *gin.Context) {
+	asset, err := h.service.GetIdentityProviderLogo(c.Request.Context(), c.Param("slug"))
+	if err != nil {
+		status := http.StatusBadGateway
+		if errors.Is(err, appauth.ErrIdentityProviderLogoUnavailable) {
+			status = http.StatusNotFound
+		}
+		response.ErrorFrom(c, status, err)
+		return
+	}
+	c.Header("Cache-Control", "public, max-age=3600")
+	c.Header("Content-Security-Policy", "sandbox; default-src 'none'; base-uri 'none'; form-action 'none'; script-src 'none'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: blob:; style-src 'unsafe-inline'")
+	c.Header("X-Content-Type-Options", "nosniff")
+	c.Data(http.StatusOK, asset.ContentType, asset.Content)
+}
+
 func (h *Handler) StartEmailRegistration(c *gin.Context) {
 	var req EmailRegistrationStartRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/backend/internal/transport/http/auth/router.go
+++ b/backend/internal/transport/http/auth/router.go
@@ -14,6 +14,7 @@ func (m *Module) RegisterPublicRoutes(api *gin.RouterGroup) {
 	api.GET("/auth/providers/:slug/start", m.Handler.StartProviderLogin)
 	api.GET("/auth/providers/:slug/callback", m.Handler.ProviderCallback)
 	api.POST("/auth/providers/:slug/callback", m.Handler.CompleteProviderLogin)
+	api.GET("/auth/providers/:slug/logo", m.Handler.IdentityProviderLogo)
 }
 
 // RegisterProtectedRoutes 注册需登录的鉴权路由。

--- a/frontend/shared/components/identity-provider-icon.tsx
+++ b/frontend/shared/components/identity-provider-icon.tsx
@@ -9,6 +9,17 @@ import {
 } from "@/shared/lib/identity-provider-icons";
 import { cn } from "@/lib/utils";
 
+function resolveCustomIdentityProviderLogoURL(logoURL: string | undefined, slug: string): string {
+  const trimmed = logoURL?.trim() ?? "";
+  if (!trimmed) {
+    return "";
+  }
+  if (/^https?:\/\//i.test(trimmed)) {
+    return `/api/v1/auth/providers/${encodeURIComponent(slug)}/logo`;
+  }
+  return trimmed;
+}
+
 export function IdentityProviderIcon({
   name,
   slug,
@@ -24,7 +35,7 @@ export function IdentityProviderIcon({
   iconClassName?: string;
   fallbackClassName?: string;
 }) {
-  const customLogoURL = logoURL?.trim() ?? "";
+  const customLogoURL = resolveCustomIdentityProviderLogoURL(logoURL, slug);
   const defaultIconURL = resolveIdentityProviderIconURL(name, slug);
   const iconCandidates = React.useMemo(
     () => [customLogoURL, defaultIconURL].filter((value): value is string => Boolean(value)),


### PR DESCRIPTION
## Summary

Fix OAuth/OIDC provider logos being blocked by the app CSP on the login page.

Instead of loosening the global `img-src` policy, this change adds a controlled same-origin provider logo endpoint. The frontend now renders configured remote provider logos through `/api/v1/auth/providers/:slug/logo`, while the backend fetches only the logo URL configured for that provider and enforces content-type, size, status-code, and response-safety checks.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [x] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [x] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./internal/application/auth ./internal/transport/http/auth`
- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm exec tsc --noEmit`
- [x] `git diff --check`

## Screenshots, API examples, or logs

N/A

## Configuration, migration, and compatibility notes

No database migration or deployment configuration change is required.

Configured remote provider logos are now served through a same-origin backend endpoint instead of being loaded directly by the browser. Existing provider `logoURL` values remain compatible.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

The new logo endpoint is not an open proxy: it only fetches the logo URL configured for the matching identity provider, allows only `http`/`https`, uses the existing outbound HTTP/SSRF policy, rejects non-image responses, rejects non-2xx responses, limits payloads to 2MB, and returns `nosniff` with a strict response CSP.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.