### PR TITLE
feat: use browser locale and optional cookie persistence

### DIFF
--- a/frontend/i18n/app-i18n-provider.tsx
+++ b/frontend/i18n/app-i18n-provider.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { NextIntlClientProvider } from "next-intl";
 
-import { DEFAULT_LOCALE, LOCALE_COOKIE_NAME, normalizeAppLocale, type AppLocale } from "@/i18n/config";
+import { DEFAULT_LOCALE, LOCALE_COOKIE_NAME, normalizeAppLocale, resolveBrowserLocale, type AppLocale } from "@/i18n/config";
 import { DEFAULT_MESSAGES, loadLocaleMessages, type AppMessages } from "@/i18n/messages";
 
 type AppI18nContextValue = {
@@ -13,18 +13,25 @@ type AppI18nContextValue = {
 
 const AppI18nContext = React.createContext<AppI18nContextValue | null>(null);
 
-function readLocaleCookie(): AppLocale {
+function readLocaleCookie(): AppLocale | null {
   if (typeof document === "undefined") {
-    return DEFAULT_LOCALE;
+    return null;
   }
   const raw = document.cookie
     .split(";")
     .map((part) => part.trim())
     .find((part) => part.startsWith(`${LOCALE_COOKIE_NAME}=`));
   if (!raw) {
-    return DEFAULT_LOCALE;
+    return null;
   }
   return normalizeAppLocale(decodeURIComponent(raw.slice(LOCALE_COOKIE_NAME.length + 1)));
+}
+
+function readBrowserLocale(): AppLocale {
+  if (typeof navigator === "undefined") {
+    return DEFAULT_LOCALE;
+  }
+  return resolveBrowserLocale(navigator.languages?.length ? navigator.languages : [navigator.language]);
 }
 
 function writeLocaleCookie(locale: AppLocale): void {
@@ -46,10 +53,12 @@ export function AppI18nProvider({ children }: { children: React.ReactNode }) {
   const [messages, setMessages] = React.useState<AppMessages>(DEFAULT_MESSAGES);
   const localeRef = React.useRef<AppLocale>(DEFAULT_LOCALE);
 
-  const setLocale = React.useCallback(async (nextLocale: AppLocale) => {
+  const applyLocale = React.useCallback(async (nextLocale: AppLocale, persist: boolean) => {
     const normalized = normalizeAppLocale(nextLocale);
     if (normalized === localeRef.current) {
-      writeLocaleCookie(normalized);
+      if (persist) {
+        writeLocaleCookie(normalized);
+      }
       applyDocumentLocale(normalized);
       return;
     }
@@ -58,13 +67,20 @@ export function AppI18nProvider({ children }: { children: React.ReactNode }) {
     localeRef.current = normalized;
     setLocaleState(normalized);
     setMessages(nextMessages);
-    writeLocaleCookie(normalized);
+    if (persist) {
+      writeLocaleCookie(normalized);
+    }
     applyDocumentLocale(normalized);
   }, []);
 
+  const setLocale = React.useCallback(async (nextLocale: AppLocale) => {
+    await applyLocale(nextLocale, true);
+  }, [applyLocale]);
+
   React.useEffect(() => {
-    void setLocale(readLocaleCookie());
-  }, [setLocale]);
+    const cookieLocale = readLocaleCookie();
+    void applyLocale(cookieLocale ?? readBrowserLocale(), cookieLocale !== null);
+  }, [applyLocale]);
 
   const value = React.useMemo<AppI18nContextValue>(
     () => ({

--- a/frontend/i18n/config.ts
+++ b/frontend/i18n/config.ts
@@ -12,5 +12,26 @@ export const APP_LOCALE_LABELS: Record<AppLocale, string> = {
 
 export function normalizeAppLocale(value: string | null | undefined): AppLocale {
   const normalized = String(value ?? "").trim();
-  return APP_LOCALES.includes(normalized as AppLocale) ? (normalized as AppLocale) : DEFAULT_LOCALE;
+  const canonical = normalized.replace("_", "-");
+  const lower = canonical.toLowerCase();
+  if (lower === "zh" || lower.startsWith("zh-")) {
+    return "zh-CN";
+  }
+  if (lower === "en" || lower.startsWith("en-")) {
+    return "en-US";
+  }
+  return APP_LOCALES.includes(canonical as AppLocale) ? (canonical as AppLocale) : DEFAULT_LOCALE;
+}
+
+export function resolveBrowserLocale(languages: readonly string[] | undefined): AppLocale {
+  for (const language of languages ?? []) {
+    const normalized = String(language ?? "").trim().toLowerCase().replace("_", "-");
+    if (normalized === "zh" || normalized.startsWith("zh-")) {
+      return "zh-CN";
+    }
+    if (normalized === "en" || normalized.startsWith("en-")) {
+      return "en-US";
+    }
+  }
+  return DEFAULT_LOCALE;
 }

--- a/frontend/i18n/resolve-error-message.ts
+++ b/frontend/i18n/resolve-error-message.ts
@@ -1,6 +1,6 @@
 import enErrors from "@/i18n/messages/en-US/errors.json";
 import zhErrors from "@/i18n/messages/zh-CN/errors.json";
-import { DEFAULT_LOCALE, LOCALE_COOKIE_NAME, normalizeAppLocale, type AppLocale } from "@/i18n/config";
+import { DEFAULT_LOCALE, LOCALE_COOKIE_NAME, normalizeAppLocale, resolveBrowserLocale, type AppLocale } from "@/i18n/config";
 import { ApiError } from "@/shared/api/http-client";
 
 const ERROR_MESSAGES: Record<AppLocale, unknown> = {
@@ -182,7 +182,12 @@ function readClientLocale(): AppLocale {
     .map((item) => item.trim())
     .find((item) => item.startsWith(`${LOCALE_COOKIE_NAME}=`))
     ?.slice(LOCALE_COOKIE_NAME.length + 1);
-  return normalizeAppLocale(cookieValue ? decodeURIComponent(cookieValue) : undefined);
+  if (cookieValue) {
+    return normalizeAppLocale(decodeURIComponent(cookieValue));
+  }
+  return typeof navigator === "undefined"
+    ? DEFAULT_LOCALE
+    : resolveBrowserLocale(navigator.languages?.length ? navigator.languages : [navigator.language]);
 }
 
 function lookupErrorMessage(locale: AppLocale, errorCode: string): string | undefined {


### PR DESCRIPTION
## Summary

Improve authentication and localization behavior.

OAuth login now supports safer same-email account linking by using normalized provider email and the provider’s configured email verification field. Third-party login no longer exposes a separate “register” UI, because OIDC/OAuth providers do not have a distinct registration step in the frontend. The OAuth callback page also avoids false “session expired” flashes caused by duplicate client-side effect execution.

The frontend now shows clearer backend validation errors in toast messages, and first-time visitors without a saved language preference fall back to the browser language before any explicit user or account locale is applied.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [x] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [x] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./...`
- [x] `cd frontend && pnpm lint`
- [x] `git diff --check`

## Screenshots, API examples, or logs

N/A

## Configuration, migration, and compatibility notes

Adds `email_verified_field` to identity provider configuration, defaulting to `email_verified`. Existing providers continue to work with the default field, and admins can override it for providers such as Discord.

OAuth auto-linking only occurs when the provider email is verified. Manual binding remains available for authenticated users and still prevents binding identities already owned by another account.

No deployment configuration changes are required.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.