### PR TITLE
feat: enhance math rendering and copy functionality in chat

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1115,6 +1115,40 @@
     font-weight: var(--font-chat-weight);
   }
 
+  .chat-font-content .katex,
+  .chat-font-content .katex
+    :where(
+      .mathnormal,
+      .mathit,
+      .mathrm,
+      .mathbf,
+      .boldsymbol,
+      .textrm,
+      .mainrm,
+      .textbf,
+      .textit,
+      .mord,
+      .mop,
+      .mbin,
+      .mrel,
+      .mopen,
+      .mclose,
+      .mpunct,
+      .minner
+    ) {
+    font-family: "Times New Roman", Times, serif !important;
+  }
+
+  .chat-font-content .katex,
+  .chat-font-content .katex :where(.base, .strut, .mord, .mop, .mbin, .mrel, .mopen, .mclose, .mpunct, .minner) {
+    font-weight: 400 !important;
+  }
+
+  .chat-font-content .katex
+    :where(.textbf, .mathbf, .boldsymbol, .mathboldfrak, .textboldfrak, .mathboldsf, .textboldsf) {
+    font-weight: 700 !important;
+  }
+
   .from-bg-200\/5 {
     --tw-gradient-from: color-mix(in oklch, var(--background) 5%, transparent) var(--tw-gradient-from-position);
     --tw-gradient-to: color-mix(in oklch, var(--background) 0%, transparent) var(--tw-gradient-to-position);

--- a/frontend/features/chat/components/markdown/streamdown-content.ts
+++ b/frontend/features/chat/components/markdown/streamdown-content.ts
@@ -43,24 +43,146 @@ export function normalizeContent(input: unknown): string {
   return "";
 }
 
-export function normalizeMathDelimiters(source: string): string {
-  if (!source || (!source.includes("\\(") && !source.includes("\\["))) {
+const MARKDOWN_LITERAL_FRAGMENT_RE = /(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`)/g;
+const INLINE_DOLLAR_MATH_RE = /(^|[^\\$])\$([^$\n]{1,800})\$/g;
+const ESCAPED_INLINE_DOLLAR_MATH_RE = /\\\$([^$\n]{1,400})\\\$/g;
+const DISPLAY_DOLLAR_MATH_RE = /(\${2,})([\s\S]*?)(\1)/g;
+
+function isMarkdownLiteralFragment(fragment: string): boolean {
+  return fragment.startsWith("```") || fragment.startsWith("~~~") || fragment.startsWith("`");
+}
+
+function mapMarkdownTextFragments(source: string, transform: (fragment: string) => string): string {
+  return source
+    .split(MARKDOWN_LITERAL_FRAGMENT_RE)
+    .map((fragment) => {
+      if (!fragment || isMarkdownLiteralFragment(fragment)) {
+        return fragment;
+      }
+      return transform(fragment);
+    })
+    .join("");
+}
+
+function looksLikeLatexMathContent(value: string): boolean {
+  const trimmedValue = value.trim();
+  if (!trimmedValue || /^\d+(?:[.,]\d+)?$/.test(trimmedValue)) {
+    return false;
+  }
+
+  return (
+    /\\[A-Za-z]+/.test(trimmedValue) ||
+    /[\^_{}=<>+\-*/]/.test(trimmedValue) ||
+    (trimmedValue.includes("|") && /[A-Za-z\\Α-ω]|[\^_{}=<>+\-*/]/.test(trimmedValue)) ||
+    /^[A-Za-z]$/.test(trimmedValue) ||
+    /[Α-ω]/.test(trimmedValue)
+  );
+}
+
+function normalizeLatexPipes(mathContent: string): string {
+  return mathContent.replace(/(^|[^\\])\|/g, "$1\\vert{}");
+}
+
+function isEscapedCharacter(source: string, index: number): boolean {
+  let slashCount = 0;
+  for (let cursor = index - 1; cursor >= 0 && source[cursor] === "\\"; cursor -= 1) {
+    slashCount += 1;
+  }
+  return slashCount % 2 === 1;
+}
+
+function getDollarMathDelimiterLength(source: string, index: number): number {
+  if (source[index] !== "$" || isEscapedCharacter(source, index) || source[index - 1] === "$") {
+    return 0;
+  }
+
+  if (source[index + 1] === "$" && source[index + 2] !== "$") {
+    return 2;
+  }
+
+  return source[index + 1] === "$" ? 0 : 1;
+}
+
+function normalizeDollarMathContent(mathContent: string, inline: boolean): string {
+  const normalizedContent = inline ? mathContent.replace(/\s*\n\s*/g, " ") : mathContent;
+  return normalizeLatexPipes(normalizedContent);
+}
+
+function normalizeDollarMathSegments(source: string): string {
+  if (!source.includes("$")) {
     return source;
   }
 
-  const fragments = source.split(/(```[\s\S]*?```|`[^`\n]*`)/g);
+  let normalizedSource = "";
+  let consumedUntil = 0;
 
-  return fragments
-    .map((fragment) => {
-      if (!fragment || fragment.startsWith("```") || fragment.startsWith("`")) {
-        return fragment;
+  for (let index = 0; index < source.length; index += 1) {
+    const delimiterLength = getDollarMathDelimiterLength(source, index);
+    if (!delimiterLength) {
+      continue;
+    }
+
+    const openingDelimiterIndex = index;
+    let closingDelimiterIndex = -1;
+    for (let cursor = openingDelimiterIndex + delimiterLength; cursor < source.length; cursor += 1) {
+      if (getDollarMathDelimiterLength(source, cursor) === delimiterLength) {
+        closingDelimiterIndex = cursor;
+        break;
       }
+    }
 
-      return fragment
-        .replace(/\\\[\s*\n?([\s\S]*?)\n?\s*\\\]/g, (_, mathContent: string) => `$$\n${mathContent.trim()}\n$$`)
-        .replace(/\\\(([\s\S]*?)\\\)/g, (_, mathContent: string) => `$${mathContent.trim()}$`);
-    })
-    .join("");
+    if (closingDelimiterIndex < 0) {
+      break;
+    }
+
+    const mathContent = source.slice(openingDelimiterIndex + delimiterLength, closingDelimiterIndex);
+    const inline = delimiterLength === 1;
+    const shouldNormalize =
+      (mathContent.includes("|") || (inline && mathContent.includes("\n"))) &&
+      looksLikeLatexMathContent(mathContent);
+
+    if (shouldNormalize) {
+      normalizedSource += source.slice(consumedUntil, openingDelimiterIndex + delimiterLength);
+      normalizedSource += normalizeDollarMathContent(mathContent, inline);
+      normalizedSource += source.slice(closingDelimiterIndex, closingDelimiterIndex + delimiterLength);
+      consumedUntil = closingDelimiterIndex + delimiterLength;
+    }
+
+    index = closingDelimiterIndex + delimiterLength - 1;
+  }
+
+  if (!consumedUntil) {
+    return source;
+  }
+
+  return normalizedSource + source.slice(consumedUntil);
+}
+
+function normalizeLatexDelimitersInText(source: string): string {
+  return source
+    .replace(/\\\[\s*\n?([\s\S]*?)\n?\s*\\\]/g, (_, mathContent: string) => `$$\n${mathContent.trim()}\n$$`)
+    .replace(/\\\(([\s\S]*?)\\\)/g, (_, mathContent: string) => `$${mathContent.trim()}$`)
+    .replace(ESCAPED_INLINE_DOLLAR_MATH_RE, (match: string, mathContent: string) => {
+      const trimmedMathContent = mathContent.trim();
+      return looksLikeLatexMathContent(trimmedMathContent) ? `$${trimmedMathContent}$` : match;
+    });
+}
+
+export function normalizeMathDelimiters(source: string): string {
+  if (!source) {
+    return source;
+  }
+
+  const shouldNormalizeDelimiters = source.includes("\\(") || source.includes("\\[") || source.includes("\\$");
+  const hasDollarMath = source.includes("$");
+  if (!shouldNormalizeDelimiters && !hasDollarMath) {
+    return source;
+  }
+
+  return mapMarkdownTextFragments(source, (fragment) => {
+    const normalizedFragment = shouldNormalizeDelimiters ? normalizeLatexDelimitersInText(fragment) : fragment;
+    return normalizedFragment.includes("$") ? normalizeDollarMathSegments(normalizedFragment) : normalizedFragment;
+  });
 }
 
 const LATEX_UNICODE_SYMBOLS: Array<[RegExp, string]> = [
@@ -72,7 +194,6 @@ const LATEX_UNICODE_SYMBOLS: Array<[RegExp, string]> = [
   [/⇔/g, " \\Leftrightarrow "],
 ];
 
-const INLINE_CODE_OR_FENCE_RE = /(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`)/g;
 const THINKING_LIKE_HTML_TAG_RE = /<\/?\s*think[\w-]*\b[^>]*>/gi;
 
 function escapeHtmlTag(value: string): string {
@@ -87,16 +208,7 @@ function escapeThinkingLikeHtmlTags(source: string): string {
     return source;
   }
 
-  return source
-    .split(INLINE_CODE_OR_FENCE_RE)
-    .map((fragment) => {
-      if (!fragment || fragment.startsWith("```") || fragment.startsWith("~~~") || fragment.startsWith("`")) {
-        return fragment;
-      }
-
-      return fragment.replace(THINKING_LIKE_HTML_TAG_RE, escapeHtmlTag);
-    })
-    .join("");
+  return mapMarkdownTextFragments(source, (fragment) => fragment.replace(THINKING_LIKE_HTML_TAG_RE, escapeHtmlTag));
 }
 
 function normalizeLatexSymbols(mathContent: string): string {
@@ -111,23 +223,23 @@ export function normalizeLatexUnicodeSymbols(source: string): string {
     return source;
   }
 
-  const fragments = source.split(/(```[\s\S]*?```|`[^`\n]*`)/g);
-
-  return fragments
-    .map((fragment) => {
-      if (!fragment || fragment.startsWith("```") || fragment.startsWith("`")) {
-        return fragment;
-      }
-
-      return fragment.replace(/(\${2,})([\s\S]*?)(\1)/g, (match, openingDelimiter: string, mathContent: string, closingDelimiter: string) => {
+  return mapMarkdownTextFragments(source, (fragment) =>
+    fragment
+      .replace(DISPLAY_DOLLAR_MATH_RE, (match, openingDelimiter: string, mathContent: string, closingDelimiter: string) => {
         if (!mathContent) {
           return match;
         }
 
         return `${openingDelimiter}${normalizeLatexSymbols(mathContent)}${closingDelimiter}`;
-      });
-    })
-    .join("");
+      })
+      .replace(INLINE_DOLLAR_MATH_RE, (match: string, prefix: string, mathContent: string) => {
+        if (!mathContent) {
+          return match;
+        }
+
+        return `${prefix}$${normalizeLatexSymbols(mathContent)}$`;
+      }),
+  );
 }
 
 export function normalizeMermaidBlocks(source: string): string {

--- a/frontend/features/chat/components/markdown/streamdown-render.tsx
+++ b/frontend/features/chat/components/markdown/streamdown-render.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { cjk } from "@streamdown/cjk";
+import { createMathPlugin } from "@streamdown/math";
 import { type PluginConfig, Streamdown } from "streamdown";
 import { useTranslations } from "next-intl";
 
@@ -13,6 +14,7 @@ import {
   AccordionTrigger,
 } from "@/components/animate-ui/components/radix/accordion";
 import { cn } from "@/lib/utils";
+import { useLatexCopy } from "@/features/chat/hooks/use-latex-copy";
 
 import {
   CollapsibleCodePre,
@@ -48,6 +50,13 @@ type StreamdownFeatureFlags = {
 
 const BASE_STREAMDOWN_PLUGINS: PluginConfig = {
   cjk,
+};
+const STREAMDOWN_MATH_PLUGIN = createMathPlugin({
+  singleDollarTextMath: true,
+});
+const STREAMDOWN_MATH_BASE_PLUGINS: PluginConfig = {
+  ...BASE_STREAMDOWN_PLUGINS,
+  math: STREAMDOWN_MATH_PLUGIN,
 };
 
 const STREAMDOWN_PLUGIN_CACHE = new Map<string, PluginConfig>();
@@ -123,6 +132,11 @@ const BASE_MARKDOWN_CLASSNAME = cn(
   "[&_[data-footnotes]_ol]:my-0 [&_[data-footnotes]_ol]:pl-4",
   "[&_[data-footnotes]_li]:my-1 [&_[data-footnotes]_li]:pl-1 [&_[data-footnotes]_li]:text-muted-foreground/82",
   "[&_[data-footnotes]_p]:my-0 [&_[data-footnotes]_p]:text-[13px] [&_[data-footnotes]_p]:leading-6 [&_[data-footnotes]_p]:text-muted-foreground/82",
+  "[&_.katex]:text-[1.04em] [&_.katex]:leading-[1.35]",
+  "[&_.katex-display]:my-3 [&_.katex-display]:max-w-full [&_.katex-display]:overflow-x-auto [&_.katex-display]:overflow-y-hidden [&_.katex-display]:px-1 [&_.katex-display]:py-1",
+  "[&_.katex-display>.katex]:min-w-fit [&_.katex-display>.katex]:max-w-none",
+  "[&_[data-latex-copyable='true']]:cursor-copy [&_[data-latex-copyable='true']]:rounded-sm [&_[data-latex-copyable='true']]:outline-none [&_[data-latex-copyable='true']]:transition-colors",
+  "[&_[data-latex-copyable='true']:hover]:bg-foreground/[0.035] [&_[data-latex-copyable='true']:focus-visible]:bg-foreground/[0.045] [&_[data-latex-copyable='true']:focus-visible]:ring-2 [&_[data-latex-copyable='true']:focus-visible]:ring-ring/25",
   "[&_strong]:font-semibold",
 );
 
@@ -183,12 +197,12 @@ function getStreamdownPluginKey(features: StreamdownFeatureFlags): string {
     .join(":");
 }
 
-function getStreamdownFeaturesFromKey(key: string): StreamdownFeatureFlags {
-  return {
-    code: key.includes("code"),
-    math: key.includes("math"),
-    mermaid: key.includes("mermaid"),
-  };
+function getInitialStreamdownPlugins(features: StreamdownFeatureFlags): PluginConfig {
+  if (!features.math) {
+    return BASE_STREAMDOWN_PLUGINS;
+  }
+
+  return STREAMDOWN_MATH_BASE_PLUGINS;
 }
 
 async function loadStreamdownPlugins(features: StreamdownFeatureFlags): Promise<PluginConfig> {
@@ -217,10 +231,7 @@ async function loadStreamdownPlugins(features: StreamdownFeatureFlags): Promise<
     }
 
     if (features.math) {
-      const { createMathPlugin } = await import("@streamdown/math");
-      plugins.math = createMathPlugin({
-        singleDollarTextMath: true,
-      });
+      plugins.math = STREAMDOWN_MATH_PLUGIN;
     }
 
     if (features.mermaid) {
@@ -249,8 +260,9 @@ async function loadStreamdownPlugins(features: StreamdownFeatureFlags): Promise<
 }
 
 function useStreamdownPlugins(content: string): PluginConfig {
-  const pluginKey = React.useMemo(() => getStreamdownPluginKey(detectStreamdownFeatures(content)), [content]);
-  const [plugins, setPlugins] = React.useState<PluginConfig>(() => STREAMDOWN_PLUGIN_CACHE.get(pluginKey) ?? BASE_STREAMDOWN_PLUGINS);
+  const features = React.useMemo(() => detectStreamdownFeatures(content), [content]);
+  const pluginKey = React.useMemo(() => getStreamdownPluginKey(features), [features]);
+  const [plugins, setPlugins] = React.useState<PluginConfig>(() => STREAMDOWN_PLUGIN_CACHE.get(pluginKey) ?? getInitialStreamdownPlugins(features));
 
   React.useEffect(() => {
     let cancelled = false;
@@ -261,9 +273,9 @@ function useStreamdownPlugins(content: string): PluginConfig {
       return;
     }
 
-    setPlugins(BASE_STREAMDOWN_PLUGINS);
+    setPlugins(getInitialStreamdownPlugins(features));
 
-    void loadStreamdownPlugins(getStreamdownFeaturesFromKey(pluginKey))
+    void loadStreamdownPlugins(features)
       .then((loadedPlugins) => {
         if (!cancelled) {
           setPlugins(loadedPlugins);
@@ -271,14 +283,14 @@ function useStreamdownPlugins(content: string): PluginConfig {
       })
       .catch(() => {
         if (!cancelled) {
-          setPlugins(BASE_STREAMDOWN_PLUGINS);
+          setPlugins(getInitialStreamdownPlugins(features));
         }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [pluginKey]);
+  }, [features, pluginKey]);
 
   return plugins;
 }
@@ -378,6 +390,15 @@ export const StreamdownRender = React.memo(function StreamdownRender({
   const normalizedContent = React.useMemo(() => normalizeStreamdownContent(content), [content]);
   const plugins = useStreamdownPlugins(normalizedContent);
   const segments = React.useMemo(() => parseStreamdownSegments(normalizedContent), [normalizedContent]);
+  const {
+    rootRef: latexRootRef,
+    onClickCapture: handleLatexClickCapture,
+    onKeyDownCapture: handleLatexKeyDownCapture,
+    onPointerDownCapture: handleLatexPointerDownCapture,
+  } = useLatexCopy({
+    contentVersion: normalizedContent,
+    renderVersion: plugins,
+  });
   const thinkingSegments = React.useMemo(
     () => segments.filter((segment): segment is Extract<RenderSegment, { type: "thinking" }> => segment.type === "thinking"),
     [segments],
@@ -404,8 +425,12 @@ export const StreamdownRender = React.memo(function StreamdownRender({
 
   return (
     <div
+      ref={latexRootRef}
       className={cn("chat-font-content min-w-0 max-w-full overflow-hidden text-foreground [overflow-wrap:anywhere]", contentSpacingClassName, className)}
       data-chat-markdown-scope=""
+      onClickCapture={handleLatexClickCapture}
+      onKeyDownCapture={handleLatexKeyDownCapture}
+      onPointerDownCapture={handleLatexPointerDownCapture}
     >
       {mergedThinkingContent ? (
         <ThinkingSegmentBlock

--- a/frontend/features/chat/hooks/use-latex-copy.ts
+++ b/frontend/features/chat/hooks/use-latex-copy.ts
@@ -1,0 +1,235 @@
+"use client";
+
+import * as React from "react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+const LATEX_COPYABLE_SELECTOR = ".katex, .katex-display";
+const LATEX_ANNOTATION_SELECTOR = "annotation[encoding='application/x-tex']";
+const LATEX_INTERACTION_EXCLUSION_SELECTOR = "a, button, input, textarea, select, summary, pre, code, [contenteditable='true']";
+const LATEX_POINTER_DRAG_THRESHOLD = 6;
+
+type UseLatexCopyOptions = {
+  contentVersion: string;
+  renderVersion: unknown;
+};
+
+type UseLatexCopyResult = {
+  rootRef: React.RefObject<HTMLDivElement | null>;
+  onClickCapture: React.MouseEventHandler<HTMLDivElement>;
+  onKeyDownCapture: React.KeyboardEventHandler<HTMLDivElement>;
+  onPointerDownCapture: React.PointerEventHandler<HTMLDivElement>;
+};
+
+function getHTMLElementFromTarget(target: EventTarget | null): HTMLElement | null {
+  if (target instanceof HTMLElement) {
+    return target;
+  }
+  if (target instanceof Node) {
+    return target.parentElement;
+  }
+  return null;
+}
+
+function hasNonCollapsedSelection(): boolean {
+  const selection = window.getSelection();
+  return Boolean(selection && !selection.isCollapsed && selection.toString().trim());
+}
+
+function isDisplayLatexElement(element: HTMLElement): boolean {
+  return element.classList.contains("katex-display") || Boolean(element.closest(".katex-display"));
+}
+
+function isDelimitedLatexSource(value: string): boolean {
+  return value.startsWith("$") || value.startsWith("\\(") || value.startsWith("\\[");
+}
+
+function formatLatexSource(source: string, displayMode: boolean): string {
+  const trimmedSource = source.trim();
+  if (!trimmedSource || isDelimitedLatexSource(trimmedSource)) {
+    return trimmedSource;
+  }
+  return displayMode ? `$$\n${trimmedSource}\n$$` : `$${trimmedSource}$`;
+}
+
+function getLatexSource(element: HTMLElement): string {
+  const annotation = element.querySelector<HTMLElement>(LATEX_ANNOTATION_SELECTOR);
+  return annotation?.textContent?.trim() ?? "";
+}
+
+function findLatexCopyElement(target: EventTarget | null, root: HTMLElement): HTMLElement | null {
+  const targetElement = getHTMLElementFromTarget(target);
+  if (!targetElement || !root.contains(targetElement)) {
+    return null;
+  }
+
+  if (targetElement.closest(LATEX_INTERACTION_EXCLUSION_SELECTOR)) {
+    return null;
+  }
+
+  const displayElement = targetElement.closest<HTMLElement>(".katex-display");
+  if (displayElement && root.contains(displayElement)) {
+    return displayElement;
+  }
+
+  const katexElement = targetElement.closest<HTMLElement>(".katex");
+  if (katexElement && root.contains(katexElement)) {
+    return katexElement;
+  }
+
+  return null;
+}
+
+function resolveLatexCopySource(target: EventTarget | null, root: HTMLElement): string {
+  const copyElement = findLatexCopyElement(target, root);
+  if (!copyElement) {
+    return "";
+  }
+
+  return formatLatexSource(getLatexSource(copyElement), isDisplayLatexElement(copyElement));
+}
+
+function annotateLatexElements(root: HTMLElement, label: string) {
+  const seenElements = new Set<HTMLElement>();
+
+  root.querySelectorAll<HTMLElement>(LATEX_COPYABLE_SELECTOR).forEach((element) => {
+    const copyElement = element.closest<HTMLElement>(".katex-display") ?? element;
+    if (seenElements.has(copyElement) || !getLatexSource(copyElement)) {
+      return;
+    }
+
+    seenElements.add(copyElement);
+    copyElement.setAttribute("data-latex-copyable", "true");
+    copyElement.setAttribute("tabindex", "0");
+    copyElement.setAttribute("role", "button");
+    copyElement.setAttribute("aria-label", label);
+    copyElement.setAttribute("title", label);
+  });
+}
+
+async function writeClipboardText(value: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  try {
+    const copied = document.execCommand("copy");
+    if (!copied) {
+      throw new Error("copy failed");
+    }
+  } finally {
+    textarea.remove();
+  }
+}
+
+export function useLatexCopy({ contentVersion, renderVersion }: UseLatexCopyOptions): UseLatexCopyResult {
+  const t = useTranslations("chat.markdown");
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const pointerDownRef = React.useRef<{ x: number; y: number } | null>(null);
+
+  React.useEffect(() => {
+    const root = rootRef.current;
+    if (!root) {
+      return;
+    }
+    annotateLatexElements(root, t("copyLatex"));
+  }, [contentVersion, renderVersion, t]);
+
+  const copyLatexFromTarget = React.useCallback(
+    async (target: EventTarget | null): Promise<boolean> => {
+      const root = rootRef.current;
+      if (!root) {
+        return false;
+      }
+
+      const source = resolveLatexCopySource(target, root);
+      if (!source) {
+        return false;
+      }
+
+      try {
+        await writeClipboardText(source);
+        toast.success(t("latexCopied"));
+      } catch {
+        toast.error(t("latexCopyFailed"));
+      }
+
+      return true;
+    },
+    [t],
+  );
+
+  const onPointerDownCapture = React.useCallback<React.PointerEventHandler<HTMLDivElement>>((event) => {
+    if (event.button !== 0) {
+      pointerDownRef.current = null;
+      return;
+    }
+    pointerDownRef.current = { x: event.clientX, y: event.clientY };
+  }, []);
+
+  const onClickCapture = React.useCallback<React.MouseEventHandler<HTMLDivElement>>(
+    (event) => {
+      if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+        return;
+      }
+
+      const pointerDown = pointerDownRef.current;
+      if (pointerDown) {
+        const deltaX = Math.abs(event.clientX - pointerDown.x);
+        const deltaY = Math.abs(event.clientY - pointerDown.y);
+        if (deltaX > LATEX_POINTER_DRAG_THRESHOLD || deltaY > LATEX_POINTER_DRAG_THRESHOLD) {
+          return;
+        }
+      }
+
+      if (hasNonCollapsedSelection()) {
+        return;
+      }
+
+      const root = rootRef.current;
+      if (!root || !resolveLatexCopySource(event.target, root)) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      void copyLatexFromTarget(event.target);
+    },
+    [copyLatexFromTarget],
+  );
+
+  const onKeyDownCapture = React.useCallback<React.KeyboardEventHandler<HTMLDivElement>>(
+    (event) => {
+      if (event.defaultPrevented || (event.key !== "Enter" && event.key !== " ")) {
+        return;
+      }
+
+      const targetElement = getHTMLElementFromTarget(event.target);
+      if (!targetElement?.hasAttribute("data-latex-copyable")) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      void copyLatexFromTarget(event.target);
+    },
+    [copyLatexFromTarget],
+  );
+
+  return {
+    rootRef,
+    onClickCapture,
+    onKeyDownCapture,
+    onPointerDownCapture,
+  };
+}

--- a/frontend/i18n/messages/en-US/chat.json
+++ b/frontend/i18n/messages/en-US/chat.json
@@ -89,6 +89,9 @@
     "previewImage": "Preview image",
     "editImage": "Edit image",
     "downloadImage": "Download image",
+    "copyLatex": "Copy formula source",
+    "latexCopied": "Formula source copied",
+    "latexCopyFailed": "Could not copy formula source",
     "externalLink": {
       "title": "Open external link?",
       "description": "You are about to leave this site. Confirm the link before continuing.",

--- a/frontend/i18n/messages/zh-CN/chat.json
+++ b/frontend/i18n/messages/zh-CN/chat.json
@@ -89,6 +89,9 @@
     "previewImage": "放大图片",
     "editImage": "编辑图片",
     "downloadImage": "下载图片",
+    "copyLatex": "复制公式源码",
+    "latexCopied": "已复制公式源码",
+    "latexCopyFailed": "公式源码复制失败",
     "externalLink": {
       "title": "打开外部链接？",
       "description": "即将跳转到外部网站，请确认链接地址。",


### PR DESCRIPTION
## Summary

Fix Markdown math rendering in chat messages and improve formula readability/interaction. The update makes Streamdown math rendering more robust for `\(...\)` / `\[...\]`, table cells containing LaTeX absolute-value pipes such as `|x|`, and inline math split across lines. It also initializes the math plugin eagerly to avoid refresh-time render misses, adds formula source copy support, applies consistent KaTeX typography, and tightens spacing around rendered dividers/headings.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm --dir frontend lint`
- [x] `pnpm --dir frontend exec tsc --noEmit`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Tested with Markdown table examples containing LaTeX formulas such as `\ln(1+x)` and `|x| < 1`. The formulas now render through KaTeX instead of being split by Markdown table parsing.

## Configuration, migration, and compatibility notes

Configuration changes: None.

API changes: None.

Database migrations: None.

Deployment changes: None.

Backward compatibility: Existing conversation content remains unchanged; rendering is improved at the frontend Markdown layer.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.