### PR TITLE
fix: repair Anthropic native tool traces bug

### DIFF
--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -968,6 +968,10 @@ func (s *Service) sendMessageInternal(
 		toolSpan.End()
 		toolCallRows = append(toolCallRows, toolResult.Rows...)
 		remainingToolCalls -= len(toolResult.Rows)
+		if toolResult.FatalErr != nil {
+			retErr = wrapUpstreamRequestError(toolResult.FatalErr)
+			return nil, retErr
+		}
 		if len(toolResult.ToolResults) == 0 {
 			break
 		}

--- a/backend/internal/application/conversation/service_tool_execution.go
+++ b/backend/internal/application/conversation/service_tool_execution.go
@@ -3,6 +3,7 @@ package conversation
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -31,6 +32,7 @@ type executeAssistantToolCallsResult struct {
 	Rows              []model.ToolCall
 	ToolResults       []llm.ToolResult
 	ExecutedToolCalls []llm.ToolCall
+	FatalErr          error
 }
 
 type toolExecutionRecord struct {
@@ -66,6 +68,7 @@ func (s *Service) executeAssistantToolCalls(ctx context.Context, input executeAs
 	}
 
 	slots := make([]toolExecutionSlot, len(toolCalls))
+	var fatalErr error
 	for i, item := range toolCalls {
 		modelToolName := strings.TrimSpace(item.ToolName)
 		executionToolName := resolveExecutionToolName(modelToolName, input.ToolNameMap)
@@ -79,6 +82,23 @@ func (s *Service) executeAssistantToolCalls(ctx context.Context, input executeAs
 			InputJSON:  strings.TrimSpace(item.ArgumentsJSON),
 			OutputJSON: "",
 			ErrorJSON:  "",
+		}
+
+		mcpConfig := resolveMCPConfig(modelToolName, input.MCPConfigs)
+		if mcpConfig == nil {
+			row.Status = "error"
+			row.ErrorJSON = toolNotEnabledForRunMessage(modelToolName)
+			slots[i] = toolExecutionSlot{
+				row:    row,
+				result: buildToolResultForModel(row, modelToolName),
+			}
+			if fatalErr == nil {
+				fatalErr = fmt.Errorf("model requested tool %q, but it is not enabled for this run", modelToolName)
+			}
+			if input.Ledger != nil {
+				input.Ledger.store(row.ToolName, row.InputJSON, toolExecutionRecord{row: row, result: slots[i].result})
+			}
+			continue
 		}
 
 		normalizedInput, validationErr := normalizeToolArguments(row.InputJSON, input.ToolSchemas[modelToolName])
@@ -110,7 +130,7 @@ func (s *Service) executeAssistantToolCalls(ctx context.Context, input executeAs
 			RequestID:      strings.TrimSpace(input.RequestID),
 			ToolName:       row.ToolName,
 			ArgumentsJSON:  row.InputJSON,
-			MCPConfig:      resolveMCPConfig(modelToolName, input.MCPConfigs),
+			MCPConfig:      mcpConfig,
 		})
 		row.LatencyMS = time.Since(toolStartedAt).Milliseconds()
 		if row.LatencyMS < 0 {
@@ -151,6 +171,7 @@ func (s *Service) executeAssistantToolCalls(ctx context.Context, input executeAs
 		Rows:              rows,
 		ToolResults:       toolResults,
 		ExecutedToolCalls: executedToolCalls,
+		FatalErr:          fatalErr,
 	}
 }
 
@@ -216,6 +237,14 @@ func buildToolResultForModel(row model.ToolCall, modelToolName string) llm.ToolR
 		Status:     row.Status,
 		Error:      row.ErrorJSON,
 	}
+}
+
+func toolNotEnabledForRunMessage(toolName string) string {
+	name := strings.TrimSpace(toolName)
+	if name == "" {
+		return "tool is not enabled for this run"
+	}
+	return fmt.Sprintf("tool %s is not enabled for this run", name)
 }
 
 func budgetToolOutputForModel(raw string, maxChars int) string {

--- a/backend/internal/application/conversation/service_tool_test.go
+++ b/backend/internal/application/conversation/service_tool_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/llm"
 )
 
 func TestExecuteToolCallRejectsToolsNotEnabledForRun(t *testing.T) {
@@ -16,6 +17,30 @@ func TestExecuteToolCallRejectsToolsNotEnabledForRun(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "not enabled for this run") {
 		t.Fatalf("expected disabled tool error, got %v", err)
+	}
+}
+
+func TestExecuteAssistantToolCallsStopsWhenToolNotEnabledForRun(t *testing.T) {
+	svc := &Service{}
+	result := svc.executeAssistantToolCalls(context.Background(), executeAssistantToolCallsInput{
+		RunID: "run_1",
+		ToolCalls: []llm.ToolCall{{
+			ToolCallID:    "toolu_1",
+			ToolType:      "function",
+			ToolName:      "web_search",
+			ArgumentsJSON: `{"query":"weather"}`,
+			Status:        "requested",
+		}},
+	})
+
+	if result.FatalErr == nil || !strings.Contains(result.FatalErr.Error(), "not enabled for this run") {
+		t.Fatalf("expected fatal disabled tool error, got %v", result.FatalErr)
+	}
+	if len(result.Rows) != 1 || result.Rows[0].Status != "error" || result.Rows[0].ToolName != "web_search" {
+		t.Fatalf("expected one failed tool row, got %#v", result.Rows)
+	}
+	if len(result.ToolResults) != 1 || result.ToolResults[0].Status != "error" {
+		t.Fatalf("expected failed model tool result, got %#v", result.ToolResults)
 	}
 }
 

--- a/backend/internal/infra/llm/anthropic.go
+++ b/backend/internal/infra/llm/anthropic.go
@@ -450,6 +450,93 @@ func anthropicNativeToolAllowedCallers(toolType string) []string {
 	}
 }
 
+type anthropicToolClassifier struct {
+	nativeServerToolNames map[string]struct{}
+	clientToolNames       map[string]struct{}
+}
+
+func newAnthropicToolClassifier(payload map[string]interface{}, clientTools []ToolDefinition) anthropicToolClassifier {
+	classifier := anthropicToolClassifier{}
+	for _, tool := range anthropicToolPayloads(payload["tools"]) {
+		toolType := strings.TrimSpace(getString(tool["type"]))
+		if !isAnthropicNativeToolType(toolType) {
+			continue
+		}
+		toolName := strings.TrimSpace(getString(tool["name"]))
+		if toolName == "" {
+			toolName = anthropicNativeToolName(toolType)
+		}
+		if toolName == "" {
+			continue
+		}
+		if classifier.nativeServerToolNames == nil {
+			classifier.nativeServerToolNames = map[string]struct{}{}
+		}
+		classifier.nativeServerToolNames[toolName] = struct{}{}
+	}
+	for _, tool := range clientTools {
+		toolName := strings.TrimSpace(tool.Name)
+		if toolName == "" {
+			continue
+		}
+		if classifier.clientToolNames == nil {
+			classifier.clientToolNames = map[string]struct{}{}
+		}
+		classifier.clientToolNames[toolName] = struct{}{}
+	}
+	return classifier
+}
+
+func (c anthropicToolClassifier) isUnsupportedNativeClientToolUse(toolName string) bool {
+	name := strings.TrimSpace(toolName)
+	if name == "" || len(c.nativeServerToolNames) == 0 {
+		return false
+	}
+	if _, ok := c.nativeServerToolNames[name]; !ok {
+		return false
+	}
+	_, clientToolDeclared := c.clientToolNames[name]
+	return !clientToolDeclared
+}
+
+func isAnthropicNativeToolType(toolType string) bool {
+	switch strings.TrimSpace(toolType) {
+	case "web_search_20250305",
+		"web_search_20260209",
+		"web_fetch_20250910",
+		"web_fetch_20260209",
+		"code_execution_20250825",
+		"code_execution_20260120",
+		"advisor_20260301",
+		"tool_search_tool_regex_20251119",
+		"tool_search_tool_bm25_20251119":
+		return true
+	default:
+		return false
+	}
+}
+
+func isAnthropicServerToolResultBlockType(blockType string) bool {
+	value := strings.TrimSpace(blockType)
+	return value != "" && strings.HasSuffix(value, "_tool_result")
+}
+
+func anthropicUnsupportedNativeToolError(toolName string, rawBody string) error {
+	return &UpstreamError{
+		StatusCode: http.StatusBadGateway,
+		Message:    anthropicUnsupportedNativeToolMessage(toolName),
+		Body:       rawBody,
+	}
+}
+
+func anthropicUnsupportedNativeToolMessage(toolName string) string {
+	name := strings.TrimSpace(toolName)
+	if name == "" {
+		name = "native_tool"
+	}
+	return fmt.Sprintf("Anthropic native tool %q must be executed server-side, but the selected upstream returned it as a client-side tool call. Disable this Claude native tool for the channel or use an MCP tool instead.", name)
+}
+
 // normalizeAnthropicRole 将内部 role 映射到 Anthropic 的 user/assistant。
 // Anthropic Messages API 只接受这两种角色（system 已被提升到顶层）。
 func normalizeAnthropicRole(role string) string {
@@ -683,7 +770,7 @@ func (c *Client) generateAnthropic(
 	}
 
 	debug := upstreamDebugSnapshot(req, payload, resp, body)
-	output, err := parseAnthropicResponse(body)
+	output, err := parseAnthropicResponse(body, newAnthropicToolClassifier(requestBody, input.Tools))
 	if err != nil {
 		return nil, attachUpstreamDebug(err, debug)
 	}
@@ -705,19 +792,24 @@ func (c *Client) generateAnthropic(
 //	    "cache_read_input_tokens": 0
 //	  }
 //	}
-func parseAnthropicResponse(body []byte) (*GenerateOutput, error) {
+func parseAnthropicResponse(body []byte, classifier anthropicToolClassifier) (*GenerateOutput, error) {
 	parsed := make(map[string]interface{})
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return nil, err
 	}
+	toolCalls, err := parseAnthropicToolUse(parsed, classifier, string(body))
+	if err != nil {
+		return nil, err
+	}
 
 	result := &GenerateOutput{
-		ResponseID: strings.TrimSpace(getString(parsed["id"])),
-		Text:       extractAnthropicText(parsed),
-		Reasoning:  extractAnthropicReasoning(parsed),
-		Usage:      parseAnthropicUsage(parsed),
-		ToolCalls:  parseAnthropicToolUse(parsed),
-		RawJSON:    string(body),
+		ResponseID:      strings.TrimSpace(getString(parsed["id"])),
+		Text:            extractAnthropicText(parsed),
+		Reasoning:       extractAnthropicReasoning(parsed),
+		Usage:           parseAnthropicUsage(parsed),
+		ToolCalls:       toolCalls,
+		ServerToolCalls: parseAnthropicServerToolUse(parsed),
+		RawJSON:         string(body),
 	}
 	return result, nil
 }
@@ -776,13 +868,17 @@ func parseAnthropicUsage(parsed map[string]interface{}) Usage {
 	}
 }
 
-// parseAnthropicToolUse 解析 Anthropic tool_use content block。
-func parseAnthropicToolUse(parsed map[string]interface{}) []ToolCall {
+// parseAnthropicToolUse 解析需要本地执行的 Anthropic tool_use content block。
+func parseAnthropicToolUse(parsed map[string]interface{}, classifier anthropicToolClassifier, rawBody string) ([]ToolCall, error) {
 	var result []ToolCall
 	for _, raw := range asSlice(parsed["content"]) {
 		block := asMap(raw)
 		if getString(block["type"]) != "tool_use" {
 			continue
+		}
+		toolName := strings.TrimSpace(getString(block["name"]))
+		if classifier.isUnsupportedNativeClientToolUse(toolName) {
+			return nil, anthropicUnsupportedNativeToolError(toolName, rawBody)
 		}
 		arguments := normalizeJSONString(block["input"])
 		if arguments == "" {
@@ -791,15 +887,62 @@ func parseAnthropicToolUse(parsed map[string]interface{}) []ToolCall {
 		result = append(result, ToolCall{
 			ToolCallID:    strings.TrimSpace(getString(block["id"])),
 			ToolType:      "function",
-			ToolName:      strings.TrimSpace(getString(block["name"])),
+			ToolName:      toolName,
 			ArgumentsJSON: arguments,
 			Status:        "requested",
 		})
 	}
 	if result == nil {
+		return make([]ToolCall, 0), nil
+	}
+	return result, nil
+}
+
+// parseAnthropicServerToolUse 解析 Anthropic server-side tool trace。
+func parseAnthropicServerToolUse(parsed map[string]interface{}) []ToolCall {
+	items := make([]ToolCall, 0)
+	indexByID := map[string]int{}
+	for _, raw := range asSlice(parsed["content"]) {
+		block := asMap(raw)
+		blockType := strings.TrimSpace(getString(block["type"]))
+		switch {
+		case blockType == "server_tool_use":
+			arguments := normalizeJSONString(block["input"])
+			if arguments == "" {
+				arguments = "{}"
+			}
+			toolCall := ToolCall{
+				ToolCallID:    strings.TrimSpace(getString(block["id"])),
+				ToolType:      blockType,
+				ToolName:      strings.TrimSpace(getString(block["name"])),
+				ArgumentsJSON: arguments,
+				Status:        "completed",
+			}
+			if toolCall.ToolCallID != "" {
+				indexByID[toolCall.ToolCallID] = len(items)
+			}
+			items = append(items, toolCall)
+		case isAnthropicServerToolResultBlockType(blockType):
+			toolUseID := strings.TrimSpace(getString(block["tool_use_id"]))
+			if toolUseID == "" {
+				continue
+			}
+			index, ok := indexByID[toolUseID]
+			if !ok {
+				continue
+			}
+			output := anthropicServerToolResultOutputJSON(block)
+			if output == "" {
+				output = "{}"
+			}
+			items[index].OutputJSON = output
+			items[index].Status = "completed"
+		}
+	}
+	if items == nil {
 		return make([]ToolCall, 0)
 	}
-	return result
+	return items
 }
 
 // ── 流式调用 ──────────────────────────────────────────────────────────────────
@@ -856,7 +999,7 @@ func (c *Client) generateAnthropicStream(
 
 	idleReader := newIdleTimeoutReader(resp.Body, resolveStreamIdleTimeout(route.StreamIdleTimeoutMS))
 	streamBody := newUpstreamBodyRecorder(idleReader)
-	if err = consumeAnthropicStream(streamBody, result, onEvent); err != nil {
+	if err = consumeAnthropicStream(streamBody, result, onEvent, newAnthropicToolClassifier(requestBody, input.Tools)); err != nil {
 		return nil, attachUpstreamDebug(err, upstreamDebugSnapshot(req, payload, resp, streamErrorBody(streamBody, err)))
 	}
 	compactAnthropicStreamToolCalls(result)
@@ -882,6 +1025,7 @@ func consumeAnthropicStream(
 	reader io.Reader,
 	result *GenerateOutput,
 	onEvent func(GenerateStreamEvent) error,
+	classifier anthropicToolClassifier,
 ) error {
 	// 使用 Anthropic 自身的 SSE dispatch，保持事件语义独立于 OpenAI-family 解析。
 	// Anthropic 专用事件处理函数。
@@ -899,7 +1043,7 @@ func consumeAnthropicStream(
 		if err := json.Unmarshal([]byte(ev.data), &parsed); err != nil {
 			return nil // 单个异常事件不应中断后续流式输出。
 		}
-		return applyAnthropicStreamEvent(parsed, ev.data, result, onEvent)
+		return applyAnthropicStreamEvent(parsed, ev.data, result, onEvent, classifier)
 	}
 
 	var (
@@ -955,6 +1099,7 @@ func applyAnthropicStreamEvent(
 	rawBody string,
 	result *GenerateOutput,
 	onEvent func(GenerateStreamEvent) error,
+	classifier anthropicToolClassifier,
 ) error {
 	eventType := strings.TrimSpace(getString(parsed["type"]))
 
@@ -978,19 +1123,34 @@ func applyAnthropicStreamEvent(
 		index := anthropicContentBlockIndex(parsed)
 		switch strings.TrimSpace(getString(block["type"])) {
 		case "tool_use":
-			toolCall := upsertAnthropicStreamToolCall(result, index, ToolCall{
+			toolName := strings.TrimSpace(getString(block["name"]))
+			if classifier.isUnsupportedNativeClientToolUse(toolName) {
+				message := anthropicUnsupportedNativeToolMessage(toolName)
+				toolCall := upsertAnthropicStreamServerToolCall(result, index, ToolCall{
+					ToolCallID:    strings.TrimSpace(getString(block["id"])),
+					ToolType:      "native_tool_use",
+					ToolName:      toolName,
+					ArgumentsJSON: normalizeJSONString(block["input"]),
+					Status:        "error",
+					ErrorJSON:     message,
+				})
+				if onEvent != nil {
+					if err := onEvent(GenerateStreamEvent{
+						ServerToolCall: &toolCall,
+						ResponseID:     result.ResponseID,
+					}); err != nil {
+						return err
+					}
+				}
+				return anthropicUnsupportedNativeToolError(toolName, rawBody)
+			}
+			_ = upsertAnthropicStreamToolCall(result, index, ToolCall{
 				ToolCallID:    strings.TrimSpace(getString(block["id"])),
 				ToolType:      "function",
-				ToolName:      strings.TrimSpace(getString(block["name"])),
+				ToolName:      toolName,
 				ArgumentsJSON: normalizeJSONString(block["input"]),
 				Status:        "requested",
 			})
-			if onEvent != nil {
-				return onEvent(GenerateStreamEvent{
-					ServerToolCall: &toolCall,
-					ResponseID:     result.ResponseID,
-				})
-			}
 		case "server_tool_use":
 			toolCall := upsertAnthropicStreamServerToolCall(result, index, ToolCall{
 				ToolCallID:    strings.TrimSpace(getString(block["id"])),
@@ -1004,6 +1164,19 @@ func applyAnthropicStreamEvent(
 					ServerToolCall: &toolCall,
 					ResponseID:     result.ResponseID,
 				})
+			}
+		default:
+			if isAnthropicServerToolResultBlockType(strings.TrimSpace(getString(block["type"]))) {
+				toolCall, ok := mergeAnthropicStreamServerToolResult(result, block)
+				if !ok {
+					return nil
+				}
+				if onEvent != nil {
+					return onEvent(GenerateStreamEvent{
+						ServerToolCall: &toolCall,
+						ResponseID:     result.ResponseID,
+					})
+				}
 			}
 		}
 
@@ -1095,21 +1268,7 @@ func applyAnthropicStreamEvent(
 
 	case "content_block_stop":
 		index := anthropicContentBlockIndex(parsed)
-		if toolCall, ok := markAnthropicStreamServerToolCallComplete(result, index); ok {
-			if onEvent != nil {
-				return onEvent(GenerateStreamEvent{
-					ServerToolCall: &toolCall,
-					ResponseID:     result.ResponseID,
-				})
-			}
-			return nil
-		}
-		if toolCall, ok := markAnthropicStreamToolCallComplete(result, index); ok && onEvent != nil {
-			return onEvent(GenerateStreamEvent{
-				ServerToolCall: &toolCall,
-				ResponseID:     result.ResponseID,
-			})
-		}
+		_, _ = markAnthropicStreamToolCallComplete(result, index)
 
 	case "message_delta":
 		// message_delta 包含最终 output_tokens
@@ -1270,6 +1429,65 @@ func markAnthropicStreamServerToolCallComplete(result *GenerateOutput, index int
 	return item, true
 }
 
+func mergeAnthropicStreamServerToolResult(result *GenerateOutput, block map[string]interface{}) (ToolCall, bool) {
+	if result == nil {
+		return ToolCall{}, false
+	}
+	toolUseID := strings.TrimSpace(getString(block["tool_use_id"]))
+	if toolUseID == "" {
+		return ToolCall{}, false
+	}
+	for index := range result.ServerToolCalls {
+		item := result.ServerToolCalls[index]
+		if strings.TrimSpace(item.ToolCallID) != toolUseID {
+			continue
+		}
+		item.OutputJSON = anthropicServerToolResultOutputJSON(block)
+		if item.OutputJSON == "" {
+			item.OutputJSON = "{}"
+		}
+		item.Status = "completed"
+		result.ServerToolCalls[index] = item
+		return item, true
+	}
+	return ToolCall{}, false
+}
+
+func anthropicServerToolResultOutputJSON(block map[string]interface{}) string {
+	return normalizeJSONString(sanitizeAnthropicServerToolResultValue(block))
+}
+
+func sanitizeAnthropicServerToolResultValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		result := make(map[string]interface{}, len(typed))
+		for key, item := range typed {
+			if isAnthropicOpaqueToolResultKey(key) {
+				continue
+			}
+			result[key] = sanitizeAnthropicServerToolResultValue(item)
+		}
+		return result
+	case []interface{}:
+		items := make([]interface{}, 0, len(typed))
+		for _, item := range typed {
+			items = append(items, sanitizeAnthropicServerToolResultValue(item))
+		}
+		return items
+	default:
+		return value
+	}
+}
+
+func isAnthropicOpaqueToolResultKey(key string) bool {
+	switch strings.TrimSpace(key) {
+	case "encrypted_content", "encryptedContent":
+		return true
+	default:
+		return false
+	}
+}
+
 func compactAnthropicStreamToolCalls(result *GenerateOutput) {
 	if result == nil || len(result.ToolCalls) == 0 {
 		compactAnthropicStreamServerToolCalls(result)
@@ -1307,7 +1525,7 @@ func compactAnthropicStreamServerToolCalls(result *GenerateOutput) {
 		if strings.TrimSpace(item.ArgumentsJSON) == "" {
 			item.ArgumentsJSON = "{}"
 		}
-		if strings.TrimSpace(item.Status) == "" {
+		if strings.TrimSpace(item.Status) == "" || strings.TrimSpace(item.Status) == "in_progress" {
 			item.Status = "completed"
 		}
 		items = append(items, item)

--- a/backend/internal/infra/llm/openai_responses.go
+++ b/backend/internal/infra/llm/openai_responses.go
@@ -54,6 +54,8 @@ func buildResponsesRequestBody(
 	if toolsEnabled && modelParamBool(input.Options, "web_search") && adapter == AdapterOpenAIResponses {
 		webSearchTools = append(webSearchTools, map[string]interface{}{"type": "web_search"})
 	}
+	nativeTools := append([]map[string]interface{}{}, providerTools...)
+	nativeTools = append(nativeTools, webSearchTools...)
 	if retention := normalizePromptCacheRetention(modelParamString(input.Options, "prompt_cache_retention")); retention != "" {
 		payload["prompt_cache_retention"] = retention
 	}
@@ -68,7 +70,7 @@ func buildResponsesRequestBody(
 	}
 	applyProviderOptions(payload, input.Options, responsesProtectedProviderOptionKeys(adapter)...)
 	if supportsResponsesIncludeDefaults(adapter) {
-		defaultIncludes := responsesDefaultIncludeValues(adapter, stream, providerTools)
+		defaultIncludes := responsesDefaultIncludeValues(adapter, stream, nativeTools)
 		appendResponseInclude(payload, responseIncludeValues(input.Options, defaultIncludes...)...)
 	} else {
 		appendResponseInclude(payload, responseIncludeValues(input.Options)...)
@@ -158,12 +160,35 @@ func supportsResponsesIncludeDefaults(adapter string) bool {
 
 func responsesDefaultIncludeValues(adapter string, stream bool, providerTools []map[string]interface{}) []string {
 	values := []string{"reasoning.encrypted_content"}
+	if adapter == AdapterOpenAIResponses {
+		values = append(values, openAIResponsesDefaultIncludeValues(providerTools)...)
+	}
 	for _, extension := range responsesProtocolExtensionsForAdapter(adapter) {
 		if extension.includeDefaults != nil {
 			values = append(values, extension.includeDefaults(stream, providerTools)...)
 		}
 	}
 	return appendUniqueStrings(nil, values...)
+}
+
+func openAIResponsesDefaultIncludeValues(tools []map[string]interface{}) []string {
+	if !responsesToolsIncludeType(tools, "web_search") {
+		return nil
+	}
+	return []string{"web_search_call.action.sources"}
+}
+
+func responsesToolsIncludeType(tools []map[string]interface{}, toolType string) bool {
+	expected := strings.TrimSpace(toolType)
+	if expected == "" {
+		return false
+	}
+	for _, tool := range tools {
+		if strings.TrimSpace(getString(tool["type"])) == expected {
+			return true
+		}
+	}
+	return false
 }
 
 func buildResponsesAPIInput(messages []Message) []map[string]interface{} {

--- a/backend/internal/infra/llm/request_params_test.go
+++ b/backend/internal/infra/llm/request_params_test.go
@@ -352,6 +352,10 @@ func TestBuildOpenAIResponsesRequestBodyWebSearchAndPromptCacheRetention(t *test
 	if !ok || len(tools) != 1 || tools[0]["type"] != "web_search" {
 		t.Fatalf("expected web_search tool, got %#v", payload["tools"])
 	}
+	include, ok := payload["include"].([]string)
+	if !ok || len(include) != 2 || include[0] != "reasoning.encrypted_content" || include[1] != "web_search_call.action.sources" {
+		t.Fatalf("expected web search sources include, got %#v", payload["include"])
+	}
 	if payload["prompt_cache_retention"] != "in-memory" {
 		t.Fatalf("expected prompt_cache_retention=in-memory, got %#v", payload["prompt_cache_retention"])
 	}

--- a/backend/internal/infra/llm/request_tools_test.go
+++ b/backend/internal/infra/llm/request_tools_test.go
@@ -1189,7 +1189,7 @@ func TestAnthropicStreamToolUseInputJSONDeltaIsCaptured(t *testing.T) {
 		``,
 	}, "\n")
 
-	if err := consumeAnthropicStream(strings.NewReader(rawStream), result, nil); err != nil {
+	if err := consumeAnthropicStream(strings.NewReader(rawStream), result, nil, anthropicToolClassifier{}); err != nil {
 		t.Fatalf("consume anthropic stream: %v", err)
 	}
 	compactAnthropicStreamToolCalls(result)
@@ -1198,6 +1198,185 @@ func TestAnthropicStreamToolUseInputJSONDeltaIsCaptured(t *testing.T) {
 	}
 	if result.ToolCalls[0].ToolCallID != "toolu_1" || result.ToolCalls[0].ToolName != "memory.save" || result.ToolCalls[0].ArgumentsJSON != `{"text":"hello world"}` {
 		t.Fatalf("unexpected anthropic stream tool call: %#v", result.ToolCalls[0])
+	}
+}
+
+func TestAnthropicStreamRejectsNativeToolUseReturnedAsClientTool(t *testing.T) {
+	payload := mustBuildAnthropicRequestBody(t, "claude-sonnet-4-6", GenerateInput{
+		Messages: []Message{{Role: "user", Content: "北京今天天气"}},
+		Options: map[string]interface{}{
+			"tools": []interface{}{
+				map[string]interface{}{"type": "web_search_20260209"},
+			},
+		},
+	}, true)
+	classifier := newAnthropicToolClassifier(payload, nil)
+	result := &GenerateOutput{ToolCalls: make([]ToolCall, 0), ServerToolCalls: make([]ToolCall, 0)}
+	events := make([]ToolCall, 0)
+	rawStream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10}}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"web_search","input":{"query":"北京天气"}}}`,
+		``,
+	}, "\n")
+
+	err := consumeAnthropicStream(strings.NewReader(rawStream), result, func(event GenerateStreamEvent) error {
+		if event.ServerToolCall != nil {
+			events = append(events, *event.ServerToolCall)
+		}
+		return nil
+	}, classifier)
+	if err == nil {
+		t.Fatalf("expected native tool mismatch error")
+	}
+	var upstreamErr *UpstreamError
+	if !errors.As(err, &upstreamErr) {
+		t.Fatalf("expected upstream error, got %T %v", err, err)
+	}
+	if !strings.Contains(upstreamErr.Message, "client-side tool call") {
+		t.Fatalf("expected clear native tool error, got %q", upstreamErr.Message)
+	}
+	if len(result.ToolCalls) != 0 {
+		t.Fatalf("expected no local tool calls, got %#v", result.ToolCalls)
+	}
+	if len(result.ServerToolCalls) != 1 || result.ServerToolCalls[0].Status != "error" || result.ServerToolCalls[0].ToolName != "web_search" {
+		t.Fatalf("expected failed server-side tool trace, got %#v", result.ServerToolCalls)
+	}
+	if len(events) != 1 || events[0].Status != "error" {
+		t.Fatalf("expected one error trace event, got %#v", events)
+	}
+}
+
+func TestAnthropicStreamKeepsDeclaredClientToolWithNativeNameLocal(t *testing.T) {
+	payload := mustBuildAnthropicRequestBody(t, "claude-sonnet-4-6", GenerateInput{
+		Messages: []Message{{Role: "user", Content: "search"}},
+		Options: map[string]interface{}{
+			"tools": []interface{}{
+				map[string]interface{}{"type": "web_search_20260209"},
+			},
+		},
+		Tools: []ToolDefinition{{Name: "web_search", Description: "Local search", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+	}, true)
+	classifier := newAnthropicToolClassifier(payload, []ToolDefinition{{Name: "web_search"}})
+	result := &GenerateOutput{ToolCalls: make([]ToolCall, 0), ServerToolCalls: make([]ToolCall, 0)}
+	rawStream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10}}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"web_search","input":{}}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"weather\"}"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	if err := consumeAnthropicStream(strings.NewReader(rawStream), result, nil, classifier); err != nil {
+		t.Fatalf("consume anthropic stream: %v", err)
+	}
+	compactAnthropicStreamToolCalls(result)
+	if len(result.ToolCalls) != 1 || result.ToolCalls[0].ToolName != "web_search" {
+		t.Fatalf("expected declared client tool call, got %#v", result.ToolCalls)
+	}
+	if len(result.ServerToolCalls) != 0 {
+		t.Fatalf("expected no server-side tool calls, got %#v", result.ServerToolCalls)
+	}
+}
+
+func TestAnthropicStreamServerToolUseIsNotLocalToolCall(t *testing.T) {
+	result := &GenerateOutput{ToolCalls: make([]ToolCall, 0), ServerToolCalls: make([]ToolCall, 0)}
+	rawStream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10}}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srv_1","name":"web_search","input":{}}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"weather\"}"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	if err := consumeAnthropicStream(strings.NewReader(rawStream), result, nil, anthropicToolClassifier{}); err != nil {
+		t.Fatalf("consume anthropic stream: %v", err)
+	}
+	compactAnthropicStreamToolCalls(result)
+	if len(result.ToolCalls) != 0 {
+		t.Fatalf("expected no local tool calls, got %#v", result.ToolCalls)
+	}
+	if len(result.ServerToolCalls) != 1 || result.ServerToolCalls[0].ToolName != "web_search" || result.ServerToolCalls[0].Status != "completed" {
+		t.Fatalf("expected completed server-side tool call, got %#v", result.ServerToolCalls)
+	}
+}
+
+func TestAnthropicStreamMergesServerToolResultIntoToolCall(t *testing.T) {
+	result := &GenerateOutput{ToolCalls: make([]ToolCall, 0), ServerToolCalls: make([]ToolCall, 0)}
+	events := make([]ToolCall, 0)
+	rawStream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10}}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srv_1","name":"web_search","input":{}}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"北京天气今天 2026\"}"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"web_search_tool_result","tool_use_id":"srv_1","content":[{"type":"web_search_result","title":"北京天气","url":"https://example.com/weather","page_age":"2026-05-24","encrypted_content":"redacted"}]}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":1}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	if err := consumeAnthropicStream(strings.NewReader(rawStream), result, func(event GenerateStreamEvent) error {
+		if event.ServerToolCall != nil {
+			events = append(events, *event.ServerToolCall)
+		}
+		return nil
+	}, anthropicToolClassifier{}); err != nil {
+		t.Fatalf("consume anthropic stream: %v", err)
+	}
+	compactAnthropicStreamToolCalls(result)
+	if len(result.ToolCalls) != 0 {
+		t.Fatalf("expected no local tool calls, got %#v", result.ToolCalls)
+	}
+	if len(result.ServerToolCalls) != 1 {
+		t.Fatalf("expected one server-side tool call, got %#v", result.ServerToolCalls)
+	}
+	call := result.ServerToolCalls[0]
+	if call.ToolName != "web_search" || call.Status != "completed" {
+		t.Fatalf("expected completed web search call, got %#v", call)
+	}
+	if !strings.Contains(call.OutputJSON, "https://example.com/weather") || !strings.Contains(call.OutputJSON, "北京天气") {
+		t.Fatalf("expected search result output to be captured, got %q", call.OutputJSON)
+	}
+	if strings.Contains(call.OutputJSON, "encrypted_content") || strings.Contains(call.OutputJSON, "redacted") {
+		t.Fatalf("expected opaque search result fields to be removed, got %q", call.OutputJSON)
+	}
+	if len(events) < 2 || events[len(events)-1].OutputJSON == "" {
+		t.Fatalf("expected streaming result event with output, got %#v", events)
 	}
 }
 

--- a/frontend/features/chat/components/message/message-process-trace.tsx
+++ b/frontend/features/chat/components/message/message-process-trace.tsx
@@ -1556,15 +1556,28 @@ function ToolTraceStructuredContent({
     const query = firstStringFromRecord(input, ["query", "q"]) || toolOutputText(call, ["query"]);
     const actionType = firstStringFromRecord(input, ["type", "action"]);
     const urls = collectToolStrings(output, urlKeys);
+    const responseText = urls.length === 0
+      ? formatToolPayload(call.output) || formatToolPayload(call.output_text) || formatToolPayload(call.output_preview)
+      : "";
+    const hasRequest = Boolean(query || (actionType && actionType !== query));
+    const hasResponse = urls.length > 0 || Boolean(responseText);
     return (
-      <div className={cn("space-y-1.5 text-muted-foreground/84", failed && "text-destructive/80")}>
+      <div className={cn("space-y-2 text-muted-foreground/84", failed && "text-destructive/80")}>
         <div>{statusText}</div>
-        {query ? <div className="break-words">{labels.tool.detail.query}: {query}</div> : null}
-        {actionType && actionType !== query ? <div className="break-words">{labels.tool.detail.action}: {actionType}</div> : null}
-        {urls.length > 0 ? (
+        {hasRequest ? (
           <div>
-            <ToolMiniLabel>{labels.tool.detail.source}</ToolMiniLabel>
-            <ToolSourceLinks urls={urls} labels={labels} />
+            <ToolMiniLabel>{labels.tool.detail.request}</ToolMiniLabel>
+            <div className="space-y-1">
+              {query ? <div className="break-words">{labels.tool.detail.query}: {query}</div> : null}
+              {actionType && actionType !== query ? <div className="break-words">{labels.tool.detail.action}: {actionType}</div> : null}
+            </div>
+          </div>
+        ) : null}
+        {hasResponse ? (
+          <div>
+            <ToolMiniLabel>{failed ? labels.tool.detail.error : labels.tool.detail.response}</ToolMiniLabel>
+            {urls.length > 0 ? <ToolSourceLinks urls={urls} labels={labels} /> : null}
+            {responseText ? <ToolPre failed={failed}>{responseText}</ToolPre> : null}
           </div>
         ) : rawDetail ? (
           <ToolDetailText failed={failed} open={open} canExpand={canExpand} labels={labels} onToggle={onToggle}>


### PR DESCRIPTION
## Summary

Fix native web search protocol handling so Anthropic server-side tools are not confused with local MCP tools, and tool traces keep request and response details consistently.

Anthropic native tools are now classified separately from MCP tools. If an Anthropic-compatible upstream returns a native tool such as `web_search` as a client-side `tool_use`, the run now fails with a clear protocol error instead of trying to execute it through MCP. Anthropic server-side tool result blocks are also merged into the same trace entry, with opaque encrypted result fields removed. OpenAI Responses web search now requests `web_search_call.action.sources` by default, and the frontend trace renderer shows web search request and response sections consistently.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [x] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [x] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./internal/infra/llm`
- [x] `cd backend && go test ./internal/application/conversation`
- [x] `cd backend && go test ./...`
- [x] `cd frontend && pnpm lint features/chat/components/message/message-process-trace.tsx`
- [x] `cd frontend && pnpm build`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Reported failure before the fix:

```shell
tool web_search is not enabled for this run
```

The failure was caused by an Anthropic-compatible upstream returning a Claude native server-side tool as a client-side `tool_use`.

## Configuration, migration, and compatibility notes

Configuration changes: None.

API changes: No public API contract changes. Internal provider protocol handling and trace payloads were improved.

Database migrations: None.

Deployment changes: None.

Backward compatibility: Existing conversations remain readable. New runs now separate native provider tools from local MCP tools more strictly and produce clearer errors for invalid upstream protocol behavior.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.