### PR TITLE
feat: add Enter key behavior setting

### DIFF
--- a/frontend/features/settings/components/sections/settings-chat.tsx
+++ b/frontend/features/settings/components/sections/settings-chat.tsx
@@ -464,8 +464,8 @@ export function SettingsChat() {
       <SettingsSection title={t("input.sectionTitle")}>
         <SettingsFieldList>
           <SettingsFieldRow
-            title={t("input.shortcutTitle")}
-            description={t("input.shortcutDescription", { shortcut: `${modifierLabel}+Enter` })}
+            title={t("input.enterBehaviorTitle")}
+            description={t("input.enterBehaviorDescription", { shortcut: `${modifierLabel}+Enter` })}
           >
             <Select
               value={settings.sendShortcut === "enter" ? "enter" : modifierShortcut}
@@ -476,8 +476,8 @@ export function SettingsChat() {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent align="start">
-                <SelectItem value="enter">Enter</SelectItem>
-                <SelectItem value={modifierShortcut}>{modifierLabel}+Enter</SelectItem>
+                <SelectItem value="enter">{t("input.enterBehavior.send")}</SelectItem>
+                <SelectItem value={modifierShortcut}>{t("input.enterBehavior.newline")}</SelectItem>
               </SelectContent>
             </Select>
           </SettingsFieldRow>

--- a/frontend/i18n/messages/en-US/settings.json
+++ b/frontend/i18n/messages/en-US/settings.json
@@ -343,8 +343,12 @@
     },
     "input": {
       "sectionTitle": "Input and sending",
-      "shortcutTitle": "Send shortcut",
-      "shortcutDescription": "This platform uses {shortcut} to submit messages.",
+      "enterBehaviorTitle": "Enter key behavior",
+      "enterBehaviorDescription": "Choose whether Enter sends messages or inserts a new line. When Enter inserts a new line, use {shortcut} to send.",
+      "enterBehavior": {
+        "send": "Enter sends message",
+        "newline": "Enter inserts new line"
+      },
       "heightTitle": "Input area height",
       "heightDescription": "Controls the maximum height allowed when the input box auto-expands.",
       "height": {

--- a/frontend/i18n/messages/zh-CN/settings.json
+++ b/frontend/i18n/messages/zh-CN/settings.json
@@ -343,8 +343,12 @@
     },
     "input": {
       "sectionTitle": "输入与发送",
-      "shortcutTitle": "发送快捷键",
-      "shortcutDescription": "当前平台使用 {shortcut} 提交消息。",
+      "enterBehaviorTitle": "Enter 键行为",
+      "enterBehaviorDescription": "选择 Enter 是发送消息还是换行。选择换行时，使用 {shortcut} 发送消息。",
+      "enterBehavior": {
+        "send": "Enter 发送消息",
+        "newline": "Enter 换行"
+      },
       "heightTitle": "输入区域高度",
       "heightDescription": "控制输入框自动扩展时允许占用的最大高度。",
       "height": {


### PR DESCRIPTION
## Summary
- Rename the chat input shortcut setting to an explicit Enter key behavior setting
- Add localized labels for Enter sending messages or inserting a new line
- Keep the existing chat.send_on_enter setting values for backwards compatibility

## Verification
- pnpm lint