### PR TITLE
feat: add conversation export functionality with API and UI integration

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -5083,6 +5083,61 @@ const docTemplate = `{
                 }
             }
         },
+        "/conversations/{id}/export": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "导出当前用户单个会话的元信息、消息、运行日志和可见处理轨迹",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "chat"
+                ],
+                "summary": "导出会话 JSON",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "会话 public_id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_conversation.ConversationExportResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_conversation.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_conversation.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_conversation.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/conversations/{id}/messages": {
             "get": {
                 "security": [
@@ -10931,6 +10986,72 @@ const docTemplate = `{
             "properties": {
                 "data": {
                     "$ref": "#/definitions/internal_transport_http_conversation.ConversationDeleteResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_conversation.ConversationExportCompatibilityResponse": {
+            "type": "object",
+            "properties": {
+                "format": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_conversation.ConversationExportResponse": {
+            "type": "object",
+            "properties": {
+                "compatibility": {
+                    "$ref": "#/definitions/internal_transport_http_conversation.ConversationExportCompatibilityResponse"
+                },
+                "conversation": {
+                    "$ref": "#/definitions/internal_transport_http_conversation.ConversationResponse"
+                },
+                "defaultMessagePublicIDs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "exportScope": {
+                    "type": "string"
+                },
+                "exportedAt": {
+                    "type": "string"
+                },
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_transport_http_conversation.MessageResponse"
+                    }
+                },
+                "runs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_transport_http_conversation.RunResponse"
+                    }
+                },
+                "totalMessages": {
+                    "type": "integer"
+                },
+                "totalRuns": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_transport_http_conversation.ConversationExportResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_conversation.ConversationExportResponse"
                 },
                 "errorMsg": {
                     "type": "string"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -5076,6 +5076,61 @@
                 }
             }
         },
+        "/conversations/{id}/export": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "导出当前用户单个会话的元信息、消息、运行日志和可见处理轨迹",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "chat"
+                ],
+                "summary": "导出会话 JSON",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "会话 public_id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_conversation.ConversationExportResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_conversation.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_conversation.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_conversation.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/conversations/{id}/messages": {
             "get": {
                 "security": [
@@ -10924,6 +10979,72 @@
             "properties": {
                 "data": {
                     "$ref": "#/definitions/internal_transport_http_conversation.ConversationDeleteResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_conversation.ConversationExportCompatibilityResponse": {
+            "type": "object",
+            "properties": {
+                "format": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_conversation.ConversationExportResponse": {
+            "type": "object",
+            "properties": {
+                "compatibility": {
+                    "$ref": "#/definitions/internal_transport_http_conversation.ConversationExportCompatibilityResponse"
+                },
+                "conversation": {
+                    "$ref": "#/definitions/internal_transport_http_conversation.ConversationResponse"
+                },
+                "defaultMessagePublicIDs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "exportScope": {
+                    "type": "string"
+                },
+                "exportedAt": {
+                    "type": "string"
+                },
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_transport_http_conversation.MessageResponse"
+                    }
+                },
+                "runs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_transport_http_conversation.RunResponse"
+                    }
+                },
+                "totalMessages": {
+                    "type": "integer"
+                },
+                "totalRuns": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_transport_http_conversation.ConversationExportResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_conversation.ConversationExportResponse"
                 },
                 "errorMsg": {
                     "type": "string"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -2681,6 +2681,49 @@ definitions:
       errorMsg:
         type: string
     type: object
+  internal_transport_http_conversation.ConversationExportCompatibilityResponse:
+    properties:
+      format:
+        type: string
+      notes:
+        type: string
+    type: object
+  internal_transport_http_conversation.ConversationExportResponse:
+    properties:
+      compatibility:
+        $ref: '#/definitions/internal_transport_http_conversation.ConversationExportCompatibilityResponse'
+      conversation:
+        $ref: '#/definitions/internal_transport_http_conversation.ConversationResponse'
+      defaultMessagePublicIDs:
+        items:
+          type: string
+        type: array
+      exportScope:
+        type: string
+      exportedAt:
+        type: string
+      messages:
+        items:
+          $ref: '#/definitions/internal_transport_http_conversation.MessageResponse'
+        type: array
+      runs:
+        items:
+          $ref: '#/definitions/internal_transport_http_conversation.RunResponse'
+        type: array
+      totalMessages:
+        type: integer
+      totalRuns:
+        type: integer
+      version:
+        type: integer
+    type: object
+  internal_transport_http_conversation.ConversationExportResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/internal_transport_http_conversation.ConversationExportResponse'
+      errorMsg:
+        type: string
+    type: object
   internal_transport_http_conversation.ConversationListResponseDoc:
     properties:
       data:
@@ -6805,6 +6848,41 @@ paths:
       security:
       - BearerAuth: []
       summary: 设置会话归档
+      tags:
+      - chat
+  /conversations/{id}/export:
+    get:
+      consumes:
+      - application/json
+      description: 导出当前用户单个会话的元信息、消息、运行日志和可见处理轨迹
+      parameters:
+      - description: 会话 public_id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_conversation.ConversationExportResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_transport_http_conversation.ErrorDoc'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/internal_transport_http_conversation.ErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_conversation.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 导出会话 JSON
       tags:
       - chat
   /conversations/{id}/messages:

--- a/backend/internal/application/conversation/dto.go
+++ b/backend/internal/application/conversation/dto.go
@@ -1,5 +1,24 @@
 package conversation
 
+import (
+	"time"
+
+	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
+)
+
+// ConversationExportResult 表示单会话 JSON 导出结果。
+type ConversationExportResult struct {
+	Version                 int
+	ExportScope             string
+	ExportedAt              time.Time
+	Conversation            *model.Conversation
+	Messages                []model.Message
+	Runs                    []model.Run
+	TotalMessages           int64
+	TotalRuns               int64
+	DefaultMessagePublicIDs []string
+}
+
 // ChatFilePolicyDTO 聊天文件策略响应（内部传输，不携带序列化标记）。
 type ChatFilePolicyDTO struct {
 	MaxMessageFiles        int

--- a/backend/internal/application/conversation/service_conversation.go
+++ b/backend/internal/application/conversation/service_conversation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
@@ -11,8 +12,10 @@ import (
 )
 
 const (
-	defaultPageSize = 20
-	maxPageSize     = 100
+	defaultPageSize             = 20
+	maxPageSize                 = 100
+	conversationExportVersion   = 1
+	conversationExportScopeFull = "full"
 )
 
 // DeleteConversationOptions 定义会话删除选项。
@@ -101,6 +104,63 @@ func (s *Service) ListMessages(ctx context.Context, userID uint, conversationID 
 		return nil, 0, err
 	}
 	return items, total, nil
+}
+
+// ExportConversation 查询单会话完整导出数据。
+func (s *Service) ExportConversation(ctx context.Context, userID uint, publicID string) (*ConversationExportResult, error) {
+	conversation, err := s.repo.GetConversationByPublicID(ctx, publicID, userID)
+	if err != nil {
+		return nil, ErrConversationNotFound
+	}
+
+	items, err := s.repo.ListAllMessages(ctx, conversation.ID)
+	if err != nil {
+		return nil, err
+	}
+	if err = s.hydrateMessageFeedback(ctx, userID, items); err != nil {
+		return nil, err
+	}
+	if err = s.hydrateMessageProcessTraces(ctx, items); err != nil {
+		return nil, err
+	}
+
+	runs, err := s.repo.ListConversationRunsByRunIDs(ctx, userID, conversation.ID, collectExportMessageRunIDs(items))
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConversationExportResult{
+		Version:                 conversationExportVersion,
+		ExportScope:             conversationExportScopeFull,
+		ExportedAt:              time.Now().UTC(),
+		Conversation:            conversation,
+		Messages:                items,
+		Runs:                    runs,
+		TotalMessages:           int64(len(items)),
+		TotalRuns:               int64(len(runs)),
+		DefaultMessagePublicIDs: exportDefaultMessagePublicIDs(items),
+	}, nil
+}
+
+func exportDefaultMessagePublicIDs(items []model.Message) []string {
+	return publicIDsFromMessages(buildLatestVisibleMessages(items))
+}
+
+func collectExportMessageRunIDs(items []model.Message) []string {
+	seen := make(map[string]struct{}, len(items))
+	runIDs := make([]string, 0, len(items))
+	for _, item := range items {
+		runID := strings.TrimSpace(item.RunID)
+		if runID == "" {
+			continue
+		}
+		if _, ok := seen[runID]; ok {
+			continue
+		}
+		seen[runID] = struct{}{}
+		runIDs = append(runIDs, runID)
+	}
+	return runIDs
 }
 
 // ListRecentMessages 查询会话最近消息窗口，供对话页恢复最新上下文。

--- a/backend/internal/application/conversation/service_conversation_export_test.go
+++ b/backend/internal/application/conversation/service_conversation_export_test.go
@@ -1,0 +1,41 @@
+package conversation
+
+import (
+	"reflect"
+	"testing"
+
+	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
+)
+
+func TestExportDefaultMessagePublicIDsUsesLatestVisibleBranch(t *testing.T) {
+	messages := []model.Message{
+		{ID: 1, PublicID: "u1", BranchReason: "default"},
+		{ID: 2, PublicID: "a1", ParentPublicID: "u1", BranchReason: "default"},
+		{ID: 3, PublicID: "u2-old", ParentPublicID: "a1", BranchReason: "default"},
+		{ID: 4, PublicID: "a2-old", ParentPublicID: "u2-old", BranchReason: "default"},
+		{ID: 5, PublicID: "u2-new", ParentPublicID: "a1", BranchReason: "retry"},
+		{ID: 6, PublicID: "a2-new", ParentPublicID: "u2-new", BranchReason: "retry"},
+	}
+
+	got := exportDefaultMessagePublicIDs(messages)
+	want := []string{"u1", "a1", "u2-new", "a2-new"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected default export message ids: got %#v want %#v", got, want)
+	}
+}
+
+func TestCollectExportMessageRunIDsTrimsAndDeduplicates(t *testing.T) {
+	messages := []model.Message{
+		{RunID: " run_1 "},
+		{RunID: "run_1"},
+		{RunID: ""},
+		{RunID: "run_2"},
+		{RunID: "run_2"},
+	}
+
+	got := collectExportMessageRunIDs(messages)
+	want := []string{"run_1", "run_2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected export run ids: got %#v want %#v", got, want)
+	}
+}

--- a/backend/internal/application/conversation/service_share.go
+++ b/backend/internal/application/conversation/service_share.go
@@ -878,7 +878,7 @@ func (s *Service) resolveShareMessageIDs(ctx context.Context, conversationID uin
 		}
 		return allIDs, defaultIDs, nil
 	}
-	return allIDs, publicIDsFromMessages(buildLatestVisibleShareMessages(messages)), nil
+	return allIDs, publicIDsFromMessages(buildLatestVisibleMessages(messages)), nil
 }
 
 func normalizeMessagePublicIDs(values []string) []string {
@@ -926,7 +926,7 @@ func resolvePublicDefaultMessageIDs(raw string, messages []model.Message) []stri
 			return result
 		}
 	}
-	return publicIDsFromMessages(buildLatestVisibleShareMessages(messages))
+	return publicIDsFromMessages(buildLatestVisibleMessages(messages))
 }
 
 func publicIDsFromMessages(messages []model.Message) []string {
@@ -940,7 +940,7 @@ func publicIDsFromMessages(messages []model.Message) []string {
 	return result
 }
 
-func buildLatestVisibleShareMessages(messages []model.Message) []model.Message {
+func buildLatestVisibleMessages(messages []model.Message) []model.Message {
 	children := make(map[string][]model.Message)
 	for _, item := range messages {
 		parentKey := strings.TrimSpace(item.ParentPublicID)

--- a/backend/internal/infra/persistence/postgres/conversation/repository.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository.go
@@ -1100,7 +1100,7 @@ func (r *Repo) ListMessagesForShare(ctx context.Context, conversationID uint, pu
 }
 
 // ListAllMessages 查询会话全部消息。
-func (r *Repo) ListAllMessages(ctx context.Context, conversationID uint) ([]models.Message, error) {
+func (r *Repo) ListAllMessages(ctx context.Context, conversationID uint) ([]domainconversation.Message, error) {
 	items := make([]models.Message, 0)
 	if err := r.db.WithContext(ctx).
 		Where("conversation_id = ?", conversationID).
@@ -1112,7 +1112,7 @@ func (r *Repo) ListAllMessages(ctx context.Context, conversationID uint) ([]mode
 	if err := r.hydrateMessageAttachments(ctx, items); err != nil {
 		return nil, err
 	}
-	return items, nil
+	return toMessageDomains(items), nil
 }
 
 // UpsertMessageFeedback 写入或更新消息反馈。

--- a/backend/internal/repository/conversation_core.go
+++ b/backend/internal/repository/conversation_core.go
@@ -75,6 +75,7 @@ type MessageRepository interface {
 	UpdateMessageBilling(ctx context.Context, messageID uint, billedCurrency string, billedNanousd int64, pricingSnapshot string) error
 	SumMessageTokens(ctx context.Context, conversationID uint) (int64, error)
 	ListMessages(ctx context.Context, conversationID uint, offset int, limit int) ([]domainconversation.Message, int64, error)
+	ListAllMessages(ctx context.Context, conversationID uint) ([]domainconversation.Message, error)
 	ListMessagesForShare(ctx context.Context, conversationID uint, publicIDs []string) ([]domainconversation.Message, error)
 	ListRecentMessages(ctx context.Context, conversationID uint, limit int) ([]domainconversation.Message, int64, error)
 	GetMessageByID(ctx context.Context, conversationID uint, messageID uint) (*domainconversation.Message, error)

--- a/backend/internal/transport/http/conversation/dto_response.go
+++ b/backend/internal/transport/http/conversation/dto_response.go
@@ -39,6 +39,24 @@ type ConversationResponse struct {
 	UpdatedAt           time.Time  `json:"updatedAt"`
 }
 
+type ConversationExportResponse struct {
+	Version                 int                                     `json:"version"`
+	ExportScope             string                                  `json:"exportScope"`
+	ExportedAt              time.Time                               `json:"exportedAt"`
+	Conversation            ConversationResponse                    `json:"conversation"`
+	Messages                []MessageResponse                       `json:"messages"`
+	Runs                    []RunResponse                           `json:"runs"`
+	TotalMessages           int64                                   `json:"totalMessages"`
+	TotalRuns               int64                                   `json:"totalRuns"`
+	DefaultMessagePublicIDs []string                                `json:"defaultMessagePublicIDs"`
+	Compatibility           ConversationExportCompatibilityResponse `json:"compatibility"`
+}
+
+type ConversationExportCompatibilityResponse struct {
+	Format string `json:"format"`
+	Notes  string `json:"notes"`
+}
+
 func toConversationResponse(item *model.Conversation) ConversationResponse {
 	labelsJSON := strings.TrimSpace(item.LabelsJSON)
 	if labelsJSON == "" || labelsJSON == "null" {
@@ -71,6 +89,45 @@ func toConversationResponse(item *model.Conversation) ConversationResponse {
 		LastShareAccessedAt: item.LastShareAccessedAt,
 		CreatedAt:           item.CreatedAt,
 		UpdatedAt:           item.UpdatedAt,
+	}
+}
+
+func toConversationExportResponse(item *appconversation.ConversationExportResult) ConversationExportResponse {
+	if item == nil {
+		return ConversationExportResponse{}
+	}
+	runModels := make(map[string]model.Run, len(item.Runs))
+	runs := make([]RunResponse, 0, len(item.Runs))
+	for _, run := range item.Runs {
+		if runID := strings.TrimSpace(run.RunID); runID != "" {
+			runModels[runID] = run
+		}
+		runs = append(runs, toRunResponse(run))
+	}
+
+	fallbackModel := ""
+	if item.Conversation != nil {
+		fallbackModel = item.Conversation.Model
+	}
+	messages := make([]MessageResponse, 0, len(item.Messages))
+	for _, message := range item.Messages {
+		messages = append(messages, toMessageResponseWithRunAndFallback(message, runModels[strings.TrimSpace(message.RunID)], fallbackModel))
+	}
+
+	return ConversationExportResponse{
+		Version:                 item.Version,
+		ExportScope:             item.ExportScope,
+		ExportedAt:              item.ExportedAt,
+		Conversation:            toConversationResponse(item.Conversation),
+		Messages:                messages,
+		Runs:                    runs,
+		TotalMessages:           item.TotalMessages,
+		TotalRuns:               item.TotalRuns,
+		DefaultMessagePublicIDs: item.DefaultMessagePublicIDs,
+		Compatibility: ConversationExportCompatibilityResponse{
+			Format: "deeix.conversation.export",
+			Notes:  "Full backup export. Import compatibility is not guaranteed.",
+		},
 	}
 }
 
@@ -1132,6 +1189,12 @@ type FileUpdateResponseDoc struct {
 type ConversationCreateResponseDoc struct {
 	ErrorMsg string               `json:"errorMsg"`
 	Data     ConversationResponse `json:"data"`
+}
+
+// ConversationExportResponseDoc 会话导出响应文档。
+type ConversationExportResponseDoc struct {
+	ErrorMsg string                     `json:"errorMsg"`
+	Data     ConversationExportResponse `json:"data"`
 }
 
 // ConversationListResponseDoc 会话分页响应文档。

--- a/backend/internal/transport/http/conversation/handler_conversation.go
+++ b/backend/internal/transport/http/conversation/handler_conversation.go
@@ -123,6 +123,46 @@ func (h *Handler) GetConversation(c *gin.Context) {
 	response.Success(c, toConversationResponse(item))
 }
 
+// ExportConversation godoc
+// @Summary 导出会话 JSON
+// @Description 导出当前用户单个会话的元信息、消息、运行日志和可见处理轨迹
+// @Tags chat
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param id path string true "会话 public_id"
+// @Success 200 {object} ConversationExportResponseDoc
+// @Failure 400 {object} ErrorDoc
+// @Failure 404 {object} ErrorDoc
+// @Failure 500 {object} ErrorDoc
+// @Router /conversations/{id}/export [get]
+func (h *Handler) ExportConversation(c *gin.Context) {
+	userID := middleware.MustUserID(c)
+	publicID, err := stringParam(c, "id")
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid conversation id")
+		return
+	}
+
+	item, err := h.service.ExportConversation(c.Request.Context(), userID, publicID)
+	if err != nil {
+		if errors.Is(err, appconversation.ErrConversationNotFound) {
+			response.Error(c, http.StatusNotFound, "conversation not found")
+			return
+		}
+		response.Error(c, http.StatusInternalServerError, "export conversation failed")
+		return
+	}
+
+	h.recordAudit(c, "export_conversation",
+		"conversation",
+		publicID,
+		map[string]interface{}{"message_count": item.TotalMessages},
+	)
+
+	response.Success(c, toConversationExportResponse(item))
+}
+
 // RenameConversation godoc
 // @Summary 重命名会话
 // @Description 修改指定会话标题

--- a/backend/internal/transport/http/conversation/router.go
+++ b/backend/internal/transport/http/conversation/router.go
@@ -14,6 +14,7 @@ func (m *Module) RegisterRoutes(authRequired *gin.RouterGroup) {
 	authRequired.DELETE("/conversation-projects/:id", m.Handler.DeleteConversationProject)
 	authRequired.POST("/conversations/project", m.Handler.BatchSetConversationProject)
 	authRequired.GET("/conversations/:id", m.Handler.GetConversation)
+	authRequired.GET("/conversations/:id/export", m.Handler.ExportConversation)
 	authRequired.PATCH("/conversations/:id/title", m.Handler.RenameConversation)
 	authRequired.PATCH("/conversations/:id/star", m.Handler.SetConversationStar)
 	authRequired.PATCH("/conversations/:id/archive", m.Handler.SetConversationArchive)

--- a/frontend/features/chat/components/app-chat-area.tsx
+++ b/frontend/features/chat/components/app-chat-area.tsx
@@ -17,6 +17,7 @@ import { useChatModelOptions } from "@/features/chat/hooks/use-chat-model-option
 import { useChatRuntime } from "@/features/chat/hooks/use-chat-runtime";
 import { useChatScrollController } from "@/features/chat/hooks/use-chat-scroll-controller";
 import { useChatViewerProfile } from "@/features/chat/hooks/use-chat-viewer-profile";
+import { useConversationExportAction } from "@/features/chat/hooks/use-conversation-export-action";
 import { useHTMLVisualPrompt } from "@/features/chat/hooks/use-visual-prompt";
 import { ChatInput } from "@/features/chat/components/sections/chat-input";
 import {
@@ -527,6 +528,18 @@ export function AppChatArea() {
     setShareDialogOpen(true);
   }, [canOperateConversation]);
 
+  const exportActiveConversation = useConversationExportAction({
+    successMessage: t("exportJSONSuccess"),
+    failureMessage: t("exportJSONFailed"),
+  });
+
+  const onExportActiveConversation = React.useCallback(async () => {
+    if (!canOperateConversation) {
+      return;
+    }
+    await exportActiveConversation(actionConversationID);
+  }, [actionConversationID, canOperateConversation, exportActiveConversation]);
+
   const messagesWithInlineError = React.useMemo<ChatAreaMessage[]>(() => {
     const errors = [
       modelsErrorMsg.trim()
@@ -806,6 +819,7 @@ export function AppChatArea() {
                   }}
                   onShare={onShareActiveConversation}
                   shareActive={activeConversationShared}
+                  onExport={onExportActiveConversation}
                   onDelete={onRequestDeleteActiveConversation}
                   markdownRender={markdownRender}
                   showModelInfo={showModelInfo}

--- a/frontend/features/chat/components/sections/chat-area.tsx
+++ b/frontend/features/chat/components/sections/chat-area.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { motion } from "motion/react";
-import { ArrowDownToLine, Share2 } from "lucide-react";
+import { ArrowDownToLine } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
@@ -21,7 +21,7 @@ import { StreamdownRender } from "@/features/chat/components/markdown/streamdown
 import type { OpenCodeArtifactInput } from "@/features/chat/model/chat-artifacts";
 import { CenteredEmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Button } from "@/components/ui/button";
+import { ConversationShareExportIconDropdown } from "@/shared/components/conversation-share-export-menu";
 import { cn } from "@/lib/utils";
 
 function CompactDivider({ summaryPreview }: { summaryPreview: string }) {
@@ -84,6 +84,7 @@ type ChatAreaProps = {
   projectMenu?: React.ComponentProps<typeof ChatLabel>["projectMenu"];
   onShare?: () => void;
   shareActive?: boolean;
+  onExport?: () => void | Promise<void>;
   onDelete?: () => void | Promise<void>;
   markdownRender?: boolean;
   showModelInfo?: boolean;
@@ -243,6 +244,7 @@ export function ChatArea({
   projectMenu,
   onShare,
   shareActive = false,
+  onExport,
   onDelete,
   markdownRender = true,
   showModelInfo = true,
@@ -264,6 +266,7 @@ export function ChatArea({
   const stableOnReactAssistantMessage = useStableEvent(onReactAssistantMessage);
   const editImageAttachmentHandler = onEditImageAttachment ? stableOnEditImageAttachment : undefined;
   const shareLabel = shareActive ? t("manageShare") : t("shareConversation");
+  const shareExportLabel = t("labelMenu.shareAndExport");
 
   return (
     <>
@@ -277,24 +280,18 @@ export function ChatArea({
             projectMenu={canOperateConversation ? projectMenu : undefined}
             onShare={canOperateConversation ? onShare : undefined}
             shareActive={shareActive}
+            onExport={canOperateConversation ? onExport : undefined}
             onDelete={canOperateConversation ? onDelete : undefined}
           />
           {canOperateConversation ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className={cn(
-                "size-8 shrink-0 rounded-lg text-muted-foreground shadow-none hover:bg-muted hover:text-foreground",
-                shareActive && "text-foreground",
-              )}
-              onClick={onShare}
-              disabled={!onShare}
-              aria-label={shareLabel}
-              title={shareLabel}
-            >
-              <Share2 className="size-4 stroke-[1.8]" />
-            </Button>
+            <ConversationShareExportIconDropdown
+              label={shareExportLabel}
+              shareLabel={shareLabel}
+              exportLabel={t("labelMenu.exportJSON")}
+              active={shareActive}
+              onShare={onShare}
+              onExport={onExport}
+            />
           ) : null}
         </div>
       </div>

--- a/frontend/features/chat/components/sections/chat-label.tsx
+++ b/frontend/features/chat/components/sections/chat-label.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ChevronDown, PencilLine, Share2, Star, StarOff, Trash } from "lucide-react";
+import { ChevronDown, PencilLine, Star, StarOff, Trash } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import {
@@ -25,6 +25,7 @@ import { Button } from "@/components/ui/button";
 import { SpinnerLabel } from "@/components/ui/spinner";
 import { AnimatedText } from "@/components/ui/animated-text";
 import { ConversationProjectSubmenu } from "@/shared/components/conversation-project-submenu";
+import { ConversationShareExportSubmenu } from "@/shared/components/conversation-share-export-menu";
 import { cn } from "@/lib/utils";
 
 type ChatLabelProps = {
@@ -45,6 +46,7 @@ type ChatLabelProps = {
   };
   onShare?: () => void;
   shareActive?: boolean;
+  onExport?: () => void | Promise<void>;
   onDelete?: () => void | Promise<void>;
 };
 
@@ -57,6 +59,7 @@ export function ChatLabel({
   projectMenu,
   onShare,
   shareActive = false,
+  onExport,
   onDelete,
 }: ChatLabelProps) {
   const t = useTranslations("chat.labelMenu");
@@ -160,20 +163,14 @@ export function ChatLabel({
               onSelect={projectMenu.onSelect}
             />
           ) : null}
-          <DropdownMenuItem
-            disabled={!onShare}
-            onSelect={(event) => {
-              event.preventDefault();
-              if (!onShare) {
-                return;
-              }
-              setMenuOpen(false);
-              onShare();
-            }}
-          >
-            <DropdownMenuItemIcon icon={Share2} />
-            {shareActive ? t("manageShare") : t("share")}
-          </DropdownMenuItem>
+          <ConversationShareExportSubmenu
+            label={t("shareAndExport")}
+            shareLabel={shareActive ? t("manageShare") : t("share")}
+            exportLabel={t("exportJSON")}
+            onShare={onShare}
+            onExport={onExport}
+            onCloseMenu={() => setMenuOpen(false)}
+          />
           <DropdownMenuSeparator />
           <DropdownMenuItem
             variant="destructive"

--- a/frontend/features/chat/hooks/use-conversation-export-action.ts
+++ b/frontend/features/chat/hooks/use-conversation-export-action.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import * as React from "react";
+import { toast } from "sonner";
+
+import { downloadConversationExport } from "@/features/chat/model/conversation-export";
+import { exportConversation } from "@/shared/api/conversation";
+import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
+
+type UseConversationExportActionOptions = {
+  successMessage: string;
+  failureMessage: string;
+};
+
+export function useConversationExportAction({
+  successMessage,
+  failureMessage,
+}: UseConversationExportActionOptions) {
+  return React.useCallback(
+    async (conversationPublicID: string) => {
+      const token = await resolveAccessToken();
+      if (!token) {
+        return;
+      }
+
+      try {
+        const data = await exportConversation(token, conversationPublicID);
+        downloadConversationExport(data);
+        toast.success(successMessage);
+      } catch (error) {
+        toast.error(failureMessage, {
+          description: error instanceof Error ? error.message : undefined,
+        });
+      }
+    },
+    [failureMessage, successMessage],
+  );
+}

--- a/frontend/features/chat/model/conversation-export.ts
+++ b/frontend/features/chat/model/conversation-export.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import type { ConversationExportDTO } from "@/shared/api/conversation.types";
+
+function safeFileNamePart(value: string) {
+  const normalized = value
+    .trim()
+    .replace(/[\\/:*?"<>|]+/g, "-")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return normalized || "conversation";
+}
+
+function formatExportTimestamp(value: string) {
+  const date = new Date(value);
+  const source = Number.isNaN(date.getTime()) ? new Date() : date;
+  const pad = (part: number) => String(part).padStart(2, "0");
+  return [
+    source.getFullYear(),
+    pad(source.getMonth() + 1),
+    pad(source.getDate()),
+    "-",
+    pad(source.getHours()),
+    pad(source.getMinutes()),
+    pad(source.getSeconds()),
+  ].join("");
+}
+
+export function resolveConversationExportFileName(data: ConversationExportDTO) {
+  const title = data.conversation?.title?.trim() || data.conversation?.publicID || "conversation";
+  return `conversation-${safeFileNamePart(title)}-${formatExportTimestamp(data.exportedAt)}.json`;
+}
+
+export function downloadConversationExport(data: ConversationExportDTO) {
+  const blob = new Blob([`${JSON.stringify(data, null, 2)}\n`], {
+    type: "application/json;charset=utf-8",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = resolveConversationExportFileName(data);
+  link.rel = "noopener";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}

--- a/frontend/features/layouts/components/navigation/nav-projects.tsx
+++ b/frontend/features/layouts/components/navigation/nav-projects.tsx
@@ -53,6 +53,7 @@ import {
   ConversationShareDialog,
   sharePatchFromDTO,
 } from "@/features/chat/components/sections/conversation-share-dialog"
+import { useConversationExportAction } from "@/features/chat/hooks/use-conversation-export-action"
 import { DeleteFilesOption } from "@/features/recent/components/delete-files-option"
 import { useActiveSidebarConversation } from "@/features/layouts/hooks/use-active-sidebar-conversation"
 import { SidebarConversationItem } from "@/features/layouts/components/navigation/sidebar-conversation-item"
@@ -234,6 +235,10 @@ export function NavProjects() {
   const deleteProjectConversationsID = React.useId()
   const deleteProjectFilesID = React.useId()
   const deleteConversationFilesID = React.useId()
+  const onExportConversation = useConversationExportAction({
+    successMessage: tRecent("exported"),
+    failureMessage: tRecent("exportFailed"),
+  })
 
   React.useEffect(() => {
     projectConversationStateRef.current = projectConversationState
@@ -665,6 +670,7 @@ export function NavProjects() {
                                 onRename={onRenameConversation}
                                 onArchive={onArchiveConversation}
                                 onShare={(publicID, shareTitle) => setShareTarget({ publicID, title: shareTitle })}
+                                onExport={onExportConversation}
                                 onDelete={onDeleteConversation}
                                 onNavigate={isMobile ? () => setOpenMobile(false) : undefined}
                                 menuTriggerID={`project-conversation-menu-trigger-${conversation.publicID}`}

--- a/frontend/features/layouts/components/navigation/nav-recents.tsx
+++ b/frontend/features/layouts/components/navigation/nav-recents.tsx
@@ -29,6 +29,7 @@ import {
   ConversationShareDialog,
   sharePatchFromDTO,
 } from "@/features/chat/components/sections/conversation-share-dialog"
+import { useConversationExportAction } from "@/features/chat/hooks/use-conversation-export-action"
 import { DeleteFilesOption } from "@/features/recent/components/delete-files-option"
 import { useActiveSidebarConversation } from "@/features/layouts/hooks/use-active-sidebar-conversation"
 import { useSidebarListFlip } from "@/features/layouts/hooks/use-sidebar-list-flip"
@@ -74,6 +75,10 @@ export function NavRecents() {
   const loadMoreRef = React.useRef<HTMLLIElement | null>(null)
   const listContainerRef = React.useRef<HTMLDivElement | null>(null)
   const deleteFilesID = React.useId()
+  const onExport = useConversationExportAction({
+    successMessage: t("exported"),
+    failureMessage: t("exportFailed"),
+  })
 
   useLoadMoreSentinel({
     enabled: hasMore && !loadingInitial && !loadMoreFailed,
@@ -213,6 +218,7 @@ export function NavRecents() {
                       onRenameCancel={onRenameCancel}
                       onArchive={onArchive}
                       onShare={onShare}
+                      onExport={onExport}
                       onDelete={onDelete}
                       onNavigate={isMobile ? () => setOpenMobile(false) : undefined}
                       menuTriggerID={`recent-item-menu-trigger-${publicID}`}

--- a/frontend/features/layouts/components/navigation/nav-starred.tsx
+++ b/frontend/features/layouts/components/navigation/nav-starred.tsx
@@ -32,6 +32,7 @@ import {
   ConversationShareDialog,
   sharePatchFromDTO,
 } from "@/features/chat/components/sections/conversation-share-dialog"
+import { useConversationExportAction } from "@/features/chat/hooks/use-conversation-export-action"
 import { DeleteFilesOption } from "@/features/recent/components/delete-files-option"
 import { useActiveSidebarConversation } from "@/features/layouts/hooks/use-active-sidebar-conversation"
 import { useSidebarListFlip } from "@/features/layouts/hooks/use-sidebar-list-flip"
@@ -90,6 +91,10 @@ export function NavStarred() {
   const [renameValue, setRenameValue] = React.useState("")
   const listContainerRef = React.useRef<HTMLDivElement | null>(null)
   const deleteFilesID = React.useId()
+  const onExport = useConversationExportAction({
+    successMessage: t("exported"),
+    failureMessage: t("exportFailed"),
+  })
 
   const starredConversationItems = React.useMemo(
     () => starredItems.map((item) => toSidebarConversationItem(item, t("untitled"))),
@@ -276,6 +281,7 @@ export function NavStarred() {
                     onRenameCancel={onRenameCancel}
                     onArchive={onArchive}
                     onShare={onShare}
+                    onExport={onExport}
                     onDelete={onDelete}
                     onNavigate={isMobile ? () => setOpenMobile(false) : undefined}
                     menuTriggerID={`starred-item-menu-trigger-${item.publicID}`}

--- a/frontend/features/layouts/components/navigation/sidebar-conversation-item.tsx
+++ b/frontend/features/layouts/components/navigation/sidebar-conversation-item.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import Link from "next/link"
-import { Archive, PencilLine, Share2, Trash } from "lucide-react"
+import { Archive, PencilLine, Trash } from "lucide-react"
 import { useTranslations } from "next-intl"
 
 import { Ellipsis } from "@/components/animate-ui/icons/ellipsis"
@@ -18,6 +18,7 @@ import {
 import { SidebarAnimatedItem } from "@/features/layouts/components/navigation/sidebar-animated-item"
 import { SIDEBAR_TRANSFER_TRANSITION } from "@/features/layouts/model/sidebar-motion"
 import { ConversationProjectSubmenu } from "@/shared/components/conversation-project-submenu"
+import { ConversationShareExportSubmenu } from "@/shared/components/conversation-share-export-menu"
 import type {
   SidebarConversationItem as SidebarConversationItemModel,
   SidebarConversationProjectMenu,
@@ -42,6 +43,7 @@ type SidebarConversationItemProps = {
   onRename: (publicID: string, currentTitle: string) => void
   onArchive: (publicID: string) => void
   onShare?: (publicID: string, title: string) => void
+  onExport?: (publicID: string) => void | Promise<void>
   onDelete: (publicID: string, title: string) => void
   onNavigate?: () => void
 }
@@ -63,6 +65,7 @@ export function SidebarConversationItem({
   onRename,
   onArchive,
   onShare,
+  onExport,
   onDelete,
   onNavigate,
 }: SidebarConversationItemProps) {
@@ -173,16 +176,14 @@ export function SidebarConversationItem({
                   onSelect={(projectID) => projectMenu.onSelect(item.publicID, projectID)}
                 />
               ) : null}
-              <DropdownMenuItem
-                disabled={!onShare}
-                onSelect={(event) => {
-                  event.preventDefault()
-                  onShare?.(item.publicID, item.title)
-                }}
-              >
-                <DropdownMenuItemIcon icon={Share2} />
-                {item.shareActive ? t("manageShare") : t("share")}
-              </DropdownMenuItem>
+              <ConversationShareExportSubmenu
+                label={t("shareAndExport")}
+                shareLabel={item.shareActive ? t("manageShare") : t("share")}
+                exportLabel={t("exportJSON")}
+                onShare={onShare ? () => onShare(item.publicID, item.title) : undefined}
+                onExport={onExport ? () => onExport(item.publicID) : undefined}
+                onCloseMenu={() => setIsMenuOpen(false)}
+              />
               <DropdownMenuItem
                 onSelect={(event) => {
                   event.preventDefault()

--- a/frontend/features/recent/components/app-recent.tsx
+++ b/frontend/features/recent/components/app-recent.tsx
@@ -62,6 +62,7 @@ export function AppRecent() {
           onShare={controller.onShare}
           onSetProject={controller.onSetProject}
           onRevokeShare={controller.onRevokeShare}
+          onExport={controller.onExport}
           onDelete={controller.onDelete}
           onRetryLoadMore={controller.retryLoadMore}
         />

--- a/frontend/features/recent/components/sections/recent-list.tsx
+++ b/frontend/features/recent/components/sections/recent-list.tsx
@@ -26,6 +26,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { CenteredEmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ConversationProjectSubmenu } from "@/shared/components/conversation-project-submenu";
+import { ConversationShareExportSubmenu } from "@/shared/components/conversation-share-export-menu";
 import { cn } from "@/lib/utils";
 import { useAppLocale } from "@/i18n/app-i18n-provider";
 import type {
@@ -101,6 +102,7 @@ function RecentConversationRow({
   onShare,
   onRevokeShare,
   onSetProject,
+  onExport,
   onDelete,
 }: {
   item: ConversationDTO;
@@ -120,10 +122,12 @@ function RecentConversationRow({
   onShare: (item: ConversationDTO) => void;
   onRevokeShare: (publicID: string) => void | Promise<void>;
   onSetProject: (publicID: string, projectID?: string) => void | Promise<void>;
+  onExport: (item: ConversationDTO) => void | Promise<void>;
   onDelete: (item: ConversationDTO) => void;
 }) {
   const t = useTranslations("recent");
   const { locale } = useAppLocale();
+  const [menuOpen, setMenuOpen] = React.useState(false);
   const archived = isArchivedConversation(item);
   const shared = item.shareStatus === "active" && Boolean(item.shareID?.trim());
   const title = item.title?.trim() || t("untitled");
@@ -219,7 +223,7 @@ function RecentConversationRow({
         )}
  
 
-        <DropdownMenu modal={false}>
+        <DropdownMenu modal={false} open={menuOpen} onOpenChange={setMenuOpen}>
           <DropdownMenuTrigger asChild>
             <button
               id={`recent-page-item-menu-trigger-${item.publicID}`}
@@ -271,15 +275,14 @@ function RecentConversationRow({
               projects={projects}
               onSelect={(projectID) => onSetProject(item.publicID, projectID)}
             />
-            <DropdownMenuItem
-              onSelect={(event) => {
-                event.preventDefault();
-                onShare(item);
-              }}
-            >
-              <DropdownMenuItemIcon icon={Share2} />
-              {shared ? t("row.manageShare") : t("row.share")}
-            </DropdownMenuItem>
+            <ConversationShareExportSubmenu
+              label={t("row.shareAndExport")}
+              shareLabel={shared ? t("row.manageShare") : t("row.share")}
+              exportLabel={t("row.exportJSON")}
+              onShare={() => onShare(item)}
+              onExport={() => onExport(item)}
+              onCloseMenu={() => setMenuOpen(false)}
+            />
             <DropdownMenuItem
               onSelect={(event) => {
                 event.preventDefault();
@@ -329,6 +332,7 @@ type RecentListProps = {
   onShare: (item: ConversationDTO) => void;
   onRevokeShare: (publicID: string) => void | Promise<void>;
   onSetProject: (publicID: string, projectID?: string) => void | Promise<void>;
+  onExport: (item: ConversationDTO) => void | Promise<void>;
   onDelete: (item: ConversationDTO) => void;
   onRetryLoadMore: () => void | Promise<void>;
 };
@@ -416,6 +420,7 @@ export function RecentList({
   onShare,
   onRevokeShare,
   onSetProject,
+  onExport,
   onDelete,
   onRetryLoadMore,
 }: RecentListProps) {
@@ -493,6 +498,7 @@ export function RecentList({
                     onShare={onShare}
                     onRevokeShare={onRevokeShare}
                     onSetProject={onSetProject}
+                    onExport={onExport}
                     onDelete={onDelete}
                   />
                 );

--- a/frontend/features/recent/hooks/use-recent-page.ts
+++ b/frontend/features/recent/hooks/use-recent-page.ts
@@ -10,6 +10,7 @@ import { useLoadMoreSentinel } from "@/shared/hooks/use-load-more-sentinel";
 import { useSidebarRecents } from "@/features/recent/context/sidebar-recents-context";
 import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
 import {
+  exportConversation,
   listConversations,
   revokeConversationShare,
   revokeConversationShares,
@@ -35,6 +36,7 @@ import {
   conversationMatchesSearch,
   normalizeConversationSearchText,
 } from "@/shared/lib/conversation-search";
+import { downloadConversationExport } from "@/features/chat/model/conversation-export";
 
 function isSharedConversation(item: ConversationDTO): boolean {
   return item.shareStatus === "active" && Boolean(item.shareID?.trim());
@@ -438,6 +440,22 @@ export function useRecentPage() {
     });
   }, [t]);
 
+  const onExport = React.useCallback(async (item: ConversationDTO) => {
+    const token = await resolveAccessToken();
+    if (!token) {
+      return;
+    }
+    try {
+      const data = await exportConversation(token, item.publicID);
+      downloadConversationExport(data);
+      toast.success(t("exported"));
+    } catch (error) {
+      toast.error(t("exportFailed"), {
+        description: resolveErrorMessage(error, t("exportFailed")),
+      });
+    }
+  }, [resolveErrorMessage, t]);
+
   const onRenameCommit = React.useCallback(async () => {
     if (!renameTarget) {
       return;
@@ -669,6 +687,7 @@ export function useRecentPage() {
     onShare,
     onSetProject,
     onRevokeShare,
+    onExport,
     onDelete,
     setRenameValue,
     onRenameCommit,

--- a/frontend/i18n/messages/en-US/chat.json
+++ b/frontend/i18n/messages/en-US/chat.json
@@ -7,6 +7,8 @@
   "stop": "Stop",
   "shareConversation": "Share this conversation",
   "manageShare": "Manage share",
+  "exportJSONSuccess": "Conversation JSON exported",
+  "exportJSONFailed": "Failed to export conversation",
   "model": "Model",
   "time": "Time",
   "tokens": "Tokens",
@@ -78,8 +80,10 @@
     "renamePlaceholder": "Enter a new conversation name",
     "moveToProject": "Move",
     "unassignedProject": "Default",
+    "shareAndExport": "Share & Export",
     "share": "Share",
     "manageShare": "Manage share",
+    "exportJSON": "Export JSON",
     "delete": "Delete"
   },
   "markdown": {

--- a/frontend/i18n/messages/en-US/recent.json
+++ b/frontend/i18n/messages/en-US/recent.json
@@ -53,6 +53,8 @@
   "loadingMore": "Loading more...",
   "retry": "Retry",
   "shareClosed": "Share closed",
+  "exported": "Conversation JSON exported",
+  "exportFailed": "Failed to export conversation",
   "conversationCount": "{count}",
   "deleteConversationLabel": "\"{title}\"",
   "selectedConversationCountLabel": "{count} conversations selected",
@@ -62,11 +64,13 @@
     "unstar": "Unstar",
     "star": "Star",
     "rename": "Rename",
+    "shareAndExport": "Share & Export",
     "manageShare": "Manage share",
     "share": "Share",
     "moveToProject": "Move",
     "unarchive": "Unarchive",
     "archive": "Archive",
+    "exportJSON": "Export JSON",
     "delete": "Delete"
   },
   "emptyState": {

--- a/frontend/i18n/messages/zh-CN/chat.json
+++ b/frontend/i18n/messages/zh-CN/chat.json
@@ -7,6 +7,8 @@
   "stop": "停止",
   "shareConversation": "分享此对话",
   "manageShare": "管理分享",
+  "exportJSONSuccess": "已导出对话 JSON",
+  "exportJSONFailed": "导出对话失败",
   "model": "模型",
   "time": "时间",
   "tokens": "Token",
@@ -78,8 +80,10 @@
     "renamePlaceholder": "请输入新的会话名称",
     "moveToProject": "移至项目",
     "unassignedProject": "默认",
+    "shareAndExport": "分享 & 导出",
     "share": "分享",
     "manageShare": "管理分享",
+    "exportJSON": "导出 JSON",
     "delete": "删除"
   },
   "markdown": {

--- a/frontend/i18n/messages/zh-CN/recent.json
+++ b/frontend/i18n/messages/zh-CN/recent.json
@@ -53,6 +53,8 @@
   "loadingMore": "加载更多...",
   "retry": "重试",
   "shareClosed": "分享已关闭",
+  "exported": "已导出对话 JSON",
+  "exportFailed": "导出对话失败",
   "conversationCount": "{count} 个",
   "deleteConversationLabel": "「{title}」",
   "selectedConversationCountLabel": "{count} 个会话",
@@ -62,11 +64,13 @@
     "unstar": "取消星标",
     "star": "设为星标",
     "rename": "重新命名",
+    "shareAndExport": "分享 & 导出",
     "manageShare": "管理分享",
     "share": "分享",
     "moveToProject": "移至项目",
     "unarchive": "取消归档",
     "archive": "归档",
+    "exportJSON": "导出 JSON",
     "delete": "删除"
   },
   "emptyState": {

--- a/frontend/shared/api/conversation.ts
+++ b/frontend/shared/api/conversation.ts
@@ -3,6 +3,7 @@ import { apiRequest, ApiError, pathParam } from "@/shared/api/http-client";
 import type { PagePayload } from "@/shared/api/common.types";
 import type {
   ConversationDTO,
+  ConversationExportDTO,
   ConversationProjectDTO,
   ConversationProjectFilter,
   ConversationProjectStatusFilter,
@@ -495,6 +496,19 @@ export async function getConversation(
 ): Promise<ConversationDTO> {
   return authedRequest<ConversationDTO>(
     `/api/v1/conversations/${pathParam(conversationPublicID)}`,
+    {
+      accessToken,
+    },
+    true,
+  );
+}
+
+export async function exportConversation(
+  accessToken: string,
+  conversationPublicID: string,
+): Promise<ConversationExportDTO> {
+  return authedRequest<ConversationExportDTO>(
+    `/api/v1/conversations/${pathParam(conversationPublicID)}/export`,
     {
       accessToken,
     },

--- a/frontend/shared/api/conversation.types.ts
+++ b/frontend/shared/api/conversation.types.ts
@@ -115,6 +115,22 @@ export type ConversationRunDTO = {
   updatedAt: string;
 };
 
+export type ConversationExportDTO = {
+  version: number;
+  exportScope: string;
+  exportedAt: string;
+  conversation: ConversationDTO;
+  messages: MessageDTO[];
+  runs: ConversationRunDTO[];
+  totalMessages: number;
+  totalRuns: number;
+  defaultMessagePublicIDs: string[];
+  compatibility: {
+    format: string;
+    notes: string;
+  };
+};
+
 export type MessageBillingCostDTO = {
   billingMode: string;
   billedCurrency: string;

--- a/frontend/shared/components/conversation-share-export-menu.tsx
+++ b/frontend/shared/components/conversation-share-export-menu.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import * as React from "react";
+import { Download, Share2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuItemIcon,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+type ConversationShareExportActionsProps = {
+  shareLabel: string;
+  exportLabel: string;
+  onShare?: () => void;
+  onExport?: () => void | Promise<void>;
+};
+
+type ConversationShareExportMenuItemsProps = ConversationShareExportActionsProps & {
+  onCloseMenu?: () => void;
+};
+
+export function ConversationShareExportMenuItems({
+  shareLabel,
+  exportLabel,
+  onShare,
+  onExport,
+  onCloseMenu,
+}: ConversationShareExportMenuItemsProps) {
+  return (
+    <>
+      <DropdownMenuItem
+        disabled={!onShare}
+        onSelect={(event) => {
+          event.preventDefault();
+          if (!onShare) {
+            return;
+          }
+          onCloseMenu?.();
+          onShare();
+        }}
+      >
+        <DropdownMenuItemIcon icon={Share2} />
+        {shareLabel}
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        disabled={!onExport}
+        onSelect={(event) => {
+          event.preventDefault();
+          if (!onExport) {
+            return;
+          }
+          onCloseMenu?.();
+          void onExport();
+        }}
+      >
+        <DropdownMenuItemIcon icon={Download} />
+        {exportLabel}
+      </DropdownMenuItem>
+    </>
+  );
+}
+
+type ConversationShareExportIconDropdownProps = {
+  label: string;
+  active?: boolean;
+  className?: string;
+} & ConversationShareExportActionsProps;
+
+export function ConversationShareExportIconDropdown({
+  label,
+  shareLabel,
+  exportLabel,
+  active = false,
+  className,
+  onShare,
+  onExport,
+}: ConversationShareExportIconDropdownProps) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <DropdownMenu modal={false} open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={cn(
+            "size-8 shrink-0 rounded-lg text-muted-foreground shadow-none hover:bg-muted hover:text-foreground",
+            active && "text-foreground",
+            className,
+          )}
+          disabled={!onShare && !onExport}
+          aria-label={label}
+          title={label}
+        >
+          <Share2 className="size-4 stroke-[1.8]" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={8} className="min-w-40">
+        <ConversationShareExportMenuItems
+          shareLabel={shareLabel}
+          exportLabel={exportLabel}
+          onShare={onShare}
+          onExport={onExport}
+          onCloseMenu={() => setOpen(false)}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export function ConversationShareExportSubmenu({
+  label,
+  shareLabel,
+  exportLabel,
+  onShare,
+  onExport,
+  onCloseMenu,
+}: { label: string } & ConversationShareExportMenuItemsProps) {
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger disabled={!onShare && !onExport}>
+        <DropdownMenuItemIcon icon={Share2} />
+        {label}
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="min-w-40 p-1.5">
+        <ConversationShareExportMenuItems
+          shareLabel={shareLabel}
+          exportLabel={exportLabel}
+          onShare={onShare}
+          onExport={onExport}
+          onCloseMenu={onCloseMenu}
+        />
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+}


### PR DESCRIPTION
## Summary

Add conversation JSON export and consolidate sharing/export actions into a unified “Share & Export” flow.

This change adds an authenticated full-conversation JSON export API, including conversation metadata, messages, runs, token/billing snapshots, attachments snapshots, visible process traces, and default visible message branch IDs. The frontend adds JSON download support and moves scattered share/export actions into a shared “Share & Export” menu across chat header, conversation title menu, sidebar conversation menus, and recent conversation rows.

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [x] Documentation

## Verification

- [x] `cd backend && go test ./internal/application/conversation ./internal/transport/http/conversation ./internal/infra/persistence/postgres/conversation`
- [x] `cd backend && make swagger`
- [x] `cd backend && go test ./...`
- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm build`
- [x] `git diff --check`

## Screenshots, API examples, or logs

New API:

```http
GET /api/v1/conversations/{id}/export
```

Response includes:

```json
{
  "version": 1,
  "exportScope": "full",
  "exportedAt": "...",
  "conversation": {},
  "messages": [],
  "runs": [],
  "totalMessages": 0,
  "totalRuns": 0,
  "defaultMessagePublicIDs": [],
  "compatibility": {
    "format": "deeix.conversation.export",
    "notes": "Full backup export. Import compatibility is not guaranteed."
  }
}
```

## Configuration, migration, and compatibility notes

No configuration or database migration is required.

API change: adds a new authenticated export endpoint. Existing conversation, sharing, message listing, and send-message APIs remain unchanged.

Swagger was regenerated to include the new export response schema.

## Documentation

- [ ] Documentation is not needed for this change.
- [x] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.