### PR TITLE
feat: implement reasoning content passback for chat completions

### DIFF
--- a/backend/internal/application/channel/model_catalog_test.go
+++ b/backend/internal/application/channel/model_catalog_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	appbilling "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/billing"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/llm"
 )
 
 func TestProtocolDefaultsForCompatibleOnlyIncludesSupportedPrimaryKinds(t *testing.T) {
@@ -200,6 +201,18 @@ func TestDetectModelVendorRecognizesCompanyVendors(t *testing.T) {
 		if got := detectModelVendor(platformModelName); got != expected {
 			t.Fatalf("detectModelVendor(%q) = %q, want %q", platformModelName, got, expected)
 		}
+	}
+}
+
+func TestReasoningContentPassbackRequiredForDeepSeekChatCompletions(t *testing.T) {
+	if !reasoningContentPassbackRequired(llm.AdapterOpenAIChatCompletions, "deepseek", "deepseek-v4-flash-free") {
+		t.Fatal("expected DeepSeek Chat Completions route to require reasoning_content passback")
+	}
+	if reasoningContentPassbackRequired(llm.AdapterOpenAIChatCompletions, "openai", "gpt-5.4") {
+		t.Fatal("expected OpenAI Chat Completions route to skip reasoning_content passback")
+	}
+	if reasoningContentPassbackRequired(llm.AdapterOpenAIResponses, "deepseek", "deepseek-v4-flash-free") {
+		t.Fatal("expected non Chat Completions route to skip reasoning_content passback")
 	}
 }
 

--- a/backend/internal/application/channel/service.go
+++ b/backend/internal/application/channel/service.go
@@ -60,6 +60,7 @@ type ResolvedRoute struct {
 	ModelCapabilitiesJSON      string
 	ModelSystemPrompt          string
 	UpstreamModel              string
+	ReasoningContentPassback   bool
 	UpstreamCbFailureThreshold int
 	UpstreamCbModelThreshold   int
 	UpstreamCbThresholdLogic   string

--- a/backend/internal/application/channel/service_helpers.go
+++ b/backend/internal/application/channel/service_helpers.go
@@ -362,6 +362,13 @@ func normalizeUpstreamModelVendor(raw string, candidates ...string) string {
 	return "unknown"
 }
 
+func reasoningContentPassbackRequired(protocol string, candidates ...string) bool {
+	if llm.NormalizeAdapter(protocol) != llm.AdapterOpenAIChatCompletions {
+		return false
+	}
+	return detectModelVendor(candidates...) == "deepseek"
+}
+
 func detectModelVendor(candidates ...string) string {
 	fallback := ""
 	for _, candidate := range candidates {

--- a/backend/internal/application/channel/service_routing.go
+++ b/backend/internal/application/channel/service_routing.go
@@ -320,6 +320,7 @@ func buildResolvedRoute(row repository.ChannelUpstreamRouteRow, apiKey string) *
 		ModelCapabilitiesJSON:      strings.TrimSpace(row.ModelCapabilitiesJSON),
 		ModelSystemPrompt:          strings.TrimSpace(row.ModelSystemPrompt),
 		UpstreamModel:              strings.TrimSpace(row.UpstreamModelName),
+		ReasoningContentPassback:   reasoningContentPassbackRequired(row.Protocol, row.ModelVendor, row.PlatformModelName, row.UpstreamModelName, row.UpstreamName),
 		UpstreamCbFailureThreshold: row.UpstreamCbFailureThreshold,
 		UpstreamCbModelThreshold:   row.UpstreamCbModelThreshold,
 		UpstreamCbThresholdLogic:   row.UpstreamCbThresholdLogic,

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -727,6 +727,14 @@ func (s *Service) sendMessageInternal(
 		}
 		streamRequested := preferStream && onDelta != nil
 		streamSupported := llm.SupportsStreamingAdapter(routeConfig.Protocol)
+		var callVisibleText strings.Builder
+		emitCallVisibleDelta := func(delta string) error {
+			if err := emitVisibleDelta(delta); err != nil {
+				return err
+			}
+			callVisibleText.WriteString(delta)
+			return nil
+		}
 		callPromptShape := summarizePromptShape(callPromptMode, currentInput.Messages, currentInput.Messages, currentInput.PreviousResponseID)
 		generationCtx, generationSpan := platformtracing.Start(ctx, "conversation.llm.generate",
 			trace.WithAttributes(append([]attribute.KeyValue{
@@ -750,7 +758,7 @@ func (s *Service) sendMessageInternal(
 			if output == nil || (strings.TrimSpace(output.Text) == "" && output.Reasoning == nil) {
 				return nil
 			}
-			cleanText, thinkText := splitThinkingContent(output.Text)
+			cleanText, thinkText := splitAssistantOutputThinkingContent(output.Text)
 			if traceRecorder != nil && output.Reasoning != nil {
 				traceRecorder.syncStructuredThink(
 					output.Reasoning.Text,
@@ -769,10 +777,10 @@ func (s *Service) sendMessageInternal(
 			if traceRecorder != nil {
 				traceRecorder.completeUpstreamThink()
 			}
-			if cleanText == "" {
-				cleanText = output.Text
+			if cleanText == "" && strings.TrimSpace(thinkText) == "" {
+				cleanText = strings.TrimSpace(output.Text)
 			}
-			if streamErr := emitVisibleDelta(cleanText); streamErr != nil {
+			if streamErr := emitCallVisibleDelta(cleanText); streamErr != nil {
 				return streamErr
 			}
 			output.Text = cleanText
@@ -836,7 +844,7 @@ func (s *Service) sendMessageInternal(
 			if visibleDelta == "" {
 				return nil
 			}
-			return emitVisibleDelta(visibleDelta)
+			return emitCallVisibleDelta(visibleDelta)
 		})
 		generateErr = streamErr
 		if generateErr == nil {
@@ -861,9 +869,12 @@ func (s *Service) sendMessageInternal(
 				traceRecorder.completeUpstreamThink()
 			}
 			if visibleTail != "" {
-				if tailErr := emitVisibleDelta(visibleTail); tailErr != nil {
+				if tailErr := emitCallVisibleDelta(visibleTail); tailErr != nil {
 					generateErr = tailErr
 				}
+			}
+			if output != nil {
+				output.Text = callVisibleText.String()
 			}
 		}
 		if generateErr != nil && shouldFallbackToNonStreaming(generateErr) {
@@ -1013,11 +1024,16 @@ func (s *Service) sendMessageInternal(
 		if len(toolResult.ToolResults) == 0 {
 			break
 		}
+		reasoningContent := ""
+		if route.ReasoningContentPassback {
+			reasoningContent = outputReasoningContent(upstreamOutput)
+		}
 		llmMessages = append(llmMessages,
 			llm.Message{
-				Role:      "assistant",
-				Content:   assistantText,
-				ToolCalls: toolResult.ExecutedToolCalls,
+				Role:             "assistant",
+				Content:          assistantText,
+				ReasoningContent: reasoningContent,
+				ToolCalls:        toolResult.ExecutedToolCalls,
 			},
 			llm.Message{
 				Role:        "tool",

--- a/backend/internal/application/conversation/service_prompt_fingerprint.go
+++ b/backend/internal/application/conversation/service_prompt_fingerprint.go
@@ -50,6 +50,7 @@ func buildPromptStateFingerprint(input promptStateFingerprintInput) string {
 				writeFingerprintField(hasher, "part_data", hex.EncodeToString(dataHash[:]))
 			}
 		}
+		writeFingerprintField(hasher, "reasoning_content", message.ReasoningContent)
 		for _, call := range message.ToolCalls {
 			writeFingerprintField(hasher, "tool_call_id", call.ToolCallID)
 			writeFingerprintField(hasher, "tool_call_type", call.ToolType)

--- a/backend/internal/application/conversation/service_tool_loop.go
+++ b/backend/internal/application/conversation/service_tool_loop.go
@@ -12,9 +12,9 @@ func syncUpstreamOutputThinking(traceRecorder *messageTraceRecorder, output *llm
 	if output == nil {
 		return ""
 	}
-	assistantText, extractedThink := splitThinkingContent(output.Text)
-	if assistantText == "" {
-		assistantText = output.Text
+	assistantText, extractedThink := splitAssistantOutputThinkingContent(output.Text)
+	if assistantText == "" && strings.TrimSpace(extractedThink) == "" {
+		assistantText = strings.TrimSpace(output.Text)
 	}
 	if traceRecorder != nil && output.Reasoning != nil {
 		traceRecorder.syncStructuredThink(
@@ -51,6 +51,19 @@ func syncUpstreamOutputTrace(traceRecorder *messageTraceRecorder, output *llm.Ge
 	assistantText := syncUpstreamOutputThinking(traceRecorder, output)
 	serverToolRows = syncUpstreamServerToolCalls(traceRecorder, output, runID)
 	return assistantText, serverToolRows
+}
+
+func outputReasoningContent(output *llm.GenerateOutput) string {
+	if output == nil {
+		return ""
+	}
+	if output.Reasoning != nil {
+		if text := strings.TrimSpace(output.Reasoning.Text); text != "" {
+			return text
+		}
+	}
+	_, extractedThink := splitAssistantOutputThinkingContent(output.Text)
+	return strings.TrimSpace(extractedThink)
 }
 
 func shouldSyncServerToolsBeforeThinking(output *llm.GenerateOutput) bool {

--- a/backend/internal/application/conversation/service_tool_test.go
+++ b/backend/internal/application/conversation/service_tool_test.go
@@ -102,3 +102,37 @@ func TestAddServerSideToolUsageAggregatesPositiveCounts(t *testing.T) {
 		t.Fatalf("expected non-positive usage to be ignored: %#v", got)
 	}
 }
+
+func TestSyncUpstreamOutputThinkingDoesNotReturnThinkingOnlyContent(t *testing.T) {
+	output := &llm.GenerateOutput{
+		Text: "<think>Need to call a tool.</think>",
+		ToolCalls: []llm.ToolCall{{
+			ToolCallID:    "call_1",
+			ToolType:      "function",
+			ToolName:      "memory.list",
+			ArgumentsJSON: "{}",
+			Status:        "requested",
+		}},
+	}
+
+	if got := syncUpstreamOutputThinking(nil, output); got != "" {
+		t.Fatalf("expected thinking-only tool call content to stay out of assistant text, got %q", got)
+	}
+}
+
+func TestOutputReasoningContentPrefersStructuredReasoning(t *testing.T) {
+	output := &llm.GenerateOutput{
+		Reasoning: &llm.ReasoningOutput{Text: "need a tool"},
+		Text:      "<think>fallback</think>",
+	}
+
+	got := outputReasoningContent(output)
+	if got != "need a tool" {
+		t.Fatalf("expected structured reasoning content, got %q", got)
+	}
+
+	got = outputReasoningContent(&llm.GenerateOutput{Text: "<think>fallback</think>"})
+	if got != "fallback" {
+		t.Fatalf("expected parsed thinking fallback, got %q", got)
+	}
+}

--- a/backend/internal/application/conversation/service_trace.go
+++ b/backend/internal/application/conversation/service_trace.go
@@ -1809,6 +1809,21 @@ func splitThinkingContent(content string) (string, string) {
 	return strings.TrimSpace(visible), strings.TrimSpace(think)
 }
 
+func splitAssistantOutputThinkingContent(content string) (string, string) {
+	_, tagName, openEnd, openPending, ok := parseLeadingThinkingOpenTag(content)
+	if openPending {
+		return strings.TrimSpace(content), ""
+	}
+	if !ok {
+		return strings.TrimSpace(content), ""
+	}
+	closeStart, closeEnd, found := findThinkingCloseTag(content, openEnd, tagName)
+	if !found {
+		return "", strings.TrimSpace(content[openEnd:])
+	}
+	return strings.TrimSpace(content[closeEnd:]), strings.TrimSpace(content[openEnd:closeStart])
+}
+
 func splitLeadingThinkingBlock(content string, flush bool) (visible string, think string, pending bool) {
 	if content == "" {
 		return "", "", false

--- a/backend/internal/application/conversation/service_trace_thinking_test.go
+++ b/backend/internal/application/conversation/service_trace_thinking_test.go
@@ -51,6 +51,43 @@ func TestSplitThinkingContentOnlyAcceptsLeadingClosedBlock(t *testing.T) {
 	}
 }
 
+func TestSplitAssistantOutputThinkingContentRemovesProtocolUnsafeThinking(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantVisible string
+		wantThink   string
+	}{
+		{
+			name:        "closed leading think block",
+			input:       "<think>hidden</think>visible",
+			wantVisible: "visible",
+			wantThink:   "hidden",
+		},
+		{
+			name:        "unclosed leading think block",
+			input:       "<thinking>tool decision",
+			wantVisible: "",
+			wantThink:   "tool decision",
+		},
+		{
+			name:        "plain visible content",
+			input:       "visible <think>literal</think>",
+			wantVisible: "visible <think>literal</think>",
+			wantThink:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			visible, think := splitAssistantOutputThinkingContent(tt.input)
+			if visible != tt.wantVisible || think != tt.wantThink {
+				t.Fatalf("unexpected split: visible=%q think=%q", visible, think)
+			}
+		})
+	}
+}
+
 func TestThinkingDeltaRouterParsesEachAssistantOutputStart(t *testing.T) {
 	router := &thinkingDeltaRouter{}
 	visible, think := router.consume("<thi")

--- a/backend/internal/infra/llm/client.go
+++ b/backend/internal/infra/llm/client.go
@@ -112,12 +112,13 @@ type CacheControl struct {
 // Message 定义发送给上游的消息结构。
 // Parts 非空时覆盖 Content 用于多模态内容。
 type Message struct {
-	Role         string
-	Content      string        // 纯文本消息内容（Parts 为空时使用）
-	Parts        []ContentPart // 多模态内容片段（设置后优先于 Content）
-	ToolCalls    []ToolCall    // assistant 请求执行的工具调用
-	ToolResults  []ToolResult  // 工具执行结果，用于回灌下一轮模型调用
-	CacheControl *CacheControl // 支持块级缓存的 adapter 可读取该提示
+	Role             string
+	Content          string        // 纯文本消息内容（Parts 为空时使用）
+	Parts            []ContentPart // 多模态内容片段（设置后优先于 Content）
+	ReasoningContent string        // OpenAI-compatible thinking mode 的 reasoning_content 回灌字段
+	ToolCalls        []ToolCall    // assistant 请求执行的工具调用
+	ToolResults      []ToolResult  // 工具执行结果，用于回灌下一轮模型调用
+	CacheControl     *CacheControl // 支持块级缓存的 adapter 可读取该提示
 }
 
 // GenerateInput 定义上游推理请求入参。
@@ -873,12 +874,13 @@ func normalizeMessages(messages []Message) []Message {
 			continue
 		}
 		normalized = append(normalized, Message{
-			Role:         normalizeRole(item.Role),
-			Content:      item.Content,
-			Parts:        item.Parts,
-			ToolCalls:    item.ToolCalls,
-			ToolResults:  item.ToolResults,
-			CacheControl: item.CacheControl,
+			Role:             normalizeRole(item.Role),
+			Content:          item.Content,
+			Parts:            item.Parts,
+			ReasoningContent: item.ReasoningContent,
+			ToolCalls:        item.ToolCalls,
+			ToolResults:      item.ToolResults,
+			CacheControl:     item.CacheControl,
 		})
 	}
 	if len(normalized) == 0 {

--- a/backend/internal/infra/llm/openai_chat_completions.go
+++ b/backend/internal/infra/llm/openai_chat_completions.go
@@ -173,6 +173,9 @@ func buildChatCompletionsMessages(msg Message) []map[string]interface{} {
 		"role":    normalizeRole(msg.Role),
 		"content": buildChatCompletionsContent(msg),
 	}
+	if reasoningContent := strings.TrimSpace(msg.ReasoningContent); reasoningContent != "" && normalizeRole(msg.Role) == "assistant" {
+		payload["reasoning_content"] = reasoningContent
+	}
 	if len(msg.ToolCalls) > 0 {
 		payload["tool_calls"] = buildChatCompletionsToolCalls(msg.ToolCalls)
 		if strings.TrimSpace(msg.Content) == "" && len(msg.Parts) == 0 {
@@ -280,12 +283,15 @@ func applyChatStreamEvent(
 			}
 		}
 	}
-	if reasoning := extractChatStreamReasoningDelta(parsed); reasoning != nil && reasoning.Text != "" && onEvent != nil {
-		if err := onEvent(GenerateStreamEvent{
-			Reasoning:  reasoning,
-			ResponseID: result.ResponseID,
-		}); err != nil {
-			return err
+	if reasoning := extractChatStreamReasoningDelta(parsed); reasoning != nil && reasoning.Text != "" {
+		mergeReasoningDeltaOutput(&result.Reasoning, reasoning)
+		if onEvent != nil {
+			if err := onEvent(GenerateStreamEvent{
+				Reasoning:  reasoning,
+				ResponseID: result.ResponseID,
+			}); err != nil {
+				return err
+			}
 		}
 	}
 	mergeChatStreamToolCalls(parsed, result)
@@ -356,7 +362,7 @@ func mergeChatStreamToolCalls(parsed map[string]interface{}, result *GenerateOut
 func parseChatCompletionsOutput(adapter string, parsed map[string]interface{}, result *GenerateOutput) {
 	choice := firstMapItem(asSlice(parsed["choices"]))
 	message := asMap(choice["message"])
-	result.Text = extractContentText(message["content"])
+	result.Text = extractChatVisibleContentText(message["content"])
 	result.Reasoning = parseChatReasoningOutput(message)
 
 	result.Usage = parseOpenAICompatibleUsageForAdapter(adapter, parsed)
@@ -374,6 +380,7 @@ func parseChatReasoningOutput(message map[string]interface{}) *ReasoningOutput {
 	text := firstNonEmptyString(
 		extractReasoningDeltaText(message["reasoning"]),
 		extractReasoningDeltaText(message["reasoning_content"]),
+		extractChatReasoningContentText(message["content"]),
 	)
 	if text == "" {
 		return nil
@@ -386,7 +393,7 @@ func parseChatReasoningOutput(message map[string]interface{}) *ReasoningOutput {
 func extractChatStreamDelta(parsed map[string]interface{}) string {
 	choice := firstMapItem(asSlice(parsed["choices"]))
 	delta := asMap(choice["delta"])
-	return extractContentText(delta["content"])
+	return extractChatVisibleContentText(delta["content"])
 }
 
 func extractChatStreamReasoningDelta(parsed map[string]interface{}) *ReasoningDelta {
@@ -424,6 +431,62 @@ func extractChatStreamReasoningDelta(parsed map[string]interface{}) *ReasoningDe
 		}
 	}
 	return nil
+}
+
+func extractChatVisibleContentText(raw interface{}) string {
+	switch value := raw.(type) {
+	case string:
+		return value
+	case []interface{}:
+		chunks := make([]string, 0, len(value))
+		for _, item := range value {
+			if text := extractChatVisibleContentText(item); text != "" {
+				chunks = append(chunks, text)
+			}
+		}
+		return strings.Join(chunks, "")
+	case map[string]interface{}:
+		if isChatReasoningContentType(value["type"]) {
+			return ""
+		}
+		if text := getString(value["text"]); text != "" {
+			return text
+		}
+		if text := getString(value["output_text"]); text != "" {
+			return text
+		}
+		if text := getString(value["input_text"]); text != "" {
+			return text
+		}
+		return extractChatVisibleContentText(value["content"])
+	default:
+		return ""
+	}
+}
+
+func extractChatReasoningContentText(raw interface{}) string {
+	switch value := raw.(type) {
+	case []interface{}:
+		parts := make([]string, 0, len(value))
+		for _, item := range value {
+			if text := extractChatReasoningContentText(item); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, "")
+	case map[string]interface{}:
+		if isChatReasoningContentType(value["type"]) {
+			return extractReasoningDeltaText(value)
+		}
+		return extractChatReasoningContentText(value["content"])
+	default:
+		return ""
+	}
+}
+
+func isChatReasoningContentType(raw interface{}) bool {
+	itemType := strings.ToLower(strings.TrimSpace(getString(raw)))
+	return strings.Contains(itemType, "reason") || strings.Contains(itemType, "think")
 }
 
 func parseChatStreamUsage(adapter string, parsed map[string]interface{}) Usage {

--- a/backend/internal/infra/llm/request_tools_test.go
+++ b/backend/internal/infra/llm/request_tools_test.go
@@ -39,7 +39,11 @@ func mustBuildGeminiRequestBody(t *testing.T, input GenerateInput) map[string]in
 func TestBuildChatCompletionsToolMessages(t *testing.T) {
 	payload := mustBuildRequestBody(t, AdapterOpenAIChatCompletions, "gpt-5", EndpointChatCompletions, GenerateInput{
 		Messages: []Message{
-			{Role: "assistant", ToolCalls: []ToolCall{{ToolCallID: "call_1", ToolType: "function", ToolName: "memory.list", ArgumentsJSON: `{"scope":"user"}`}}},
+			{
+				Role:             "assistant",
+				ReasoningContent: "need memory",
+				ToolCalls:        []ToolCall{{ToolCallID: "call_1", ToolType: "function", ToolName: "memory.list", ArgumentsJSON: `{"scope":"user"}`}},
+			},
 			{Role: "tool", ToolResults: []ToolResult{{ToolCallID: "call_1", ToolName: "memory.list", OutputJSON: `{"items":[]}`, Status: "success"}}},
 		},
 	}, false)
@@ -51,12 +55,87 @@ func TestBuildChatCompletionsToolMessages(t *testing.T) {
 	if messages[0]["role"] != "assistant" {
 		t.Fatalf("expected assistant tool call message, got %#v", messages[0])
 	}
+	if messages[0]["reasoning_content"] != "need memory" {
+		t.Fatalf("expected reasoning_content passback, got %#v", messages[0])
+	}
 	toolCalls := messages[0]["tool_calls"].([]map[string]interface{})
 	if toolCalls[0]["id"] != "call_1" {
 		t.Fatalf("expected tool call id, got %#v", toolCalls[0])
 	}
 	if messages[1]["role"] != "tool" || messages[1]["tool_call_id"] != "call_1" {
 		t.Fatalf("expected tool result message, got %#v", messages[1])
+	}
+}
+
+func TestParseChatCompletionsOutputSeparatesReasoningContentParts(t *testing.T) {
+	result := &GenerateOutput{}
+	parseChatCompletionsOutput(AdapterOpenAIChatCompletions, map[string]interface{}{
+		"choices": []interface{}{
+			map[string]interface{}{
+				"message": map[string]interface{}{
+					"content": []interface{}{
+						map[string]interface{}{"type": "reasoning", "text": "hidden reasoning"},
+						map[string]interface{}{"type": "text", "text": "visible answer"},
+					},
+					"tool_calls": []interface{}{
+						map[string]interface{}{
+							"id":   "call_1",
+							"type": "function",
+							"function": map[string]interface{}{
+								"name":      "memory.list",
+								"arguments": "{}",
+							},
+						},
+					},
+				},
+			},
+		},
+	}, result)
+
+	if result.Text != "visible answer" {
+		t.Fatalf("expected only visible content, got %q", result.Text)
+	}
+	if result.Reasoning == nil || result.Reasoning.Text != "hidden reasoning" {
+		t.Fatalf("expected reasoning content to be separated, got %#v", result.Reasoning)
+	}
+	if len(result.ToolCalls) != 1 || result.ToolCalls[0].ToolName != "memory.list" {
+		t.Fatalf("expected tool call to be preserved, got %#v", result.ToolCalls)
+	}
+}
+
+func TestApplyChatStreamEventSeparatesReasoningContentParts(t *testing.T) {
+	result := &GenerateOutput{}
+	var visible string
+	var reasoning string
+	err := applyChatStreamEvent(AdapterOpenAIChatCompletions, map[string]interface{}{
+		"choices": []interface{}{
+			map[string]interface{}{
+				"delta": map[string]interface{}{
+					"content": []interface{}{
+						map[string]interface{}{"type": "reasoning", "text": "hidden"},
+						map[string]interface{}{"type": "text", "text": "visible"},
+					},
+				},
+			},
+		},
+	}, result, func(event GenerateStreamEvent) error {
+		visible += event.Delta
+		if event.Reasoning != nil {
+			reasoning += event.Reasoning.Text
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("apply chat stream event: %v", err)
+	}
+	if visible != "visible" || result.Text != "visible" {
+		t.Fatalf("expected only visible stream content, visible=%q result=%q", visible, result.Text)
+	}
+	if reasoning != "hidden" {
+		t.Fatalf("expected reasoning stream content, got %q", reasoning)
+	}
+	if result.Reasoning == nil || result.Reasoning.Text != "hidden" {
+		t.Fatalf("expected stream reasoning to be stored for passback, got %#v", result.Reasoning)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix DeepSeek OpenAI-compatible tool-call follow-up failures in thinking mode.

DeepSeek Chat Completions may return `reasoning_content` together with tool calls, and requires that `reasoning_content` be passed back in the next API request. The conversation tool loop previously only preserved visible assistant content, so DeepSeek tool follow-up requests could fail with `reasoning_content in the thinking mode must be passed back to the API`.

This change adds a route capability for `reasoning_content` passback, stores streamed reasoning content, and includes it only for DeepSeek Chat Completions assistant tool-call messages.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [x] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./internal/application/channel`
- [x] `cd backend && go test ./internal/application/conversation`
- [x] `cd backend && go test ./internal/infra/llm`
- [x] `cd backend && go test ./...`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Before fix, DeepSeek tool follow-up requests could fail with:

```shell
HTTP 400, Error from provider (DeepSeek): The `reasoning_content` in the thinking mode must be passed back to the API.
```

## Configuration, migration, and compatibility notes

No config changes, database migrations, or deployment changes are required.

The new `reasoning_content` passback is scoped to DeepSeek routes using the OpenAI Chat Completions protocol. Other providers and protocols keep their existing request behavior.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.