### PR TITLE
feat: add admin announcements management and API documentation

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -15,6 +15,244 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin/announcements": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "分页查询站点公告",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-announcements"
+                ],
+                "summary": "管理员查询公告",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "状态：active/inactive",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "类型：critical/warning/info/normal/general",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "是否置顶",
+                        "name": "pinned",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "搜索关键词",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "页码",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "每页数量",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AdminAnnouncementListResponseDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "创建一条 Markdown 站点公告",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-announcements"
+                ],
+                "summary": "管理员创建公告",
+                "parameters": [
+                    {
+                        "description": "公告配置",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.CreateAnnouncementRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/announcements/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "软删除公告",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-announcements"
+                ],
+                "summary": "管理员删除公告",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "公告ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDeleteResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "更新公告标题、内容、状态、优先级和有效期",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-announcements"
+                ],
+                "summary": "管理员更新公告",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "公告ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "公告更新字段",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.PatchAnnouncementRequestDoc"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/audit-logs": {
             "get": {
                 "security": [
@@ -3762,6 +4000,168 @@ const docTemplate = `{
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/internal_transport_http_admin.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/announcements": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "登录用户获取当前可展示的站点公告列表",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "announcements"
+                ],
+                "summary": "获取当前公告",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementListResponseDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/announcements/{id}/close": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "登录用户关闭当前公告版本；公告更新后会重新展示",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "announcements"
+                ],
+                "summary": "关闭公告",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "公告ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "公告版本",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementStateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementCloseResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/announcements/{id}/dismiss-today": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "登录用户对当前公告版本记录今日不再显示",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "announcements"
+                ],
+                "summary": "今日不再显示公告",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "公告ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "公告版本",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementStateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDismissResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
                         }
                     }
                 }
@@ -8079,6 +8479,282 @@ const docTemplate = `{
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AdminAnnouncementListResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponse"
+                            }
+                        },
+                        "total": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementCloseDataResponse": {
+            "type": "object",
+            "properties": {
+                "closed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementCloseResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementCloseDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementDataResponse": {
+            "type": "object",
+            "properties": {
+                "announcement": {
+                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponse"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementDeleteDataResponse": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementDeleteResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDeleteDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementDismissDataResponse": {
+            "type": "object",
+            "properties": {
+                "dismissed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementDismissResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDismissDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementListResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponse"
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementResponse": {
+            "type": "object",
+            "properties": {
+                "closedAt": {
+                    "type": "string"
+                },
+                "contentMarkdown": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserID": {
+                    "type": "integer"
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "startsAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementStateRequest": {
+            "type": "object",
+            "required": [
+                "updatedAt"
+            ],
+            "properties": {
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.CreateAnnouncementRequest": {
+            "type": "object",
+            "required": [
+                "contentMarkdown",
+                "title"
+            ],
+            "properties": {
+                "contentMarkdown": {
+                    "type": "string",
+                    "maxLength": 20000,
+                    "minLength": 1
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "startsAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "inactive"
+                    ]
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "minLength": 1
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "critical",
+                        "warning",
+                        "info",
+                        "normal",
+                        "general"
+                    ]
+                }
+            }
+        },
+        "internal_transport_http_announcement.ErrorDoc": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "details": {},
+                "errorCode": {
+                    "type": "string",
+                    "example": "invalid_request"
+                },
+                "errorMsg": {
+                    "type": "string",
+                    "example": "invalid request"
+                },
+                "requestId": {
+                    "type": "string",
+                    "example": ""
+                }
+            }
+        },
+        "internal_transport_http_announcement.PatchAnnouncementRequestDoc": {
+            "type": "object",
+            "properties": {
+                "contentMarkdown": {
+                    "type": "string",
+                    "maxLength": 20000
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "startsAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "inactive"
+                    ]
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 120
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "critical",
+                        "warning",
+                        "info",
+                        "normal",
+                        "general"
+                    ]
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -8,6 +8,244 @@
     },
     "basePath": "/api/v1",
     "paths": {
+        "/admin/announcements": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "分页查询站点公告",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-announcements"
+                ],
+                "summary": "管理员查询公告",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "状态：active/inactive",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "类型：critical/warning/info/normal/general",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "是否置顶",
+                        "name": "pinned",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "搜索关键词",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "页码",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "每页数量",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AdminAnnouncementListResponseDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "创建一条 Markdown 站点公告",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-announcements"
+                ],
+                "summary": "管理员创建公告",
+                "parameters": [
+                    {
+                        "description": "公告配置",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.CreateAnnouncementRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/announcements/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "软删除公告",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-announcements"
+                ],
+                "summary": "管理员删除公告",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "公告ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDeleteResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "更新公告标题、内容、状态、优先级和有效期",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-announcements"
+                ],
+                "summary": "管理员更新公告",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "公告ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "公告更新字段",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.PatchAnnouncementRequestDoc"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/audit-logs": {
             "get": {
                 "security": [
@@ -3755,6 +3993,168 @@
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/internal_transport_http_admin.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/announcements": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "登录用户获取当前可展示的站点公告列表",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "announcements"
+                ],
+                "summary": "获取当前公告",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementListResponseDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/announcements/{id}/close": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "登录用户关闭当前公告版本；公告更新后会重新展示",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "announcements"
+                ],
+                "summary": "关闭公告",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "公告ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "公告版本",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementStateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementCloseResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/announcements/{id}/dismiss-today": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "登录用户对当前公告版本记录今日不再显示",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "announcements"
+                ],
+                "summary": "今日不再显示公告",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "公告ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "公告版本",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementStateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDismissResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
                         }
                     }
                 }
@@ -8072,6 +8472,282 @@
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AdminAnnouncementListResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponse"
+                            }
+                        },
+                        "total": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementCloseDataResponse": {
+            "type": "object",
+            "properties": {
+                "closed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementCloseResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementCloseDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementDataResponse": {
+            "type": "object",
+            "properties": {
+                "announcement": {
+                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponse"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementDeleteDataResponse": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementDeleteResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDeleteDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementDismissDataResponse": {
+            "type": "object",
+            "properties": {
+                "dismissed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementDismissResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDismissDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementListResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponse"
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementResponse": {
+            "type": "object",
+            "properties": {
+                "closedAt": {
+                    "type": "string"
+                },
+                "contentMarkdown": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserID": {
+                    "type": "integer"
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "startsAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.AnnouncementStateRequest": {
+            "type": "object",
+            "required": [
+                "updatedAt"
+            ],
+            "properties": {
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_announcement.CreateAnnouncementRequest": {
+            "type": "object",
+            "required": [
+                "contentMarkdown",
+                "title"
+            ],
+            "properties": {
+                "contentMarkdown": {
+                    "type": "string",
+                    "maxLength": 20000,
+                    "minLength": 1
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "startsAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "inactive"
+                    ]
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "minLength": 1
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "critical",
+                        "warning",
+                        "info",
+                        "normal",
+                        "general"
+                    ]
+                }
+            }
+        },
+        "internal_transport_http_announcement.ErrorDoc": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "details": {},
+                "errorCode": {
+                    "type": "string",
+                    "example": "invalid_request"
+                },
+                "errorMsg": {
+                    "type": "string",
+                    "example": "invalid request"
+                },
+                "requestId": {
+                    "type": "string",
+                    "example": ""
+                }
+            }
+        },
+        "internal_transport_http_announcement.PatchAnnouncementRequestDoc": {
+            "type": "object",
+            "properties": {
+                "contentMarkdown": {
+                    "type": "string",
+                    "maxLength": 20000
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "startsAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "inactive"
+                    ]
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 120
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "critical",
+                        "warning",
+                        "info",
+                        "normal",
+                        "general"
+                    ]
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -481,6 +481,192 @@ definitions:
       username:
         type: string
     type: object
+  internal_transport_http_announcement.AdminAnnouncementListResponseDoc:
+    properties:
+      data:
+        properties:
+          results:
+            items:
+              $ref: '#/definitions/internal_transport_http_announcement.AnnouncementResponse'
+            type: array
+          total:
+            type: integer
+        type: object
+      errorMsg:
+        type: string
+    type: object
+  internal_transport_http_announcement.AnnouncementCloseDataResponse:
+    properties:
+      closed:
+        type: boolean
+    type: object
+  internal_transport_http_announcement.AnnouncementCloseResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/internal_transport_http_announcement.AnnouncementCloseDataResponse'
+      errorMsg:
+        type: string
+    type: object
+  internal_transport_http_announcement.AnnouncementDataResponse:
+    properties:
+      announcement:
+        $ref: '#/definitions/internal_transport_http_announcement.AnnouncementResponse'
+    type: object
+  internal_transport_http_announcement.AnnouncementDeleteDataResponse:
+    properties:
+      deleted:
+        type: boolean
+    type: object
+  internal_transport_http_announcement.AnnouncementDeleteResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/internal_transport_http_announcement.AnnouncementDeleteDataResponse'
+      errorMsg:
+        type: string
+    type: object
+  internal_transport_http_announcement.AnnouncementDismissDataResponse:
+    properties:
+      dismissed:
+        type: boolean
+    type: object
+  internal_transport_http_announcement.AnnouncementDismissResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/internal_transport_http_announcement.AnnouncementDismissDataResponse'
+      errorMsg:
+        type: string
+    type: object
+  internal_transport_http_announcement.AnnouncementListResponseDoc:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/internal_transport_http_announcement.AnnouncementResponse'
+        type: array
+      errorMsg:
+        type: string
+    type: object
+  internal_transport_http_announcement.AnnouncementResponse:
+    properties:
+      closedAt:
+        type: string
+      contentMarkdown:
+        type: string
+      createdAt:
+        type: string
+      createdByUserID:
+        type: integer
+      expiresAt:
+        type: string
+      id:
+        type: integer
+      pinned:
+        type: boolean
+      priority:
+        type: integer
+      startsAt:
+        type: string
+      status:
+        type: string
+      title:
+        type: string
+      type:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  internal_transport_http_announcement.AnnouncementResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/internal_transport_http_announcement.AnnouncementDataResponse'
+      errorMsg:
+        type: string
+    type: object
+  internal_transport_http_announcement.AnnouncementStateRequest:
+    properties:
+      updatedAt:
+        type: string
+    required:
+    - updatedAt
+    type: object
+  internal_transport_http_announcement.CreateAnnouncementRequest:
+    properties:
+      contentMarkdown:
+        maxLength: 20000
+        minLength: 1
+        type: string
+      expiresAt:
+        type: string
+      pinned:
+        type: boolean
+      priority:
+        type: integer
+      startsAt:
+        type: string
+      status:
+        enum:
+        - active
+        - inactive
+        type: string
+      title:
+        maxLength: 120
+        minLength: 1
+        type: string
+      type:
+        enum:
+        - critical
+        - warning
+        - info
+        - normal
+        - general
+        type: string
+    required:
+    - contentMarkdown
+    - title
+    type: object
+  internal_transport_http_announcement.ErrorDoc:
+    properties:
+      data: {}
+      details: {}
+      errorCode:
+        example: invalid_request
+        type: string
+      errorMsg:
+        example: invalid request
+        type: string
+      requestId:
+        example: ""
+        type: string
+    type: object
+  internal_transport_http_announcement.PatchAnnouncementRequestDoc:
+    properties:
+      contentMarkdown:
+        maxLength: 20000
+        type: string
+      expiresAt:
+        type: string
+      pinned:
+        type: boolean
+      priority:
+        type: integer
+      startsAt:
+        type: string
+      status:
+        enum:
+        - active
+        - inactive
+        type: string
+      title:
+        maxLength: 120
+        type: string
+      type:
+        enum:
+        - critical
+        - warning
+        - info
+        - normal
+        - general
+        type: string
+    type: object
   internal_transport_http_auth.ActiveSessionListResponse:
     properties:
       results:
@@ -3988,6 +4174,158 @@ info:
   title: DEEIX Chat API
   version: 0.1.2
 paths:
+  /admin/announcements:
+    get:
+      consumes:
+      - application/json
+      description: 分页查询站点公告
+      parameters:
+      - description: 状态：active/inactive
+        in: query
+        name: status
+        type: string
+      - description: 类型：critical/warning/info/normal/general
+        in: query
+        name: type
+        type: string
+      - description: 是否置顶
+        in: query
+        name: pinned
+        type: boolean
+      - description: 搜索关键词
+        in: query
+        name: q
+        type: string
+      - description: 页码
+        in: query
+        name: page
+        type: integer
+      - description: 每页数量
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.AdminAnnouncementListResponseDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 管理员查询公告
+      tags:
+      - admin-announcements
+    post:
+      consumes:
+      - application/json
+      description: 创建一条 Markdown 站点公告
+      parameters:
+      - description: 公告配置
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_transport_http_announcement.CreateAnnouncementRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.AnnouncementResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 管理员创建公告
+      tags:
+      - admin-announcements
+  /admin/announcements/{id}:
+    delete:
+      consumes:
+      - application/json
+      description: 软删除公告
+      parameters:
+      - description: 公告ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.AnnouncementDeleteResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 管理员删除公告
+      tags:
+      - admin-announcements
+    patch:
+      consumes:
+      - application/json
+      description: 更新公告标题、内容、状态、优先级和有效期
+      parameters:
+      - description: 公告ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: 公告更新字段
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_transport_http_announcement.PatchAnnouncementRequestDoc'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.AnnouncementResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 管理员更新公告
+      tags:
+      - admin-announcements
   /admin/audit-logs:
     get:
       consumes:
@@ -6365,6 +6703,109 @@ paths:
       summary: 管理员更新用户状态
       tags:
       - admin
+  /announcements:
+    get:
+      consumes:
+      - application/json
+      description: 登录用户获取当前可展示的站点公告列表
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.AnnouncementListResponseDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 获取当前公告
+      tags:
+      - announcements
+  /announcements/{id}/close:
+    post:
+      consumes:
+      - application/json
+      description: 登录用户关闭当前公告版本；公告更新后会重新展示
+      parameters:
+      - description: 公告ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: 公告版本
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_transport_http_announcement.AnnouncementStateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.AnnouncementCloseResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 关闭公告
+      tags:
+      - announcements
+  /announcements/{id}/dismiss-today:
+    post:
+      consumes:
+      - application/json
+      description: 登录用户对当前公告版本记录今日不再显示
+      parameters:
+      - description: 公告ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: 公告版本
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_transport_http_announcement.AnnouncementStateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.AnnouncementDismissResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 今日不再显示公告
+      tags:
+      - announcements
   /auth/login:
     post:
       consumes:

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/admin"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/announcement"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/audit"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/auth"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/billing"
@@ -37,6 +38,7 @@ import (
 	platformlogger "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/observability/logger"
 	platformtracing "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/observability/tracing"
 	platformdb "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/postgres"
+	announcementrepo "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/postgres/announcement"
 	auditrepo "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/postgres/audit"
 	billingrepo "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/postgres/billing"
 	channelrepo "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/postgres/channel"
@@ -50,6 +52,7 @@ import (
 	platformruntime "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/runtime"
 	platformhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http"
 	adminhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/admin"
+	announcementhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/announcement"
 	authhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/auth"
 	billinghttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/billing"
 	channelhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/channel"
@@ -230,6 +233,10 @@ func NewApp() (*App, error) {
 	userSettingsService := usersettings.NewService(userSettingsRepo)
 	userSettingsHandler := usersettingshttp.NewHandler(userSettingsService)
 	userSettingsModule := usersettingshttp.NewModule(userSettingsHandler)
+	announcementRepo := announcementrepo.NewRepo(db)
+	announcementService := announcement.NewService(announcementRepo)
+	announcementHandler := announcementhttp.NewHandler(announcementService)
+	announcementModule := announcementhttp.NewModule(announcementHandler)
 
 	hc := newHealthChecker(db, redisClient)
 	rateLimiter := platformcache.NewRateLimiter(redisClient)
@@ -242,6 +249,7 @@ func NewApp() (*App, error) {
 		Memory:       memoryModule,
 		Billing:      billingModule,
 		Admin:        adminModule,
+		Announcement: announcementModule,
 		Settings:     settingsModule,
 		UserSettings: userSettingsModule,
 	}, hc, rateLimiter)

--- a/backend/internal/application/announcement/errs.go
+++ b/backend/internal/application/announcement/errs.go
@@ -1,0 +1,10 @@
+package announcement
+
+import "errors"
+
+var (
+	// ErrInvalidAnnouncement 表示公告配置非法。
+	ErrInvalidAnnouncement = errors.New("invalid announcement")
+	// ErrAnnouncementNotFound 表示公告不存在。
+	ErrAnnouncementNotFound = errors.New("announcement not found")
+)

--- a/backend/internal/application/announcement/service.go
+++ b/backend/internal/application/announcement/service.go
@@ -1,0 +1,278 @@
+package announcement
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	domainannouncement "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/announcement"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
+)
+
+const (
+	maxAnnouncementTitleLength   = 120
+	maxAnnouncementContentLength = 20000
+)
+
+// Service 封装公告业务逻辑。
+type Service struct {
+	repo repository.AnnouncementRepository
+}
+
+// NewService 创建公告服务。
+func NewService(repo repository.AnnouncementRepository) *Service {
+	return &Service{repo: repo}
+}
+
+// ListActive 查询当前用户可展示公告。
+func (s *Service) ListActive(ctx context.Context, userID uint, now time.Time) ([]domainannouncement.Announcement, error) {
+	if userID == 0 {
+		return nil, repository.ErrInvalidInput
+	}
+	return s.repo.ListActiveAnnouncements(ctx, userID, now)
+}
+
+// ListAdmin 查询管理员公告列表。
+func (s *Service) ListAdmin(ctx context.Context, input ListInput) ([]domainannouncement.Announcement, int64, error) {
+	page, pageSize := normalizePage(input.Page, input.PageSize)
+	return s.repo.ListAdminAnnouncements(ctx, repository.AnnouncementListFilter{
+		Query:  strings.TrimSpace(input.Query),
+		Status: strings.TrimSpace(input.Status),
+		Type:   strings.TrimSpace(input.Type),
+		Pinned: input.Pinned,
+	}, (page-1)*pageSize, pageSize)
+}
+
+// Create 创建公告。
+func (s *Service) Create(ctx context.Context, actorUserID uint, input WriteInput) (*domainannouncement.Announcement, error) {
+	if actorUserID == 0 {
+		return nil, repository.ErrInvalidInput
+	}
+	item, err := normalizeWriteInput(input, true)
+	if err != nil {
+		return nil, err
+	}
+	item.CreatedByUserID = actorUserID
+	return s.repo.CreateAnnouncement(ctx, item)
+}
+
+// Update 更新公告。
+func (s *Service) Update(ctx context.Context, id uint, input PatchInput) (*domainannouncement.Announcement, error) {
+	if id == 0 {
+		return nil, repository.ErrInvalidInput
+	}
+	patch, err := normalizePatchInput(input)
+	if err != nil {
+		return nil, err
+	}
+	item, err := s.repo.PatchAnnouncement(ctx, id, patch)
+	if err != nil {
+		return nil, mapRepositoryError(err)
+	}
+	return item, nil
+}
+
+// Delete 删除公告。
+func (s *Service) Delete(ctx context.Context, id uint) error {
+	if id == 0 {
+		return repository.ErrInvalidInput
+	}
+	return mapRepositoryError(s.repo.DeleteAnnouncement(ctx, id))
+}
+
+// DismissToday 记录当前用户今天不再显示指定公告版本。
+func (s *Service) DismissToday(ctx context.Context, userID uint, announcementID uint, announcementUpdatedAt time.Time, now time.Time, dismissedUntil time.Time) error {
+	if userID == 0 || announcementID == 0 || announcementUpdatedAt.IsZero() || !dismissedUntil.After(now) {
+		return repository.ErrInvalidInput
+	}
+	return mapRepositoryError(s.repo.DismissAnnouncementToday(ctx, userID, announcementID, announcementUpdatedAt, now, dismissedUntil))
+}
+
+// Close 记录当前用户关闭指定公告版本。
+func (s *Service) Close(ctx context.Context, userID uint, announcementID uint, announcementUpdatedAt time.Time, now time.Time) error {
+	if userID == 0 || announcementID == 0 || announcementUpdatedAt.IsZero() {
+		return repository.ErrInvalidInput
+	}
+	return mapRepositoryError(s.repo.CloseAnnouncement(ctx, userID, announcementID, announcementUpdatedAt, now))
+}
+
+// ListInput 定义公告列表入参。
+type ListInput struct {
+	Query    string
+	Status   string
+	Type     string
+	Pinned   *bool
+	Page     int
+	PageSize int
+}
+
+// WriteInput 定义公告创建入参。
+type WriteInput struct {
+	Title           string
+	ContentMarkdown string
+	Status          string
+	Type            string
+	Pinned          bool
+	Priority        int
+	StartsAt        *time.Time
+	ExpiresAt       *time.Time
+}
+
+// PatchInput 定义公告更新入参。
+type PatchInput struct {
+	Title              *string
+	ContentMarkdown    *string
+	Status             *string
+	Type               *string
+	Pinned             *bool
+	Priority           *int
+	StartsAtSet        bool
+	StartsAt           *time.Time
+	ExpiresAtSet       bool
+	ExpiresAt          *time.Time
+	CreatedByUserIDSet bool
+	CreatedByUserID    uint
+}
+
+func normalizeWriteInput(input WriteInput, requireContent bool) (*domainannouncement.Announcement, error) {
+	title := strings.TrimSpace(input.Title)
+	content := strings.TrimSpace(input.ContentMarkdown)
+	status := normalizeStatus(input.Status)
+	announcementType := normalizeType(input.Type)
+	if title == "" || len(title) > maxAnnouncementTitleLength {
+		return nil, ErrInvalidAnnouncement
+	}
+	if requireContent && content == "" {
+		return nil, ErrInvalidAnnouncement
+	}
+	if len(content) > maxAnnouncementContentLength {
+		return nil, ErrInvalidAnnouncement
+	}
+	if status == "" {
+		return nil, ErrInvalidAnnouncement
+	}
+	if announcementType == "" {
+		return nil, ErrInvalidAnnouncement
+	}
+	if !validWindow(input.StartsAt, input.ExpiresAt) {
+		return nil, ErrInvalidAnnouncement
+	}
+	return &domainannouncement.Announcement{
+		Title:           title,
+		ContentMarkdown: content,
+		Status:          status,
+		Type:            announcementType,
+		Pinned:          input.Pinned,
+		Priority:        input.Priority,
+		StartsAt:        input.StartsAt,
+		ExpiresAt:       input.ExpiresAt,
+	}, nil
+}
+
+func normalizePatchInput(input PatchInput) (repository.AnnouncementPatch, error) {
+	patch := repository.AnnouncementPatch{
+		StartsAtSet:        input.StartsAtSet,
+		StartsAt:           input.StartsAt,
+		ExpiresAtSet:       input.ExpiresAtSet,
+		ExpiresAt:          input.ExpiresAt,
+		CreatedByUserIDSet: input.CreatedByUserIDSet,
+		CreatedByUserID:    input.CreatedByUserID,
+	}
+	if input.Title != nil {
+		title := strings.TrimSpace(*input.Title)
+		if title == "" || len(title) > maxAnnouncementTitleLength {
+			return repository.AnnouncementPatch{}, ErrInvalidAnnouncement
+		}
+		patch.Title = &title
+	}
+	if input.ContentMarkdown != nil {
+		content := strings.TrimSpace(*input.ContentMarkdown)
+		if content == "" || len(content) > maxAnnouncementContentLength {
+			return repository.AnnouncementPatch{}, ErrInvalidAnnouncement
+		}
+		patch.ContentMarkdown = &content
+	}
+	if input.Status != nil {
+		status := normalizeStatus(*input.Status)
+		if status == "" {
+			return repository.AnnouncementPatch{}, ErrInvalidAnnouncement
+		}
+		patch.Status = &status
+	}
+	if input.Type != nil {
+		announcementType := normalizeType(*input.Type)
+		if announcementType == "" {
+			return repository.AnnouncementPatch{}, ErrInvalidAnnouncement
+		}
+		patch.Type = &announcementType
+	}
+	if input.Pinned != nil {
+		patch.Pinned = input.Pinned
+	}
+	if input.Priority != nil {
+		patch.Priority = input.Priority
+	}
+	if input.StartsAtSet && input.ExpiresAtSet && !validWindow(input.StartsAt, input.ExpiresAt) {
+		return repository.AnnouncementPatch{}, ErrInvalidAnnouncement
+	}
+	return patch, nil
+}
+
+func normalizeStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case "", domainannouncement.StatusActive:
+		return domainannouncement.StatusActive
+	case domainannouncement.StatusInactive:
+		return domainannouncement.StatusInactive
+	default:
+		return ""
+	}
+}
+
+func normalizeType(announcementType string) string {
+	switch strings.TrimSpace(announcementType) {
+	case "", domainannouncement.TypeGeneral:
+		return domainannouncement.TypeGeneral
+	case domainannouncement.TypeCritical:
+		return domainannouncement.TypeCritical
+	case domainannouncement.TypeWarning:
+		return domainannouncement.TypeWarning
+	case domainannouncement.TypeInfo:
+		return domainannouncement.TypeInfo
+	case domainannouncement.TypeNormal:
+		return domainannouncement.TypeNormal
+	default:
+		return ""
+	}
+}
+
+func validWindow(startsAt *time.Time, expiresAt *time.Time) bool {
+	if startsAt == nil || expiresAt == nil {
+		return true
+	}
+	return expiresAt.After(*startsAt)
+}
+
+func normalizePage(page int, pageSize int) (int, int) {
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	if pageSize > 200 {
+		pageSize = 200
+	}
+	return page, pageSize
+}
+
+func mapRepositoryError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, repository.ErrNotFound) {
+		return ErrAnnouncementNotFound
+	}
+	return err
+}

--- a/backend/internal/application/announcement/service_test.go
+++ b/backend/internal/application/announcement/service_test.go
@@ -1,0 +1,128 @@
+package announcement
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	domainannouncement "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/announcement"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
+)
+
+func TestCreateAnnouncementValidation(t *testing.T) {
+	service := NewService(&fakeRepo{})
+	if _, err := service.Create(context.Background(), 1, WriteInput{Status: domainannouncement.StatusActive}); !errors.Is(err, ErrInvalidAnnouncement) {
+		t.Fatalf("Create() error = %v, want ErrInvalidAnnouncement", err)
+	}
+	if _, err := service.Create(context.Background(), 0, WriteInput{Title: "A", ContentMarkdown: "Body"}); !errors.Is(err, repository.ErrInvalidInput) {
+		t.Fatalf("Create() error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestCreateAnnouncementAcceptsValidWindow(t *testing.T) {
+	start := time.Date(2026, 6, 1, 8, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	repo := &fakeRepo{}
+	service := NewService(repo)
+
+	item, err := service.Create(context.Background(), 7, WriteInput{
+		Title:           "Notice",
+		ContentMarkdown: "Hello",
+		Status:          domainannouncement.StatusActive,
+		Priority:        10,
+		StartsAt:        &start,
+		ExpiresAt:       &end,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if item.CreatedByUserID != 7 || item.Priority != 10 || item.Status != domainannouncement.StatusActive {
+		t.Fatalf("Create() item = %#v", item)
+	}
+	if item.Type != domainannouncement.TypeGeneral {
+		t.Fatalf("Create() type = %q, want %q", item.Type, domainannouncement.TypeGeneral)
+	}
+}
+
+func TestUpdateAnnouncementRejectsInvalidStatus(t *testing.T) {
+	service := NewService(&fakeRepo{})
+	status := "archived"
+	if _, err := service.Update(context.Background(), 1, PatchInput{Status: &status}); !errors.Is(err, ErrInvalidAnnouncement) {
+		t.Fatalf("Update() error = %v, want ErrInvalidAnnouncement", err)
+	}
+}
+
+func TestDismissTodayRejectsInvalidInput(t *testing.T) {
+	service := NewService(&fakeRepo{})
+	now := time.Date(2026, 6, 1, 8, 0, 0, 0, time.UTC)
+	if err := service.DismissToday(context.Background(), 0, 1, now, now, now.Add(time.Hour)); !errors.Is(err, repository.ErrInvalidInput) {
+		t.Fatalf("DismissToday() error = %v, want ErrInvalidInput", err)
+	}
+	if err := service.DismissToday(context.Background(), 1, 1, time.Time{}, now, now.Add(time.Hour)); !errors.Is(err, repository.ErrInvalidInput) {
+		t.Fatalf("DismissToday() error = %v, want ErrInvalidInput", err)
+	}
+	if err := service.DismissToday(context.Background(), 1, 1, now, now, now); !errors.Is(err, repository.ErrInvalidInput) {
+		t.Fatalf("DismissToday() error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestCloseRejectsInvalidInput(t *testing.T) {
+	service := NewService(&fakeRepo{})
+	now := time.Now()
+	if err := service.Close(context.Background(), 0, 1, now, now); !errors.Is(err, repository.ErrInvalidInput) {
+		t.Fatalf("Close() error = %v, want ErrInvalidInput", err)
+	}
+	if err := service.Close(context.Background(), 1, 0, now, now); !errors.Is(err, repository.ErrInvalidInput) {
+		t.Fatalf("Close() error = %v, want ErrInvalidInput", err)
+	}
+	if err := service.Close(context.Background(), 1, 1, time.Time{}, now); !errors.Is(err, repository.ErrInvalidInput) {
+		t.Fatalf("Close() error = %v, want ErrInvalidInput", err)
+	}
+}
+
+type fakeRepo struct {
+	item domainannouncement.Announcement
+}
+
+func (r *fakeRepo) ListActiveAnnouncements(context.Context, uint, time.Time) ([]domainannouncement.Announcement, error) {
+	return []domainannouncement.Announcement{}, nil
+}
+
+func (r *fakeRepo) ListAdminAnnouncements(context.Context, repository.AnnouncementListFilter, int, int) ([]domainannouncement.Announcement, int64, error) {
+	return []domainannouncement.Announcement{}, 0, nil
+}
+
+func (r *fakeRepo) CreateAnnouncement(_ context.Context, item *domainannouncement.Announcement) (*domainannouncement.Announcement, error) {
+	item.ID = 1
+	r.item = *item
+	return item, nil
+}
+
+func (r *fakeRepo) PatchAnnouncement(_ context.Context, id uint, patch repository.AnnouncementPatch) (*domainannouncement.Announcement, error) {
+	if id == 0 {
+		return nil, repository.ErrInvalidInput
+	}
+	if patch.Status != nil {
+		r.item.Status = *patch.Status
+	}
+	if patch.Type != nil {
+		r.item.Type = *patch.Type
+	}
+	if patch.Pinned != nil {
+		r.item.Pinned = *patch.Pinned
+	}
+	return &r.item, nil
+}
+
+func (r *fakeRepo) DeleteAnnouncement(context.Context, uint) error {
+	return nil
+}
+
+func (r *fakeRepo) DismissAnnouncementToday(context.Context, uint, uint, time.Time, time.Time, time.Time) error {
+	return nil
+}
+
+func (r *fakeRepo) CloseAnnouncement(context.Context, uint, uint, time.Time, time.Time) error {
+	return nil
+}

--- a/backend/internal/domain/announcement/doc.go
+++ b/backend/internal/domain/announcement/doc.go
@@ -1,0 +1,2 @@
+// Package announcement 定义站点公告领域对象。
+package announcement

--- a/backend/internal/domain/announcement/types.go
+++ b/backend/internal/domain/announcement/types.go
@@ -1,0 +1,50 @@
+package announcement
+
+import "time"
+
+const (
+	// StatusActive 表示公告启用。
+	StatusActive = "active"
+	// StatusInactive 表示公告停用。
+	StatusInactive = "inactive"
+
+	// TypeCritical 表示紧急公告。
+	TypeCritical = "critical"
+	// TypeWarning 表示警告公告。
+	TypeWarning = "warning"
+	// TypeInfo 表示提示公告。
+	TypeInfo = "info"
+	// TypeNormal 表示普通公告。
+	TypeNormal = "normal"
+	// TypeGeneral 表示常规公告。
+	TypeGeneral = "general"
+)
+
+// Announcement 表示一条站点公告。
+type Announcement struct {
+	ID              uint
+	Title           string
+	ContentMarkdown string
+	Status          string
+	Type            string
+	Pinned          bool
+	Priority        int
+	StartsAt        *time.Time
+	ExpiresAt       *time.Time
+	CreatedByUserID uint
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+	ClosedAt        *time.Time
+}
+
+// UserState 记录用户对公告版本的展示偏好。
+type UserState struct {
+	ID                    uint
+	AnnouncementID        uint
+	UserID                uint
+	AnnouncementUpdatedAt time.Time
+	DismissedUntil        *time.Time
+	ClosedAt              *time.Time
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+}

--- a/backend/internal/infra/persistence/models/announcement.go
+++ b/backend/internal/infra/persistence/models/announcement.go
@@ -1,0 +1,37 @@
+package model
+
+import "time"
+
+// Announcement 记录站点公告。
+type Announcement struct {
+	BaseModel
+	Title           string     `gorm:"size:120;not null;default:'';comment:公告标题"`
+	ContentMarkdown string     `gorm:"type:text;not null;default:'';comment:公告 Markdown 内容"`
+	Status          string     `gorm:"size:32;not null;default:'active';index:idx_system_announcements_status;comment:状态(active/inactive)"`
+	Type            string     `gorm:"size:32;not null;default:'general';index:idx_system_announcements_type;comment:公告类型(critical/warning/info/normal/general)"`
+	Pinned          bool       `gorm:"not null;default:false;index:idx_system_announcements_pinned;comment:是否置顶"`
+	Priority        int        `gorm:"not null;default:0;index:idx_system_announcements_priority;comment:排序优先级"`
+	StartsAt        *time.Time `gorm:"index:idx_system_announcements_starts_at;comment:开始展示时间"`
+	ExpiresAt       *time.Time `gorm:"index:idx_system_announcements_expires_at;comment:结束展示时间"`
+	CreatedByUserID uint       `gorm:"not null;default:0;index:idx_system_announcements_created_by;comment:创建管理员ID"`
+}
+
+// TableName 指定表名。
+func (Announcement) TableName() string {
+	return "system_announcements"
+}
+
+// AnnouncementUserState 记录用户对公告版本的展示状态。
+type AnnouncementUserState struct {
+	BaseModel
+	AnnouncementID        uint       `gorm:"not null;index:idx_announcement_user_states_announcement;comment:公告ID"`
+	UserID                uint       `gorm:"not null;index:idx_announcement_user_states_user;comment:用户ID"`
+	AnnouncementUpdatedAt time.Time  `gorm:"not null;comment:公告版本更新时间"`
+	DismissedUntil        *time.Time `gorm:"index:idx_announcement_user_states_dismissed_until;comment:暂不显示截止时间"`
+	ClosedAt              *time.Time `gorm:"index:idx_announcement_user_states_closed_at;comment:关闭时间"`
+}
+
+// TableName 指定表名。
+func (AnnouncementUserState) TableName() string {
+	return "announcement_user_states"
+}

--- a/backend/internal/infra/persistence/models/table_names_test.go
+++ b/backend/internal/infra/persistence/models/table_names_test.go
@@ -53,6 +53,8 @@ func TestTableNamesUseRestructuredDomains(t *testing.T) {
 		UserMemory{},
 		AuditLog{},
 		SystemEvent{},
+		Announcement{},
+		AnnouncementUserState{},
 		SystemSetting{},
 		UserSetting{},
 	}

--- a/backend/internal/infra/persistence/postgres/announcement/repository.go
+++ b/backend/internal/infra/persistence/postgres/announcement/repository.go
@@ -1,0 +1,324 @@
+package announcement
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	domainannouncement "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/announcement"
+	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/models"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Repo 封装公告数据访问。
+type Repo struct {
+	db *gorm.DB
+}
+
+// NewRepo 创建公告仓储。
+func NewRepo(db *gorm.DB) *Repo {
+	return &Repo{db: db}
+}
+
+// ListActiveAnnouncements 查询当前可展示公告。
+func (r *Repo) ListActiveAnnouncements(ctx context.Context, userID uint, now time.Time) ([]domainannouncement.Announcement, error) {
+	type announcementRow struct {
+		model.Announcement
+		UserClosedAt *time.Time `gorm:"column:user_closed_at"`
+	}
+	items := make([]announcementRow, 0)
+	if err := r.db.WithContext(ctx).
+		Model(&model.Announcement{}).
+		Select("system_announcements.*, states.closed_at AS user_closed_at").
+		Joins(`LEFT JOIN announcement_user_states states
+			ON states.deleted_at IS NULL
+				AND states.announcement_id = system_announcements.id
+				AND states.user_id = ?
+				AND states.announcement_updated_at = system_announcements.updated_at`, userID).
+		Where("status = ?", domainannouncement.StatusActive).
+		Where("(starts_at IS NULL OR starts_at <= ?)", now).
+		Where("(expires_at IS NULL OR expires_at > ?)", now).
+		Where("(states.dismissed_until IS NULL OR states.dismissed_until <= ?)", now).
+		Order("CASE WHEN states.closed_at IS NULL THEN 0 ELSE 1 END ASC, pinned DESC, priority DESC, updated_at DESC, id DESC").
+		Find(&items).Error; err != nil {
+		return nil, translateError(err)
+	}
+	results := make([]domainannouncement.Announcement, 0, len(items))
+	for _, item := range items {
+		announcement := toDomain(item.Announcement)
+		announcement.ClosedAt = item.UserClosedAt
+		results = append(results, announcement)
+	}
+	return results, nil
+}
+
+// ListAdminAnnouncements 分页查询后台公告。
+func (r *Repo) ListAdminAnnouncements(ctx context.Context, filter repository.AnnouncementListFilter, offset int, limit int) ([]domainannouncement.Announcement, int64, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	items := make([]model.Announcement, 0, limit)
+	var total int64
+	query := r.db.WithContext(ctx).Model(&model.Announcement{})
+	if status := strings.TrimSpace(filter.Status); status != "" {
+		query = query.Where("status = ?", status)
+	}
+	if announcementType := strings.TrimSpace(filter.Type); announcementType != "" {
+		query = query.Where("type = ?", announcementType)
+	}
+	if filter.Pinned != nil {
+		query = query.Where("pinned = ?", *filter.Pinned)
+	}
+	if keyword := strings.TrimSpace(filter.Query); keyword != "" {
+		like := "%" + keyword + "%"
+		query = query.Where("title ILIKE ? OR content_markdown ILIKE ?", like, like)
+	}
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, translateError(err)
+	}
+	if err := query.
+		Order("pinned DESC, priority DESC, updated_at DESC, id DESC").
+		Offset(offset).
+		Limit(limit).
+		Find(&items).Error; err != nil {
+		return nil, 0, translateError(err)
+	}
+	results := make([]domainannouncement.Announcement, 0, len(items))
+	for _, item := range items {
+		results = append(results, toDomain(item))
+	}
+	return results, total, nil
+}
+
+// CreateAnnouncement 创建公告。
+func (r *Repo) CreateAnnouncement(ctx context.Context, item *domainannouncement.Announcement) (*domainannouncement.Announcement, error) {
+	if item == nil {
+		return nil, repository.ErrInvalidInput
+	}
+	record := model.Announcement{
+		Title:           strings.TrimSpace(item.Title),
+		ContentMarkdown: strings.TrimSpace(item.ContentMarkdown),
+		Status:          normalizeStatus(item.Status),
+		Type:            normalizeType(item.Type),
+		Pinned:          item.Pinned,
+		Priority:        item.Priority,
+		StartsAt:        item.StartsAt,
+		ExpiresAt:       item.ExpiresAt,
+		CreatedByUserID: item.CreatedByUserID,
+	}
+	if err := r.db.WithContext(ctx).Create(&record).Error; err != nil {
+		return nil, translateError(err)
+	}
+	result := toDomain(record)
+	return &result, nil
+}
+
+// PatchAnnouncement 更新公告字段。
+func (r *Repo) PatchAnnouncement(ctx context.Context, id uint, patch repository.AnnouncementPatch) (*domainannouncement.Announcement, error) {
+	if id == 0 {
+		return nil, repository.ErrInvalidInput
+	}
+	var result domainannouncement.Announcement
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var record model.Announcement
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ?", id).
+			First(&record).Error; err != nil {
+			return translateError(err)
+		}
+		updates := map[string]interface{}{}
+		if patch.Title != nil {
+			updates["title"] = strings.TrimSpace(*patch.Title)
+		}
+		if patch.ContentMarkdown != nil {
+			updates["content_markdown"] = strings.TrimSpace(*patch.ContentMarkdown)
+		}
+		if patch.Status != nil {
+			status := normalizeStatus(*patch.Status)
+			if status == "" {
+				return repository.ErrInvalidInput
+			}
+			updates["status"] = status
+		}
+		if patch.Type != nil {
+			announcementType := normalizeType(*patch.Type)
+			if announcementType == "" {
+				return repository.ErrInvalidInput
+			}
+			updates["type"] = announcementType
+		}
+		if patch.Pinned != nil {
+			updates["pinned"] = *patch.Pinned
+		}
+		if patch.Priority != nil {
+			updates["priority"] = *patch.Priority
+		}
+		if patch.StartsAtSet {
+			updates["starts_at"] = patch.StartsAt
+		}
+		if patch.ExpiresAtSet {
+			updates["expires_at"] = patch.ExpiresAt
+		}
+		nextStartsAt := record.StartsAt
+		if patch.StartsAtSet {
+			nextStartsAt = patch.StartsAt
+		}
+		nextExpiresAt := record.ExpiresAt
+		if patch.ExpiresAtSet {
+			nextExpiresAt = patch.ExpiresAt
+		}
+		if nextStartsAt != nil && nextExpiresAt != nil && !nextExpiresAt.After(*nextStartsAt) {
+			return repository.ErrInvalidInput
+		}
+		if patch.CreatedByUserIDSet {
+			updates["created_by_user_id"] = patch.CreatedByUserID
+		}
+		if len(updates) > 0 {
+			if err := tx.Model(&record).Updates(updates).Error; err != nil {
+				return translateError(err)
+			}
+		}
+		if err := tx.Where("id = ?", id).First(&record).Error; err != nil {
+			return translateError(err)
+		}
+		result = toDomain(record)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteAnnouncement 软删除公告。
+func (r *Repo) DeleteAnnouncement(ctx context.Context, id uint) error {
+	if id == 0 {
+		return repository.ErrInvalidInput
+	}
+	result := r.db.WithContext(ctx).Delete(&model.Announcement{}, id)
+	if result.Error != nil {
+		return translateError(result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return repository.ErrNotFound
+	}
+	return nil
+}
+
+// DismissAnnouncementToday 记录用户今天不再显示指定公告版本。
+func (r *Repo) DismissAnnouncementToday(ctx context.Context, userID uint, announcementID uint, announcementUpdatedAt time.Time, now time.Time, dismissedUntil time.Time) error {
+	if userID == 0 || announcementID == 0 || announcementUpdatedAt.IsZero() || !dismissedUntil.After(now) {
+		return repository.ErrInvalidInput
+	}
+	return r.saveUserState(ctx, userID, announcementID, announcementUpdatedAt, now, &dismissedUntil, nil)
+}
+
+// CloseAnnouncement 记录用户关闭指定公告版本。
+func (r *Repo) CloseAnnouncement(ctx context.Context, userID uint, announcementID uint, announcementUpdatedAt time.Time, now time.Time) error {
+	if userID == 0 || announcementID == 0 || announcementUpdatedAt.IsZero() {
+		return repository.ErrInvalidInput
+	}
+	return r.saveUserState(ctx, userID, announcementID, announcementUpdatedAt, now, nil, &now)
+}
+
+func (r *Repo) saveUserState(ctx context.Context, userID uint, announcementID uint, announcementUpdatedAt time.Time, now time.Time, dismissedUntil *time.Time, closedAt *time.Time) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var announcement model.Announcement
+		if err := tx.
+			Where("id = ?", announcementID).
+			Where("updated_at = ?", announcementUpdatedAt).
+			Where("status = ?", domainannouncement.StatusActive).
+			Where("(starts_at IS NULL OR starts_at <= ?)", now).
+			Where("(expires_at IS NULL OR expires_at > ?)", now).
+			First(&announcement).Error; err != nil {
+			return translateError(err)
+		}
+
+		state := model.AnnouncementUserState{
+			AnnouncementID:        announcement.ID,
+			UserID:                userID,
+			AnnouncementUpdatedAt: announcement.UpdatedAt,
+			DismissedUntil:        dismissedUntil,
+			ClosedAt:              closedAt,
+		}
+		assignments := []string{"updated_at", "deleted_at"}
+		if dismissedUntil != nil {
+			assignments = append(assignments, "dismissed_until")
+		}
+		if closedAt != nil {
+			assignments = append(assignments, "closed_at")
+		}
+		if err := tx.Clauses(clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "announcement_id"},
+				{Name: "user_id"},
+				{Name: "announcement_updated_at"},
+			},
+			DoUpdates: clause.AssignmentColumns(assignments),
+		}).Create(&state).Error; err != nil {
+			return translateError(err)
+		}
+		return nil
+	})
+}
+
+func toDomain(item model.Announcement) domainannouncement.Announcement {
+	return domainannouncement.Announcement{
+		ID:              item.ID,
+		Title:           item.Title,
+		ContentMarkdown: item.ContentMarkdown,
+		Status:          item.Status,
+		Type:            item.Type,
+		Pinned:          item.Pinned,
+		Priority:        item.Priority,
+		StartsAt:        item.StartsAt,
+		ExpiresAt:       item.ExpiresAt,
+		CreatedByUserID: item.CreatedByUserID,
+		CreatedAt:       item.CreatedAt,
+		UpdatedAt:       item.UpdatedAt,
+	}
+}
+
+func normalizeStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case "", domainannouncement.StatusActive:
+		return domainannouncement.StatusActive
+	case domainannouncement.StatusInactive:
+		return domainannouncement.StatusInactive
+	default:
+		return ""
+	}
+}
+
+func normalizeType(announcementType string) string {
+	switch strings.TrimSpace(announcementType) {
+	case "", domainannouncement.TypeGeneral:
+		return domainannouncement.TypeGeneral
+	case domainannouncement.TypeCritical:
+		return domainannouncement.TypeCritical
+	case domainannouncement.TypeWarning:
+		return domainannouncement.TypeWarning
+	case domainannouncement.TypeInfo:
+		return domainannouncement.TypeInfo
+	case domainannouncement.TypeNormal:
+		return domainannouncement.TypeNormal
+	default:
+		return ""
+	}
+}
+
+func translateError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return repository.ErrNotFound
+	}
+	return err
+}

--- a/backend/internal/infra/persistence/postgres/postgres.go
+++ b/backend/internal/infra/persistence/postgres/postgres.go
@@ -141,6 +141,8 @@ func migrate(db *gorm.DB, cfg config.Config) error {
 		"billing_usage_ledgers":          "按量用量账本表",
 		"audit_logs":                     "可追溯审计日志表",
 		"system_events":                  "后台系统事件表",
+		"system_announcements":           "站点公告表",
+		"announcement_user_states":       "用户公告展示状态表",
 		"system_settings":                "系统动态配置表",
 		"user_settings":                  "用户个人偏好配置表",
 		"file_chunks":                    "RAG文件分片表",
@@ -167,6 +169,9 @@ func migrate(db *gorm.DB, cfg config.Config) error {
 		return err
 	}
 	if err := applyBillingBaselineIndexes(db); err != nil {
+		return err
+	}
+	if err := applyAnnouncementBaseline(db); err != nil {
 		return err
 	}
 	if err := applyVectorBaseline(db, vectorBaselineRequired(cfg)); err != nil {
@@ -220,6 +225,8 @@ func applySchemaBaseline(db *gorm.DB) error {
 		&model.UsageLedger{},
 		&model.AuditLog{},
 		&model.SystemEvent{},
+		&model.Announcement{},
+		&model.AnnouncementUserState{},
 		&model.SystemSetting{},
 		&model.UserSetting{},
 		&model.FileChunk{},
@@ -290,6 +297,37 @@ func applyBillingBaselineIndexes(db *gorm.DB) error {
 		ON "billing_redemption_codes" ("status", "mode", "id")`,
 		`CREATE INDEX IF NOT EXISTS idx_billing_redemptions_code_user_created
 		ON "billing_redemptions" ("code_id", "user_id", "created_at")`,
+	}
+
+	for _, statement := range statements {
+		if err := db.Exec(statement).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyAnnouncementBaseline(db *gorm.DB) error {
+	statements := []string{
+		`ALTER TABLE "system_announcements"
+		ADD COLUMN IF NOT EXISTS "type" varchar(32) NOT NULL DEFAULT 'general'`,
+		`COMMENT ON COLUMN "system_announcements"."type" IS '公告类型(critical/warning/info/normal/general)'`,
+		`ALTER TABLE "system_announcements"
+		ADD COLUMN IF NOT EXISTS "pinned" boolean NOT NULL DEFAULT false`,
+		`COMMENT ON COLUMN "system_announcements"."pinned" IS '是否置顶'`,
+		`CREATE INDEX IF NOT EXISTS idx_system_announcements_sort
+		ON "system_announcements" ("pinned", "priority", "updated_at", "id")`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_announcement_user_states_version
+		ON "announcement_user_states" ("announcement_id", "user_id", "announcement_updated_at")`,
+		`ALTER TABLE "announcement_user_states"
+		ADD COLUMN IF NOT EXISTS "closed_at" timestamptz`,
+		`COMMENT ON COLUMN "announcement_user_states"."closed_at" IS '关闭时间'`,
+		`CREATE INDEX IF NOT EXISTS idx_announcement_user_states_user_dismissed
+		ON "announcement_user_states" ("user_id", "dismissed_until")
+		WHERE "dismissed_until" IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS idx_announcement_user_states_user_closed
+		ON "announcement_user_states" ("user_id", "closed_at")
+		WHERE "closed_at" IS NOT NULL`,
 	}
 
 	for _, statement := range statements {

--- a/backend/internal/repository/announcement.go
+++ b/backend/internal/repository/announcement.go
@@ -1,0 +1,43 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	domainannouncement "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/announcement"
+)
+
+// AnnouncementRepository 定义公告流程依赖的持久化能力。
+type AnnouncementRepository interface {
+	ListActiveAnnouncements(ctx context.Context, userID uint, now time.Time) ([]domainannouncement.Announcement, error)
+	ListAdminAnnouncements(ctx context.Context, filter AnnouncementListFilter, offset int, limit int) ([]domainannouncement.Announcement, int64, error)
+	CreateAnnouncement(ctx context.Context, item *domainannouncement.Announcement) (*domainannouncement.Announcement, error)
+	PatchAnnouncement(ctx context.Context, id uint, patch AnnouncementPatch) (*domainannouncement.Announcement, error)
+	DeleteAnnouncement(ctx context.Context, id uint) error
+	DismissAnnouncementToday(ctx context.Context, userID uint, announcementID uint, announcementUpdatedAt time.Time, now time.Time, dismissedUntil time.Time) error
+	CloseAnnouncement(ctx context.Context, userID uint, announcementID uint, announcementUpdatedAt time.Time, now time.Time) error
+}
+
+// AnnouncementListFilter 描述管理员公告列表筛选条件。
+type AnnouncementListFilter struct {
+	Query  string
+	Status string
+	Type   string
+	Pinned *bool
+}
+
+// AnnouncementPatch 描述可更新的公告字段。
+type AnnouncementPatch struct {
+	Title              *string
+	ContentMarkdown    *string
+	Status             *string
+	Type               *string
+	Pinned             *bool
+	Priority           *int
+	StartsAtSet        bool
+	StartsAt           *time.Time
+	ExpiresAtSet       bool
+	ExpiresAt          *time.Time
+	CreatedByUserIDSet bool
+	CreatedByUserID    uint
+}

--- a/backend/internal/transport/http/announcement/dto.go
+++ b/backend/internal/transport/http/announcement/dto.go
@@ -1,0 +1,207 @@
+package announcement
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	appannouncement "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/announcement"
+	domainannouncement "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/announcement"
+)
+
+// ErrorDoc 用于 Swagger 标注通用错误响应。
+type ErrorDoc struct {
+	ErrorMsg  string      `json:"errorMsg" example:"invalid request"`
+	ErrorCode string      `json:"errorCode,omitempty" example:"invalid_request"`
+	Details   interface{} `json:"details,omitempty"`
+	RequestID string      `json:"requestId,omitempty" example:""`
+	Data      interface{} `json:"data"`
+}
+
+// AnnouncementResponse 面向前端的公告响应。
+type AnnouncementResponse struct {
+	ID              uint       `json:"id"`
+	Title           string     `json:"title"`
+	ContentMarkdown string     `json:"contentMarkdown"`
+	Status          string     `json:"status"`
+	Type            string     `json:"type"`
+	Pinned          bool       `json:"pinned"`
+	Priority        int        `json:"priority"`
+	StartsAt        *time.Time `json:"startsAt"`
+	ExpiresAt       *time.Time `json:"expiresAt"`
+	CreatedByUserID uint       `json:"createdByUserID"`
+	CreatedAt       time.Time  `json:"createdAt"`
+	UpdatedAt       time.Time  `json:"updatedAt"`
+	ClosedAt        *time.Time `json:"closedAt"`
+}
+
+// CreateAnnouncementRequest 创建公告请求。
+type CreateAnnouncementRequest struct {
+	Title           string     `json:"title" binding:"required,min=1,max=120"`
+	ContentMarkdown string     `json:"contentMarkdown" binding:"required,min=1,max=20000"`
+	Status          string     `json:"status" binding:"omitempty,oneof=active inactive"`
+	Type            string     `json:"type" binding:"omitempty,oneof=critical warning info normal general"`
+	Pinned          bool       `json:"pinned"`
+	Priority        int        `json:"priority"`
+	StartsAt        *time.Time `json:"startsAt"`
+	ExpiresAt       *time.Time `json:"expiresAt"`
+}
+
+// PatchAnnouncementRequest 更新公告请求。
+type PatchAnnouncementRequest struct {
+	Title           *string             `json:"title" binding:"omitempty,min=1,max=120"`
+	ContentMarkdown *string             `json:"contentMarkdown" binding:"omitempty,min=1,max=20000"`
+	Status          *string             `json:"status" binding:"omitempty,oneof=active inactive"`
+	Type            *string             `json:"type" binding:"omitempty,oneof=critical warning info normal general"`
+	Pinned          *bool               `json:"pinned"`
+	Priority        *int                `json:"priority"`
+	StartsAt        nullableTimeRequest `json:"startsAt"`
+	ExpiresAt       nullableTimeRequest `json:"expiresAt"`
+}
+
+// PatchAnnouncementRequestDoc 用于 Swagger 展示 nullable 字段。
+type PatchAnnouncementRequestDoc struct {
+	Title           *string    `json:"title" maxLength:"120"`
+	ContentMarkdown *string    `json:"contentMarkdown" maxLength:"20000"`
+	Status          *string    `json:"status" enums:"active,inactive"`
+	Type            *string    `json:"type" enums:"critical,warning,info,normal,general"`
+	Pinned          *bool      `json:"pinned"`
+	Priority        *int       `json:"priority"`
+	StartsAt        *time.Time `json:"startsAt"`
+	ExpiresAt       *time.Time `json:"expiresAt"`
+}
+
+// AnnouncementStateRequest 更新用户公告状态请求。
+type AnnouncementStateRequest struct {
+	UpdatedAt time.Time `json:"updatedAt" binding:"required"`
+}
+
+type nullableTimeRequest struct {
+	Set   bool
+	Value *time.Time
+}
+
+func (v *nullableTimeRequest) UnmarshalJSON(raw []byte) error {
+	v.Set = true
+	if string(raw) == "null" {
+		v.Value = nil
+		return nil
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err != nil {
+		return err
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		v.Value = nil
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339, text)
+	if err != nil {
+		return err
+	}
+	v.Value = &parsed
+	return nil
+}
+
+// AnnouncementListResponseDoc 公告列表响应文档。
+type AnnouncementListResponseDoc struct {
+	ErrorMsg string                 `json:"errorMsg"`
+	Data     []AnnouncementResponse `json:"data"`
+}
+
+// AdminAnnouncementListResponseDoc 后台公告分页响应文档。
+type AdminAnnouncementListResponseDoc struct {
+	ErrorMsg string `json:"errorMsg"`
+	Data     struct {
+		Total   int64                  `json:"total"`
+		Results []AnnouncementResponse `json:"results"`
+	} `json:"data"`
+}
+
+// AnnouncementDataResponse 公告操作响应。
+type AnnouncementDataResponse struct {
+	Announcement AnnouncementResponse `json:"announcement"`
+}
+
+// AnnouncementResponseDoc 公告操作响应文档。
+type AnnouncementResponseDoc struct {
+	ErrorMsg string                   `json:"errorMsg"`
+	Data     AnnouncementDataResponse `json:"data"`
+}
+
+// AnnouncementDeleteDataResponse 公告删除响应。
+type AnnouncementDeleteDataResponse struct {
+	Deleted bool `json:"deleted"`
+}
+
+// AnnouncementDeleteResponseDoc 公告删除响应文档。
+type AnnouncementDeleteResponseDoc struct {
+	ErrorMsg string                         `json:"errorMsg"`
+	Data     AnnouncementDeleteDataResponse `json:"data"`
+}
+
+// AnnouncementDismissDataResponse 公告不再显示响应。
+type AnnouncementDismissDataResponse struct {
+	Dismissed bool `json:"dismissed"`
+}
+
+// AnnouncementDismissResponseDoc 公告不再显示响应文档。
+type AnnouncementDismissResponseDoc struct {
+	ErrorMsg string                          `json:"errorMsg"`
+	Data     AnnouncementDismissDataResponse `json:"data"`
+}
+
+// AnnouncementCloseDataResponse 公告关闭响应。
+type AnnouncementCloseDataResponse struct {
+	Closed bool `json:"closed"`
+}
+
+// AnnouncementCloseResponseDoc 公告关闭响应文档。
+type AnnouncementCloseResponseDoc struct {
+	ErrorMsg string                        `json:"errorMsg"`
+	Data     AnnouncementCloseDataResponse `json:"data"`
+}
+
+func toAnnouncementResponse(item domainannouncement.Announcement) AnnouncementResponse {
+	return AnnouncementResponse{
+		ID:              item.ID,
+		Title:           item.Title,
+		ContentMarkdown: item.ContentMarkdown,
+		Status:          item.Status,
+		Type:            item.Type,
+		Pinned:          item.Pinned,
+		Priority:        item.Priority,
+		StartsAt:        item.StartsAt,
+		ExpiresAt:       item.ExpiresAt,
+		CreatedByUserID: item.CreatedByUserID,
+		CreatedAt:       item.CreatedAt,
+		UpdatedAt:       item.UpdatedAt,
+		ClosedAt:        item.ClosedAt,
+	}
+}
+
+func toAnnouncementResponses(items []domainannouncement.Announcement) []AnnouncementResponse {
+	results := make([]AnnouncementResponse, 0, len(items))
+	for _, item := range items {
+		results = append(results, toAnnouncementResponse(item))
+	}
+	return results
+}
+
+func createInputFromRequest(req CreateAnnouncementRequest) appannouncement.WriteInput {
+	status := req.Status
+	if strings.TrimSpace(status) == "" {
+		status = domainannouncement.StatusActive
+	}
+	return appannouncement.WriteInput{
+		Title:           req.Title,
+		ContentMarkdown: req.ContentMarkdown,
+		Status:          status,
+		Type:            req.Type,
+		Pinned:          req.Pinned,
+		Priority:        req.Priority,
+		StartsAt:        req.StartsAt,
+		ExpiresAt:       req.ExpiresAt,
+	}
+}

--- a/backend/internal/transport/http/announcement/handler.go
+++ b/backend/internal/transport/http/announcement/handler.go
@@ -1,0 +1,275 @@
+package announcement
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	appannouncement "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/announcement"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/shared/response"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+// Handler 封装公告 HTTP 处理。
+type Handler struct {
+	service *appannouncement.Service
+}
+
+// NewHandler 创建公告处理器。
+func NewHandler(service *appannouncement.Service) *Handler {
+	return &Handler{service: service}
+}
+
+// ListAnnouncements godoc
+// @Summary 获取当前公告
+// @Description 登录用户获取当前可展示的站点公告列表
+// @Tags announcements
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Success 200 {object} AnnouncementListResponseDoc
+// @Failure 500 {object} ErrorDoc
+// @Router /announcements [get]
+func (h *Handler) ListAnnouncements(c *gin.Context) {
+	items, err := h.service.ListActive(c.Request.Context(), middleware.MustUserID(c), time.Now())
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, "list announcements failed")
+		return
+	}
+	response.Success(c, toAnnouncementResponses(items))
+}
+
+// DismissAnnouncementToday godoc
+// @Summary 今日不再显示公告
+// @Description 登录用户对当前公告版本记录今日不再显示
+// @Tags announcements
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param id path int true "公告ID"
+// @Param body body AnnouncementStateRequest true "公告版本"
+// @Success 200 {object} AnnouncementDismissResponseDoc
+// @Failure 400 {object} ErrorDoc
+// @Failure 404 {object} ErrorDoc
+// @Failure 500 {object} ErrorDoc
+// @Router /announcements/{id}/dismiss-today [post]
+func (h *Handler) DismissAnnouncementToday(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil || id == 0 {
+		response.Error(c, http.StatusBadRequest, "invalid announcement id")
+		return
+	}
+	var req AnnouncementStateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.InvalidRequestBody(c, err)
+		return
+	}
+	now := time.Now()
+	year, month, day := now.Date()
+	dismissedUntil := time.Date(year, month, day+1, 0, 0, 0, 0, now.Location())
+	if err := h.service.DismissToday(c.Request.Context(), middleware.MustUserID(c), uint(id), req.UpdatedAt, now, dismissedUntil); err != nil {
+		writeAnnouncementError(c, err)
+		return
+	}
+	response.Success(c, AnnouncementDismissDataResponse{Dismissed: true})
+}
+
+// CloseAnnouncement godoc
+// @Summary 关闭公告
+// @Description 登录用户关闭当前公告版本；公告更新后会重新展示
+// @Tags announcements
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param id path int true "公告ID"
+// @Param body body AnnouncementStateRequest true "公告版本"
+// @Success 200 {object} AnnouncementCloseResponseDoc
+// @Failure 400 {object} ErrorDoc
+// @Failure 404 {object} ErrorDoc
+// @Failure 500 {object} ErrorDoc
+// @Router /announcements/{id}/close [post]
+func (h *Handler) CloseAnnouncement(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil || id == 0 {
+		response.Error(c, http.StatusBadRequest, "invalid announcement id")
+		return
+	}
+	var req AnnouncementStateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.InvalidRequestBody(c, err)
+		return
+	}
+	if err := h.service.Close(c.Request.Context(), middleware.MustUserID(c), uint(id), req.UpdatedAt, time.Now()); err != nil {
+		writeAnnouncementError(c, err)
+		return
+	}
+	response.Success(c, AnnouncementCloseDataResponse{Closed: true})
+}
+
+// ListAdminAnnouncements godoc
+// @Summary 管理员查询公告
+// @Description 分页查询站点公告
+// @Tags admin-announcements
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param status query string false "状态：active/inactive"
+// @Param type query string false "类型：critical/warning/info/normal/general"
+// @Param pinned query bool false "是否置顶"
+// @Param q query string false "搜索关键词"
+// @Param page query int false "页码"
+// @Param page_size query int false "每页数量"
+// @Success 200 {object} AdminAnnouncementListResponseDoc
+// @Failure 500 {object} ErrorDoc
+// @Router /admin/announcements [get]
+func (h *Handler) ListAdminAnnouncements(c *gin.Context) {
+	page, pageSize := pageParams(c)
+	var pinned *bool
+	if raw := c.Query("pinned"); raw != "" {
+		if parsed, err := strconv.ParseBool(raw); err == nil {
+			pinned = &parsed
+		}
+	}
+	items, total, err := h.service.ListAdmin(c.Request.Context(), appannouncement.ListInput{
+		Query:    c.Query("q"),
+		Status:   c.Query("status"),
+		Type:     c.Query("type"),
+		Pinned:   pinned,
+		Page:     page,
+		PageSize: pageSize,
+	})
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, "list announcements failed")
+		return
+	}
+	response.SuccessPage(c, total, toAnnouncementResponses(items))
+}
+
+// CreateAnnouncement godoc
+// @Summary 管理员创建公告
+// @Description 创建一条 Markdown 站点公告
+// @Tags admin-announcements
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param body body CreateAnnouncementRequest true "公告配置"
+// @Success 200 {object} AnnouncementResponseDoc
+// @Failure 400 {object} ErrorDoc
+// @Failure 500 {object} ErrorDoc
+// @Router /admin/announcements [post]
+func (h *Handler) CreateAnnouncement(c *gin.Context) {
+	var req CreateAnnouncementRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.InvalidRequestBody(c, err)
+		return
+	}
+	item, err := h.service.Create(c.Request.Context(), middleware.MustUserID(c), createInputFromRequest(req))
+	if err != nil {
+		writeAnnouncementError(c, err)
+		return
+	}
+	response.Success(c, AnnouncementDataResponse{Announcement: toAnnouncementResponse(*item)})
+}
+
+// PatchAnnouncement godoc
+// @Summary 管理员更新公告
+// @Description 更新公告标题、内容、状态、优先级和有效期
+// @Tags admin-announcements
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param id path int true "公告ID"
+// @Param body body PatchAnnouncementRequestDoc true "公告更新字段"
+// @Success 200 {object} AnnouncementResponseDoc
+// @Failure 400 {object} ErrorDoc
+// @Failure 404 {object} ErrorDoc
+// @Failure 500 {object} ErrorDoc
+// @Router /admin/announcements/{id} [patch]
+func (h *Handler) PatchAnnouncement(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil || id == 0 {
+		response.Error(c, http.StatusBadRequest, "invalid announcement id")
+		return
+	}
+	var req PatchAnnouncementRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.InvalidRequestBody(c, err)
+		return
+	}
+	item, err := h.service.Update(c.Request.Context(), uint(id), appannouncement.PatchInput{
+		Title:           req.Title,
+		ContentMarkdown: req.ContentMarkdown,
+		Status:          req.Status,
+		Type:            req.Type,
+		Pinned:          req.Pinned,
+		Priority:        req.Priority,
+		StartsAtSet:     req.StartsAt.Set,
+		StartsAt:        req.StartsAt.Value,
+		ExpiresAtSet:    req.ExpiresAt.Set,
+		ExpiresAt:       req.ExpiresAt.Value,
+	})
+	if err != nil {
+		writeAnnouncementError(c, err)
+		return
+	}
+	response.Success(c, AnnouncementDataResponse{Announcement: toAnnouncementResponse(*item)})
+}
+
+// DeleteAnnouncement godoc
+// @Summary 管理员删除公告
+// @Description 软删除公告
+// @Tags admin-announcements
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param id path int true "公告ID"
+// @Success 200 {object} AnnouncementDeleteResponseDoc
+// @Failure 400 {object} ErrorDoc
+// @Failure 404 {object} ErrorDoc
+// @Failure 500 {object} ErrorDoc
+// @Router /admin/announcements/{id} [delete]
+func (h *Handler) DeleteAnnouncement(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil || id == 0 {
+		response.Error(c, http.StatusBadRequest, "invalid announcement id")
+		return
+	}
+	if err := h.service.Delete(c.Request.Context(), uint(id)); err != nil {
+		writeAnnouncementError(c, err)
+		return
+	}
+	response.Success(c, AnnouncementDeleteDataResponse{Deleted: true})
+}
+
+func writeAnnouncementError(c *gin.Context, err error) {
+	if errors.Is(err, appannouncement.ErrAnnouncementNotFound) {
+		response.Error(c, http.StatusNotFound, "announcement not found")
+		return
+	}
+	if errors.Is(err, appannouncement.ErrInvalidAnnouncement) {
+		response.ErrorFrom(c, http.StatusBadRequest, err)
+		return
+	}
+	response.Error(c, http.StatusInternalServerError, "announcement operation failed")
+}
+
+func pageParams(c *gin.Context) (int, int) {
+	page := 1
+	pageSize := 20
+	if raw := c.Query("page"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			page = parsed
+		}
+	}
+	if raw := c.Query("page_size"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			pageSize = parsed
+		}
+	}
+	if pageSize > 200 {
+		pageSize = 200
+	}
+	return page, pageSize
+}

--- a/backend/internal/transport/http/announcement/module.go
+++ b/backend/internal/transport/http/announcement/module.go
@@ -1,0 +1,11 @@
+package announcement
+
+// Module 聚合公告 HTTP 处理器。
+type Module struct {
+	Handler *Handler
+}
+
+// NewModule 创建公告 HTTP 模块。
+func NewModule(handler *Handler) *Module {
+	return &Module{Handler: handler}
+}

--- a/backend/internal/transport/http/announcement/router.go
+++ b/backend/internal/transport/http/announcement/router.go
@@ -1,0 +1,18 @@
+package announcement
+
+import "github.com/gin-gonic/gin"
+
+// RegisterRoutes 注册公告用户侧路由。
+func (m *Module) RegisterRoutes(authRequired *gin.RouterGroup) {
+	authRequired.GET("/announcements", m.Handler.ListAnnouncements)
+	authRequired.POST("/announcements/:id/dismiss-today", m.Handler.DismissAnnouncementToday)
+	authRequired.POST("/announcements/:id/close", m.Handler.CloseAnnouncement)
+}
+
+// RegisterAdminRoutes 注册公告管理路由。
+func (m *Module) RegisterAdminRoutes(adminGroup *gin.RouterGroup) {
+	adminGroup.GET("/announcements", m.Handler.ListAdminAnnouncements)
+	adminGroup.POST("/announcements", m.Handler.CreateAnnouncement)
+	adminGroup.PATCH("/announcements/:id", m.Handler.PatchAnnouncement)
+	adminGroup.DELETE("/announcements/:id", m.Handler.DeleteAnnouncement)
+}

--- a/backend/internal/transport/http/server.go
+++ b/backend/internal/transport/http/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/shared/buildinfo"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/shared/response"
 	adminhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/admin"
+	announcementhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/announcement"
 	authhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/auth"
 	billinghttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/billing"
 	channelhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/channel"
@@ -54,6 +55,7 @@ type Modules struct {
 	Memory       *memoryhttp.Module
 	Billing      *billinghttp.Module
 	Admin        *adminhttp.Module
+	Announcement *announcementhttp.Module
 	Settings     *settingshttp.Module
 	UserSettings *usersettingshttp.Module
 }
@@ -140,13 +142,16 @@ func NewEngine(cfg *config.Runtime, log *zap.Logger, modules Modules, hc HealthC
 	if modules.Billing != nil {
 		modules.Billing.RegisterRoutes(authRequired)
 	}
+	if modules.Announcement != nil {
+		modules.Announcement.RegisterRoutes(authRequired)
+	}
 	if modules.UserSettings != nil {
 		modules.UserSettings.RegisterRoutes(authRequired)
 	}
 	if modules.Settings != nil {
 		modules.Settings.RegisterRoutes(authRequired)
 	}
-	if modules.Admin != nil || modules.Auth != nil || modules.Billing != nil || modules.Channel != nil || modules.MCP != nil || modules.Settings != nil {
+	if modules.Admin != nil || modules.Auth != nil || modules.Billing != nil || modules.Channel != nil || modules.MCP != nil || modules.Settings != nil || modules.Announcement != nil {
 		adminGroup := authRequired.Group("/admin")
 		adminGroup.Use(middleware.AdminOnly())
 		if modules.Auth != nil {
@@ -166,6 +171,9 @@ func NewEngine(cfg *config.Runtime, log *zap.Logger, modules Modules, hc HealthC
 		}
 		if modules.Settings != nil {
 			modules.Settings.RegisterAdminRoutes(adminGroup)
+		}
+		if modules.Announcement != nil {
+			modules.Announcement.RegisterAdminRoutes(adminGroup)
 		}
 	}
 

--- a/frontend/app/(admin)/admin/announcements/page.tsx
+++ b/frontend/app/(admin)/admin/announcements/page.tsx
@@ -1,0 +1,10 @@
+import { AdminShell } from "@/features/admin/components/admin-shell";
+import { AdminAnnouncementsPage } from "@/features/admin/components/sections/announcements/admin-announcements";
+
+export default function AdminAnnouncementsRoute() {
+  return (
+    <AdminShell activeSection="announcements" basePath="/admin">
+      <AdminAnnouncementsPage />
+    </AdminShell>
+  );
+}

--- a/frontend/features/admin/api/announcements.ts
+++ b/frontend/features/admin/api/announcements.ts
@@ -1,0 +1,67 @@
+import { authedRequest } from "@/shared/api/authed-client";
+import { pathParam } from "@/shared/api/http-client";
+import type { PagePayload } from "@/shared/api/common.types";
+import type {
+  AdminAnnouncementDTO,
+  AdminAnnouncementData,
+  AdminAnnouncementDeleteData,
+  AdminAnnouncementPage,
+  CreateAdminAnnouncementRequest,
+  UpdateAdminAnnouncementRequest,
+} from "@/features/admin/api/announcements.types";
+import { normalizeAdminPagePayload, resolveAdminPage, type AdminListQueryOptions } from "./shared";
+
+export async function listAdminAnnouncements(
+  accessToken: string,
+  options: AdminListQueryOptions = {},
+): Promise<AdminAnnouncementPage> {
+  const { page, pageSize } = resolveAdminPage(options);
+  const params = new URLSearchParams({
+    page: String(page),
+    page_size: String(pageSize),
+  });
+  if (options.query?.trim()) params.set("q", options.query.trim());
+  if (options.status?.trim()) params.set("status", options.status.trim());
+  if (options.type?.trim()) params.set("type", options.type.trim());
+  if (options.pinned?.trim()) params.set("pinned", options.pinned.trim());
+  const data = await authedRequest<PagePayload<AdminAnnouncementDTO>>(
+    `/api/v1/admin/announcements?${params.toString()}`,
+    { accessToken },
+    true,
+  );
+  return normalizeAdminPagePayload(data);
+}
+
+export async function createAdminAnnouncement(
+  accessToken: string,
+  payload: CreateAdminAnnouncementRequest,
+): Promise<AdminAnnouncementData> {
+  return authedRequest<AdminAnnouncementData>(
+    "/api/v1/admin/announcements",
+    { method: "POST", accessToken, body: payload },
+    true,
+  );
+}
+
+export async function updateAdminAnnouncement(
+  accessToken: string,
+  announcementID: number,
+  payload: UpdateAdminAnnouncementRequest,
+): Promise<AdminAnnouncementData> {
+  return authedRequest<AdminAnnouncementData>(
+    `/api/v1/admin/announcements/${pathParam(announcementID)}`,
+    { method: "PATCH", accessToken, body: payload },
+    true,
+  );
+}
+
+export async function deleteAdminAnnouncement(
+  accessToken: string,
+  announcementID: number,
+): Promise<AdminAnnouncementDeleteData> {
+  return authedRequest<AdminAnnouncementDeleteData>(
+    `/api/v1/admin/announcements/${pathParam(announcementID)}`,
+    { method: "DELETE", accessToken },
+    true,
+  );
+}

--- a/frontend/features/admin/api/announcements.types.ts
+++ b/frontend/features/admin/api/announcements.types.ts
@@ -1,0 +1,27 @@
+import type { PagePayload } from "@/shared/api/common.types";
+import type { AnnouncementDTO } from "@/shared/api/announcements.types";
+
+export type AdminAnnouncementDTO = AnnouncementDTO;
+
+export type AdminAnnouncementPage = PagePayload<AdminAnnouncementDTO>;
+
+export type CreateAdminAnnouncementRequest = {
+  title: string;
+  contentMarkdown: string;
+  status?: "active" | "inactive";
+  type?: "critical" | "warning" | "info" | "normal" | "general";
+  pinned?: boolean;
+  priority: number;
+  startsAt?: string | null;
+  expiresAt?: string | null;
+};
+
+export type UpdateAdminAnnouncementRequest = Partial<CreateAdminAnnouncementRequest>;
+
+export type AdminAnnouncementData = {
+  announcement: AdminAnnouncementDTO;
+};
+
+export type AdminAnnouncementDeleteData = {
+  deleted: boolean;
+};

--- a/frontend/features/admin/api/index.ts
+++ b/frontend/features/admin/api/index.ts
@@ -1,4 +1,5 @@
 export * from "./accounts";
+export * from "./announcements";
 export * from "./auth";
 export * from "./audit";
 export * from "./billing";

--- a/frontend/features/admin/api/shared.ts
+++ b/frontend/features/admin/api/shared.ts
@@ -8,6 +8,8 @@ export type AdminPageOptions = {
 export type AdminListQueryOptions = AdminPageOptions & {
   query?: string;
   status?: string;
+  type?: string;
+  pinned?: string;
   sort?: string;
 };
 

--- a/frontend/features/admin/components/admin-date-range-filter.tsx
+++ b/frontend/features/admin/components/admin-date-range-filter.tsx
@@ -20,6 +20,7 @@ type AdminDateRangeFilterProps = {
   onFromChange: (value: string) => void;
   onToChange: (value: string) => void;
   disabled?: boolean;
+  placeholder?: string;
 };
 
 function parseDateValue(value: string): Date | undefined {
@@ -41,6 +42,7 @@ export function AdminDateRangeFilter({
   onFromChange,
   onToChange,
   disabled = false,
+  placeholder,
 }: AdminDateRangeFilterProps) {
   const locale = useLocale();
   const t = useTranslations("common.dateRange");
@@ -55,7 +57,7 @@ export function AdminDateRangeFilter({
     ? selectedRange.to
       ? `${format(selectedRange.from, "yyyy-MM-dd")} - ${format(selectedRange.to, "yyyy-MM-dd")}`
       : format(selectedRange.from, "yyyy-MM-dd")
-    : t("placeholder");
+    : (placeholder ?? t("placeholder"));
 
   return (
     <div className="space-y-2">

--- a/frontend/features/admin/components/admin-date-time-picker.tsx
+++ b/frontend/features/admin/components/admin-date-time-picker.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { format } from "date-fns";
+import { enUS, zhCN } from "date-fns/locale";
+import { CalendarIcon } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ADMIN_DATE_PICKER_TRIGGER_CLASSNAME } from "@/features/admin/components/admin-date-range-filter";
+import { cn } from "@/lib/utils";
+
+type AdminDateTimePickerProps = {
+  value: string;
+  disabled?: boolean;
+  label: string;
+  placeholder: string;
+  defaultTime?: string;
+  onChange: (value: string) => void;
+};
+
+export function adminDateTimeFormValue(value: string | null | undefined): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return `${format(date, "yyyy-MM-dd")}T${format(date, "HH:mm:ss")}`;
+}
+
+export function adminDateTimeValueToISOString(value: string): string | null | undefined {
+  const text = value.trim();
+  if (!text) return null;
+  const date = new Date(text);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function parseDatePart(value: string): Date | undefined {
+  const [dateText] = value.trim().split("T");
+  if (!dateText) return undefined;
+  const [year, month, day] = dateText.split("-").map((part) => Number.parseInt(part, 10));
+  if (!year || !month || !day) return undefined;
+  const date = new Date(year, month - 1, day);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function normalizeTimeValue(value: string, fallback: string): string {
+  const trimmed = value.trim();
+  if (/^\d{2}:\d{2}:\d{2}$/.test(trimmed)) return trimmed;
+  if (/^\d{2}:\d{2}$/.test(trimmed)) return `${trimmed}:00`;
+  const [, timeText = ""] = trimmed.split("T");
+  if (/^\d{2}:\d{2}:\d{2}$/.test(timeText)) return timeText;
+  if (/^\d{2}:\d{2}$/.test(timeText)) return `${timeText}:00`;
+  return fallback;
+}
+
+function buildDateTimeValue(date: Date, time: string, fallback: string): string {
+  return `${format(date, "yyyy-MM-dd")}T${normalizeTimeValue(time, fallback)}`;
+}
+
+function timePart(value: string, index: number, fallback: string): string {
+  return normalizeTimeValue(value, fallback).split(":")[index] || "00";
+}
+
+function updateTimePart(value: string, index: number, nextPart: string, fallback: string): string {
+  const parts = normalizeTimeValue(value, fallback).split(":");
+  const max = index === 0 ? 23 : 59;
+  const parsed = Number.parseInt(nextPart, 10);
+  const normalized = String(Number.isFinite(parsed) ? Math.min(Math.max(parsed, 0), max) : 0).padStart(2, "0");
+  parts[index] = normalized;
+  return parts.join(":");
+}
+
+export function AdminDateTimePicker({
+  value,
+  disabled = false,
+  label,
+  placeholder,
+  defaultTime = "23:59:59",
+  onChange,
+}: AdminDateTimePickerProps) {
+  const locale = useLocale();
+  const tDateRange = useTranslations("common.dateRange");
+  const selectedDate = parseDatePart(value);
+  const normalizedTime = selectedDate ? normalizeTimeValue(value, defaultTime) : "";
+
+  const handleTimePartChange = (index: number, nextPart: string) => {
+    if (!selectedDate) return;
+    onChange(buildDateTimeValue(selectedDate, updateTimePart(normalizedTime, index, nextPart, defaultTime), defaultTime));
+  };
+
+  return (
+    <div className="space-y-1">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <div className="grid gap-5 md:grid-cols-2">
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              className={cn(
+                ADMIN_DATE_PICKER_TRIGGER_CLASSNAME,
+                "h-8 justify-between",
+                !selectedDate && "text-muted-foreground",
+              )}
+              disabled={disabled}
+            >
+              <span className="min-w-0 truncate">
+                {selectedDate ? format(selectedDate, "yyyy-MM-dd") : placeholder}
+              </span>
+              <CalendarIcon className="size-3.5 opacity-70" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <Calendar
+              mode="single"
+              selected={selectedDate}
+              locale={locale === "zh-CN" ? zhCN : enUS}
+              onSelect={(date) => onChange(date ? buildDateTimeValue(date, normalizeTimeValue(value, defaultTime), defaultTime) : "")}
+              autoFocus
+            />
+          </PopoverContent>
+        </Popover>
+        <div className="grid grid-cols-4 gap-2">
+          <Input
+            type="number"
+            min={0}
+            max={23}
+            value={selectedDate ? timePart(normalizedTime, 0, defaultTime) : ""}
+            placeholder="HH"
+            disabled={disabled || !selectedDate}
+            className="px-2 text-center tabular-nums"
+            onChange={(event) => handleTimePartChange(0, event.target.value)}
+          />
+          <Input
+            type="number"
+            min={0}
+            max={59}
+            value={selectedDate ? timePart(normalizedTime, 1, defaultTime) : ""}
+            placeholder="MM"
+            disabled={disabled || !selectedDate}
+            className="px-2 text-center tabular-nums"
+            onChange={(event) => handleTimePartChange(1, event.target.value)}
+          />
+          <Input
+            type="number"
+            min={0}
+            max={59}
+            value={selectedDate ? timePart(normalizedTime, 2, defaultTime) : ""}
+            placeholder="SS"
+            disabled={disabled || !selectedDate}
+            className="px-2 text-center tabular-nums"
+            onChange={(event) => handleTimePartChange(2, event.target.value)}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            className="h-8 w-full px-0 text-xs text-muted-foreground"
+            disabled={disabled || !selectedDate}
+            onClick={() => onChange("")}
+            aria-label={tDateRange("clear")}
+          >
+            {tDateRange("clear")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/features/admin/components/admin-sidebar.tsx
+++ b/frontend/features/admin/components/admin-sidebar.tsx
@@ -40,6 +40,7 @@ export function AdminSidebar({
         models: "sections.models",
         "tool-settings": "sections.toolSettings",
         billing: "sections.billing",
+        announcements: "sections.announcements",
         logs: "sections.logs",
         "login-settings": "sections.loginSettings",
         "conversation-settings": "sections.conversationSettings",

--- a/frontend/features/admin/components/sections/announcements/admin-announcements.tsx
+++ b/frontend/features/admin/components/sections/announcements/admin-announcements.tsx
@@ -1,0 +1,678 @@
+"use client";
+
+import * as React from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { Edit3, Pin, Plus, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableEmptyRow,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableSkeletonRows,
+} from "@/components/ui/table";
+import { TablePagination, TableToolbar } from "@/components/ui/table-tools";
+import { SpinnerLabel } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+import { StreamdownRender } from "@/features/chat/components/markdown/streamdown-render";
+import { AdminDateRangeFilter } from "@/features/admin/components/admin-date-range-filter";
+import { adminDateTimeFormValue, adminDateTimeValueToISOString } from "@/features/admin/components/admin-date-time-picker";
+import {
+  createAdminAnnouncement,
+  deleteAdminAnnouncement,
+  listAdminAnnouncements,
+  updateAdminAnnouncement,
+} from "@/features/admin/api";
+import type {
+  AdminAnnouncementDTO,
+  CreateAdminAnnouncementRequest,
+  UpdateAdminAnnouncementRequest,
+} from "@/features/admin/api/announcements.types";
+import { resolveAdminErrorMessage } from "@/features/admin/utils/admin-error";
+import { useAuthSession } from "@/shared/auth/auth-session-context";
+import { cn } from "@/lib/utils";
+
+type AnnouncementForm = {
+  id?: number;
+  title: string;
+  contentMarkdown: string;
+  status: "active" | "inactive";
+  type: "critical" | "warning" | "info" | "normal" | "general";
+  pinned: boolean;
+  priority: string;
+  startsAt: string;
+  expiresAt: string;
+};
+
+const emptyForm: AnnouncementForm = {
+  title: "",
+  contentMarkdown: "",
+  status: "active",
+  type: "general",
+  pinned: false,
+  priority: "0",
+  startsAt: "",
+  expiresAt: "",
+};
+
+function toDateRangeValue(value: string): string {
+  const [dateText] = value.trim().split("T");
+  return /^\d{4}-\d{2}-\d{2}$/.test(dateText) ? dateText : "";
+}
+
+function dateRangeBoundaryValue(value: string, boundary: "start" | "end"): string {
+  if (!value.trim()) {
+    return "";
+  }
+  return `${value}T${boundary === "start" ? "00:00:00" : "23:59:59"}`;
+}
+
+function formFromAnnouncement(item: AdminAnnouncementDTO): AnnouncementForm {
+  return {
+    id: item.id,
+    title: item.title,
+    contentMarkdown: item.contentMarkdown,
+    status: item.status === "inactive" ? "inactive" : "active",
+    type: normalizeAnnouncementType(item.type),
+    pinned: Boolean(item.pinned),
+    priority: String(item.priority ?? 0),
+    startsAt: adminDateTimeFormValue(item.startsAt),
+    expiresAt: adminDateTimeFormValue(item.expiresAt),
+  };
+}
+
+function formatDateTime(value: string | null, locale: string): string {
+  if (!value) {
+    return "-";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "-";
+  }
+  return new Intl.DateTimeFormat(locale, {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function activeWindowLabel(item: AdminAnnouncementDTO, locale: string): string {
+  const start = formatDateTime(item.startsAt, locale);
+  const end = formatDateTime(item.expiresAt, locale);
+  if (start === "-" && end === "-") {
+    return "-";
+  }
+  return `${start} / ${end}`;
+}
+
+function isCurrentlyVisible(item: AdminAnnouncementDTO): boolean {
+  const now = Date.now();
+  const startsAt = item.startsAt ? new Date(item.startsAt).getTime() : null;
+  const expiresAt = item.expiresAt ? new Date(item.expiresAt).getTime() : null;
+  return item.status === "active" &&
+    (startsAt === null || startsAt <= now) &&
+    (expiresAt === null || expiresAt > now);
+}
+
+function payloadFromForm(form: AnnouncementForm): CreateAdminAnnouncementRequest {
+  return {
+    title: form.title.trim(),
+    contentMarkdown: form.contentMarkdown.trim(),
+    status: form.status,
+    type: form.type,
+    pinned: form.pinned,
+    priority: Number.parseInt(form.priority, 10) || 0,
+    startsAt: adminDateTimeValueToISOString(form.startsAt) ?? null,
+    expiresAt: adminDateTimeValueToISOString(form.expiresAt) ?? null,
+  };
+}
+
+function normalizeAnnouncementType(value: string): AnnouncementForm["type"] {
+  switch (value) {
+    case "critical":
+    case "warning":
+    case "info":
+    case "normal":
+    case "general":
+      return value;
+    default:
+      return "general";
+  }
+}
+
+function announcementTypeClassName(value: string): string {
+  switch (value) {
+    case "critical":
+      return "border-red-500/30 bg-red-50 text-red-700 dark:bg-red-500/10 dark:text-red-300";
+    case "warning":
+      return "border-yellow-500/30 bg-yellow-50 text-yellow-700 dark:bg-yellow-500/10 dark:text-yellow-300";
+    case "info":
+      return "border-blue-500/30 bg-blue-50 text-blue-700 dark:bg-blue-500/10 dark:text-blue-300";
+    case "normal":
+      return "border-emerald-500/30 bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300";
+    default:
+      return "border-border bg-background text-muted-foreground";
+  }
+}
+
+export function AdminAnnouncementsPage() {
+  const t = useTranslations("adminAnnouncements");
+  const common = useTranslations("common");
+  const locale = useLocale();
+  const { accessToken } = useAuthSession();
+  const [items, setItems] = React.useState<AdminAnnouncementDTO[]>([]);
+  const [total, setTotal] = React.useState(0);
+  const [page, setPage] = React.useState(1);
+  const [pageSize, setPageSize] = React.useState(25);
+  const [query, setQuery] = React.useState("");
+  const [status, setStatus] = React.useState("");
+  const [typeFilter, setTypeFilter] = React.useState("");
+  const [pinnedFilter, setPinnedFilter] = React.useState("");
+  const [loading, setLoading] = React.useState(true);
+  const [saving, setSaving] = React.useState(false);
+  const [form, setForm] = React.useState<AnnouncementForm>(emptyForm);
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [deleteTarget, setDeleteTarget] = React.useState<AdminAnnouncementDTO | null>(null);
+  const [priorityDrafts, setPriorityDrafts] = React.useState<Record<number, string>>({});
+
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await listAdminAnnouncements(accessToken, { page, pageSize, query, status, type: typeFilter, pinned: pinnedFilter });
+      setItems(data.results);
+      setTotal(data.total);
+    } catch (error) {
+      toast.error(t("toast.loadFailed"), { description: resolveAdminErrorMessage(error) });
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken, page, pageSize, pinnedFilter, query, status, t, typeFilter]);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  function openCreate() {
+    setForm(emptyForm);
+    setDialogOpen(true);
+  }
+
+  function openEdit(item: AdminAnnouncementDTO) {
+    setForm(formFromAnnouncement(item));
+    setDialogOpen(true);
+  }
+
+  async function save() {
+    const payload = payloadFromForm(form);
+    if (!payload.title || !payload.contentMarkdown) {
+      toast.error(t("toast.invalid"));
+      return;
+    }
+    setSaving(true);
+    try {
+      if (form.id) {
+        const updatePayload: UpdateAdminAnnouncementRequest = payload;
+        const data = await updateAdminAnnouncement(accessToken, form.id, updatePayload);
+        setItems((current) => current.map((item) => item.id === data.announcement.id ? data.announcement : item));
+        toast.success(t("toast.updated"));
+      } else {
+        const data = await createAdminAnnouncement(accessToken, payload);
+        setItems((current) => [data.announcement, ...current].slice(0, pageSize));
+        setTotal((current) => current + 1);
+        toast.success(t("toast.created"));
+      }
+      setDialogOpen(false);
+    } catch (error) {
+      toast.error(form.id ? t("toast.updateFailed") : t("toast.createFailed"), { description: resolveAdminErrorMessage(error) });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function toggleStatus(item: AdminAnnouncementDTO, checked: boolean) {
+    const nextStatus = checked ? "active" : "inactive";
+    setItems((current) => current.map((row) => row.id === item.id ? { ...row, status: nextStatus } : row));
+    try {
+      const data = await updateAdminAnnouncement(accessToken, item.id, { status: nextStatus });
+      setItems((current) => current.map((row) => row.id === item.id ? data.announcement : row));
+    } catch (error) {
+      setItems((current) => current.map((row) => row.id === item.id ? item : row));
+      toast.error(t("toast.statusFailed"), { description: resolveAdminErrorMessage(error) });
+    }
+  }
+
+  async function togglePinned(item: AdminAnnouncementDTO, checked: boolean) {
+    setItems((current) => current.map((row) => row.id === item.id ? { ...row, pinned: checked } : row));
+    try {
+      const data = await updateAdminAnnouncement(accessToken, item.id, { pinned: checked });
+      setItems((current) => current.map((row) => row.id === item.id ? data.announcement : row));
+    } catch (error) {
+      setItems((current) => current.map((row) => row.id === item.id ? item : row));
+      toast.error(t("toast.updateFailed"), { description: resolveAdminErrorMessage(error) });
+    }
+  }
+
+  async function updateType(item: AdminAnnouncementDTO, value: string) {
+    const nextType = normalizeAnnouncementType(value);
+    if (nextType === normalizeAnnouncementType(item.type)) {
+      return;
+    }
+    setItems((current) => current.map((row) => row.id === item.id ? { ...row, type: nextType } : row));
+    try {
+      const data = await updateAdminAnnouncement(accessToken, item.id, { type: nextType });
+      setItems((current) => current.map((row) => row.id === item.id ? data.announcement : row));
+    } catch (error) {
+      setItems((current) => current.map((row) => row.id === item.id ? item : row));
+      toast.error(t("toast.updateFailed"), { description: resolveAdminErrorMessage(error) });
+    }
+  }
+
+  function setPriorityDraft(id: number, value: string) {
+    setPriorityDrafts((current) => ({ ...current, [id]: value }));
+  }
+
+  function clearPriorityDraft(id: number) {
+    setPriorityDrafts((current) => {
+      const next = { ...current };
+      delete next[id];
+      return next;
+    });
+  }
+
+  async function commitPriority(item: AdminAnnouncementDTO) {
+    const draft = priorityDrafts[item.id];
+    if (draft === undefined) {
+      return;
+    }
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      clearPriorityDraft(item.id);
+      return;
+    }
+    const nextPriority = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(nextPriority)) {
+      clearPriorityDraft(item.id);
+      toast.error(t("toast.priorityInvalid"));
+      return;
+    }
+    if (nextPriority === item.priority) {
+      clearPriorityDraft(item.id);
+      return;
+    }
+
+    clearPriorityDraft(item.id);
+    setItems((current) => current.map((row) => row.id === item.id ? { ...row, priority: nextPriority } : row));
+    try {
+      const data = await updateAdminAnnouncement(accessToken, item.id, { priority: nextPriority });
+      setItems((current) => current.map((row) => row.id === item.id ? data.announcement : row));
+    } catch (error) {
+      setItems((current) => current.map((row) => row.id === item.id ? item : row));
+      toast.error(t("toast.updateFailed"), { description: resolveAdminErrorMessage(error) });
+    }
+  }
+
+  function handlePriorityKeyDown(event: React.KeyboardEvent<HTMLInputElement>, item: AdminAnnouncementDTO) {
+    if (event.key === "Enter") {
+      event.currentTarget.blur();
+      return;
+    }
+    if (event.key === "Escape") {
+      clearPriorityDraft(item.id);
+      event.currentTarget.blur();
+    }
+  }
+
+  async function confirmDelete() {
+    if (!deleteTarget) {
+      return;
+    }
+    const target = deleteTarget;
+    setSaving(true);
+    try {
+      await deleteAdminAnnouncement(accessToken, target.id);
+      setItems((current) => current.filter((item) => item.id !== target.id));
+      setTotal((current) => Math.max(0, current - 1));
+      setDeleteTarget(null);
+      toast.success(t("toast.deleted"));
+    } catch (error) {
+      toast.error(t("toast.deleteFailed"), { description: resolveAdminErrorMessage(error) });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3 pb-10">
+      <div className="flex h-10 items-center px-1">
+        <h3 className="text-sm font-semibold">{t("title")}</h3>
+      </div>
+
+      <div className="space-y-3">
+        <TableToolbar
+          query={query}
+          onQueryChange={(value) => {
+            setQuery(value);
+            setPage(1);
+          }}
+          queryPlaceholder={t("searchPlaceholder")}
+          filters={[
+            {
+              key: "status",
+              label: t("statusFilter"),
+              value: status,
+              onValueChange: (value) => {
+                setStatus(value);
+                setPage(1);
+              },
+              options: [
+                { value: "", label: t("allStatuses") },
+                { value: "active", label: t("status.active") },
+                { value: "inactive", label: t("status.inactive") },
+              ],
+            },
+            {
+              key: "type",
+              label: t("typeFilter"),
+              value: typeFilter,
+              onValueChange: (value) => {
+                setTypeFilter(value);
+                setPage(1);
+              },
+              options: [
+                { value: "", label: t("allTypes") },
+                { value: "general", label: t("types.general") },
+                { value: "normal", label: t("types.normal") },
+                { value: "info", label: t("types.info") },
+                { value: "warning", label: t("types.warning") },
+                { value: "critical", label: t("types.critical") },
+              ],
+            },
+            {
+              key: "pinned",
+              label: t("pinnedFilter"),
+              value: pinnedFilter,
+              onValueChange: (value) => {
+                setPinnedFilter(value);
+                setPage(1);
+              },
+              options: [
+                { value: "", label: t("allPinned") },
+                { value: "true", label: t("pinned.yes") },
+                { value: "false", label: t("pinned.no") },
+              ],
+            },
+          ]}
+          loading={loading || saving}
+          onRefresh={load}
+        >
+          <Button type="button" size="sm" onClick={openCreate} disabled={loading || saving}>
+            <Plus className="size-3.5 stroke-1" />
+            {t("create")}
+          </Button>
+        </TableToolbar>
+
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="min-w-[260px]">{t("columns.title")}</TableHead>
+              <TableHead className="w-[86px]">{t("columns.type")}</TableHead>
+              <TableHead className="w-[72px] text-center">{t("columns.pinned")}</TableHead>
+              <TableHead className="w-[86px] text-center">{t("columns.status")}</TableHead>
+              <TableHead className="w-[90px]">{t("columns.priority")}</TableHead>
+              <TableHead className="w-[190px]">{t("columns.window")}</TableHead>
+              <TableHead stickyEnd className="w-[92px]" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading ? <TableSkeletonRows colSpan={7} rowCount={5} /> : null}
+            {!loading && items.length === 0 ? <TableEmptyRow colSpan={7}>{t("empty")}</TableEmptyRow> : null}
+            {!loading && items.map((item) => {
+              const visible = isCurrentlyVisible(item);
+              return (
+                <TableRow key={item.id} tone={!visible ? "muted" : undefined} className={cn(!visible && "text-muted-foreground")}>
+                  <TableCell className="max-w-[360px] py-2">
+                    <div className="min-w-0">
+                      <p className="flex min-w-0 items-center gap-1.5 truncate font-medium text-foreground">
+                        {item.pinned ? <Pin className="size-3 shrink-0 text-primary" /> : null}
+                        <span className="min-w-0 truncate">{item.title}</span>
+                      </p>
+                      <p className="truncate text-[11px] text-muted-foreground">{item.contentMarkdown}</p>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Select
+                      value={normalizeAnnouncementType(item.type)}
+                      onValueChange={(value) => void updateType(item, value)}
+                      disabled={saving}
+                    >
+                      <SelectTrigger size="xs" className={cn("h-7 w-[82px] px-2 text-[11px]", announcementTypeClassName(item.type))}>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent position="popper" align="center" className="z-[100]">
+                        <SelectItem value="general" className="text-[11px]">{t("types.general")}</SelectItem>
+                        <SelectItem value="normal" className="text-[11px]">{t("types.normal")}</SelectItem>
+                        <SelectItem value="info" className="text-[11px]">{t("types.info")}</SelectItem>
+                        <SelectItem value="warning" className="text-[11px]">{t("types.warning")}</SelectItem>
+                        <SelectItem value="critical" className="text-[11px]">{t("types.critical")}</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <div className="flex justify-center">
+                      <Switch
+                        size="sm"
+                        checked={Boolean(item.pinned)}
+                        onCheckedChange={(checked) => void togglePinned(item, checked)}
+                        disabled={saving}
+                        aria-label={t("fields.pinned")}
+                      />
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <div className="flex justify-center">
+                      <Switch
+                        size="sm"
+                        checked={item.status === "active"}
+                        onCheckedChange={(checked) => void toggleStatus(item, checked)}
+                        disabled={saving}
+                        aria-label={item.status === "active" ? t("disable") : t("enable")}
+                      />
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Input
+                      type="text"
+                      inputMode="numeric"
+                      value={priorityDrafts[item.id] ?? String(item.priority)}
+                      onChange={(event) => setPriorityDraft(item.id, event.target.value)}
+                      onBlur={() => void commitPriority(item)}
+                      onKeyDown={(event) => handlePriorityKeyDown(event, item)}
+                      disabled={saving}
+                      aria-label={t("fields.priority")}
+                      className="h-7 w-[58px] px-2 text-left text-xs tabular-nums"
+                    />
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground">{activeWindowLabel(item, locale)}</TableCell>
+                  <TableCell stickyEnd className="text-right">
+                    <div className="flex justify-end gap-1">
+                      <Button type="button" size="icon-sm" variant="ghost" onClick={() => openEdit(item)} aria-label={t("edit")}>
+                        <Edit3 className="size-3.5 stroke-1" />
+                      </Button>
+                      <Button type="button" size="icon-sm" variant="ghost" className="text-destructive hover:bg-destructive/10 hover:text-destructive" onClick={() => setDeleteTarget(item)} aria-label={t("delete")}>
+                        <Trash2 className="size-3.5 stroke-1" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+
+        <TablePagination
+          total={total}
+          page={page}
+          pageCount={pageCount}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={(nextSize) => {
+            setPageSize(nextSize);
+            setPage(1);
+          }}
+          loading={loading}
+        />
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={(nextOpen) => !saving && setDialogOpen(nextOpen)}>
+        <DialogContent className="sm:max-w-[920px]">
+          <DialogHeader>
+            <DialogTitle>{form.id ? t("editTitle") : t("createTitle")}</DialogTitle>
+            <DialogDescription>{t("dialogDescription")}</DialogDescription>
+          </DialogHeader>
+
+          <form
+            className="space-y-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void save();
+            }}
+          >
+            <div className="grid gap-5 md:grid-cols-2">
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{t("fields.title")}</p>
+                <Input value={form.title} onChange={(event) => setForm({ ...form, title: event.target.value })} disabled={saving} />
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{t("fields.timeRange")}</p>
+                <AdminDateRangeFilter
+                  fromValue={toDateRangeValue(form.startsAt)}
+                  toValue={toDateRangeValue(form.expiresAt)}
+                  disabled={saving}
+                  placeholder={t("fields.alwaysActive")}
+                  onFromChange={(value) => setForm((current) => ({ ...current, startsAt: dateRangeBoundaryValue(value, "start") }))}
+                  onToChange={(value) => setForm((current) => ({ ...current, expiresAt: dateRangeBoundaryValue(value, "end") }))}
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-5 md:grid-cols-4">
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{t("fields.type")}</p>
+                <Select value={form.type} onValueChange={(value) => setForm({ ...form, type: normalizeAnnouncementType(value) })} disabled={saving}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="general">{t("types.general")}</SelectItem>
+                    <SelectItem value="normal">{t("types.normal")}</SelectItem>
+                    <SelectItem value="info">{t("types.info")}</SelectItem>
+                    <SelectItem value="warning">{t("types.warning")}</SelectItem>
+                    <SelectItem value="critical">{t("types.critical")}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{t("fields.priority")}</p>
+                <Input type="number" value={form.priority} onChange={(event) => setForm({ ...form, priority: event.target.value })} disabled={saving} />
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{t("fields.pinned")}</p>
+                <div className="flex h-9 items-center">
+                  <Switch
+                    size="sm"
+                    checked={form.pinned}
+                    onCheckedChange={(checked) => setForm({ ...form, pinned: checked })}
+                    disabled={saving}
+                    aria-label={t("fields.pinned")}
+                  />
+                </div>
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{t("fields.status")}</p>
+                <div className="flex h-9 items-center">
+                  <Switch
+                    size="sm"
+                    checked={form.status === "active"}
+                    onCheckedChange={(checked) => setForm({ ...form, status: checked ? "active" : "inactive" })}
+                    disabled={saving}
+                    aria-label={t("fields.status")}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="grid gap-5 md:grid-cols-2">
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{t("fields.contentMarkdown")}</p>
+                <Textarea
+                  value={form.contentMarkdown}
+                  onChange={(event) => setForm({ ...form, contentMarkdown: event.target.value })}
+                  disabled={saving}
+                  className="h-[220px] resize-none text-xs"
+                />
+              </div>
+
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{t("fields.preview")}</p>
+                <div className="h-[220px] overflow-y-auto rounded-md border border-border/60 bg-muted/20 px-3 py-2">
+                  <StreamdownRender content={form.contentMarkdown || t("previewEmpty")} className="text-sm" />
+                </div>
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={() => setDialogOpen(false)} disabled={saving}>
+                {common("actions.cancel")}
+              </Button>
+              <Button type="submit" disabled={saving}>
+                {saving ? <SpinnerLabel>{common("actions.saving")}</SpinnerLabel> : common("actions.save")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={Boolean(deleteTarget)} onOpenChange={(open) => !saving && !open && setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("deleteTitle")}</DialogTitle>
+            <DialogDescription>{t("deleteDescription")}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" variant="outline" size="sm" onClick={() => setDeleteTarget(null)} disabled={saving}>
+              {common("actions.cancel")}
+            </Button>
+            <Button type="button" variant="destructive" size="sm" onClick={confirmDelete} disabled={saving}>
+              {saving ? t("deleting") : t("delete")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/features/admin/components/sections/billing/admin-billing.tsx
+++ b/frontend/features/admin/components/sections/billing/admin-billing.tsx
@@ -1,15 +1,12 @@
 "use client";
 
 import * as React from "react";
-import { format } from "date-fns";
-import { enUS, zhCN } from "date-fns/locale";
-import { CalendarIcon, Check, CircleAlert, Copy, Download, Pencil, Plus, Save, Trash2, Upload, X } from "lucide-react";
+import { Check, CircleAlert, Copy, Download, Pencil, Plus, Save, Trash2, Upload, X } from "lucide-react";
 import { motion } from "motion/react";
 import { useLocale, useTranslations } from "next-intl";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
-import { Calendar } from "@/components/ui/calendar";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
@@ -24,7 +21,6 @@ import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -35,7 +31,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { SpinnerLabel } from "@/components/ui/spinner";
 import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/components/ui/field";
-import { ADMIN_DATE_PICKER_TRIGGER_CLASSNAME } from "@/features/admin/components/admin-date-range-filter";
+import { AdminDateTimePicker, adminDateTimeFormValue, adminDateTimeValueToISOString } from "@/features/admin/components/admin-date-time-picker";
 import { AdminBulkConfirmDialog } from "@/features/admin/components/bulk-confirm-dialog";
 import { PlanBillingDialog, PricingBillingDialog } from "@/features/admin/components/sections/billing/billing-dialogs";
 import { PeriodBillingTable, PricingUnitCell } from "@/features/admin/components/sections/billing/billing-tables";
@@ -218,58 +214,11 @@ function redemptionFormFromCode(item: AdminRedemptionCodeDTO): RedemptionFormSta
 }
 
 function redemptionExpiresFormValue(value: string | null | undefined): string {
-  if (!value) return "";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "";
-  return `${format(date, "yyyy-MM-dd")}T${format(date, "HH:mm:ss")}`;
+  return adminDateTimeFormValue(value);
 }
 
 function datetimeLocalToISOString(value: string): string | null | undefined {
-  const text = value.trim();
-  if (!text) return null;
-  const date = new Date(text);
-  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
-}
-
-function parseRedemptionExpiresDate(value: string): Date | undefined {
-  const [dateText] = value.trim().split("T");
-  if (!dateText) return undefined;
-  const [year, month, day] = dateText.split("-").map((part) => Number.parseInt(part, 10));
-  if (!year || !month || !day) return undefined;
-  const date = new Date(year, month - 1, day);
-  return Number.isNaN(date.getTime()) ? undefined : date;
-}
-
-function redemptionExpiresTimeValue(value: string): string {
-  const trimmed = value.trim();
-  if (/^\d{2}:\d{2}:\d{2}$/.test(trimmed)) return trimmed;
-  if (/^\d{2}:\d{2}$/.test(trimmed)) return `${trimmed}:59`;
-  const [, timeText = ""] = value.trim().split("T");
-  if (/^\d{2}:\d{2}:\d{2}$/.test(timeText)) return timeText;
-  if (/^\d{2}:\d{2}$/.test(timeText)) return `${timeText}:59`;
-  return "23:59:59";
-}
-
-function redemptionExpiresValue(date: Date, time: string): string {
-  const normalizedTime = /^\d{2}:\d{2}:\d{2}$/.test(time)
-    ? time
-    : /^\d{2}:\d{2}$/.test(time)
-      ? `${time}:59`
-      : "23:59:59";
-  return `${format(date, "yyyy-MM-dd")}T${normalizedTime}`;
-}
-
-function redemptionTimePart(value: string, index: number): string {
-  return redemptionExpiresTimeValue(value).split(":")[index] || "00";
-}
-
-function updateRedemptionTimePart(value: string, index: number, nextPart: string): string {
-  const parts = redemptionExpiresTimeValue(value).split(":");
-  const max = index === 0 ? 23 : 59;
-  const parsed = Number.parseInt(nextPart, 10);
-  const normalized = String(Number.isFinite(parsed) ? Math.min(Math.max(parsed, 0), max) : 0).padStart(2, "0");
-  parts[index] = normalized;
-  return parts.join(":");
+  return adminDateTimeValueToISOString(value);
 }
 
 function parseOptionalPositiveInt(value: string): number | null | undefined {
@@ -288,107 +237,6 @@ function parseRequiredPositiveInt(value: string): number | undefined {
 function isRedemptionCodeFormatValid(value: string): boolean {
   const text = value.trim();
   return !text || /^[A-Za-z0-9_-]{3,64}$/.test(text);
-}
-
-function RedemptionExpiresAtPicker({
-  value,
-  disabled,
-  onChange,
-  label,
-  placeholder,
-}: {
-  value: string;
-  disabled: boolean;
-  onChange: (value: string) => void;
-  label: string;
-  placeholder: string;
-}) {
-  const locale = useLocale();
-  const tDateRange = useTranslations("common.dateRange");
-  const selectedDate = parseRedemptionExpiresDate(value);
-  const timeValue = selectedDate ? redemptionExpiresTimeValue(value) : "";
-  const updateTimePart = (index: number, nextPart: string) => {
-    if (!selectedDate) return;
-    onChange(redemptionExpiresValue(selectedDate, updateRedemptionTimePart(timeValue, index, nextPart)));
-  };
-
-  return (
-    <div className="space-y-1">
-      <p className="text-xs text-muted-foreground">{label}</p>
-      <div className="grid gap-5 md:grid-cols-2">
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button
-              type="button"
-              variant="outline"
-              className={cn(
-                ADMIN_DATE_PICKER_TRIGGER_CLASSNAME,
-                "h-8 justify-between",
-                !selectedDate && "text-muted-foreground",
-              )}
-              disabled={disabled}
-            >
-              <span className="min-w-0 truncate">
-                {selectedDate ? format(selectedDate, "yyyy-MM-dd") : placeholder}
-              </span>
-              <CalendarIcon className="size-3.5 opacity-70" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-auto p-0" align="start">
-            <Calendar
-              mode="single"
-              selected={selectedDate}
-              locale={locale === "zh-CN" ? zhCN : enUS}
-              onSelect={(date) => onChange(date ? redemptionExpiresValue(date, redemptionExpiresTimeValue(value)) : "")}
-              autoFocus
-            />
-          </PopoverContent>
-        </Popover>
-        <div className="grid grid-cols-4 gap-2">
-          <Input
-            type="number"
-            min={0}
-            max={23}
-            value={selectedDate ? redemptionTimePart(timeValue, 0) : ""}
-            placeholder="HH"
-            disabled={disabled || !selectedDate}
-            className="px-2 text-center tabular-nums"
-            onChange={(event) => updateTimePart(0, event.target.value)}
-          />
-          <Input
-            type="number"
-            min={0}
-            max={59}
-            value={selectedDate ? redemptionTimePart(timeValue, 1) : ""}
-            placeholder="MM"
-            disabled={disabled || !selectedDate}
-            className="px-2 text-center tabular-nums"
-            onChange={(event) => updateTimePart(1, event.target.value)}
-          />
-          <Input
-            type="number"
-            min={0}
-            max={59}
-            value={selectedDate ? redemptionTimePart(timeValue, 2) : ""}
-            placeholder="SS"
-            disabled={disabled || !selectedDate}
-            className="px-2 text-center tabular-nums"
-            onChange={(event) => updateTimePart(2, event.target.value)}
-          />
-          <Button
-            type="button"
-            variant="outline"
-            className="h-8 w-full px-0 text-xs text-muted-foreground"
-            disabled={disabled || !selectedDate}
-            onClick={() => onChange("")}
-            aria-label={tDateRange("clear")}
-          >
-            {tDateRange("clear")}
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 export function AdminBillingPage() {
@@ -2434,7 +2282,7 @@ export function AdminBillingPage() {
                 </div>
               </div>
 
-              <RedemptionExpiresAtPicker
+              <AdminDateTimePicker
                 value={redemptionForm.expiresAt}
                 disabled={redemptionSaving}
                 label={t("redemption.expiresAt")}

--- a/frontend/features/admin/model/admin-sections.ts
+++ b/frontend/features/admin/model/admin-sections.ts
@@ -4,6 +4,7 @@ export const ADMIN_SECTIONS = [
   { id: "models", label: "Models", href: "/models" },
   { id: "tool-settings", label: "Tools", href: "/tools" },
   { id: "billing", label: "Billing", href: "/billing" },
+  { id: "announcements", label: "Announcements", href: "/announcements" },
   { id: "logs", label: "Logs", href: "/logs" },
   { id: "login-settings", label: "Login & auth", href: "/login" },
   { id: "conversation-settings", label: "Conversation", href: "/conversation" },

--- a/frontend/features/announcements/components/announcement-dialog-host.tsx
+++ b/frontend/features/announcements/components/announcement-dialog-host.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import * as React from "react";
+import { usePathname } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import { Pin } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { StreamdownRender } from "@/features/chat/components/markdown/streamdown-render";
+import { closeAnnouncement, dismissAnnouncementToday, listAnnouncements } from "@/shared/api/announcements";
+import type { AnnouncementDTO } from "@/shared/api/announcements.types";
+import { useAuthSession } from "@/shared/auth/auth-session-context";
+import { cn } from "@/lib/utils";
+
+type AnnouncementSortMode = "default" | "type" | "time";
+
+function isSkippedPath(pathname: string | null): boolean {
+  if (!pathname) {
+    return false;
+  }
+  return pathname === "/share" || pathname.startsWith("/share/");
+}
+
+function formatAnnouncementDate(value: string, locale: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "-";
+  }
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+}
+
+function formatAnnouncementTime(value: string, locale: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "-";
+  }
+  return new Intl.DateTimeFormat(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(date);
+}
+
+function normalizeAnnouncementType(value: string): "critical" | "warning" | "info" | "normal" | "general" {
+  switch (value) {
+    case "critical":
+    case "warning":
+    case "info":
+    case "normal":
+    case "general":
+      return value;
+    default:
+      return "general";
+  }
+}
+
+function announcementTypeRank(value: string): number {
+  switch (normalizeAnnouncementType(value)) {
+    case "critical":
+      return 5;
+    case "warning":
+      return 4;
+    case "info":
+      return 3;
+    case "normal":
+      return 2;
+    default:
+      return 1;
+  }
+}
+
+function announcementTypeAccentClassName(value: string): string {
+  switch (normalizeAnnouncementType(value)) {
+    case "critical":
+      return "before:bg-red-500/55 dark:before:bg-red-400/55";
+    case "warning":
+      return "before:bg-yellow-500/60 dark:before:bg-yellow-400/55";
+    case "info":
+      return "before:bg-blue-500/55 dark:before:bg-blue-400/55";
+    case "normal":
+      return "before:bg-emerald-500/55 dark:before:bg-emerald-400/55";
+    default:
+      return "before:bg-border";
+  }
+}
+
+function announcementTime(value: string): number {
+  const time = new Date(value).getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
+function isAnnouncementRead(item: AnnouncementDTO): boolean {
+  return Boolean(item.closedAt);
+}
+
+function compareReadState(a: AnnouncementDTO, b: AnnouncementDTO): number {
+  return Number(isAnnouncementRead(a)) - Number(isAnnouncementRead(b));
+}
+
+export function AnnouncementDialogHost() {
+  const t = useTranslations("announcements");
+  const locale = useLocale();
+  const pathname = usePathname();
+  const { accessToken, user, userStatus } = useAuthSession();
+  const [queue, setQueue] = React.useState<AnnouncementDTO[]>([]);
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const [sortMode, setSortMode] = React.useState<AnnouncementSortMode>("default");
+  const [stateSaving, setStateSaving] = React.useState(false);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    if (userStatus !== "ready" || !accessToken || user?.initialSecurityRequired || isSkippedPath(pathname)) {
+      setQueue([]);
+      setActiveIndex(0);
+      return;
+    }
+
+    async function load() {
+      try {
+        const items = await listAnnouncements(accessToken);
+        if (!cancelled) {
+          setQueue(items);
+          setActiveIndex(0);
+        }
+      } catch {
+        if (!cancelled) {
+          setQueue([]);
+          setActiveIndex(0);
+        }
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [accessToken, pathname, user?.initialSecurityRequired, userStatus]);
+
+  const sortedQueue = React.useMemo(() => {
+    if (sortMode === "time") {
+      return [...queue].sort((a, b) => compareReadState(a, b) || announcementTime(b.updatedAt) - announcementTime(a.updatedAt) || b.id - a.id);
+    }
+    if (sortMode === "type") {
+      return [...queue].sort((a, b) => compareReadState(a, b) || announcementTypeRank(b.type) - announcementTypeRank(a.type) || announcementTime(b.updatedAt) - announcementTime(a.updatedAt) || b.id - a.id);
+    }
+    return queue;
+  }, [queue, sortMode]);
+
+  React.useEffect(() => {
+    setActiveIndex(0);
+  }, [sortMode]);
+
+  const hasUnread = queue.some((item) => !isAnnouncementRead(item));
+  const active = hasUnread ? (sortedQueue[Math.min(activeIndex, Math.max(sortedQueue.length - 1, 0))] ?? null) : null;
+  const open = hasUnread;
+
+  const closeDialog = React.useCallback(() => {
+    setQueue([]);
+    setActiveIndex(0);
+  }, []);
+
+  const dismissAllToday = React.useCallback(async () => {
+    if (!accessToken || stateSaving) {
+      return;
+    }
+    setStateSaving(true);
+    try {
+      await Promise.all(queue.map((item) => dismissAnnouncementToday(accessToken, item.id, item.updatedAt)));
+      closeDialog();
+    } catch {
+      toast.error(t("dismissFailed"));
+    } finally {
+      setStateSaving(false);
+    }
+  }, [accessToken, closeDialog, queue, stateSaving, t]);
+
+  const closeAll = React.useCallback(async () => {
+    if (!accessToken || stateSaving) {
+      return;
+    }
+    setStateSaving(true);
+    try {
+      await Promise.all(queue.map((item) => closeAnnouncement(accessToken, item.id, item.updatedAt)));
+      closeDialog();
+    } catch {
+      toast.error(t("closeFailed"));
+    } finally {
+      setStateSaving(false);
+    }
+  }, [accessToken, closeDialog, queue, stateSaving, t]);
+
+  if (!active) {
+    return null;
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => {
+      if (!nextOpen) {
+        void closeAll();
+      }
+    }}>
+      <DialogContent className="flex max-h-[min(84svh,720px)] flex-col overflow-hidden sm:max-w-[760px]">
+        <DialogHeader className="shrink-0">
+          <div className="min-w-0">
+            <DialogTitle className="truncate">{t("title")}</DialogTitle>
+          </div>
+        </DialogHeader>
+        <div className="grid h-[27rem] max-h-[calc(100svh-11rem)] min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-0 overflow-hidden md:grid-cols-[13rem_minmax(0,1fr)] md:grid-rows-1">
+          <div className="flex min-h-0 flex-col border-b border-border/60 md:border-b-0 md:border-r">
+            <Tabs value={sortMode} onValueChange={(value) => setSortMode(value as AnnouncementSortMode)} className="shrink-0 px-2 pt-2 pb-1">
+              <TabsList className="grid h-7 w-full grid-cols-3">
+                <TabsTrigger value="default" className="px-1.5">{t("sort.default")}</TabsTrigger>
+                <TabsTrigger value="type" className="px-1.5">{t("sort.type")}</TabsTrigger>
+                <TabsTrigger value="time" className="px-1.5">{t("sort.time")}</TabsTrigger>
+              </TabsList>
+            </Tabs>
+            <div className="flex gap-2 overflow-x-auto px-2 py-2 md:block md:min-h-0 md:flex-1 md:space-y-0.5 md:overflow-y-auto">
+              {sortedQueue.map((item, index) => (
+                <button
+                  key={`${item.id}:${item.updatedAt}`}
+                  type="button"
+                  className={cn(
+                    "relative min-w-36 rounded-md py-1 pl-3.5 pr-5 text-left text-xs transition-colors before:absolute before:left-1.5 before:top-2 before:bottom-2 before:w-0.5 before:rounded-full md:h-[3.125rem] md:w-full",
+                    announcementTypeAccentClassName(item.type),
+                    isAnnouncementRead(item) && "opacity-55",
+                    index === activeIndex
+                      ? "bg-muted text-foreground"
+                      : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+                  )}
+                  onClick={() => setActiveIndex(index)}
+                >
+                  {item.pinned ? (
+                    <Pin className="absolute right-1.5 top-1.5 size-3 text-muted-foreground/70" />
+                  ) : null}
+                  <span className="block truncate font-medium">{item.title}</span>
+                  <span className="mt-0.5 block text-xs text-muted-foreground">
+                    {formatAnnouncementDate(item.updatedAt, locale)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="min-h-0 overflow-y-auto px-4 py-3">
+            <div className="mb-2 flex min-w-0 items-center justify-between gap-3 text-xs text-muted-foreground">
+              <span className="min-w-0 truncate">{active.title}</span>
+              <span className="shrink-0 tabular-nums">{formatAnnouncementTime(active.updatedAt, locale)}</span>
+            </div>
+            <StreamdownRender content={active.contentMarkdown} className="text-sm" />
+          </div>
+        </div>
+        <DialogFooter className="shrink-0">
+          <Button type="button" variant="ghost" onClick={() => void dismissAllToday()} disabled={stateSaving}>
+            {t("dismissAllToday")}
+          </Button>
+          <Button type="button" onClick={() => void closeAll()} disabled={stateSaving}>
+            {t("close")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/features/layouts/components/sections/project-layout.tsx
+++ b/frontend/features/layouts/components/sections/project-layout.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { AnnouncementDialogHost } from "@/features/announcements/components/announcement-dialog-host";
 import { AppearancePreferencesSync } from "@/features/settings/components/appearance-preferences-sync";
 import { AppSidebar } from "@/features/layouts/components/navigation/app-sidebar";
 import { InitialSecurityGuard } from "@/features/layouts/components/sections/initial-security-guard";
@@ -23,6 +24,7 @@ export function ProjectLayout({
           <UserLocaleSync />
           <AppearancePreferencesSync />
           <InitialSecurityGuard />
+          <AnnouncementDialogHost />
           <SidebarRouteCloser />
           <AppSidebar />
           <SidebarInset>

--- a/frontend/i18n/messages.ts
+++ b/frontend/i18n/messages.ts
@@ -1,4 +1,5 @@
 import enAdminBilling from "@/i18n/messages/en-US/admin-billing.json";
+import enAdminAnnouncements from "@/i18n/messages/en-US/admin-announcements.json";
 import enAdminChannels from "@/i18n/messages/en-US/admin-channels.json";
 import enAdminConversation from "@/i18n/messages/en-US/admin-conversation.json";
 import enAdminFiles from "@/i18n/messages/en-US/admin-files.json";
@@ -8,6 +9,7 @@ import enAdminModels from "@/i18n/messages/en-US/admin-models.json";
 import enAdminTools from "@/i18n/messages/en-US/admin-tools.json";
 import enAdminUsers from "@/i18n/messages/en-US/admin-users.json";
 import enChat from "@/i18n/messages/en-US/chat.json";
+import enAnnouncements from "@/i18n/messages/en-US/announcements.json";
 import enCommon from "@/i18n/messages/en-US/common.json";
 import enErrors from "@/i18n/messages/en-US/errors.json";
 import enFiles from "@/i18n/messages/en-US/files.json";
@@ -26,6 +28,7 @@ export const DEFAULT_MESSAGES = {
   login: enLogin,
   guide: enGuide,
   chat: enChat,
+  announcements: enAnnouncements,
   recent: enRecent,
   share: enShare,
   files: enFiles,
@@ -37,6 +40,7 @@ export const DEFAULT_MESSAGES = {
   adminLogin: enAdminLogin,
   adminModels: enAdminModels,
   adminBilling: enAdminBilling,
+  adminAnnouncements: enAdminAnnouncements,
   adminLogs: enAdminLogs,
   adminTools: enAdminTools,
 };
@@ -52,6 +56,7 @@ export async function loadLocaleMessages(locale: AppLocale): Promise<AppMessages
     login,
     guide,
     chat,
+    announcements,
     recent,
     share,
     files,
@@ -63,6 +68,7 @@ export async function loadLocaleMessages(locale: AppLocale): Promise<AppMessages
     adminLogin,
     adminModels,
     adminBilling,
+    adminAnnouncements,
     adminLogs,
     adminTools,
   ] = await Promise.all([
@@ -71,6 +77,7 @@ export async function loadLocaleMessages(locale: AppLocale): Promise<AppMessages
     import("@/i18n/messages/zh-CN/login.json"),
     import("@/i18n/messages/zh-CN/guide.json"),
     import("@/i18n/messages/zh-CN/chat.json"),
+    import("@/i18n/messages/zh-CN/announcements.json"),
     import("@/i18n/messages/zh-CN/recent.json"),
     import("@/i18n/messages/zh-CN/share.json"),
     import("@/i18n/messages/zh-CN/files.json"),
@@ -82,6 +89,7 @@ export async function loadLocaleMessages(locale: AppLocale): Promise<AppMessages
     import("@/i18n/messages/zh-CN/admin-login.json"),
     import("@/i18n/messages/zh-CN/admin-models.json"),
     import("@/i18n/messages/zh-CN/admin-billing.json"),
+    import("@/i18n/messages/zh-CN/admin-announcements.json"),
     import("@/i18n/messages/zh-CN/admin-logs.json"),
     import("@/i18n/messages/zh-CN/admin-tools.json"),
   ]);
@@ -92,6 +100,7 @@ export async function loadLocaleMessages(locale: AppLocale): Promise<AppMessages
     login: login.default,
     guide: guide.default,
     chat: chat.default,
+    announcements: announcements.default,
     recent: recent.default,
     share: share.default,
     files: files.default,
@@ -103,6 +112,7 @@ export async function loadLocaleMessages(locale: AppLocale): Promise<AppMessages
     adminLogin: adminLogin.default,
     adminModels: adminModels.default,
     adminBilling: adminBilling.default,
+    adminAnnouncements: adminAnnouncements.default,
     adminLogs: adminLogs.default,
     adminTools: adminTools.default,
   };

--- a/frontend/i18n/messages/en-US/admin-announcements.json
+++ b/frontend/i18n/messages/en-US/admin-announcements.json
@@ -1,0 +1,72 @@
+{
+  "title": "Announcements",
+  "description": "Manage notices, model changes, and operational messages shown after sign-in.",
+  "create": "Create",
+  "edit": "Edit",
+  "delete": "Delete",
+  "enable": "Enable",
+  "disable": "Disable",
+  "deleting": "Deleting",
+  "searchPlaceholder": "Search title or content",
+  "statusFilter": "Status",
+  "allStatuses": "All",
+  "typeFilter": "Type",
+  "allTypes": "All",
+  "pinnedFilter": "Pinned",
+  "allPinned": "All",
+  "createTitle": "Create announcement",
+  "editTitle": "Edit announcement",
+  "dialogDescription": "Write announcement content in Markdown. Updated content is shown again as a new version.",
+  "deleteTitle": "Delete announcement",
+  "deleteDescription": "Deleted announcements are no longer shown and do not affect other user data.",
+  "empty": "No announcements",
+  "previewEmpty": "Preview",
+  "status": {
+    "active": "Active",
+    "inactive": "Inactive"
+  },
+  "pinned": {
+    "yes": "Pinned",
+    "no": "Not pinned"
+  },
+  "types": {
+    "critical": "Critical",
+    "warning": "Warning",
+    "info": "Info",
+    "normal": "Normal",
+    "general": "General"
+  },
+  "columns": {
+    "title": "Announcement",
+    "type": "Type",
+    "pinned": "Pinned",
+    "status": "Status",
+    "priority": "Priority",
+    "window": "Display time"
+  },
+  "fields": {
+    "title": "Title",
+    "priority": "Priority",
+    "type": "Type",
+    "pinned": "Pinned",
+    "status": "Status",
+    "timeRange": "Display time",
+    "alwaysActive": "Always active",
+    "startsAt": "Starts at",
+    "expiresAt": "Expires at",
+    "contentMarkdown": "Content",
+    "preview": "Preview"
+  },
+  "toast": {
+    "loadFailed": "Failed to load announcements",
+    "invalid": "Enter a title and content.",
+    "created": "Announcement created",
+    "createFailed": "Failed to create announcement",
+    "updated": "Announcement updated",
+    "updateFailed": "Failed to update announcement",
+    "priorityInvalid": "Priority must be a number",
+    "statusFailed": "Failed to update status",
+    "deleted": "Announcement deleted",
+    "deleteFailed": "Failed to delete announcement"
+  }
+}

--- a/frontend/i18n/messages/en-US/admin-users.json
+++ b/frontend/i18n/messages/en-US/admin-users.json
@@ -6,6 +6,7 @@
     "models": "Models",
     "toolSettings": "Tools",
     "billing": "Billing",
+    "announcements": "Announcements",
     "logs": "Logs",
     "loginSettings": "Sign-in & auth",
     "conversationSettings": "Conversation",

--- a/frontend/i18n/messages/en-US/announcements.json
+++ b/frontend/i18n/messages/en-US/announcements.json
@@ -1,0 +1,19 @@
+{
+  "title": "Announcements",
+  "types": {
+    "critical": "Critical",
+    "warning": "Warning",
+    "info": "Info",
+    "normal": "Normal",
+    "general": "General"
+  },
+  "sort": {
+    "default": "Default",
+    "type": "Type",
+    "time": "Time"
+  },
+  "dismissAllToday": "Don't show today",
+  "dismissFailed": "Failed to save announcement state",
+  "closeFailed": "Failed to save announcement close state",
+  "close": "Close"
+}

--- a/frontend/i18n/messages/zh-CN/admin-announcements.json
+++ b/frontend/i18n/messages/zh-CN/admin-announcements.json
@@ -1,0 +1,72 @@
+{
+  "title": "公告",
+  "description": "维护登录后展示的站点声明、模型调整和运营通知。",
+  "create": "创建",
+  "edit": "编辑",
+  "delete": "删除",
+  "enable": "启用",
+  "disable": "停用",
+  "deleting": "删除中",
+  "searchPlaceholder": "搜索标题或内容",
+  "statusFilter": "状态",
+  "allStatuses": "全部",
+  "typeFilter": "类型",
+  "allTypes": "全部",
+  "pinnedFilter": "置顶",
+  "allPinned": "全部",
+  "createTitle": "创建公告",
+  "editTitle": "编辑公告",
+  "dialogDescription": "使用 Markdown 编写公告内容，更新后用户侧会按新版本重新展示。",
+  "deleteTitle": "删除公告",
+  "deleteDescription": "删除后公告不再展示，此操作不会影响已登录用户的其他数据。",
+  "empty": "暂无公告",
+  "previewEmpty": "预览",
+  "status": {
+    "active": "启用",
+    "inactive": "停用"
+  },
+  "pinned": {
+    "yes": "已置顶",
+    "no": "未置顶"
+  },
+  "types": {
+    "critical": "紧急",
+    "warning": "警告",
+    "info": "提示",
+    "normal": "普通",
+    "general": "常规"
+  },
+  "columns": {
+    "title": "公告",
+    "type": "类型",
+    "pinned": "置顶",
+    "status": "状态",
+    "priority": "优先级",
+    "window": "展示时间"
+  },
+  "fields": {
+    "title": "标题",
+    "priority": "优先级",
+    "type": "类型",
+    "pinned": "置顶",
+    "status": "状态",
+    "timeRange": "展示时间",
+    "alwaysActive": "长期有效",
+    "startsAt": "开始时间",
+    "expiresAt": "过期时间",
+    "contentMarkdown": "内容",
+    "preview": "预览"
+  },
+  "toast": {
+    "loadFailed": "公告加载失败",
+    "invalid": "请填写标题和内容。",
+    "created": "公告已创建",
+    "createFailed": "创建公告失败",
+    "updated": "公告已更新",
+    "updateFailed": "更新公告失败",
+    "priorityInvalid": "优先级必须是数字",
+    "statusFailed": "状态更新失败",
+    "deleted": "公告已删除",
+    "deleteFailed": "删除公告失败"
+  }
+}

--- a/frontend/i18n/messages/zh-CN/admin-users.json
+++ b/frontend/i18n/messages/zh-CN/admin-users.json
@@ -6,6 +6,7 @@
     "models": "模型",
     "toolSettings": "工具",
     "billing": "计费",
+    "announcements": "公告",
     "logs": "日志",
     "loginSettings": "登录认证",
     "conversationSettings": "会话配置",

--- a/frontend/i18n/messages/zh-CN/announcements.json
+++ b/frontend/i18n/messages/zh-CN/announcements.json
@@ -1,0 +1,19 @@
+{
+  "title": "公告",
+  "types": {
+    "critical": "紧急",
+    "warning": "警告",
+    "info": "提示",
+    "normal": "普通",
+    "general": "常规"
+  },
+  "sort": {
+    "default": "默认",
+    "type": "类型",
+    "time": "时间"
+  },
+  "dismissAllToday": "今日不再显示",
+  "dismissFailed": "公告状态保存失败",
+  "closeFailed": "公告关闭状态保存失败",
+  "close": "关闭"
+}

--- a/frontend/shared/api/announcements.ts
+++ b/frontend/shared/api/announcements.ts
@@ -1,0 +1,22 @@
+import { authedRequest } from "@/shared/api/authed-client";
+import type { AnnouncementDTO } from "@/shared/api/announcements.types";
+
+export async function listAnnouncements(accessToken: string): Promise<AnnouncementDTO[]> {
+  return authedRequest<AnnouncementDTO[]>("/api/v1/announcements", { accessToken }, true);
+}
+
+export async function dismissAnnouncementToday(accessToken: string, announcementID: number, updatedAt: string): Promise<void> {
+  await authedRequest<{ dismissed: boolean }>(
+    `/api/v1/announcements/${encodeURIComponent(String(announcementID))}/dismiss-today`,
+    { method: "POST", accessToken, body: { updatedAt } },
+    true,
+  );
+}
+
+export async function closeAnnouncement(accessToken: string, announcementID: number, updatedAt: string): Promise<void> {
+  await authedRequest<{ closed: boolean }>(
+    `/api/v1/announcements/${encodeURIComponent(String(announcementID))}/close`,
+    { method: "POST", accessToken, body: { updatedAt } },
+    true,
+  );
+}

--- a/frontend/shared/api/announcements.types.ts
+++ b/frontend/shared/api/announcements.types.ts
@@ -1,0 +1,15 @@
+export type AnnouncementDTO = {
+  id: number;
+  title: string;
+  contentMarkdown: string;
+  status: "active" | "inactive" | string;
+  type: "critical" | "warning" | "info" | "normal" | "general" | string;
+  pinned: boolean;
+  priority: number;
+  startsAt: string | null;
+  expiresAt: string | null;
+  createdByUserID: number;
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string | null;
+};


### PR DESCRIPTION
## Summary

Add a site announcement system for signed-in users and admin management.

Admins can create, edit, enable/disable, delete, prioritize, pin, and classify Markdown announcements. Signed-in users see active announcements in a grouped dialog with sorting by default order, type, or time. Announcement state is persisted per user and announcement version: closing an announcement marks the current version as read, while “today do not show” suppresses it only until the next day.

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [x] Documentation

## Verification

- [x] `cd backend && go test ./internal/application/announcement/... ./internal/infra/persistence/postgres/announcement/... ./internal/infra/persistence/models`
- [x] `cd backend && make swagger`
- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm build`

## Screenshots, API examples, or logs

UI changes include the admin announcement management page and the signed-in user announcement dialog.

New/updated API endpoints:
- `GET /api/v1/announcements`
- `POST /api/v1/announcements/{id}/dismiss-today`
- `POST /api/v1/announcements/{id}/close`
- `GET /api/v1/admin/announcements`
- `POST /api/v1/admin/announcements`
- `PATCH /api/v1/admin/announcements/{id}`
- `DELETE /api/v1/admin/announcements/{id}`

## Configuration, migration, and compatibility notes

Adds announcement persistence tables and fields through the existing startup migration path:
- `system_announcements`
- `announcement_user_states`
- announcement fields including `type`, `pinned`
- per-user announcement state fields including `dismissed_until`, `closed_at`

Announcement user state is versioned by `announcement_updated_at`, so updated announcements are shown again even if a previous version was closed.

Swagger docs were regenerated.

## Documentation

- [ ] Documentation is not needed for this change.
- [x] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.