### PR TITLE
refactor: enhance message handling and billing logic

### DIFF
--- a/backend/internal/application/conversation/service.go
+++ b/backend/internal/application/conversation/service.go
@@ -146,6 +146,7 @@ type SendMessageInput struct {
 type SendMessageResult struct {
 	UserMessage         model.Message
 	AssistantMessage    model.Message
+	Billable            bool
 	UpstreamID          uint
 	UpstreamName        string
 	PlatformModelName   string

--- a/backend/internal/application/conversation/service_branch.go
+++ b/backend/internal/application/conversation/service_branch.go
@@ -102,7 +102,11 @@ func (s *Service) resolveMessageBranch(
 		}
 	}
 	if branchReason == "default" {
-		ancestorMessages, parentMessage = normalizeDefaultBranchContext(ancestorMessages, parentMessage)
+		normalizedAncestors, contextParent := normalizeDefaultBranchContext(ancestorMessages, parentMessage)
+		ancestorMessages = normalizedAncestors
+		if strings.TrimSpace(parentPublicID) == "" {
+			parentMessage = contextParent
+		}
 	}
 
 	state := &messageBranchState{

--- a/backend/internal/application/conversation/service_message_completion.go
+++ b/backend/internal/application/conversation/service_message_completion.go
@@ -325,6 +325,7 @@ func buildInterruptedSendMessageResult(input persistInterruptedMessageGeneration
 	result := &SendMessageResult{
 		UserMessage:         *input.UserMessage,
 		AssistantMessage:    *input.AssistantMessage,
+		Billable:            true,
 		EffectiveOptions:    input.EffectiveOptions,
 		UsageSpeed:          input.Usage.Speed,
 		UsageServiceTier:    input.Usage.ServiceTier,

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -226,6 +226,26 @@ func (s *Service) sendMessageInternal(
 			}
 		}
 		runState.finalize(ctx, retErr)
+		if retErr != nil && result == nil && userMessage != nil && assistantMessage != nil {
+			latencyMS := time.Since(startedAt).Milliseconds()
+			if latencyMS < 0 {
+				latencyMS = 0
+			}
+			result = &SendMessageResult{
+				UserMessage:      *userMessage,
+				AssistantMessage: *assistantMessage,
+				Billable:         false,
+				LatencyMS:        latencyMS,
+			}
+			if resolvedRoute != nil {
+				result.UpstreamID = resolvedRoute.UpstreamID
+				result.UpstreamName = resolvedRoute.UpstreamName
+				result.PlatformModelName = resolvedRoute.PlatformModelName
+				result.RoutedBindingCode = resolvedRoute.BindingCode
+				result.UpstreamModelName = resolvedRoute.UpstreamModel
+				result.UpstreamProtocol = resolvedRoute.Protocol
+			}
+		}
 	}()
 
 	resolvedAttachments, err := s.resolveAttachments(ctx, input.UserID, input.FileIDs)
@@ -1291,6 +1311,7 @@ func (s *Service) sendMessageInternal(
 	return &SendMessageResult{
 		UserMessage:         *userMessage,
 		AssistantMessage:    *assistantMessage,
+		Billable:            true,
 		UpstreamID:          run.UpstreamID,
 		UpstreamName:        run.UpstreamName,
 		PlatformModelName:   route.PlatformModelName,

--- a/backend/internal/transport/http/conversation/handler_message_send.go
+++ b/backend/internal/transport/http/conversation/handler_message_send.go
@@ -335,6 +335,14 @@ func (h *Handler) SendMessage(c *gin.Context) {
 	result, err := h.service.SendMessage(c.Request.Context(), input)
 	if err != nil {
 		if result != nil {
+			if !result.Billable {
+				if releaseErr := h.releaseSendMessageUsageReservation(reservation, "模型调用失败退回预扣"); releaseErr != nil {
+					handleSendMessageBillingError(c, releaseErr)
+					return
+				}
+				handleSendMessageError(c, err)
+				return
+			}
 			if billingErr := h.recordAndApplySendMessageBilling(c.Request.Context(), middleware.MustUserID(c), conversation, req, result, reservation); billingErr != nil {
 				if shouldReleaseReservationAfterBillingError(billingErr) {
 					_ = h.releaseSendMessageUsageReservation(reservation, "计费失败退回预扣")
@@ -439,6 +447,22 @@ func (h *Handler) StreamMessage(c *gin.Context) {
 	})
 	if err != nil {
 		if result != nil {
+			if !result.Billable {
+				if releaseErr := h.releaseSendMessageUsageReservation(reservation, "模型调用失败退回预扣"); releaseErr != nil {
+					_ = flushStreamEvent(billingStreamErrorPayload(releaseErr))
+					h.service.FinishMessageGeneration(input.ClientRunID)
+					return
+				}
+				payload := streamErrorPayload(err)
+				payload["data"] = toSendMessageResponse(result)
+				if debug := appconversation.MessageErrorDebug(err); debug != nil {
+					payload["debug"] = debug
+				}
+				_ = flushStreamEvent(payload)
+				h.service.FinishMessageGeneration(input.ClientRunID)
+				h.recordStreamSendMessageAuditAsync(c, conversation, req, result, "stream_message")
+				return
+			}
 			billingCtx, billingCancel := context.WithTimeout(context.Background(), 10*time.Second)
 			billingErr := h.recordAndApplySendMessageBilling(billingCtx, middleware.MustUserID(c), conversation, req, result, reservation)
 			billingCancel()

--- a/frontend/features/chat/components/message/message-meta.tsx
+++ b/frontend/features/chat/components/message/message-meta.tsx
@@ -31,6 +31,7 @@ import { Button } from "@/components/ui/button";
 import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
 import { upsertUserMemory } from "@/shared/api/memory";
 import { useLocalizedErrorMessage } from "@/i18n/use-localized-error";
+import { resolvePersistedPublicID } from "@/features/chat/model/message-submit";
 import { billingRateMultiplierNote, cacheWriteBillingLabel, cacheWriteBillingNote } from "@/shared/lib/billing-display";
 import type { BillingDisplayLabels } from "@/shared/lib/billing-display";
 import type { ChatBillingCost, ChatMessageBranchNavigator } from "@/features/chat/types/messages";
@@ -207,6 +208,7 @@ export function UserMessageMeta({
   const t = useTranslations("chat.messages");
   const { locale } = useAppLocale();
   const dateLabel = formatMessageDate(item.createdAt, locale);
+  const hasPersistedMessage = Boolean(resolvePersistedPublicID(item.publicID));
   const canShowBranchNavigator = Boolean(showBranchNavigator && item.branchNavigator && !busy && !item.isPending);
 
   return (
@@ -214,7 +216,7 @@ export function UserMessageMeta({
       {dateLabel ? <span className="mr-1 shrink-0 tabular-nums">{dateLabel}</span> : null}
       {!readOnly ? (
         <div className="flex items-center">
-          {showRetry ? (
+          {showRetry && hasPersistedMessage ? (
             <MetaIconButton
               label={t("retryMessage")}
               disabled={item.isPending}
@@ -225,7 +227,7 @@ export function UserMessageMeta({
           ) : null}
           <MetaIconButton
             label={t("editMessage")}
-            disabled={item.isPending}
+            disabled={item.isPending || !hasPersistedMessage}
             onClick={onEdit}
           >
             <Brush size={14} strokeWidth={1.8} animateOnHover="default" />
@@ -891,7 +893,7 @@ export function AssistantMessageMeta({
   const t = useTranslations("chat.messages");
   const isLive = Boolean(item.isPending || item.isStreaming);
   const canRetry = !readOnly && !busy && !isLive;
-  const canContinue = Boolean(canRetry && item.publicID && item.status === "interrupted");
+  const canContinue = Boolean(canRetry && resolvePersistedPublicID(item.publicID) && item.status === "interrupted");
   const canShowBranchNavigator = Boolean(showBranchNavigator && item.branchNavigator && !busy && !isLive);
 
   return (

--- a/frontend/features/chat/hooks/use-chat-branch-state.ts
+++ b/frontend/features/chat/hooks/use-chat-branch-state.ts
@@ -122,6 +122,8 @@ function mergePendingAssistantState(messages: ChatAreaMessage[], pendingExchange
     if (!sameAssistant) {
       return item;
     }
+    const serverStatus = item.status?.trim().toLowerCase() || "success";
+    const serverHasTerminalState = !item.isPending && !item.isStreaming && serverStatus !== "pending";
     const existingAlert = item.inlineAlert;
     const nextAlert = pendingAlert
       ? {
@@ -132,7 +134,7 @@ function mergePendingAssistantState(messages: ChatAreaMessage[], pendingExchange
       : existingAlert;
     return {
       ...item,
-      content: pendingText ? pendingText : item.content,
+      content: serverHasTerminalState && item.content ? item.content : pendingText ? pendingText : item.content,
       contentType: pendingExchange.assistantContentType ?? item.contentType,
       isPending: pendingExchange.assistantPending,
       isStreaming: pendingExchange.assistantStreaming,
@@ -149,7 +151,11 @@ function mergePendingAssistantState(messages: ChatAreaMessage[], pendingExchange
       latencyMS: pendingExchange.assistantLatencyMS ?? item.latencyMS,
       compactDone: pendingExchange.compactDone ?? item.compactDone,
       platformModelName: pendingExchange.platformModelName ?? item.platformModelName,
-      status: pendingExchange.assistantPending ? "pending" : pendingExchange.assistantStatus ?? item.status,
+      status: pendingExchange.assistantPending
+        ? "pending"
+        : serverHasTerminalState
+          ? item.status
+          : pendingExchange.assistantStatus ?? item.status,
     };
   });
 }

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -282,11 +282,28 @@ export function useChatMessageSubmit({
     }
     const userPublicID = pendingExchange.userPublicID || pendingExchange.tempUserPublicID;
     const assistantPublicID = pendingExchange.assistantPublicID || pendingExchange.tempAssistantPublicID;
-    if (!serverMessagePublicIDs.has(userPublicID) || !serverMessagePublicIDs.has(assistantPublicID)) {
+    if (serverMessagePublicIDs.has(userPublicID) && serverMessagePublicIDs.has(assistantPublicID)) {
+      setPendingExchange(null);
       return;
     }
-    setPendingExchange(null);
-  }, [pendingExchange, serverMessagePublicIDs, setPendingExchange]);
+
+    const pendingRunID = pendingExchange.runID?.trim();
+    if (!pendingRunID || pendingExchange.assistantPending) {
+      return;
+    }
+    const serverAssistant = combinedMessages.find(
+      (item) =>
+        item.role === "assistant" &&
+        item.runID === pendingRunID &&
+        resolvePersistedPublicID(item.publicID) &&
+        !item.isPending &&
+        !item.isStreaming &&
+        item.status !== "pending",
+    );
+    if (serverAssistant) {
+      setPendingExchange(null);
+    }
+  }, [combinedMessages, pendingExchange, serverMessagePublicIDs, setPendingExchange]);
 
   const submitMessage = React.useCallback(
     async ({
@@ -654,6 +671,7 @@ export function useChatMessageSubmit({
         }
         reload();
       } catch (error) {
+        flushStreamTextNow();
         resetStreamBuffer();
         if (streamAbortController.signal.aborted) {
           shouldKeepConversationLayout = true;
@@ -761,28 +779,36 @@ export function useChatMessageSubmit({
 
   const onSendMessage = React.useCallback(async () => {
     const content = draft.trim();
-    const parentMessage = resolveDefaultSubmissionParentMessage(visibleMessages);
+    const parentMessagePublicID =
+      resolvePersistedPublicID(currentLeafMessage?.publicID) ??
+      resolveDefaultSubmissionParentMessage(visibleMessages)?.publicID ??
+      null;
     await submitMessage({
       content,
       currentAttachments: attachments,
       resetComposer: true,
-      parentMessagePublicID: parentMessage?.publicID ?? currentLeafMessage?.publicID ?? null,
+      parentMessagePublicID,
       branchReason: "default",
     });
   }, [attachments, currentLeafMessage?.publicID, draft, submitMessage, visibleMessages]);
 
   const onRetryUserMessage = React.useCallback(
     async (message: ChatAreaMessage) => {
+      const sourceMessagePublicID = resolvePersistedPublicID(message.publicID);
+      if (!sourceMessagePublicID) {
+        toast.error(t("retryReplyFailed"), { description: t("continueReplyUnavailable") });
+        return;
+      }
       await submitMessage({
         content: message.content.trim(),
         currentAttachments: toPendingAttachments(message),
         resetComposer: false,
         parentMessagePublicID: message.parentPublicID,
-        sourceMessagePublicID: message.publicID,
+        sourceMessagePublicID,
         branchReason: "retry",
       });
     },
-    [submitMessage],
+    [submitMessage, t],
   );
 
   const onRetryAssistantMessage = React.useCallback(
@@ -792,12 +818,17 @@ export function useChatMessageSubmit({
         toast.error(t("retryReplyFailed"), { description: t("retryReplyMissingUser") });
         return;
       }
+      const sourceMessagePublicID = resolvePersistedPublicID(parentUser.publicID);
+      if (!sourceMessagePublicID) {
+        toast.error(t("retryReplyFailed"), { description: t("continueReplyUnavailable") });
+        return;
+      }
       await submitMessage({
         content: parentUser.content.trim(),
         currentAttachments: toPendingAttachments(parentUser),
         resetComposer: false,
         parentMessagePublicID: parentUser.parentPublicID,
-        sourceMessagePublicID: parentUser.publicID,
+        sourceMessagePublicID,
         branchReason: "retry",
       });
     },
@@ -825,17 +856,22 @@ export function useChatMessageSubmit({
 
   const onEditUserMessage = React.useCallback(
     async (message: ChatAreaMessage, content: string) => {
+      const sourceMessagePublicID = resolvePersistedPublicID(message.publicID);
+      if (!sourceMessagePublicID) {
+        toast.error(t("retryReplyFailed"), { description: t("continueReplyUnavailable") });
+        return false;
+      }
       const ok = await submitMessage({
         content: content.trim(),
         currentAttachments: toPendingAttachments(message),
         resetComposer: false,
         parentMessagePublicID: message.parentPublicID,
-        sourceMessagePublicID: message.publicID,
+        sourceMessagePublicID,
         branchReason: "edit",
       });
       return ok;
     },
-    [submitMessage],
+    [submitMessage, t],
   );
 
   const onCycleMessageBranch = React.useCallback(


### PR DESCRIPTION
## Summary

Fix conversation streaming failure handling so failed turns keep a stable server-backed message chain.

When a streaming request fails after the backend has already created the user/assistant message pair, the stream error now returns those real message IDs even if no visible content was produced. Non-billable failure results release the reserved usage balance instead of recording usage. The frontend reconciles pending messages with server terminal states, avoids losing buffered stream text on failure, and only exposes retry/edit/continue actions for persisted messages that can actually be addressed by the backend.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [x] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./internal/application/conversation/...`
- [x] `cd backend && go test ./internal/transport/http/conversation/...`
- [x] `cd frontend && pnpm lint`
- [x] `git diff --check`

## Screenshots, API examples, or logs

No screenshots. This is a streaming/message-chain behavior fix.

## Configuration, migration, and compatibility notes

No database migration, environment variable, Docker, or public configuration changes.

Streaming error events may now include `data.userMessage` and `data.assistantMessage` for non-billable failed turns when the backend already created the message pair. This keeps frontend branch reconciliation on real server message IDs and does not charge usage for no-output failures.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.