### PR TITLE
refactor: improve conversation metadata generation logic

### DIFF
--- a/backend/internal/application/conversation/service_metadata.go
+++ b/backend/internal/application/conversation/service_metadata.go
@@ -52,7 +52,7 @@ type conversationMetadataLLMResult struct {
 }
 
 func (s *Service) maybeGenerateConversationMetadataAsync(conversation model.Conversation, userMsg model.Message, assistantMsg model.Message) {
-	if conversation.MessageCount != 0 {
+	if !shouldGenerateConversationMetadata(conversation) {
 		return
 	}
 	if strings.TrimSpace(userMsg.Content) == "" && strings.TrimSpace(assistantMsg.Content) == "" {
@@ -117,7 +117,7 @@ func (s *Service) generateConversationMetadata(ctx context.Context, conversation
 		}()
 	}
 
-	if s.routeResolver != nil && s.llmClient != nil {
+	if s.routeResolver != nil && s.llmClient != nil && conversationLabelsEmpty(conversation.LabelsJSON) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -453,6 +453,15 @@ func shouldAutoReplaceConversationTitle(title string) bool {
 	default:
 		return false
 	}
+}
+
+func shouldGenerateConversationMetadata(conversation model.Conversation) bool {
+	return shouldAutoReplaceConversationTitle(conversation.Title) || conversationLabelsEmpty(conversation.LabelsJSON)
+}
+
+func conversationLabelsEmpty(labelsJSON string) bool {
+	value := strings.TrimSpace(strings.ToLower(labelsJSON))
+	return value == "" || value == "null" || value == "[]"
 }
 
 func truncateByEstimatedTokens(text string, maxTokens int64) string {

--- a/backend/internal/application/conversation/service_metadata_test.go
+++ b/backend/internal/application/conversation/service_metadata_test.go
@@ -71,3 +71,27 @@ func TestConversationTitleFromFirstUserMessage(t *testing.T) {
 		}
 	}
 }
+
+func TestShouldGenerateConversationMetadataAfterFailedFirstTurn(t *testing.T) {
+	conversation := model.Conversation{
+		Title:        "新会话",
+		LabelsJSON:   "[]",
+		MessageCount: 2,
+	}
+
+	if !shouldGenerateConversationMetadata(conversation) {
+		t.Fatal("expected placeholder metadata to be generated even when failed messages already exist")
+	}
+}
+
+func TestConversationLabelsEmpty(t *testing.T) {
+	emptyCases := []string{"", "null", "[]", "  []  "}
+	for _, value := range emptyCases {
+		if !conversationLabelsEmpty(value) {
+			t.Fatalf("expected labels %q to be empty", value)
+		}
+	}
+	if conversationLabelsEmpty(`["技术"]`) {
+		t.Fatal("expected non-empty labels to be preserved")
+	}
+}


### PR DESCRIPTION
## Summary

Fix automatic conversation title and label generation after failed first turns.

Conversation metadata generation no longer depends on `message_count == 0`. If a failed first turn already created server-side messages, later successful turns can still generate metadata as long as the title is still a placeholder or labels are empty. Existing manual titles are preserved, existing labels are not overwritten, and the existing 5000-token metadata prompt limit remains unchanged.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./internal/application/conversation/...`
- [x] `git diff --check`

## Screenshots, API examples, or logs

No screenshots. Backend conversation metadata behavior fix.

## Configuration, migration, and compatibility notes

No configuration, database migration, environment variable, Docker, or API contract changes.

The existing metadata prompt truncation limit remains unchanged at 5000 estimated tokens.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.