### PR TITLE
refactor: enhance AdminDateTimePicker with date granularity

### DIFF
--- a/frontend/features/admin/components/admin-date-time-picker.tsx
+++ b/frontend/features/admin/components/admin-date-time-picker.tsx
@@ -4,6 +4,7 @@ import { format } from "date-fns";
 import { enUS, zhCN } from "date-fns/locale";
 import { CalendarIcon } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
+import type { Matcher } from "react-day-picker";
 
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -18,6 +19,8 @@ type AdminDateTimePickerProps = {
   label: string;
   placeholder: string;
   defaultTime?: string;
+  granularity?: "date" | "datetime";
+  disabledDate?: Matcher | Matcher[];
   onChange: (value: string) => void;
 };
 
@@ -77,12 +80,15 @@ export function AdminDateTimePicker({
   label,
   placeholder,
   defaultTime = "23:59:59",
+  granularity = "datetime",
+  disabledDate,
   onChange,
 }: AdminDateTimePickerProps) {
   const locale = useLocale();
   const tDateRange = useTranslations("common.dateRange");
   const selectedDate = parseDatePart(value);
   const normalizedTime = selectedDate ? normalizeTimeValue(value, defaultTime) : "";
+  const dateOnly = granularity === "date";
 
   const handleTimePartChange = (index: number, nextPart: string) => {
     if (!selectedDate) return;
@@ -92,7 +98,7 @@ export function AdminDateTimePicker({
   return (
     <div className="space-y-1">
       <p className="text-xs text-muted-foreground">{label}</p>
-      <div className="grid gap-5 md:grid-cols-2">
+      <div className={cn("grid gap-5", !dateOnly && "md:grid-cols-2")}>
         <Popover>
           <PopoverTrigger asChild>
             <Button
@@ -116,53 +122,70 @@ export function AdminDateTimePicker({
               mode="single"
               selected={selectedDate}
               locale={locale === "zh-CN" ? zhCN : enUS}
-              onSelect={(date) => onChange(date ? buildDateTimeValue(date, normalizeTimeValue(value, defaultTime), defaultTime) : "")}
+              onSelect={(date) => onChange(date ? (dateOnly ? format(date, "yyyy-MM-dd") : buildDateTimeValue(date, normalizeTimeValue(value, defaultTime), defaultTime)) : "")}
+              disabled={disabledDate}
               autoFocus
             />
+            {dateOnly && selectedDate ? (
+              <div className="px-2 pb-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  className="h-6 w-full text-xs"
+                  disabled={disabled}
+                  onClick={() => onChange("")}
+                >
+                  {tDateRange("clear")}
+                </Button>
+              </div>
+            ) : null}
           </PopoverContent>
         </Popover>
-        <div className="grid grid-cols-4 gap-2">
-          <Input
-            type="number"
-            min={0}
-            max={23}
-            value={selectedDate ? timePart(normalizedTime, 0, defaultTime) : ""}
-            placeholder="HH"
-            disabled={disabled || !selectedDate}
-            className="px-2 text-center tabular-nums"
-            onChange={(event) => handleTimePartChange(0, event.target.value)}
-          />
-          <Input
-            type="number"
-            min={0}
-            max={59}
-            value={selectedDate ? timePart(normalizedTime, 1, defaultTime) : ""}
-            placeholder="MM"
-            disabled={disabled || !selectedDate}
-            className="px-2 text-center tabular-nums"
-            onChange={(event) => handleTimePartChange(1, event.target.value)}
-          />
-          <Input
-            type="number"
-            min={0}
-            max={59}
-            value={selectedDate ? timePart(normalizedTime, 2, defaultTime) : ""}
-            placeholder="SS"
-            disabled={disabled || !selectedDate}
-            className="px-2 text-center tabular-nums"
-            onChange={(event) => handleTimePartChange(2, event.target.value)}
-          />
-          <Button
-            type="button"
-            variant="outline"
-            className="h-8 w-full px-0 text-xs text-muted-foreground"
-            disabled={disabled || !selectedDate}
-            onClick={() => onChange("")}
-            aria-label={tDateRange("clear")}
-          >
-            {tDateRange("clear")}
-          </Button>
-        </div>
+        {dateOnly ? null : (
+          <div className="grid grid-cols-4 gap-2">
+            <Input
+              type="number"
+              min={0}
+              max={23}
+              value={selectedDate ? timePart(normalizedTime, 0, defaultTime) : ""}
+              placeholder="HH"
+              disabled={disabled || !selectedDate}
+              className="px-2 text-center tabular-nums"
+              onChange={(event) => handleTimePartChange(0, event.target.value)}
+            />
+            <Input
+              type="number"
+              min={0}
+              max={59}
+              value={selectedDate ? timePart(normalizedTime, 1, defaultTime) : ""}
+              placeholder="MM"
+              disabled={disabled || !selectedDate}
+              className="px-2 text-center tabular-nums"
+              onChange={(event) => handleTimePartChange(1, event.target.value)}
+            />
+            <Input
+              type="number"
+              min={0}
+              max={59}
+              value={selectedDate ? timePart(normalizedTime, 2, defaultTime) : ""}
+              placeholder="SS"
+              disabled={disabled || !selectedDate}
+              className="px-2 text-center tabular-nums"
+              onChange={(event) => handleTimePartChange(2, event.target.value)}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              className="h-8 w-full px-0 text-xs text-muted-foreground"
+              disabled={disabled || !selectedDate}
+              onClick={() => onChange("")}
+              aria-label={tDateRange("clear")}
+            >
+              {tDateRange("clear")}
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/features/admin/components/sections/accounts/account-user-editor.tsx
+++ b/frontend/features/admin/components/sections/accounts/account-user-editor.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import * as React from "react";
-import { format } from "date-fns";
-import { CalendarIcon } from "lucide-react";
 import { motion } from "motion/react";
 import { useLocale, useTranslations } from "next-intl";
 
@@ -33,10 +31,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Calendar } from "@/components/ui/calendar";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   Sheet,
   SheetContent,
@@ -54,7 +50,7 @@ import {
 import { resolveAvatarImageSrc } from "@/shared/lib/avatar";
 import { TimeZoneSelect } from "@/shared/components/time-zone-select";
 import { cn } from "@/lib/utils";
-import { ADMIN_DATE_PICKER_TRIGGER_CLASSNAME } from "@/features/admin/components/admin-date-range-filter";
+import { AdminDateTimePicker } from "@/features/admin/components/admin-date-time-picker";
 import type { UserDTO } from "@/shared/api/auth.types";
 import type { AdminUserRole, AdminUserStatus } from "@/features/admin/api/admin.types";
 import {
@@ -134,7 +130,6 @@ type CreateUserDialogProps = {
     username: string;
     displayName: string;
   };
-  createSubscriptionExpiryDate?: Date;
   onOpenCreateAvatarDialog: () => void;
   onCreateSubmit: React.FormEventHandler<HTMLFormElement>;
   resolveCreateUserInitial: (username: string, displayName: string) => string;
@@ -150,7 +145,6 @@ export function CreateUserDialog({
   billingMode,
   billingPlans,
   createAvatarSource,
-  createSubscriptionExpiryDate,
   onOpenCreateAvatarDialog,
   onCreateSubmit,
   resolveCreateUserInitial,
@@ -252,40 +246,20 @@ export function CreateUserDialog({
             </div>
 
             <DialogCollapsible open={createPayload.subscriptionTier !== "free"}>
-              <div className="space-y-1 pt-0.5">
-                <p className="text-xs text-muted-foreground">{t("editor.expiryTime")}</p>
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className={cn(
-                        ADMIN_DATE_PICKER_TRIGGER_CLASSNAME,
-                        "justify-between",
-                        !createSubscriptionExpiryDate && "text-muted-foreground",
-                      )}
-                      disabled={createPayload.subscriptionTier === "free"}
-                    >
-                      {createSubscriptionExpiryDate ? format(createSubscriptionExpiryDate, "yyyy-MM-dd") : t("editor.selectExpiryDate")}
-                      <CalendarIcon className="size-3.5 opacity-70" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="start">
-                    <Calendar
-                      mode="single"
-                      selected={createSubscriptionExpiryDate}
-                      onSelect={(date) =>
-                        setCreatePayload((current) => ({
-                          ...current,
-                          subscriptionExpiresAt: date ? format(date, "yyyy-MM-dd") : "",
-                        }))
-                      }
-                      disabled={{ before: new Date() }}
-                      autoFocus
-                    />
-                  </PopoverContent>
-                </Popover>
-              </div>
+              <AdminDateTimePicker
+                value={createPayload.subscriptionExpiresAt}
+                label={t("editor.expiryTime")}
+                placeholder={t("editor.selectExpiryDate")}
+                granularity="date"
+                disabled={createPayload.subscriptionTier === "free"}
+                disabledDate={{ before: new Date() }}
+                onChange={(value) =>
+                  setCreatePayload((current) => ({
+                    ...current,
+                    subscriptionExpiresAt: value,
+                  }))
+                }
+              />
             </DialogCollapsible>
           </div>
           ) : null}
@@ -313,7 +287,6 @@ type EditUserSheetProps = {
   setEditPayload: React.Dispatch<React.SetStateAction<EditUserPayload>>;
   billingMode: AdminBillingMode;
   billingPlans: AdminBillingPlanDTO[];
-  editSubscriptionExpiryDate?: Date;
   statusChanged: boolean;
   timeZoneOptions: string[];
   roleOptions: AdminUserRole[];
@@ -380,7 +353,6 @@ export function EditUserSheet({
   setEditPayload,
   billingMode,
   billingPlans,
-  editSubscriptionExpiryDate,
   statusChanged,
   timeZoneOptions,
   roleOptions,
@@ -638,40 +610,20 @@ export function EditUserSheet({
                     </Combobox>
                   </div>
                   <DialogCollapsible open={editPayload.subscriptionTier !== "free"}>
-                    <div className="space-y-1">
-                      <Label className="text-xs text-muted-foreground">{t("editor.expiryTime")}</Label>
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            className={cn(
-                              ADMIN_DATE_PICKER_TRIGGER_CLASSNAME,
-                              "justify-between",
-                              !editSubscriptionExpiryDate && "text-muted-foreground",
-                            )}
-                            disabled={pending || editPayload.subscriptionTier === "free"}
-                          >
-                            {editSubscriptionExpiryDate ? format(editSubscriptionExpiryDate, "yyyy-MM-dd") : t("editor.selectExpiryDate")}
-                            <CalendarIcon className="size-3.5 opacity-70" />
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0" align="start">
-                          <Calendar
-                            mode="single"
-                            selected={editSubscriptionExpiryDate}
-                            onSelect={(date) =>
-                              setEditPayload((current) => ({
-                                ...current,
-                                subscriptionExpiresAt: date ? format(date, "yyyy-MM-dd") : "",
-                              }))
-                            }
-                            disabled={{ before: new Date() }}
-                            autoFocus
-                          />
-                        </PopoverContent>
-                      </Popover>
-                    </div>
+                    <AdminDateTimePicker
+                      value={editPayload.subscriptionExpiresAt}
+                      label={t("editor.expiryTime")}
+                      placeholder={t("editor.selectExpiryDate")}
+                      granularity="date"
+                      disabled={pending || editPayload.subscriptionTier === "free"}
+                      disabledDate={{ before: new Date() }}
+                      onChange={(value) =>
+                        setEditPayload((current) => ({
+                          ...current,
+                          subscriptionExpiresAt: value,
+                        }))
+                      }
+                    />
                   </DialogCollapsible>
                 </div>
               ) : null}

--- a/frontend/features/admin/components/sections/accounts/accounts-users.tsx
+++ b/frontend/features/admin/components/sections/accounts/accounts-users.tsx
@@ -448,8 +448,6 @@ export function AccountsUsers({
     billingPlans,
     createAvatarSource,
     avatarDialogPreviewSrc,
-    createSubscriptionExpiryDate,
-    editSubscriptionExpiryDate,
     editStatusChanged,
     pageCount,
     filteredItems,
@@ -806,7 +804,6 @@ export function AccountsUsers({
           billingMode={billingMode}
           billingPlans={billingPlans}
           createAvatarSource={createAvatarSource}
-          createSubscriptionExpiryDate={createSubscriptionExpiryDate}
           onOpenCreateAvatarDialog={handleOpenCreateAvatarDialog}
           onCreateSubmit={onCreateUser}
           resolveCreateUserInitial={resolveCreateUserInitial}
@@ -827,7 +824,6 @@ export function AccountsUsers({
           setEditPayload={setEditPayload}
           billingMode={billingMode}
           billingPlans={billingPlans}
-          editSubscriptionExpiryDate={editSubscriptionExpiryDate}
           statusChanged={editStatusChanged}
           timeZoneOptions={timeZoneOptions}
           roleOptions={roleOptions}

--- a/frontend/features/admin/hooks/use-admin-users-page.ts
+++ b/frontend/features/admin/hooks/use-admin-users-page.ts
@@ -105,8 +105,6 @@ type UseAdminUsersPageState = {
   billingPlans: AdminBillingPlanDTO[];
   createAvatarSource: Pick<CreateUserPayload, "username" | "displayName">;
   avatarDialogPreviewSrc: string | undefined;
-  createSubscriptionExpiryDate: Date | undefined;
-  editSubscriptionExpiryDate: Date | undefined;
   editStatusChanged: boolean;
   pageCount: number;
   batchTimezoneOptions: { label: string; value: string }[];
@@ -175,17 +173,7 @@ function createEditPayload(user: UserDTO, fallbackSubscriptionTier = "free"): Ed
 }
 
 function hasPatchChanges(payload: AdminUserPatchPayload): boolean {
-  return (
-    "avatarURL" in payload ||
-    "displayName" in payload ||
-    "email" in payload ||
-    "phone" in payload ||
-    "role" in payload ||
-    "status" in payload ||
-    "timezone" in payload ||
-    "locale" in payload ||
-    "profilePreferences" in payload
-  );
+  return Object.keys(payload).some((key) => key !== "reason");
 }
 
 function roundBillingBalance(value: number): number {
@@ -293,14 +281,6 @@ export function useAdminUsersPage({
     return undefined;
   }, [avatarDialog, createAvatarSource]);
 
-  const createSubscriptionExpiryDate = React.useMemo(
-    () => resolveSubscriptionExpiryDate(createPayload.subscriptionExpiresAt),
-    [createPayload.subscriptionExpiresAt],
-  );
-  const editSubscriptionExpiryDate = React.useMemo(
-    () => resolveSubscriptionExpiryDate(editPayload.subscriptionExpiresAt),
-    [editPayload.subscriptionExpiresAt],
-  );
   const editStatusChanged = editDialogTarget ? editPayload.status !== editDialogTarget.status : false;
   const pageCount = Math.max(1, Math.ceil(total / pageSize));
   const batchTimezoneOptions = React.useMemo(
@@ -1144,8 +1124,6 @@ export function useAdminUsersPage({
     billingPlans,
     createAvatarSource,
     avatarDialogPreviewSrc,
-    createSubscriptionExpiryDate,
-    editSubscriptionExpiryDate,
     editStatusChanged,
     pageCount,
     batchTimezoneOptions,

--- a/frontend/features/admin/utils/account-display.ts
+++ b/frontend/features/admin/utils/account-display.ts
@@ -34,10 +34,17 @@ const BILLING_ACCOUNT_STATUS_LABELS: Record<string, string> = {
 };
 
 export function resolveSubscriptionExpiryDate(value: string): Date | undefined {
-  if (!value) {
+  const text = value.trim();
+  if (!text) {
     return undefined;
   }
-  const date = new Date(`${value}T00:00:00`);
+  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(text);
+  if (dateOnlyMatch) {
+    const [, year, month, day] = dateOnlyMatch;
+    const date = new Date(Number(year), Number(month) - 1, Number(day));
+    return Number.isNaN(date.getTime()) ? undefined : date;
+  }
+  const date = new Date(text);
   return Number.isNaN(date.getTime()) ? undefined : date;
 }
 
@@ -46,7 +53,9 @@ export function resolveSubscriptionExpiryISO(value: string): string | undefined 
   if (!date) {
     return undefined;
   }
-  date.setHours(23, 59, 59, 999);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value.trim())) {
+    date.setHours(23, 59, 59, 999);
+  }
   return date.toISOString();
 }
 


### PR DESCRIPTION
## Summary

Fix admin user billing edits and align related settings UI behavior.

- Fixed admin user edit save detection so subscription-only changes send the expected PATCH request instead of silently closing.
- Made user PATCH change detection future-safe by treating any business payload field as a change while excluding standalone `reason`.
- Confirmed balance edits use the dedicated billing balance API path and are not affected by the subscription save issue.
- Replaced the account editor’s custom subscription expiry calendar with the shared admin date picker.
- Added date-only mode to the shared admin date picker, with localized calendar rendering and an in-popover clear action.
- Kept datetime mode unchanged for features that need time precision, such as redemption codes and announcements.
- Kept subscription plan and expiry date aligned in one row in the edit sheet.
- Unified user settings page content width with admin settings pages.

## Change type

- [x] Bug fix
- [x] Refactor

## Affected areas

- [x] Frontend / UI
- [x] Billing / payments
- [x] Admin console

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Not included.

## Configuration, migration, and compatibility notes

No backend API, database schema, configuration, or deployment changes.

## Documentation

- [x] Documentation is not needed for this change.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed for admin user updates and billing edits.

## Checklist

- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.