### PR TITLE
fix: enhance strong font weight in markdown rendering

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -51,6 +51,7 @@
   --font-heiti: "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", "Source Han Sans SC", sans-serif;
   --font-chat: var(--font-sans);
   --font-chat-weight: 400;
+  --font-chat-strong-weight: 700;
   --ui-font-scale: 1;
   --chat-font-scale: 1;
   --radius: 0.5rem;
@@ -115,6 +116,7 @@
   --font-heiti: "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", "Source Han Sans SC", sans-serif;
   --font-chat: var(--font-sans);
   --font-chat-weight: 400;
+  --font-chat-strong-weight: 700;
   --radius: 0.5rem;
   --shadow-x: 0;
   --shadow-y: 1px;
@@ -1064,14 +1066,17 @@
 
 :root[data-chat-font-weight="medium"] {
   --font-chat-weight: 500;
+  --font-chat-strong-weight: 700;
 }
 
 :root[data-chat-font-weight="semibold"] {
   --font-chat-weight: 600;
+  --font-chat-strong-weight: 800;
 }
 
 :root[data-chat-font-weight="bold"] {
   --font-chat-weight: 700;
+  --font-chat-strong-weight: 900;
 }
 
 :root[data-font-size="small"] {
@@ -1203,6 +1208,10 @@
   ):not(pre *):not(code):not(code *) {
     font-family: var(--font-chat);
     font-weight: var(--font-chat-weight);
+  }
+
+  .chat-font-content[data-chat-markdown-scope] :where(strong, strong *, b, b *):not(pre *):not(code):not(code *) {
+    font-weight: var(--font-chat-strong-weight);
   }
 
   .chat-font-content .katex,

--- a/frontend/features/chat/components/markdown/streamdown-components.tsx
+++ b/frontend/features/chat/components/markdown/streamdown-components.tsx
@@ -73,6 +73,11 @@ type MarkdownParagraphProps = React.HTMLAttributes<HTMLParagraphElement> & {
   node?: unknown;
 };
 
+type MarkdownStrongProps = React.HTMLAttributes<HTMLElement> & {
+  children?: React.ReactNode;
+  node?: unknown;
+};
+
 type MarkdownHeadingProps = React.HTMLAttributes<HTMLHeadingElement> & {
   children?: React.ReactNode;
 };
@@ -942,6 +947,21 @@ export function MarkdownParagraph({ children, className, node: _node, style, ...
     >
       {paragraphChildren}
     </p>
+  );
+}
+
+export function MarkdownStrong({ children, className, node: _node, style, ...props }: MarkdownStrongProps) {
+  return (
+    <strong
+      {...props}
+      className={cn("font-bold text-foreground", className)}
+      style={{
+        ...sanitizeHTMLStyle(style),
+        fontWeight: "var(--font-chat-strong-weight)",
+      }}
+    >
+      {children}
+    </strong>
   );
 }
 

--- a/frontend/features/chat/components/markdown/streamdown-render.tsx
+++ b/frontend/features/chat/components/markdown/streamdown-render.tsx
@@ -31,6 +31,7 @@ import {
   MarkdownHTMLSpan,
   MarkdownHTMLSummary,
   MarkdownArtifactActionsContext,
+  MarkdownStrong,
   ThinkingHeading,
   type MarkdownArtifactActions,
   type MarkdownImageActions,
@@ -188,6 +189,7 @@ const DEFAULT_STREAMDOWN_COMPONENTS = {
   a: MarkdownLink,
   article: MarkdownHTMLArticle,
   aside: MarkdownHTMLAside,
+  b: MarkdownStrong,
   details: MarkdownHTMLDetails,
   div: MarkdownHTMLDiv,
   img: MarkdownImage,
@@ -196,6 +198,7 @@ const DEFAULT_STREAMDOWN_COMPONENTS = {
   pre: CollapsibleCodePre,
   section: MarkdownHTMLSection,
   span: MarkdownHTMLSpan,
+  strong: MarkdownStrong,
   summary: MarkdownHTMLSummary,
 } as const;
 


### PR DESCRIPTION
## Summary

Fix Markdown bold rendering in chat messages and improve admin user billing edit behavior.

- Fixed Markdown `**bold**` / `<strong>` rendering so it is no longer flattened by global chat font-weight settings.
- Added explicit Streamdown `strong` / `b` component rendering with a dedicated chat strong weight.
- Adjusted chat strong weight per configured chat body weight so bold emphasis remains visible when possible.
- Fixed admin user edit save detection so subscription-only changes send the expected request instead of silently closing.
- Made admin user PATCH change detection more maintainable by treating any business payload field as a change while excluding standalone audit `reason`.
- Replaced custom subscription expiry calendars in user create/edit flows with the shared admin date picker.
- Added date-only support to the shared admin date picker, including localized calendar and in-popover clear action.
- Kept subscription plan and expiry date aligned in one row in the edit sheet.

## Change type

- [x] Bug fix
- [x] Refactor

## Affected areas

- [x] Frontend / UI
- [x] Conversations / streaming
- [x] Billing / payments
- [x] Admin console

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Not included.

## Configuration, migration, and compatibility notes

No backend API, database schema, configuration, deployment, or generated Swagger changes.

## Documentation

- [x] Documentation is not needed for this change.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed for admin user updates and billing edits.

## Checklist

- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.