### PR TITLE
refactor: increase varchar sizes for event related fields

### DIFF
--- a/backend/internal/infra/persistence/models/chat.go
+++ b/backend/internal/infra/persistence/models/chat.go
@@ -273,19 +273,19 @@ type ChatRunEvent struct {
 	UserID          uint       `gorm:"not null;default:0;index:idx_chat_run_events_user_id;comment:用户ID"`
 	RunID           string     `gorm:"size:64;not null;default:'';index:idx_chat_run_events_run_id;uniqueIndex:uk_chat_run_events_run_scope_event,priority:1;comment:运行ID"`
 	EventScope      string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_scope;uniqueIndex:uk_chat_run_events_run_scope_event,priority:2;comment:事件范围(trace_block/trace_event/tool_call)"`
-	EventID         string     `gorm:"size:96;not null;default:'';uniqueIndex:uk_chat_run_events_run_scope_event,priority:3;comment:事件ID"`
+	EventID         string     `gorm:"size:255;not null;default:'';uniqueIndex:uk_chat_run_events_run_scope_event,priority:3;comment:事件ID"`
 	EventType       string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_type;comment:事件类型"`
 	Phase           string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_phase;comment:阶段(process/tools/upstream_think)"`
 	Stage           string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_stage;comment:链路阶段(process/think/tool/answer)"`
 	RoundID         string     `gorm:"size:64;not null;default:'';index:idx_chat_run_events_round_id;comment:链路轮次ID"`
-	ParentEventID   string     `gorm:"size:96;not null;default:'';index:idx_chat_run_events_parent_event_id;comment:父事件ID"`
+	ParentEventID   string     `gorm:"size:255;not null;default:'';index:idx_chat_run_events_parent_event_id;comment:父事件ID"`
 	Status          string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_status;comment:事件状态(streaming/completed/error)"`
-	Title           string     `gorm:"size:64;not null;default:'';comment:轨迹标题"`
+	Title           string     `gorm:"size:255;not null;default:'';comment:轨迹标题"`
 	Summary         string     `gorm:"size:255;not null;default:'';comment:轨迹摘要"`
 	ContentMarkdown string     `gorm:"type:text;not null;default:'';comment:轨迹Markdown内容"`
 	PayloadJSON     string     `gorm:"type:text;not null;default:'';comment:轨迹负载JSON"`
 	Seq             int        `gorm:"not null;default:0;index:idx_chat_run_events_seq;comment:事件顺序"`
-	ToolCallID      string     `gorm:"size:64;not null;default:'';index:idx_chat_run_events_tool_call_id;comment:工具调用ID"`
+	ToolCallID      string     `gorm:"size:255;not null;default:'';index:idx_chat_run_events_tool_call_id;comment:工具调用ID"`
 	ToolName        string     `gorm:"size:128;not null;default:'';index:idx_chat_run_events_tool_name;comment:工具名称"`
 	LatencyMS       int64      `gorm:"not null;default:0;comment:调用时长毫秒"`
 	InputJSON       string     `gorm:"type:text;not null;default:'';comment:输入JSON"`

--- a/backend/internal/infra/persistence/postgres/postgres.go
+++ b/backend/internal/infra/persistence/postgres/postgres.go
@@ -396,6 +396,15 @@ func applyConversationBaselineIndexes(db *gorm.DB) error {
 		`COMMENT ON COLUMN "chat_runs"."task_type" IS '任务类型'`,
 		`CREATE INDEX IF NOT EXISTS idx_chat_runs_task_type
 		ON "chat_runs" ("task_type")`,
+		`ALTER TABLE "chat_run_events"
+		ALTER COLUMN "event_id" TYPE varchar(255),
+		ALTER COLUMN "parent_event_id" TYPE varchar(255),
+		ALTER COLUMN "title" TYPE varchar(255),
+		ALTER COLUMN "tool_call_id" TYPE varchar(255)`,
+		`COMMENT ON COLUMN "chat_run_events"."event_id" IS '事件ID'`,
+		`COMMENT ON COLUMN "chat_run_events"."parent_event_id" IS '父事件ID'`,
+		`COMMENT ON COLUMN "chat_run_events"."title" IS '轨迹标题'`,
+		`COMMENT ON COLUMN "chat_run_events"."tool_call_id" IS '工具调用ID'`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS uk_file_objects_active_user_content
 		ON "file_objects" ("user_id", "sha256", "size_bytes")
 		WHERE status = 'active' AND deleted_at IS NULL AND sha256 <> ''`,


### PR DESCRIPTION
## Summary

Fix chat run event persistence failures caused by overly short event identifier columns.

When providers such as Grok return native web search / server-side tool events, their external tool call IDs can exceed the previous `varchar(64)` / `varchar(96)` limits in `chat_run_events`. This could make event recording fail and interrupt generation with `value too long for type character varying(64)`.

This change expands the affected chat run event fields and adds startup schema migration for existing deployments.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./internal/infra/persistence/postgres/conversation/... ./internal/infra/persistence/models/... ./internal/application/conversation/...`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Reported error:

```text
ERROR: value too long for type character varying(64) (SQLSTATE 22001)
```

Triggered while inserting into `chat_run_events` for native web search / server-side tool event records.

## Configuration, migration, and compatibility notes

Adds startup schema migration for existing databases:

- `chat_run_events.event_id`: `varchar(255)`
- `chat_run_events.parent_event_id`: `varchar(255)`
- `chat_run_events.title`: `varchar(255)`
- `chat_run_events.tool_call_id`: `varchar(255)`

No API contract or configuration changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.