### PR TITLE
feat: implement branch selection path resolution

### DIFF
--- a/frontend/features/chat/components/markdown/streamdown-content.ts
+++ b/frontend/features/chat/components/markdown/streamdown-content.ts
@@ -108,6 +108,9 @@ function normalizeDollarMathContent(mathContent: string, inline: boolean): strin
   return normalizeLatexPipes(normalizedContent);
 }
 
+const PARAGRAPH_BREAK_RE = /\n[ \t]*\n/;
+const HTML_BLOCK_TAG_RE = /<\/?\s*(?:div|p|section|article|aside|main|blockquote|ul|ol|li|table|thead|tbody|tr|th|td|h[1-6]|pre|hr|details|summary|nav|header|footer|figure|figcaption)\b/i;
+
 function normalizeDollarMathSegments(source: string): string {
   if (!source.includes("$")) {
     return source;
@@ -137,6 +140,12 @@ function normalizeDollarMathSegments(source: string): string {
 
     const mathContent = source.slice(openingDelimiterIndex + delimiterLength, closingDelimiterIndex);
     const inline = delimiterLength === 1;
+
+    if (inline && (PARAGRAPH_BREAK_RE.test(mathContent) || HTML_BLOCK_TAG_RE.test(mathContent))) {
+      index = closingDelimiterIndex + delimiterLength - 1;
+      continue;
+    }
+
     const shouldNormalize =
       (mathContent.includes("|") || (inline && mathContent.includes("\n"))) &&
       looksLikeLatexMathContent(mathContent);

--- a/frontend/features/chat/hooks/use-chat-branch-state.ts
+++ b/frontend/features/chat/hooks/use-chat-branch-state.ts
@@ -6,11 +6,22 @@ import { useTranslations } from "next-intl";
 import type { ChatAreaMessage, MessageAttachment } from "@/features/chat/types/messages";
 import type { PendingExchange } from "@/features/chat/types/chat-runtime";
 import {
+  applyBranchSelectionPath,
   buildVisibleMessages,
   mapServerMessage,
   reconcileBranchSelections,
+  resolveBranchSelectionPath,
 } from "@/features/chat/model/chat-thread";
+import type { BranchSelectionPathItem } from "@/features/chat/model/chat-thread";
 import type { MessageDTO } from "@/shared/api/conversation.types";
+
+type PendingBranchSelectionInput = {
+  parentPublicID: string | null;
+  userPublicID?: string;
+  assistantPublicID?: string;
+  tempUserPublicID: string;
+  tempAssistantPublicID: string;
+};
 
 function buildPendingMessages({
   conversationID,
@@ -160,6 +171,44 @@ function mergePendingAssistantState(messages: ChatAreaMessage[], pendingExchange
   });
 }
 
+function resolvePendingBranchSelectionPath(
+  messages: ChatAreaMessage[],
+  pendingExchange: PendingBranchSelectionInput | null,
+): BranchSelectionPathItem[] {
+  if (!pendingExchange) {
+    return [];
+  }
+
+  const assistantPublicID = pendingExchange.assistantPublicID || pendingExchange.tempAssistantPublicID;
+  const resolvedPath = resolveBranchSelectionPath(messages, assistantPublicID);
+  if (resolvedPath.length > 0) {
+    return resolvedPath;
+  }
+
+  const userPublicID = pendingExchange.userPublicID || pendingExchange.tempUserPublicID;
+  return [
+    { parentPublicID: pendingExchange.parentPublicID, publicID: userPublicID },
+    { parentPublicID: userPublicID, publicID: assistantPublicID },
+  ];
+}
+
+function serializeBranchSelectionPath(path: BranchSelectionPathItem[]): string {
+  return path.map((item) => `${item.parentPublicID?.trim() || ""}>${item.publicID?.trim() || ""}`).join("|");
+}
+
+function branchSelectionPathResolvedByServer(
+  path: BranchSelectionPathItem[],
+  serverMessagePublicIDs: Set<string>,
+): boolean {
+  if (path.length === 0) {
+    return false;
+  }
+  return path.every((item) => {
+    const publicID = item.publicID?.trim() || "";
+    return Boolean(publicID && serverMessagePublicIDs.has(publicID));
+  });
+}
+
 export function useChatBranchState({
   conversationID,
   resetToken,
@@ -175,9 +224,11 @@ export function useChatBranchState({
 }) {
   const t = useTranslations("chat.messages");
   const [branchSelections, setBranchSelections] = React.useState<Record<string, string>>({});
+  const [submittedBranchSelectionPath, setSubmittedBranchSelectionPath] = React.useState<BranchSelectionPathItem[]>([]);
 
   React.useEffect(() => {
     setBranchSelections({});
+    setSubmittedBranchSelectionPath([]);
   }, [conversationID, resetToken]);
 
   const serverTreeMessages = React.useMemo(
@@ -214,6 +265,72 @@ export function useChatBranchState({
   React.useEffect(() => {
     combinedMessagesRef.current = combinedMessages;
   }, [combinedMessages]);
+  const pendingParentPublicID = pendingExchange?.parentPublicID ?? null;
+  const pendingUserPublicID = pendingExchange?.userPublicID;
+  const pendingAssistantPublicID = pendingExchange?.assistantPublicID;
+  const pendingTempUserPublicID = pendingExchange?.tempUserPublicID;
+  const pendingTempAssistantPublicID = pendingExchange?.tempAssistantPublicID;
+  const pendingBranchSelectionInput = React.useMemo<PendingBranchSelectionInput | null>(
+    () =>
+      pendingTempUserPublicID && pendingTempAssistantPublicID
+        ? {
+            parentPublicID: pendingParentPublicID,
+            userPublicID: pendingUserPublicID,
+            assistantPublicID: pendingAssistantPublicID,
+            tempUserPublicID: pendingTempUserPublicID,
+            tempAssistantPublicID: pendingTempAssistantPublicID,
+          }
+        : null,
+    [
+      pendingAssistantPublicID,
+      pendingParentPublicID,
+      pendingTempAssistantPublicID,
+      pendingTempUserPublicID,
+      pendingUserPublicID,
+    ],
+  );
+  const pendingBranchSelectionPath = React.useMemo(
+    () => resolvePendingBranchSelectionPath(combinedMessages, pendingBranchSelectionInput),
+    [combinedMessages, pendingBranchSelectionInput],
+  );
+  const pendingBranchSelectionKey = React.useMemo(
+    () => serializeBranchSelectionPath(pendingBranchSelectionPath),
+    [pendingBranchSelectionPath],
+  );
+  React.useEffect(() => {
+    if (pendingBranchSelectionPath.length === 0) {
+      return;
+    }
+    setSubmittedBranchSelectionPath((prev) =>
+      serializeBranchSelectionPath(prev) === pendingBranchSelectionKey ? prev : pendingBranchSelectionPath,
+    );
+  }, [pendingBranchSelectionKey, pendingBranchSelectionPath]);
+  const submittedBranchSelectionKey = React.useMemo(
+    () => serializeBranchSelectionPath(submittedBranchSelectionPath),
+    [submittedBranchSelectionPath],
+  );
+  const activeBranchSelectionPath = pendingBranchSelectionPath.length > 0
+    ? pendingBranchSelectionPath
+    : submittedBranchSelectionPath;
+  const activeBranchSelectionKey = pendingBranchSelectionPath.length > 0
+    ? pendingBranchSelectionKey
+    : submittedBranchSelectionKey;
+  const pendingBranchSelectionPathRef = React.useRef(pendingBranchSelectionPath);
+  React.useEffect(() => {
+    pendingBranchSelectionPathRef.current = activeBranchSelectionPath;
+  }, [activeBranchSelectionPath, activeBranchSelectionKey]);
+  const pendingObsoletePublicIDs = React.useMemo(
+    () => [pendingTempUserPublicID, pendingTempAssistantPublicID],
+    [pendingTempAssistantPublicID, pendingTempUserPublicID],
+  );
+  const pendingObsoletePublicIDKey = React.useMemo(
+    () => pendingObsoletePublicIDs.map((item) => item?.trim() || "").join("|"),
+    [pendingObsoletePublicIDs],
+  );
+  const pendingObsoletePublicIDsRef = React.useRef(pendingObsoletePublicIDs);
+  React.useEffect(() => {
+    pendingObsoletePublicIDsRef.current = pendingObsoletePublicIDs;
+  }, [pendingObsoletePublicIDs]);
   const messageStructureKey = React.useMemo(
     () =>
       combinedMessages
@@ -223,8 +340,26 @@ export function useChatBranchState({
   );
 
   React.useEffect(() => {
-    setBranchSelections((prev) => reconcileBranchSelections(combinedMessagesRef.current, prev));
-  }, [messageStructureKey]);
+    setBranchSelections((prev) => {
+      const reconciled = reconcileBranchSelections(combinedMessagesRef.current, prev);
+      const targetPath = pendingBranchSelectionPathRef.current;
+      if (targetPath.length === 0) {
+        return reconciled;
+      }
+      return applyBranchSelectionPath(reconciled, targetPath, pendingObsoletePublicIDsRef.current);
+    });
+  }, [activeBranchSelectionKey, messageStructureKey, pendingObsoletePublicIDKey]);
+
+  React.useEffect(() => {
+    if (pendingBranchSelectionPath.length > 0 || submittedBranchSelectionPath.length === 0) {
+      return;
+    }
+    if (!branchSelectionPathResolvedByServer(submittedBranchSelectionPath, serverMessagePublicIDs)) {
+      return;
+    }
+    setBranchSelections((prev) => applyBranchSelectionPath(prev, submittedBranchSelectionPath));
+    setSubmittedBranchSelectionPath([]);
+  }, [pendingBranchSelectionPath.length, serverMessagePublicIDs, submittedBranchSelectionKey, submittedBranchSelectionPath]);
 
   const visibleMessages = React.useMemo(
     () => buildVisibleMessages(combinedMessages, branchSelections),

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -24,7 +24,12 @@ import {
   resolveErrorSummary,
   toConversationPatch,
 } from "@/features/chat/utils/chat-runtime";
-import { buildChildrenIndex, toBranchKey } from "@/features/chat/model/chat-thread";
+import {
+  applyBranchSelectionPath,
+  buildChildrenIndex,
+  resolveBranchSelectionPath,
+  toBranchKey,
+} from "@/features/chat/model/chat-thread";
 import { sanitizeConversationOptions } from "@/features/chat/model/conversation-options";
 import { buildMediaImagePreviewMarkdown } from "@/features/chat/model/media-image-preview";
 import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
@@ -283,6 +288,16 @@ export function useChatMessageSubmit({
     const userPublicID = pendingExchange.userPublicID || pendingExchange.tempUserPublicID;
     const assistantPublicID = pendingExchange.assistantPublicID || pendingExchange.tempAssistantPublicID;
     if (serverMessagePublicIDs.has(userPublicID) && serverMessagePublicIDs.has(assistantPublicID)) {
+      const serverPath = resolveBranchSelectionPath(combinedMessages, assistantPublicID);
+      if (serverPath.length > 0) {
+        setBranchSelections((prev) =>
+          applyBranchSelectionPath(
+            prev,
+            serverPath,
+            [pendingExchange.tempUserPublicID, pendingExchange.tempAssistantPublicID],
+          ),
+        );
+      }
       setPendingExchange(null);
       return;
     }
@@ -295,15 +310,26 @@ export function useChatMessageSubmit({
       (item) =>
         item.role === "assistant" &&
         item.runID === pendingRunID &&
+        serverMessagePublicIDs.has(item.publicID) &&
         resolvePersistedPublicID(item.publicID) &&
         !item.isPending &&
         !item.isStreaming &&
         item.status !== "pending",
     );
     if (serverAssistant) {
+      const serverPath = resolveBranchSelectionPath(combinedMessages, serverAssistant.publicID);
+      if (serverPath.length > 0) {
+        setBranchSelections((prev) =>
+          applyBranchSelectionPath(
+            prev,
+            serverPath,
+            [pendingExchange.tempUserPublicID, pendingExchange.tempAssistantPublicID],
+          ),
+        );
+      }
       setPendingExchange(null);
     }
-  }, [combinedMessages, pendingExchange, serverMessagePublicIDs, setPendingExchange]);
+  }, [combinedMessages, pendingExchange, serverMessagePublicIDs, setBranchSelections, setPendingExchange]);
 
   const submitMessage = React.useCallback(
     async ({
@@ -640,13 +666,22 @@ export function useChatMessageSubmit({
                 : completed.assistantMessage.content,
           };
         });
-        setBranchSelections((prev) => {
-          const next = { ...prev };
-          next[toBranchKey(resolvedParentPublicID)] = completed.userMessage.publicID;
-          delete next[tempUserPublicID];
-          next[completed.userMessage.publicID] = completed.assistantMessage.publicID;
-          return next;
-        });
+        setBranchSelections((prev) =>
+          applyBranchSelectionPath(
+            prev,
+            [
+              {
+                parentPublicID: completed.userMessage.parentPublicID || resolvedParentPublicID,
+                publicID: completed.userMessage.publicID,
+              },
+              {
+                parentPublicID: completed.userMessage.publicID,
+                publicID: completed.assistantMessage.publicID,
+              },
+            ],
+            [tempUserPublicID, tempAssistantPublicID],
+          ),
+        );
         touchByPublicID(
           targetConversationID,
           toConversationPatch(targetConversation, requestPlatformModelName),

--- a/frontend/features/chat/model/chat-thread.ts
+++ b/frontend/features/chat/model/chat-thread.ts
@@ -155,6 +155,11 @@ function extractInlineAlertDetails(item: MessageDTO): UpstreamDebugInfo | undefi
 
 const ROOT_BRANCH_KEY = "__root__";
 
+export type BranchSelectionPathItem = {
+  parentPublicID?: string | null;
+  publicID?: string | null;
+};
+
 export function mapServerMessage(
   item: MessageDTO,
   labels: { generationInterrupted: string; streamInterrupted?: string; imageRunning?: string } = {
@@ -234,6 +239,63 @@ export function buildChildrenIndex(messages: ChatAreaMessage[]) {
     children.set(parentKey, siblings);
   }
   return children;
+}
+
+export function applyBranchSelectionPath(
+  previous: Record<string, string>,
+  path: BranchSelectionPathItem[],
+  obsoletePublicIDs: Array<string | null | undefined> = [],
+): Record<string, string> {
+  const obsolete = new Set(obsoletePublicIDs.map((item) => item?.trim() || "").filter(Boolean));
+  let changed = false;
+  const next = { ...previous };
+
+  for (const [key, value] of Object.entries(next)) {
+    if (obsolete.has(key) || obsolete.has(value)) {
+      delete next[key];
+      changed = true;
+    }
+  }
+
+  for (const item of path) {
+    const publicID = item.publicID?.trim() || "";
+    if (!publicID) {
+      continue;
+    }
+    const parentKey = toBranchKey(item.parentPublicID);
+    if (next[parentKey] !== publicID) {
+      next[parentKey] = publicID;
+      changed = true;
+    }
+  }
+
+  return changed ? next : previous;
+}
+
+export function resolveBranchSelectionPath(
+  messages: ChatAreaMessage[],
+  leafPublicID: string | null | undefined,
+): BranchSelectionPathItem[] {
+  const leafID = leafPublicID?.trim() || "";
+  if (!leafID) {
+    return [];
+  }
+
+  const byPublicID = new Map(messages.map((item) => [item.publicID, item]));
+  const path: BranchSelectionPathItem[] = [];
+  const visited = new Set<string>();
+  let current = byPublicID.get(leafID) ?? null;
+
+  while (current && !visited.has(current.publicID)) {
+    visited.add(current.publicID);
+    path.push({
+      parentPublicID: current.parentPublicID,
+      publicID: current.publicID,
+    });
+    current = current.parentPublicID ? byPublicID.get(current.parentPublicID) ?? null : null;
+  }
+
+  return path;
 }
 
 export function reconcileBranchSelections(messages: ChatAreaMessage[], previous: Record<string, string>) {


### PR DESCRIPTION
## Summary

Fix chat retry and branch reconciliation so completed retries switch to the latest generated branch instead of staying on the previous branch. The branch selection path is now resolved from the server message chain and applied consistently while replacing temporary pending message IDs with persisted server IDs.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm build`
- [x] `git diff --check`

## Screenshots, API examples, or logs

N/A

## Configuration, migration, and compatibility notes

No configuration, database migration, deployment, or public API contract changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.