### PR TITLE
feat: enhance conversation metadata handling with improved JSON parsing

### DIFF
--- a/backend/internal/application/conversation/service_metadata.go
+++ b/backend/internal/application/conversation/service_metadata.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -79,18 +80,29 @@ func (s *Service) generateConversationMetadata(ctx context.Context, conversation
 
 	title := ""
 	labelsJSON := ""
-	var generateErr error
+	var titleErr error
+	var labelsErr error
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
-	setGenerateErr := func(err error) {
+	setTitleErr := func(err error) {
 		if err == nil {
 			return
 		}
 		mu.Lock()
 		defer mu.Unlock()
-		if generateErr == nil {
-			generateErr = err
+		if titleErr == nil {
+			titleErr = err
+		}
+	}
+	setLabelsErr := func(err error) {
+		if err == nil {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if labelsErr == nil {
+			labelsErr = err
 		}
 	}
 
@@ -107,7 +119,7 @@ func (s *Service) generateConversationMetadata(ctx context.Context, conversation
 			prompt := renderConversationMetadataPrompt(cfg.ConversationTitlePrompt, conversationMetadataTitlePrompt, messages)
 			out, err := s.callConversationMetadataLLM(ctx, cfg.ConversationTaskModel, conversation.Model, conversation.UserID, conversation.ID, prompt)
 			if err != nil {
-				setGenerateErr(err)
+				setTitleErr(err)
 				return
 			}
 			s.recordBasicServiceUsage(ctx, conversation.UserID, conversation.ID, "title", "标题", out.PlatformModelName, out.RoutedBindingCode, out.ProviderProtocol, out.UpstreamName, out.UpstreamModel, "5m", out.Usage, out.Messages, out.Text, out.LatencyMS)
@@ -124,7 +136,7 @@ func (s *Service) generateConversationMetadata(ctx context.Context, conversation
 			labelsPrompt := renderConversationMetadataPrompt(cfg.ConversationLabelsPrompt, conversationMetadataLabelsPrompt, messages)
 			labelsOut, err := s.callConversationMetadataLLM(ctx, cfg.ConversationTaskModel, conversation.Model, conversation.UserID, conversation.ID, labelsPrompt)
 			if err != nil {
-				setGenerateErr(err)
+				setLabelsErr(err)
 				return
 			}
 			s.recordBasicServiceUsage(ctx, conversation.UserID, conversation.ID, "labels", "标签", labelsOut.PlatformModelName, labelsOut.RoutedBindingCode, labelsOut.ProviderProtocol, labelsOut.UpstreamName, labelsOut.UpstreamModel, "5m", labelsOut.Usage, labelsOut.Messages, labelsOut.Text, labelsOut.LatencyMS)
@@ -134,7 +146,7 @@ func (s *Service) generateConversationMetadata(ctx context.Context, conversation
 			}
 			raw, marshalErr := json.Marshal(labels)
 			if marshalErr != nil {
-				setGenerateErr(marshalErr)
+				setLabelsErr(marshalErr)
 				return
 			}
 			mu.Lock()
@@ -147,8 +159,12 @@ func (s *Service) generateConversationMetadata(ctx context.Context, conversation
 	mu.Lock()
 	resolvedTitle := strings.TrimSpace(title)
 	resolvedLabelsJSON := strings.TrimSpace(labelsJSON)
-	resolvedErr := generateErr
+	resolvedTitleErr := titleErr
+	resolvedLabelsErr := labelsErr
 	mu.Unlock()
+
+	resolvedTitle = resolveConversationMetadataTitle(shouldReplaceTitle, resolvedTitle, userMsg.Content)
+	resolvedErr := resolveConversationMetadataError(resolvedTitle, resolvedLabelsJSON, resolvedTitleErr, resolvedLabelsErr)
 
 	if resolvedTitle == "" && resolvedLabelsJSON == "" {
 		return nil, resolvedErr
@@ -201,89 +217,104 @@ func renderConversationMetadataPrompt(raw string, fallback string, messages stri
 // callConversationMetadataLLM 使用内部文本任务路由生成会话标题或标签。
 // 即使会话当前模型是图片模型，也只会解析聊天路由。
 func (s *Service) callConversationMetadataLLM(ctx context.Context, configuredModel string, conversationModel string, userID uint, conversationID uint, prompt string) (*conversationMetadataLLMResult, error) {
-	route, err := s.resolveTextTaskRoute(ctx, configuredModel, conversationModel, userID, conversationID, "")
+	routes, err := s.resolveTextTaskRouteCandidates(ctx, configuredModel, conversationModel, userID, conversationID, "")
 	if err != nil {
 		return nil, fmt.Errorf("metadata route resolve: %w", err)
 	}
-	if route == nil || strings.TrimSpace(route.PlatformModelName) == "" {
+	if len(routes) == 0 {
 		return nil, ErrModelRouteNotConfigured
 	}
 	attributionReferer, attributionTitle := s.llmAttribution()
-	routeConfig := llm.RouteConfig{
-		Protocol:            route.Protocol,
-		BaseURL:             route.BaseURL,
-		APIKey:              route.APIKey,
-		HeadersJSON:         route.HeadersJSON,
-		ConnectTimeoutMS:    route.ConnectTimeoutMS,
-		ReadTimeoutMS:       route.ReadTimeoutMS,
-		StreamIdleTimeoutMS: route.StreamIdleTimeoutMS,
-		Endpoint:            llm.DefaultEndpointForAdapter(route.Protocol),
-		UpstreamModel:       route.UpstreamModel,
-		AttributionReferer:  attributionReferer,
-		AttributionTitle:    attributionTitle,
-	}
 	messages := []llm.Message{{Role: "user", Content: prompt}}
-	startedAt := time.Now()
-	out, err := s.llmClient.Generate(ctx, routeConfig, llm.GenerateInput{Messages: messages})
-	if err != nil {
-		return nil, fmt.Errorf("metadata llm generate: %w", err)
+	var lastErr error
+	for _, route := range routes {
+		if route == nil || strings.TrimSpace(route.PlatformModelName) == "" {
+			continue
+		}
+		routeConfig := llm.RouteConfig{
+			Protocol:            route.Protocol,
+			BaseURL:             route.BaseURL,
+			APIKey:              route.APIKey,
+			HeadersJSON:         route.HeadersJSON,
+			ConnectTimeoutMS:    route.ConnectTimeoutMS,
+			ReadTimeoutMS:       route.ReadTimeoutMS,
+			StreamIdleTimeoutMS: route.StreamIdleTimeoutMS,
+			Endpoint:            llm.DefaultEndpointForAdapter(route.Protocol),
+			UpstreamModel:       route.UpstreamModel,
+			AttributionReferer:  attributionReferer,
+			AttributionTitle:    attributionTitle,
+		}
+		startedAt := time.Now()
+		out, generateErr := s.llmClient.Generate(ctx, routeConfig, llm.GenerateInput{Messages: messages})
+		if generateErr != nil {
+			lastErr = fmt.Errorf("metadata llm generate: %w", generateErr)
+			continue
+		}
+		return &conversationMetadataLLMResult{
+			Text:              strings.TrimSpace(out.Text),
+			Usage:             out.Usage,
+			Messages:          messages,
+			PlatformModelName: route.PlatformModelName,
+			RoutedBindingCode: route.BindingCode,
+			ProviderProtocol:  route.Protocol,
+			UpstreamName:      route.UpstreamName,
+			UpstreamModel:     route.UpstreamModel,
+			LatencyMS:         time.Since(startedAt).Milliseconds(),
+		}, nil
 	}
-	return &conversationMetadataLLMResult{
-		Text:              strings.TrimSpace(out.Text),
-		Usage:             out.Usage,
-		Messages:          messages,
-		PlatformModelName: route.PlatformModelName,
-		RoutedBindingCode: route.BindingCode,
-		ProviderProtocol:  route.Protocol,
-		UpstreamName:      route.UpstreamName,
-		UpstreamModel:     route.UpstreamModel,
-		LatencyMS:         time.Since(startedAt).Milliseconds(),
-	}, nil
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, ErrModelRouteNotConfigured
 }
 
 func parseGeneratedConversationTitle(raw string) string {
+	object := extractMetadataJSONObject(raw, metadataTitleObjectPattern)
+	if object == "" {
+		return ""
+	}
 	var payload struct {
 		Title string
 	}
-	if unmarshalStrictJSONObject(raw, &payload) == nil {
+	if json.Unmarshal([]byte(object), &payload) == nil {
 		return payload.Title
 	}
-	if title := extractLooseGeneratedConversationTitle(raw); title != "" {
-		return title
+	match := metadataLooseTitlePattern.FindStringSubmatch(object)
+	if len(match) == 0 {
+		return ""
 	}
-	return ""
+	return firstNonEmptyString(match[1], match[2], match[3])
 }
 
 func parseGeneratedConversationLabels(raw string) []string {
+	object := extractMetadataJSONObject(raw, metadataLabelsObjectPattern)
+	if object == "" {
+		return nil
+	}
 	var payload struct {
 		Labels []string
 		Tags   []string
 	}
-	if unmarshalJSONObject(raw, &payload) == nil {
+	if json.Unmarshal([]byte(object), &payload) == nil {
 		if len(payload.Labels) > 0 {
 			return payload.Labels
 		}
 		return payload.Tags
 	}
-	return nil
-}
-
-func unmarshalJSONObject(raw string, dst interface{}) error {
-	source := stripMarkdownCodeFence(raw)
-	if err := json.Unmarshal([]byte(source), dst); err == nil {
+	match := metadataLooseLabelsPattern.FindStringSubmatch(object)
+	if len(match) == 0 {
 		return nil
 	}
-	start := strings.Index(source, "{")
-	end := strings.LastIndex(source, "}")
-	if start >= 0 && end > start {
-		return json.Unmarshal([]byte(source[start:end+1]), dst)
-	}
-	return fmt.Errorf("no json object")
+	return parseMetadataStringList(match[1])
 }
 
-func unmarshalStrictJSONObject(raw string, dst interface{}) error {
-	return json.Unmarshal([]byte(stripMarkdownCodeFence(raw)), dst)
-}
+var (
+	metadataTitleObjectPattern  = regexp.MustCompile(`(?is)\{[^{}]*["']?title["']?\s*:\s*(?:"[^"]*"|'[^']*'|[^{}\[\]\r\n]+)[^{}]*\}`)
+	metadataLabelsObjectPattern = regexp.MustCompile(`(?is)\{[^{}]*["']?(?:labels|tags)["']?\s*:\s*\[[^\]]*\][^{}]*\}`)
+	metadataLooseTitlePattern   = regexp.MustCompile(`(?is)^\s*\{\s*["']?title["']?\s*:\s*(?:"([^"]*)"|'([^']*)'|([^,}\r\n]+))\s*\}\s*$`)
+	metadataLooseLabelsPattern  = regexp.MustCompile(`(?is)^\s*\{\s*["']?(?:labels|tags)["']?\s*:\s*\[([^\]]*)\]\s*\}\s*$`)
+	metadataQuotedStringPattern = regexp.MustCompile(`"([^"]+)"|'([^']+)'`)
+)
 
 func stripMarkdownCodeFence(raw string) string {
 	source := strings.TrimSpace(raw)
@@ -300,89 +331,52 @@ func stripMarkdownCodeFence(raw string) string {
 	return strings.TrimSpace(source)
 }
 
-func extractLooseGeneratedConversationTitle(raw string) string {
+func extractMetadataJSONObject(raw string, pattern *regexp.Regexp) string {
 	source := strings.TrimSpace(stripMarkdownCodeFence(raw))
-	if !strings.HasPrefix(source, "{") || !strings.HasSuffix(source, "}") {
+	if source == "" {
 		return ""
 	}
-	value := looseObjectFieldValue(strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(source, "{"), "}")), "title")
-	if value == "" {
-		return ""
+	if strings.HasPrefix(source, "{") && strings.HasSuffix(source, "}") && pattern.MatchString(source) {
+		return source
 	}
-	if strings.HasPrefix(value, "{") || strings.HasPrefix(value, "[") {
-		return ""
-	}
-	if strings.HasPrefix(value, `"`) || strings.HasPrefix(value, `'`) {
-		return extractQuotedLooseValue(value)
-	}
-	for index, char := range value {
-		switch char {
-		case ',', '\n', '\r':
-			return strings.TrimSpace(value[:index])
-		}
-	}
-	return strings.TrimSpace(value)
+	return strings.TrimSpace(pattern.FindString(source))
 }
 
-func looseObjectFieldValue(object string, key string) string {
-	lower := strings.ToLower(object)
-	needle := strings.ToLower(key)
-	searchOffset := 0
-	for {
-		index := strings.Index(lower[searchOffset:], needle)
-		if index < 0 {
-			return ""
+func parseMetadataStringList(value string) []string {
+	body := strings.TrimSpace(value)
+	if body == "" {
+		return nil
+	}
+	matches := metadataQuotedStringPattern.FindAllStringSubmatch(body, -1)
+	if len(matches) > 0 {
+		result := make([]string, 0, len(matches))
+		for _, match := range matches {
+			item := firstNonEmptyString(match[1], match[2])
+			if item = strings.TrimSpace(item); item != "" {
+				result = append(result, item)
+			}
 		}
-		keyStart := searchOffset + index
-		keyEnd := keyStart + len(needle)
-		if value, ok := looseObjectFieldValueAt(object, keyStart, keyEnd); ok {
-			return value
-		}
-		searchOffset = keyEnd
-		if searchOffset >= len(object) {
-			return ""
+		return result
+	}
+	parts := strings.Split(body, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		item := strings.TrimSpace(strings.Trim(part, " \t\r\n\"'`“”‘’"))
+		if item != "" {
+			result = append(result, item)
 		}
 	}
+	return result
 }
 
-func looseObjectFieldValueAt(object string, keyStart int, keyEnd int) (string, bool) {
-	beforeKey := strings.TrimSpace(object[:keyStart])
-	afterKey := strings.TrimSpace(object[keyEnd:])
-	if keyStart > 0 && keyEnd < len(object) && (object[keyStart-1] == '"' || object[keyStart-1] == '\'') && object[keyEnd] == object[keyStart-1] {
-		beforeKey = strings.TrimSpace(object[:keyStart-1])
-		afterKey = strings.TrimSpace(object[keyEnd+1:])
+func resolveConversationMetadataError(title string, labelsJSON string, titleErr error, labelsErr error) error {
+	if strings.TrimSpace(title) != "" || strings.TrimSpace(labelsJSON) != "" {
+		return nil
 	}
-	if beforeKey != "" && !strings.HasSuffix(beforeKey, ",") {
-		return "", false
+	if titleErr != nil {
+		return titleErr
 	}
-	if !strings.HasPrefix(afterKey, ":") {
-		return "", false
-	}
-	return strings.TrimSpace(afterKey[1:]), true
-}
-
-func extractQuotedLooseValue(value string) string {
-	if value == "" {
-		return ""
-	}
-	quote := value[0]
-	value = value[1:]
-	escaped := false
-	for index := 0; index < len(value); index++ {
-		current := value[index]
-		if escaped {
-			escaped = false
-			continue
-		}
-		if current == '\\' {
-			escaped = true
-			continue
-		}
-		if current == quote {
-			return strings.TrimSpace(value[:index])
-		}
-	}
-	return ""
+	return labelsErr
 }
 
 func sanitizeGeneratedConversationTitle(raw string) string {
@@ -406,6 +400,14 @@ func conversationTitleFromFirstUserMessage(content string) string {
 		value = string(runes[:conversationFirstMessageTitleMaxRunes])
 	}
 	return strings.TrimSpace(value)
+}
+
+func resolveConversationMetadataTitle(shouldReplaceTitle bool, generatedTitle string, firstUserMessage string) string {
+	title := strings.TrimSpace(generatedTitle)
+	if title != "" || !shouldReplaceTitle {
+		return title
+	}
+	return conversationTitleFromFirstUserMessage(firstUserMessage)
 }
 
 func sanitizeGeneratedConversationLabels(raw []string) []string {

--- a/backend/internal/application/conversation/service_metadata_test.go
+++ b/backend/internal/application/conversation/service_metadata_test.go
@@ -1,6 +1,7 @@
 package conversation
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -35,6 +36,7 @@ func TestParseGeneratedConversationTitleHandlesLooseJSON(t *testing.T) {
 		"```json\n{\"title\":\"项目协作规范说明文档\"}\n```":     "项目协作规范说明文档",
 		`{"title": 项目协作规范说明文档}`:                        "项目协作规范说明文档",
 		`{title: 项目协作规范说明文档}`:                          "项目协作规范说明文档",
+		`标题如下：{ "title": "项目协作规范说明文档" }`:               "项目协作规范说明文档",
 	}
 	for raw, want := range cases {
 		got := sanitizeGeneratedConversationTitle(parseGeneratedConversationTitle(raw))
@@ -48,12 +50,32 @@ func TestParseGeneratedConversationTitleRejectsDirtyOutput(t *testing.T) {
 	cases := []string{
 		`title: 项目协作规范说明文档`,
 		`这是标题：项目协作规范说明文档`,
-		`标题如下：{"title": 项目协作规范说明文档}`,
 		`{"subtitle": 项目协作规范说明文档}`,
 	}
 	for _, raw := range cases {
 		if got := sanitizeGeneratedConversationTitle(parseGeneratedConversationTitle(raw)); got != "" {
 			t.Fatalf("expected dirty title output to be rejected for %q, got %q", raw, got)
+		}
+	}
+}
+
+func TestParseGeneratedConversationLabelsHandlesLooseJSON(t *testing.T) {
+	cases := map[string][]string{
+		`{"labels":["技术","运维"]}`:                     {"技术", "运维"},
+		"```json\n{\"labels\":[\"技术\",\"运维\"]}\n```": {"技术", "运维"},
+		`标签如下：{ "labels": ["技术", "运维"] }`:            {"技术", "运维"},
+		`{labels: [技术, 运维]}`:                         {"技术", "运维"},
+		`{tags: ["技术", "运维"]}`:                       {"技术", "运维"},
+	}
+	for raw, want := range cases {
+		got := sanitizeGeneratedConversationLabels(parseGeneratedConversationLabels(raw))
+		if len(got) != len(want) {
+			t.Fatalf("unexpected labels length for %q: got %#v, want %#v", raw, got, want)
+		}
+		for index := range want {
+			if got[index] != want[index] {
+				t.Fatalf("unexpected labels for %q: got %#v, want %#v", raw, got, want)
+			}
 		}
 	}
 }
@@ -69,6 +91,32 @@ func TestConversationTitleFromFirstUserMessage(t *testing.T) {
 		if got := conversationTitleFromFirstUserMessage(input); got != want {
 			t.Fatalf("unexpected first-message title for %q: got %q, want %q", input, got, want)
 		}
+	}
+}
+
+func TestConversationMetadataFallsBackToFirstUserMessageTitle(t *testing.T) {
+	resolvedTitle := resolveConversationMetadataTitle(
+		shouldAutoReplaceConversationTitle("新对话"),
+		"",
+		"设置为跟随后，Grok 4.3 对话标题没有自动生成",
+	)
+	if resolvedTitle == "" || resolvedTitle == "新对话" {
+		t.Fatalf("expected first user message fallback title, got %q", resolvedTitle)
+	}
+}
+
+func TestConversationMetadataErrorDoesNotLeakWhenEitherTaskSucceeds(t *testing.T) {
+	titleErr := errors.New("title failed")
+	labelsErr := errors.New("labels failed")
+
+	if err := resolveConversationMetadataError("有效标题", "", nil, labelsErr); err != nil {
+		t.Fatalf("expected labels error not to fail metadata when title exists, got %v", err)
+	}
+	if err := resolveConversationMetadataError("", `["技术"]`, titleErr, nil); err != nil {
+		t.Fatalf("expected title error not to fail metadata when labels exist, got %v", err)
+	}
+	if err := resolveConversationMetadataError("", "", titleErr, labelsErr); !errors.Is(err, titleErr) {
+		t.Fatalf("expected first task error when nothing is generated, got %v", err)
 	}
 }
 

--- a/backend/internal/application/conversation/service_text_task_route.go
+++ b/backend/internal/application/conversation/service_text_task_route.go
@@ -13,6 +13,19 @@ const textTaskFollowModel = "follow"
 // resolveTextTaskRoute 解析标题、标签、压缩等内部文本任务使用的聊天路由。
 // follow 优先复用当前会话模型；当前模型不是聊天模型时，回退到系统默认聊天路由。
 func (s *Service) resolveTextTaskRoute(ctx context.Context, configured string, conversationModel string, userID uint, conversationID uint, requestID string) (*channel.ResolvedRoute, error) {
+	routes, err := s.resolveTextTaskRouteCandidates(ctx, configured, conversationModel, userID, conversationID, requestID)
+	if err != nil {
+		return nil, err
+	}
+	if len(routes) == 0 {
+		return nil, ErrModelRouteNotConfigured
+	}
+	return routes[0], nil
+}
+
+// resolveTextTaskRouteCandidates 返回内部文本任务的候选路由。
+// 指定模型只使用指定路由；follow 先使用当前会话模型，再使用默认聊天路由作为任务兜底。
+func (s *Service) resolveTextTaskRouteCandidates(ctx context.Context, configured string, conversationModel string, userID uint, conversationID uint, requestID string) ([]*channel.ResolvedRoute, error) {
 	if s.routeResolver == nil {
 		return nil, ErrModelRouteNotConfigured
 	}
@@ -28,8 +41,11 @@ func (s *Service) resolveTextTaskRoute(ctx context.Context, configured string, c
 		if err != nil {
 			return nil, fmt.Errorf("text task route resolve: %w", err)
 		}
-		return route, nil
+		return []*channel.ResolvedRoute{route}, nil
 	}
+
+	routes := make([]*channel.ResolvedRoute, 0, 2)
+	var routeErr error
 
 	// follow 只在当前会话模型本身具备聊天路由时直接复用；图片、视频等非文本模型不参与内部文本任务。
 	if modelName := strings.TrimSpace(conversationModel); modelName != "" {
@@ -41,7 +57,9 @@ func (s *Service) resolveTextTaskRoute(ctx context.Context, configured string, c
 			RequestID:         strings.TrimSpace(requestID),
 		})
 		if err == nil {
-			return route, nil
+			routes = append(routes, route)
+		} else if routeErr == nil {
+			routeErr = err
 		}
 	}
 
@@ -53,11 +71,42 @@ func (s *Service) resolveTextTaskRoute(ctx context.Context, configured string, c
 			RequestID:      strings.TrimSpace(requestID),
 		})
 		if err != nil {
-			return nil, fmt.Errorf("default text task route resolve: %w", err)
+			if len(routes) == 0 {
+				return nil, fmt.Errorf("default text task route resolve: %w", err)
+			}
+			return routes, nil
 		}
-		return route, nil
+		if !textTaskRouteExists(routes, route) {
+			routes = append(routes, route)
+		}
+	}
+	if len(routes) > 0 {
+		return routes, nil
+	}
+	if routeErr != nil {
+		return nil, fmt.Errorf("text task route resolve: %w", routeErr)
 	}
 	return nil, ErrModelRouteNotConfigured
+}
+
+func textTaskRouteExists(routes []*channel.ResolvedRoute, route *channel.ResolvedRoute) bool {
+	if route == nil {
+		return true
+	}
+	for _, item := range routes {
+		if item == nil {
+			continue
+		}
+		if strings.TrimSpace(item.BindingCode) != "" && strings.TrimSpace(item.BindingCode) == strings.TrimSpace(route.BindingCode) {
+			return true
+		}
+		if strings.TrimSpace(item.PlatformModelName) == strings.TrimSpace(route.PlatformModelName) &&
+			strings.TrimSpace(item.Protocol) == strings.TrimSpace(route.Protocol) &&
+			strings.TrimSpace(item.UpstreamModel) == strings.TrimSpace(route.UpstreamModel) {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveTextTaskModel 返回内部文本任务实际使用的平台模型名。

--- a/backend/internal/application/conversation/service_text_task_route_test.go
+++ b/backend/internal/application/conversation/service_text_task_route_test.go
@@ -1,0 +1,93 @@
+package conversation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/channel"
+)
+
+type textTaskRouteResolverStub struct {
+	routes       map[string]*channel.ResolvedRoute
+	defaultRoute *channel.ResolvedRoute
+	fail         map[string]error
+}
+
+func (r *textTaskRouteResolverStub) ResolveRoute(_ context.Context, input channel.ResolveRouteInput) (*channel.ResolvedRoute, error) {
+	if err := r.fail[input.PlatformModelName]; err != nil {
+		return nil, err
+	}
+	route := r.routes[input.PlatformModelName]
+	if route == nil {
+		return nil, errors.New("route not found")
+	}
+	return route, nil
+}
+
+func (r *textTaskRouteResolverStub) ResolveDefaultRoute(context.Context, channel.ResolveRouteInput) (*channel.ResolvedRoute, error) {
+	if r.defaultRoute == nil {
+		return nil, errors.New("default route not found")
+	}
+	return r.defaultRoute, nil
+}
+
+func (r *textTaskRouteResolverStub) MarkRouteFailure(context.Context, *channel.ResolvedRoute, error) {
+}
+
+func (r *textTaskRouteResolverStub) MarkRouteSuccess(context.Context, *channel.ResolvedRoute) {}
+
+func TestResolveTextTaskRouteCandidatesFollowUsesCurrentThenDefault(t *testing.T) {
+	service := &Service{routeResolver: &textTaskRouteResolverStub{
+		routes: map[string]*channel.ResolvedRoute{
+			"grok-4.3": {PlatformModelName: "grok-4.3", BindingCode: "current", Protocol: "xai_responses", UpstreamModel: "grok-4.3"},
+		},
+		defaultRoute: &channel.ResolvedRoute{PlatformModelName: "gpt-5-mini", BindingCode: "default", Protocol: "openai_responses", UpstreamModel: "gpt-5-mini"},
+	}}
+
+	routes, err := service.resolveTextTaskRouteCandidates(context.Background(), textTaskFollowModel, "grok-4.3", 1, 2, "")
+	if err != nil {
+		t.Fatalf("resolve candidates: %v", err)
+	}
+	if len(routes) != 2 {
+		t.Fatalf("expected current and default routes, got %#v", routes)
+	}
+	if routes[0].BindingCode != "current" || routes[1].BindingCode != "default" {
+		t.Fatalf("unexpected route order: %#v", routes)
+	}
+}
+
+func TestResolveTextTaskRouteCandidatesSpecifiedModelDoesNotAddDefault(t *testing.T) {
+	service := &Service{routeResolver: &textTaskRouteResolverStub{
+		routes: map[string]*channel.ResolvedRoute{
+			"gpt-5-mini": {PlatformModelName: "gpt-5-mini", BindingCode: "specified", Protocol: "openai_responses", UpstreamModel: "gpt-5-mini"},
+		},
+		defaultRoute: &channel.ResolvedRoute{PlatformModelName: "fallback", BindingCode: "default", Protocol: "openai_responses", UpstreamModel: "fallback"},
+	}}
+
+	routes, err := service.resolveTextTaskRouteCandidates(context.Background(), "gpt-5-mini", "grok-4.3", 1, 2, "")
+	if err != nil {
+		t.Fatalf("resolve candidates: %v", err)
+	}
+	if len(routes) != 1 || routes[0].BindingCode != "specified" {
+		t.Fatalf("expected only specified route, got %#v", routes)
+	}
+}
+
+func TestResolveTextTaskRouteCandidatesFollowFallsBackWhenCurrentRouteFails(t *testing.T) {
+	service := &Service{routeResolver: &textTaskRouteResolverStub{
+		routes: map[string]*channel.ResolvedRoute{},
+		fail: map[string]error{
+			"grok-4.3": errors.New("current route unavailable"),
+		},
+		defaultRoute: &channel.ResolvedRoute{PlatformModelName: "gpt-5-mini", BindingCode: "default", Protocol: "openai_responses", UpstreamModel: "gpt-5-mini"},
+	}}
+
+	routes, err := service.resolveTextTaskRouteCandidates(context.Background(), textTaskFollowModel, "grok-4.3", 1, 2, "")
+	if err != nil {
+		t.Fatalf("resolve candidates: %v", err)
+	}
+	if len(routes) != 1 || routes[0].BindingCode != "default" {
+		t.Fatalf("expected default route after current route failure, got %#v", routes)
+	}
+}


### PR DESCRIPTION
## Summary

Fix conversation metadata generation when the task model is set to `follow`.

This change makes title and label generation independent from each other and improves the `follow` task model behavior. When `follow` is used, metadata generation now tries the current conversation model first and falls back to the default chat route if the request fails. Explicitly configured task models remain strict and do not fall back to another model.

The metadata result parser was also tightened around the expected structured outputs:

- `{ "title": "..." }`
- `{ "labels": ["...", "..."] }`

It supports code fences, surrounding text, and limited loose JSON for those two shapes only. If title generation still produces no usable title, the first user message is used as a deterministic fallback so conversations do not remain titled “新对话”.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./internal/application/conversation/...`

## Screenshots, API examples, or logs

No screenshots or API examples.

Behavior verified by tests:

- `follow` metadata tasks use the current conversation model first.
- `follow` metadata tasks fall back to the default chat route when the current route fails.
- Explicit task model configuration does not add fallback candidates.
- Title and label task errors do not block each other when either task succeeds.
- Title and label parsers accept the expected structured JSON shapes and limited loose output.

## Configuration, migration, and compatibility notes

No database migration, deployment configuration, environment variable, public API, or Swagger contract changes.

Compatibility notes:

- Existing `conversation_task_model = follow` behavior is preserved but made more reliable with one fallback attempt.
- Explicit task model configuration remains strict.
- Title fallback uses the first user message only when the generated title is empty or unusable.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including metadata task routing and model fallback behavior.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.