### PR TITLE
fix: admin layout and user input placeholder

### DIFF
--- a/frontend/features/admin/components/sections/conversation/admin-conversation.tsx
+++ b/frontend/features/admin/components/sections/conversation/admin-conversation.tsx
@@ -23,6 +23,7 @@ import {
   SettingsFieldList,
   SettingsPage,
   SettingsSection,
+  SettingsSectionSeparator,
 } from "@/shared/components/settings-layout";
 import { getAdminReferenceData, listAdminSettings, patchAdminSettings } from "@/features/admin/api";
 import {
@@ -502,6 +503,8 @@ export function AdminConversationSettingsPage() {
           {conversationFields.map(renderField)}
         </SettingsFieldList>
       </SettingsSection>
+
+      <SettingsSectionSeparator />
 
       <SettingsSection title={t("sections.optionPassthrough")} actions={modelOptionActions}>
         <SettingsFieldList>

--- a/frontend/features/chat/components/sections/chat-input.tsx
+++ b/frontend/features/chat/components/sections/chat-input.tsx
@@ -386,7 +386,7 @@ function ChatInputComponent({
           rows={1}
           style={{ fontFamily: "var(--font-chat)", fontWeight: "var(--font-chat-weight)" }}
           className={cn(
-            "rounded-3xl min-h-12 overflow-y-auto px-5 pt-4 text-[15px] leading-6 placeholder:text-[inherit] placeholder:font-[inherit] placeholder:leading-[inherit]",
+            "rounded-3xl min-h-12 overflow-y-auto px-5 pt-4 text-[15px] leading-6 placeholder:text-muted-foreground placeholder:font-[inherit] placeholder:leading-[inherit]",
             inputHeightClassName,
             speechInput.active ? "placeholder:font-normal placeholder:text-muted-foreground" : "",
           )}


### PR DESCRIPTION
## Summary

Polish frontend UI consistency for admin conversation settings and the chat composer.

This change adds the missing section separator between “会话配置” and “参数透传” in the admin conversation settings page, matching the layout pattern used by other admin settings pages. It also fixes the homepage chat input placeholder color by removing the custom inherited placeholder color and restoring the design-system muted placeholder style.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`

## Screenshots, API examples, or logs

No screenshots attached.

UI changes:

- Added `SettingsSectionSeparator` between admin conversation settings sections.
- Changed chat composer placeholder from inherited text color to `text-muted-foreground`.

## Configuration, migration, and compatibility notes

No configuration, migration, deployment, API contract, database schema, or compatibility changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed; this change is UI-only.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.
