### PR TITLE
feat: supports hiding internal task models from external display

### DIFF
--- a/backend/internal/application/channel/dto.go
+++ b/backend/internal/application/channel/dto.go
@@ -138,6 +138,7 @@ type ModelView struct {
 	Icon              string
 	CapabilitiesJSON  string
 	SystemPrompt      string
+	AccessScope       string
 	Status            string
 	Description       string
 	SortOrder         int

--- a/backend/internal/application/channel/errs.go
+++ b/backend/internal/application/channel/errs.go
@@ -35,6 +35,10 @@ var (
 	ErrInvalidUpstreamBaseURL = errors.New("invalid upstream base url")
 	// ErrInvalidKinds 模型类型无效。
 	ErrInvalidKinds = errors.New("invalid kinds")
+	// ErrInvalidModelAccessScope 模型使用范围无效。
+	ErrInvalidModelAccessScope = errors.New("invalid model access scope")
+	// ErrModelAccessDenied 模型不允许当前调用范围使用。
+	ErrModelAccessDenied = errors.New("model access denied")
 	// ErrSystemPromptTooLong 系统提示词长度超过允许范围。
 	ErrSystemPromptTooLong = errors.New("system prompt too long")
 	// ErrInvalidModelOrder 模型排序参数无效。

--- a/backend/internal/application/channel/input.go
+++ b/backend/internal/application/channel/input.go
@@ -48,6 +48,7 @@ type CreateModelInput struct {
 	Icon              string
 	CapabilitiesJSON  string
 	SystemPrompt      string
+	AccessScope       string
 	Status            string
 	Description       string
 }
@@ -60,6 +61,7 @@ type UpdateModelInput struct {
 	Icon              *string
 	CapabilitiesJSON  *string
 	SystemPrompt      *string
+	AccessScope       *string
 	Status            *string
 	Description       *string
 }

--- a/backend/internal/application/channel/service.go
+++ b/backend/internal/application/channel/service.go
@@ -77,6 +77,7 @@ type ResolvedRoute struct {
 type ResolveRouteInput struct {
 	PlatformModelName string
 	TaskType          string
+	Scope             string
 	UserID            uint
 	ConversationID    uint
 	RequestID         string
@@ -95,6 +96,14 @@ const (
 	routeFailureIgnore    routeFailureClass = "ignore"
 	circuitProbeTTLSec                      = 30
 	modelCatalogCacheTTL                    = 30 * time.Second
+)
+
+const (
+	ModelAccessScopePublic   = "public"
+	ModelAccessScopeInternal = "internal"
+
+	RouteScopeUser     = "user"
+	RouteScopeInternal = "internal"
 )
 
 // localAPIKeyCounters 存储各上游的本地 round-robin 计数器（Redis 不可用时的降级实现）。

--- a/backend/internal/application/channel/service_default_route.go
+++ b/backend/internal/application/channel/service_default_route.go
@@ -25,6 +25,7 @@ func (s *Service) ResolveDefaultRoute(ctx context.Context, input ResolveRouteInp
 		route, routeErr := s.ResolveRoute(ctx, ResolveRouteInput{
 			PlatformModelName: name,
 			TaskType:          input.TaskType,
+			Scope:             input.Scope,
 			UserID:            input.UserID,
 			ConversationID:    input.ConversationID,
 			RequestID:         strings.TrimSpace(input.RequestID),

--- a/backend/internal/application/channel/service_helpers.go
+++ b/backend/internal/application/channel/service_helpers.go
@@ -76,6 +76,7 @@ func toModelView(item repository.ChannelModelListRow) ModelView {
 		Icon:              item.Icon,
 		CapabilitiesJSON:  item.CapabilitiesJSON,
 		SystemPrompt:      item.SystemPrompt,
+		AccessScope:       normalizeModelAccessScopeValue(item.AccessScope),
 		Status:            item.Status,
 		Description:       item.Description,
 		SortOrder:         item.SortOrder,
@@ -170,6 +171,22 @@ func normalizeStatus(raw string) string {
 		return "active"
 	}
 	return v
+}
+
+func normalizeModelAccessScope(raw string) (string, error) {
+	value := normalizeModelAccessScopeValue(raw)
+	if value != ModelAccessScopePublic && value != ModelAccessScopeInternal {
+		return "", ErrInvalidModelAccessScope
+	}
+	return value, nil
+}
+
+func normalizeModelAccessScopeValue(raw string) string {
+	value := strings.TrimSpace(strings.ToLower(raw))
+	if value == "" {
+		return ModelAccessScopePublic
+	}
+	return value
 }
 
 func normalizePriority(value int) int {

--- a/backend/internal/application/channel/service_model.go
+++ b/backend/internal/application/channel/service_model.go
@@ -57,7 +57,7 @@ func (s *Service) ListActiveModels(ctx context.Context) ([]ModelView, error) {
 		if err != nil {
 			return nil, err
 		}
-		return filterRoutableModels(items), nil
+		return filterPublicRoutableModels(items), nil
 	}
 	mode, err := s.modelPricingFilter.GetBillingMode(ctx)
 	if err != nil {
@@ -68,7 +68,7 @@ func (s *Service) ListActiveModels(ctx context.Context) ([]ModelView, error) {
 		if err != nil {
 			return nil, err
 		}
-		return filterRoutableModels(items), nil
+		return filterPublicRoutableModels(items), nil
 	}
 
 	s.modelCatalogMu.RLock()
@@ -83,7 +83,7 @@ func (s *Service) ListActiveModels(ctx context.Context) ([]ModelView, error) {
 	if err != nil {
 		return nil, err
 	}
-	views := filterRoutableModels(items)
+	views := filterPublicRoutableModels(items)
 	pricingByPlatformModelName, err := s.modelPricingFilter.ListPublicModelPricing(ctx)
 	if err != nil {
 		return nil, err
@@ -141,11 +141,14 @@ func cloneModelViews(items []ModelView) []ModelView {
 	return results
 }
 
-// filterRoutableModels 过滤出有有效上游来源的可路由模型。
-func filterRoutableModels(items []repository.ChannelModelListRow) []ModelView {
+// filterPublicRoutableModels 过滤出公开接口可展示的有效可路由模型。
+func filterPublicRoutableModels(items []repository.ChannelModelListRow) []ModelView {
 	results := make([]ModelView, 0, len(items))
 	for _, item := range items {
 		if item.ActiveSourceCount <= 0 {
+			continue
+		}
+		if normalizeModelAccessScopeValue(item.AccessScope) != ModelAccessScopePublic {
 			continue
 		}
 		results = append(results, toModelView(item))
@@ -226,6 +229,10 @@ func (s *Service) CreateModel(ctx context.Context, input CreateModelInput) (*Mod
 	if len([]rune(systemPrompt)) > maxSystemPromptChars {
 		return nil, ErrSystemPromptTooLong
 	}
+	accessScope, err := normalizeModelAccessScope(input.AccessScope)
+	if err != nil {
+		return nil, err
+	}
 
 	item := &domainchannel.PlatformModel{
 		PlatformModelName: platformModelName,
@@ -234,6 +241,7 @@ func (s *Service) CreateModel(ctx context.Context, input CreateModelInput) (*Mod
 		Icon:              normalizeModelIcon(input.Icon, input.Vendor, platformModelName),
 		CapabilitiesJSON:  strings.TrimSpace(input.CapabilitiesJSON),
 		SystemPrompt:      systemPrompt,
+		AccessScope:       accessScope,
 		Status:            normalizeStatus(input.Status),
 		Description:       strings.TrimSpace(input.Description),
 	}
@@ -294,6 +302,13 @@ func (s *Service) UpdateModel(ctx context.Context, modelID uint, input UpdateMod
 			return nil, ErrSystemPromptTooLong
 		}
 		update.SystemPrompt = &systemPrompt
+	}
+	if input.AccessScope != nil {
+		accessScope, err := normalizeModelAccessScope(*input.AccessScope)
+		if err != nil {
+			return nil, err
+		}
+		update.AccessScope = &accessScope
 	}
 	if input.Status != nil {
 		status := normalizeStatus(*input.Status)

--- a/backend/internal/application/channel/service_routing.go
+++ b/backend/internal/application/channel/service_routing.go
@@ -23,8 +23,12 @@ func (s *Service) ResolveRoute(ctx context.Context, input ResolveRouteInput) (*R
 	if err != nil {
 		return nil, ErrModelNotFound
 	}
-	if _, err := s.repo.GetActiveModelByName(ctx, platformModelName); err != nil {
+	platformModel, err := s.repo.GetActiveModelByName(ctx, platformModelName)
+	if err != nil {
 		return nil, err
+	}
+	if !routeScopeAllowsModelAccess(input.Scope, platformModel.AccessScope) {
+		return nil, ErrModelAccessDenied
 	}
 
 	rows, err := s.repo.ListActiveRoutesByModel(ctx, platformModelName)
@@ -123,6 +127,22 @@ func (s *Service) ResolveRoute(ctx context.Context, input ResolveRouteInput) (*R
 	}
 
 	return nil, ErrAllRoutesUnavailable
+}
+
+func normalizeRouteScope(raw string) string {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case RouteScopeInternal:
+		return RouteScopeInternal
+	default:
+		return RouteScopeUser
+	}
+}
+
+func routeScopeAllowsModelAccess(routeScope string, modelAccessScope string) bool {
+	if normalizeRouteScope(routeScope) == RouteScopeInternal {
+		return true
+	}
+	return normalizeModelAccessScopeValue(modelAccessScope) == ModelAccessScopePublic
 }
 
 // MarkRouteSuccess 标记上游调用成功，清除失败计数。

--- a/backend/internal/application/channel/service_routing_test.go
+++ b/backend/internal/application/channel/service_routing_test.go
@@ -61,3 +61,20 @@ func TestBuildResolvedRouteSnapshotsModelIdentity(t *testing.T) {
 		t.Fatalf("expected platform model snapshot, got %#v", route)
 	}
 }
+
+func TestRouteScopeAllowsModelAccessDefaultsToUserScope(t *testing.T) {
+	for _, scope := range []string{"", "unknown", RouteScopeUser} {
+		if routeScopeAllowsModelAccess(scope, ModelAccessScopeInternal) {
+			t.Fatalf("scope %q should not access internal model", scope)
+		}
+		if !routeScopeAllowsModelAccess(scope, ModelAccessScopePublic) {
+			t.Fatalf("scope %q should access public model", scope)
+		}
+	}
+}
+
+func TestRouteScopeAllowsInternalModelForInternalScope(t *testing.T) {
+	if !routeScopeAllowsModelAccess(RouteScopeInternal, ModelAccessScopeInternal) {
+		t.Fatalf("internal scope should access internal model")
+	}
+}

--- a/backend/internal/application/conversation/service_generation_support.go
+++ b/backend/internal/application/conversation/service_generation_support.go
@@ -114,6 +114,7 @@ func (s *Service) callCompactLLM(ctx context.Context, platformModelName string, 
 	route, err := s.routeResolver.ResolveRoute(ctx, channel.ResolveRouteInput{
 		PlatformModelName: code,
 		TaskType:          channel.TaskTypeChat,
+		Scope:             channel.RouteScopeInternal,
 	})
 	if err != nil {
 		return "", fmt.Errorf("compact route resolve: %w", err)

--- a/backend/internal/application/conversation/service_media_generation.go
+++ b/backend/internal/application/conversation/service_media_generation.go
@@ -116,6 +116,7 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 	route, err := s.routeResolver.ResolveRoute(ctx, channel.ResolveRouteInput{
 		PlatformModelName: platformModelName,
 		TaskType:          taskRouteType,
+		Scope:             channel.RouteScopeUser,
 		UserID:            input.UserID,
 		ConversationID:    input.ConversationID,
 		RequestID:         strings.TrimSpace(input.RequestID),

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -338,12 +338,13 @@ func (s *Service) sendMessageInternal(
 	route, err := s.routeResolver.ResolveRoute(ctx, channel.ResolveRouteInput{
 		PlatformModelName: conversation.Model,
 		TaskType:          channel.TaskTypeChat,
+		Scope:             channel.RouteScopeUser,
 		UserID:            input.UserID,
 		ConversationID:    input.ConversationID,
 		RequestID:         strings.TrimSpace(input.RequestID),
 	})
 	if err != nil {
-		if errors.Is(err, channel.ErrRouteNotFound) || errors.Is(err, channel.ErrModelNotFound) {
+		if errors.Is(err, channel.ErrRouteNotFound) || errors.Is(err, channel.ErrModelNotFound) || errors.Is(err, channel.ErrModelAccessDenied) {
 			retErr = ErrModelRouteNotConfigured
 			return nil, retErr
 		}

--- a/backend/internal/application/conversation/service_text_task_route.go
+++ b/backend/internal/application/conversation/service_text_task_route.go
@@ -34,6 +34,7 @@ func (s *Service) resolveTextTaskRouteCandidates(ctx context.Context, configured
 		route, err := s.routeResolver.ResolveRoute(ctx, channel.ResolveRouteInput{
 			PlatformModelName: value,
 			TaskType:          channel.TaskTypeChat,
+			Scope:             channel.RouteScopeInternal,
 			UserID:            userID,
 			ConversationID:    conversationID,
 			RequestID:         strings.TrimSpace(requestID),
@@ -52,6 +53,7 @@ func (s *Service) resolveTextTaskRouteCandidates(ctx context.Context, configured
 		route, err := s.routeResolver.ResolveRoute(ctx, channel.ResolveRouteInput{
 			PlatformModelName: modelName,
 			TaskType:          channel.TaskTypeChat,
+			Scope:             channel.RouteScopeInternal,
 			UserID:            userID,
 			ConversationID:    conversationID,
 			RequestID:         strings.TrimSpace(requestID),
@@ -66,6 +68,7 @@ func (s *Service) resolveTextTaskRouteCandidates(ctx context.Context, configured
 	if resolver, ok := s.routeResolver.(defaultRouteResolver); ok {
 		route, err := resolver.ResolveDefaultRoute(ctx, channel.ResolveRouteInput{
 			TaskType:       channel.TaskTypeChat,
+			Scope:          channel.RouteScopeInternal,
 			UserID:         userID,
 			ConversationID: conversationID,
 			RequestID:      strings.TrimSpace(requestID),

--- a/backend/internal/domain/channel/types.go
+++ b/backend/internal/domain/channel/types.go
@@ -72,6 +72,7 @@ type PlatformModel struct {
 	Icon              string
 	CapabilitiesJSON  string
 	SystemPrompt      string
+	AccessScope       string
 	Status            string
 	Description       string
 	SortOrder         int

--- a/backend/internal/infra/persistence/models/channel.go
+++ b/backend/internal/infra/persistence/models/channel.go
@@ -37,6 +37,7 @@ type LLMPlatformModel struct {
 	KindsJSON        string `gorm:"type:text;not null;default:'[\"chat\"]';comment:模型类型JSON数组"`
 	CapabilitiesJSON string `gorm:"type:text;not null;default:'{}';comment:平台能力配置JSON"`
 	SystemPrompt     string `gorm:"type:text;not null;default:'';comment:模型级系统提示词"`
+	AccessScope      string `gorm:"size:32;not null;default:'public';index:idx_llm_platform_models_access_scope;comment:模型使用范围: public用户可用 internal仅内部任务"`
 	Icon             string `gorm:"size:64;comment:模型图标标识"`
 	Description      string `gorm:"type:text;comment:模型说明"`
 	Status           string `gorm:"size:32;not null;default:'active';index:idx_llm_platform_models_status;comment:平台模型状态"`

--- a/backend/internal/infra/persistence/postgres/channel/repository.go
+++ b/backend/internal/infra/persistence/postgres/channel/repository.go
@@ -273,6 +273,9 @@ func (r *Repo) UpdateModel(ctx context.Context, modelID uint, input repository.U
 	if input.SystemPrompt != nil {
 		updates["system_prompt"] = *input.SystemPrompt
 	}
+	if input.AccessScope != nil {
+		updates["access_scope"] = *input.AccessScope
+	}
 	if input.Status != nil {
 		updates["status"] = *input.Status
 	}
@@ -435,7 +438,7 @@ func (r *Repo) modelListQuery(ctx context.Context) *gorm.DB {
 	return r.db.WithContext(ctx).
 		Table("llm_platform_models AS m").
 		Select(
-			"m.id, m.name AS platform_model_name, m.vendor, m.kinds_json, m.icon, m.capabilities_json, m.system_prompt, m.status, m.description, m.sort_order, m.created_at, m.updated_at, " +
+			"m.id, m.name AS platform_model_name, m.vendor, m.kinds_json, m.icon, m.capabilities_json, m.system_prompt, m.access_scope, m.status, m.description, m.sort_order, m.created_at, m.updated_at, " +
 				"COALESCE(stats.source_count, 0) AS source_count, COALESCE(stats.active_source_count, 0) AS active_source_count, COALESCE(stats.protocols_json, '[]') AS protocols_json",
 		).
 		Joins(
@@ -1355,6 +1358,7 @@ func toPlatformModelDomain(item model.LLMPlatformModel) domainchannel.PlatformMo
 		Icon:              item.Icon,
 		CapabilitiesJSON:  item.CapabilitiesJSON,
 		SystemPrompt:      item.SystemPrompt,
+		AccessScope:       item.AccessScope,
 		Status:            item.Status,
 		Description:       item.Description,
 		SortOrder:         item.SortOrder,
@@ -1374,6 +1378,7 @@ func toPlatformModelModel(item *domainchannel.PlatformModel) model.LLMPlatformMo
 		Icon:             item.Icon,
 		CapabilitiesJSON: item.CapabilitiesJSON,
 		SystemPrompt:     item.SystemPrompt,
+		AccessScope:      item.AccessScope,
 		Status:           item.Status,
 		Description:      item.Description,
 		SortOrder:        item.SortOrder,

--- a/backend/internal/infra/persistence/postgres/postgres.go
+++ b/backend/internal/infra/persistence/postgres/postgres.go
@@ -255,6 +255,11 @@ func applyLLMBaselineIndexes(db *gorm.DB) error {
 		`ALTER TABLE "llm_platform_models"
 		ADD COLUMN IF NOT EXISTS "system_prompt" text NOT NULL DEFAULT ''`,
 		`COMMENT ON COLUMN "llm_platform_models"."system_prompt" IS '模型级系统提示词'`,
+		`ALTER TABLE "llm_platform_models"
+		ADD COLUMN IF NOT EXISTS "access_scope" varchar(32) NOT NULL DEFAULT 'public'`,
+		`COMMENT ON COLUMN "llm_platform_models"."access_scope" IS '模型使用范围: public用户可用 internal仅内部任务'`,
+		`CREATE INDEX IF NOT EXISTS idx_llm_platform_models_access_scope
+			ON "llm_platform_models" ("access_scope")`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_upstream_models_upstream_name
 			ON "llm_upstream_models" ("upstream_id", "upstream_model_name")`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_upstream_models_binding_code

--- a/backend/internal/repository/channel.go
+++ b/backend/internal/repository/channel.go
@@ -214,6 +214,7 @@ type UpdateChannelModelInput struct {
 	Icon              *string
 	CapabilitiesJSON  *string
 	SystemPrompt      *string
+	AccessScope       *string
 	Status            *string
 	Description       *string
 }
@@ -315,6 +316,7 @@ func (input UpdateChannelModelInput) IsZero() bool {
 		input.Icon == nil &&
 		input.CapabilitiesJSON == nil &&
 		input.SystemPrompt == nil &&
+		input.AccessScope == nil &&
 		input.Status == nil &&
 		input.Description == nil
 }

--- a/backend/internal/transport/http/channel/dto_request.go
+++ b/backend/internal/transport/http/channel/dto_request.go
@@ -53,6 +53,7 @@ type CreateModelRequest struct {
 	Icon              string `json:"icon" binding:"max=128"`
 	CapabilitiesJSON  string `json:"capabilitiesJSON" binding:"max=10000"`
 	SystemPrompt      string `json:"systemPrompt" binding:"max=20000"`
+	AccessScope       string `json:"accessScope" binding:"omitempty,oneof=public internal"`
 	Status            string `json:"status" binding:"omitempty,oneof=active inactive"`
 	Description       string `json:"description" binding:"max=10000"`
 }
@@ -65,6 +66,7 @@ type UpdateModelRequest struct {
 	Icon              *string `json:"icon" binding:"omitempty,max=128"`
 	CapabilitiesJSON  *string `json:"capabilitiesJSON" binding:"omitempty,max=10000"`
 	SystemPrompt      *string `json:"systemPrompt" binding:"omitempty,max=20000"`
+	AccessScope       *string `json:"accessScope" binding:"omitempty,oneof=public internal"`
 	Status            *string `json:"status" binding:"omitempty,oneof=active inactive"`
 	Description       *string `json:"description" binding:"omitempty,max=10000"`
 }

--- a/backend/internal/transport/http/channel/dto_response.go
+++ b/backend/internal/transport/http/channel/dto_response.go
@@ -96,6 +96,7 @@ type ModelResponse struct {
 	Icon              string `json:"icon"`
 	CapabilitiesJSON  string `json:"capabilitiesJSON"`
 	SystemPrompt      string `json:"systemPrompt"`
+	AccessScope       string `json:"accessScope"`
 	Status            string `json:"status"`
 	Description       string `json:"description"`
 	SortOrder         int    `json:"sortOrder"`
@@ -115,6 +116,7 @@ func toModelResponse(v appchannel.ModelView) ModelResponse {
 		Icon:              v.Icon,
 		CapabilitiesJSON:  v.CapabilitiesJSON,
 		SystemPrompt:      v.SystemPrompt,
+		AccessScope:       v.AccessScope,
 		Status:            v.Status,
 		Description:       v.Description,
 		SortOrder:         v.SortOrder,

--- a/backend/internal/transport/http/channel/handler.go
+++ b/backend/internal/transport/http/channel/handler.go
@@ -957,6 +957,7 @@ func (h *Handler) CreateModel(c *gin.Context) {
 		Icon:              req.Icon,
 		CapabilitiesJSON:  req.CapabilitiesJSON,
 		SystemPrompt:      req.SystemPrompt,
+		AccessScope:       req.AccessScope,
 		Status:            req.Status,
 		Description:       req.Description,
 	})
@@ -968,6 +969,8 @@ func (h *Handler) CreateModel(c *gin.Context) {
 			response.Error(c, http.StatusBadRequest, "invalid json config")
 		case errors.Is(err, appchannel.ErrInvalidKinds):
 			response.Error(c, http.StatusBadRequest, "invalid kinds")
+		case errors.Is(err, appchannel.ErrInvalidModelAccessScope):
+			response.Error(c, http.StatusBadRequest, "invalid model access scope")
 		case errors.Is(err, appchannel.ErrSystemPromptTooLong):
 			response.Error(c, http.StatusBadRequest, "system prompt too long")
 		case errors.Is(err, appchannel.ErrInvalidPlatformModelName):
@@ -1014,6 +1017,7 @@ func (h *Handler) UpdateModel(c *gin.Context) {
 		Icon:              req.Icon,
 		CapabilitiesJSON:  req.CapabilitiesJSON,
 		SystemPrompt:      req.SystemPrompt,
+		AccessScope:       req.AccessScope,
 		Status:            req.Status,
 		Description:       req.Description,
 	})
@@ -1025,6 +1029,8 @@ func (h *Handler) UpdateModel(c *gin.Context) {
 			response.Error(c, http.StatusBadRequest, "invalid json config")
 		case errors.Is(err, appchannel.ErrInvalidKinds):
 			response.Error(c, http.StatusBadRequest, "invalid kinds")
+		case errors.Is(err, appchannel.ErrInvalidModelAccessScope):
+			response.Error(c, http.StatusBadRequest, "invalid model access scope")
 		case errors.Is(err, appchannel.ErrSystemPromptTooLong):
 			response.Error(c, http.StatusBadRequest, "system prompt too long")
 		case errors.Is(err, appchannel.ErrInvalidPlatformModelName):

--- a/frontend/features/admin/api/llm.types.ts
+++ b/frontend/features/admin/api/llm.types.ts
@@ -1,6 +1,7 @@
 import type { PagePayload } from "@/shared/api/common.types";
 
 export type AdminLLMStatus = "active" | "inactive";
+export type AdminLLMModelAccessScope = "public" | "internal";
 export type AdminLLMAdapter =
   | "openai_responses"
   | "openai_chat_completions"
@@ -69,6 +70,7 @@ export type AdminLLMModelDTO = {
   icon: string;
   capabilitiesJSON: string;
   systemPrompt: string;
+  accessScope: AdminLLMModelAccessScope;
   status: AdminLLMStatus;
   description: string;
   sortOrder: number;
@@ -259,6 +261,7 @@ export type CreateAdminLLMModelRequest = {
   icon?: string;
   capabilitiesJSON?: string;
   systemPrompt?: string;
+  accessScope?: AdminLLMModelAccessScope;
   status?: AdminLLMStatus;
   description?: string;
 };
@@ -270,6 +273,7 @@ export type UpdateAdminLLMModelRequest = {
   icon?: string;
   capabilitiesJSON?: string;
   systemPrompt?: string;
+  accessScope?: AdminLLMModelAccessScope;
   status?: AdminLLMStatus;
   description?: string;
 };

--- a/frontend/features/admin/components/sections/models/admin-models.tsx
+++ b/frontend/features/admin/components/sections/models/admin-models.tsx
@@ -438,6 +438,7 @@ export function AdminModelsPage() {
           onEdit={models.setEditTarget}
           onViewSources={models.setSourcesModel}
           onToggleStatus={(item, status) => void models.handleToggleStatus(item, status)}
+          onToggleAccessScope={(item, scope) => void models.handleToggleAccessScope(item, scope)}
           onDelete={models.setDeleteTarget}
           onTestModel={handleTestModel}
           onTestSource={handleTestSource}

--- a/frontend/features/admin/components/sections/models/model-sheet.tsx
+++ b/frontend/features/admin/components/sections/models/model-sheet.tsx
@@ -58,6 +58,7 @@ import { LobeHubIcon } from "@/shared/components/lobehub-icon";
 import { KNOWN_VENDOR_OPTIONS, resolveLobeHubIconURL, resolveModelIdentity } from "@/shared/lib/model-identity";
 import type {
   AdminLLMModelDTO,
+  AdminLLMModelAccessScope,
   AdminLLMModelUpstreamSourceDTO,
   AdminLLMModelVendor,
   AdminLLMStatus,
@@ -97,6 +98,7 @@ type FormState = {
   icon: string;
   capabilitiesJSON: string;
   systemPrompt: string;
+  accessScope: AdminLLMModelAccessScope;
   status: AdminLLMStatus;
   description: string;
 };
@@ -138,6 +140,7 @@ function buildInitialState(target: AdminLLMModelDTO | null): FormState {
       icon: "",
       capabilitiesJSON: "",
       systemPrompt: "",
+      accessScope: "public",
       status: "active",
       description: "",
     };
@@ -151,6 +154,7 @@ function buildInitialState(target: AdminLLMModelDTO | null): FormState {
     icon: target.icon ?? "",
     capabilitiesJSON: normalizeCapabilitiesJSON(target.capabilitiesJSON),
     systemPrompt: target.systemPrompt ?? "",
+    accessScope: target.accessScope === "internal" ? "internal" : "public",
     status: target.status,
     description: target.description ?? "",
   };
@@ -354,6 +358,7 @@ export function ModelSheet({ open, mode, target, onClose, onSuccess }: ModelShee
           icon: form.icon.trim() || undefined,
           capabilitiesJSON: normalizeCapabilitiesJSON(form.capabilitiesJSON) || undefined,
           systemPrompt: form.systemPrompt.trim() || undefined,
+          accessScope: form.accessScope,
           status: form.status,
           description: form.description.trim() || undefined,
         });
@@ -372,6 +377,7 @@ export function ModelSheet({ open, mode, target, onClose, onSuccess }: ModelShee
         icon: form.icon.trim() || undefined,
         capabilitiesJSON: normalizeCapabilitiesJSON(form.capabilitiesJSON) || undefined,
         systemPrompt: form.systemPrompt.trim(),
+        accessScope: form.accessScope,
         status: form.status,
         description: form.description.trim() || undefined,
       };
@@ -500,6 +506,23 @@ export function ModelSheet({ open, mode, target, onClose, onSuccess }: ModelShee
                       {t(`status.${s}`)}
                     </SelectItem>
                   ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div>
+              <Label>{t("sheet.accessScope")}</Label>
+              <Select
+                value={form.accessScope}
+                onValueChange={(v) => setField("accessScope", v as AdminLLMModelAccessScope)}
+                disabled={pending}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="public">{t("accessScope.public")}</SelectItem>
+                  <SelectItem value="internal">{t("accessScope.internal")}</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/frontend/features/admin/components/sections/models/models-table.tsx
+++ b/frontend/features/admin/components/sections/models/models-table.tsx
@@ -47,6 +47,13 @@ import {
   TableSkeletonRows,
 } from "@/components/ui/table";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -64,6 +71,7 @@ import {
 import { LobeHubIcon } from "@/shared/components/lobehub-icon";
 import { resolveLobeHubIconURL, resolveModelIdentity } from "@/shared/lib/model-identity";
 import type {
+  AdminLLMModelAccessScope,
   AdminLLMModelDTO,
   AdminLLMModelUpstreamSourceDTO,
   AdminLLMStatus,
@@ -224,6 +232,7 @@ type ModelsTableProps = {
   onEdit: (item: AdminLLMModelDTO) => void;
   onViewSources: (item: AdminLLMModelDTO) => void;
   onToggleStatus: (item: AdminLLMModelDTO, status: AdminLLMStatus) => void;
+  onToggleAccessScope: (item: AdminLLMModelDTO, scope: AdminLLMModelAccessScope) => void;
   onDelete: (item: AdminLLMModelDTO) => void;
   onTestModel?: (item: AdminLLMModelDTO) => void;
   onTestSource?: (source: AdminLLMModelUpstreamSourceDTO) => void;
@@ -243,6 +252,7 @@ type ModelTableRowProps = {
   onEdit: (item: AdminLLMModelDTO) => void;
   onViewSources: (item: AdminLLMModelDTO) => void;
   onToggleStatus: (item: AdminLLMModelDTO, status: AdminLLMStatus) => void;
+  onToggleAccessScope: (item: AdminLLMModelDTO, scope: AdminLLMModelAccessScope) => void;
   onDelete: (item: AdminLLMModelDTO) => void;
   onTestModel?: (item: AdminLLMModelDTO) => void;
   onTestSource?: (source: AdminLLMModelUpstreamSourceDTO) => void;
@@ -271,6 +281,7 @@ const ModelTableRow = React.memo(function ModelTableRow({
   onEdit,
   onViewSources,
   onToggleStatus,
+  onToggleAccessScope,
   onDelete,
   onTestModel,
   onTestSource,
@@ -355,6 +366,25 @@ const ModelTableRow = React.memo(function ModelTableRow({
               aria-label={t("table.modelStatusAria", { name: item.platformModelName })}
             />
           </div>
+        </TableCell>
+
+        <TableCell className="w-[112px] whitespace-nowrap py-1" onClick={(event) => event.stopPropagation()}>
+          <Select
+            value={item.accessScope === "internal" ? "internal" : "public"}
+            onValueChange={(value) => onToggleAccessScope(item, value as AdminLLMModelAccessScope)}
+          >
+            <SelectTrigger
+              size="sm"
+              className="h-7 w-[96px] border-input/40 bg-transparent px-2 text-xs shadow-none"
+              aria-label={t("table.modelAccessScopeAria", { name: item.platformModelName })}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="public" className="text-xs">{t("accessScope.public")}</SelectItem>
+              <SelectItem value="internal" className="text-xs">{t("accessScope.internal")}</SelectItem>
+            </SelectContent>
+          </Select>
         </TableCell>
 
         <TableCell className="whitespace-nowrap py-1 text-muted-foreground">
@@ -600,6 +630,7 @@ export function ModelsTable({
   onEdit,
   onViewSources,
   onToggleStatus,
+  onToggleAccessScope,
   onDelete,
   onTestModel,
   onTestSource,
@@ -924,6 +955,7 @@ export function ModelsTable({
           <TableHead className="w-[120px]">{t("table.vendor")}</TableHead>
           <TableHead className="w-[96px] text-center">{t("table.sources")}</TableHead>
           <TableHead className="w-[72px] text-center">{t("fields.status")}</TableHead>
+          <TableHead className="w-[112px]">{t("table.accessScope")}</TableHead>
           <TableHead className="w-[140px]">{t("sources.updatedAt")}</TableHead>
           <TableHead className="w-[56px]" stickyEnd />
         </TableRow>
@@ -931,11 +963,11 @@ export function ModelsTable({
 
       <TableBody>
         {loading && items.length === 0 ? (
-          <TableSkeletonRows colSpan={9} rowCount={10} />
+          <TableSkeletonRows colSpan={10} rowCount={10} />
         ) : null}
 
         {items.length === 0 && !loading ? (
-          <TableEmptyRow colSpan={9}>{t("table.empty")}</TableEmptyRow>
+          <TableEmptyRow colSpan={10}>{t("table.empty")}</TableEmptyRow>
         ) : null}
 
         {renderedItems.map((item) => (
@@ -952,6 +984,7 @@ export function ModelsTable({
             onEdit={onEdit}
             onViewSources={onViewSources}
             onToggleStatus={onToggleStatus}
+            onToggleAccessScope={onToggleAccessScope}
             onDelete={onDelete}
             onTestModel={onTestModel}
             onTestSource={onTestSource}

--- a/frontend/features/admin/hooks/use-admin-models.ts
+++ b/frontend/features/admin/hooks/use-admin-models.ts
@@ -12,6 +12,7 @@ import {
 import type {
   AdminLLMAdapter,
   AdminBatchDeleteData,
+  AdminLLMModelAccessScope,
   AdminLLMModelDTO,
   AdminLLMModelUpstreamSourceDTO,
   AdminLLMStatus,
@@ -65,6 +66,7 @@ type UseAdminModelsState = {
   setSourcesModel: (target: AdminLLMModelDTO | null) => void;
   loadModels: (page?: number, pageSize?: number) => Promise<void>;
   handleToggleStatus: (item: AdminLLMModelDTO, nextStatus: AdminLLMStatus) => Promise<void>;
+  handleToggleAccessScope: (item: AdminLLMModelDTO, nextScope: AdminLLMModelAccessScope) => Promise<void>;
   handleBulkApplyKinds: () => Promise<void>;
   handleBulkApplyProtocol: () => Promise<void>;
   handleBulkApplyVendor: () => Promise<void>;
@@ -208,6 +210,30 @@ export function useAdminModels(): UseAdminModelsState {
       }
     },
     [items, loadModels, page, pageSize, sortValue, statusFilter, t],
+  );
+
+  const handleToggleAccessScope = React.useCallback(
+    async (item: AdminLLMModelDTO, nextScope: AdminLLMModelAccessScope) => {
+      const token = await resolveAccessToken();
+      if (!token) {
+        toast.error(t("sessionExpired"), { description: t("signInAgain") });
+        return;
+      }
+      const previousItem = items.find((model) => model.id === item.id) ?? item;
+      setItems((current) => patchByID(current, item.id, (model) => model.id, { accessScope: nextScope }));
+      try {
+        const data = await updateAdminLLMModel(token, item.id, { accessScope: nextScope });
+        setItems((current) => replaceByID(current, item.id, (model) => model.id, data.model));
+        toast.success(nextScope === "public" ? t("modelScopePublic") : t("modelScopeInternal"));
+        if (sortValue === "updated_desc") {
+          void loadModels(page, pageSize);
+        }
+      } catch (error) {
+        setItems((current) => replaceByID(current, item.id, (model) => model.id, previousItem));
+        toast.error(t("modelScopeUpdateFailed"), { description: resolveErrorMessage(error) });
+      }
+    },
+    [items, loadModels, page, pageSize, sortValue, t],
   );
 
   const handleSourceStatusChange = React.useCallback((modelID: number, previous: AdminLLMStatus, next: AdminLLMStatus) => {
@@ -608,6 +634,7 @@ export function useAdminModels(): UseAdminModelsState {
     setSourcesModel,
     loadModels,
     handleToggleStatus,
+    handleToggleAccessScope,
     handleBulkApplyKinds,
     handleBulkApplyProtocol,
     handleBulkApplyVendor,

--- a/frontend/i18n/messages/en-US/admin-models.json
+++ b/frontend/i18n/messages/en-US/admin-models.json
@@ -15,6 +15,10 @@
     "inactive": "Disabled",
     "circuitOpen": "Circuit open"
   },
+  "accessScope": {
+    "public": "Platform-wide",
+    "internal": "Internal tasks"
+  },
   "kinds": {
     "chat": "Chat",
     "audio": "Audio",
@@ -30,10 +34,12 @@
     "kind": "Type",
     "vendor": "Vendor",
     "sources": "Sources",
+    "accessScope": "Availability",
     "empty": "No models",
     "selectAllModels": "Select all",
     "selectModel": "Select {name}",
     "modelStatusAria": "{name} status",
+    "modelAccessScopeAria": "{name} availability",
     "modelActions": "Model actions",
     "editModel": "Edit",
     "viewSources": "Sources",
@@ -184,6 +190,9 @@
     "operationFailed": "Action failed",
     "modelCreated": "Model created",
     "modelUpdated": "Model updated",
+    "modelScopePublic": "Model set to globally available",
+    "modelScopeInternal": "Model set to internal tasks",
+    "modelScopeUpdateFailed": "Failed to update availability",
     "createFailed": "Could not create model",
     "updateFailed": "Could not update model"
   },
@@ -211,6 +220,7 @@
     "noMatchedVendors": "No matching vendors",
     "kind": "Kind",
     "selectKind": "Select kind",
+    "accessScope": "Availability",
     "icon": "Icon (LobeHub icon name)",
     "iconAutoDescription": "When empty, the icon is inferred from the model name first. Current vendor category: {vendor}.",
     "description": "Description",

--- a/frontend/i18n/messages/zh-CN/admin-models.json
+++ b/frontend/i18n/messages/zh-CN/admin-models.json
@@ -15,6 +15,10 @@
     "inactive": "停用",
     "circuitOpen": "熔断中"
   },
+  "accessScope": {
+    "public": "全平台",
+    "internal": "内部任务"
+  },
   "kinds": {
     "chat": "对话",
     "audio": "语音",
@@ -30,10 +34,12 @@
     "kind": "类型",
     "vendor": "厂商",
     "sources": "来源",
+    "accessScope": "可用范围",
     "empty": "暂无模型数据",
     "selectAllModels": "全选模型",
     "selectModel": "选择 {name}",
     "modelStatusAria": "{name} 状态",
+    "modelAccessScopeAria": "{name} 可用范围",
     "modelActions": "模型操作",
     "editModel": "编辑模型",
     "viewSources": "查看上游来源",
@@ -184,6 +190,9 @@
     "operationFailed": "操作失败",
     "modelCreated": "模型已创建",
     "modelUpdated": "模型已更新",
+    "modelScopePublic": "模型已设为全局可用",
+    "modelScopeInternal": "模型已设为内部任务可用",
+    "modelScopeUpdateFailed": "可用范围更新失败",
     "createFailed": "创建失败",
     "updateFailed": "更新失败"
   },
@@ -211,6 +220,7 @@
     "noMatchedVendors": "没有匹配的厂商",
     "kind": "类别",
     "selectKind": "选择类别",
+    "accessScope": "可用范围",
     "icon": "图标（LobeHub icon 名）",
     "iconAutoDescription": "未填写时将优先按模型名自动匹配模型 icon；当前归类为 {vendor}。",
     "description": "描述",


### PR DESCRIPTION
## Summary

Add model availability scope so admins can mark platform models as either platform-wide or internal-task-only. Internal task models are hidden from user model lists and blocked from direct user routing, while system tasks such as title generation, labels, and compaction can still route to them explicitly.

The implementation adds a first-class `access_scope` platform model field, routes user and internal calls with explicit scope, uses a safe default that treats missing/unknown route scope as user scope, and adds admin UI controls for configuring the scope from the model sheet and models table.

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [x] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [x] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./internal/application/channel/... ./internal/application/conversation/... ./internal/transport/http/channel/... ./internal/infra/persistence/postgres/channel/...`
- [x] `cd frontend && pnpm lint`
- [x] i18n JSON parse check for `zh-CN` and `en-US` admin model messages

## Screenshots, API examples, or logs

Not included. UI change is limited to the admin model form/table availability controls.

## Configuration, migration, and compatibility notes

Adds `llm_platform_models.access_scope varchar(32) NOT NULL DEFAULT 'public'` through the PostgreSQL baseline. Existing models remain platform-wide by default.

Admin model create/update APIs now accept and return `accessScope` with values `public` or `internal`. Public model listing excludes internal-task models.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.