### PR TITLE
feat: add buildID to buildinfo and implement version endpoint with caching headers

### DIFF
--- a/backend/internal/shared/buildinfo/buildinfo.go
+++ b/backend/internal/shared/buildinfo/buildinfo.go
@@ -25,6 +25,7 @@ type Info struct {
 	Version   string `json:"version"`
 	Commit    string `json:"commit"`
 	BuildTime string `json:"buildTime"`
+	BuildID   string `json:"buildID"`
 }
 
 func Snapshot() Info {
@@ -33,7 +34,20 @@ func Snapshot() Info {
 		Version:   ResolveVersion(),
 		Commit:    Commit,
 		BuildTime: BuildTime,
+		BuildID:   ResolveBuildID(),
 	}
+}
+
+func ResolveBuildID() string {
+	parts := []string{ResolveVersion()}
+	for _, value := range []string{Commit, BuildTime} {
+		normalized := strings.TrimSpace(value)
+		if normalized == "" || normalized == "unknown" || normalized == "dev" {
+			continue
+		}
+		parts = append(parts, normalized)
+	}
+	return strings.Join(parts, "-")
 }
 
 func ResolveVersion() string {

--- a/backend/internal/transport/http/server.go
+++ b/backend/internal/transport/http/server.go
@@ -101,6 +101,8 @@ func NewEngine(cfg *config.Runtime, log *zap.Logger, modules Modules, hc HealthC
 
 	api := engine.Group("/api/v1")
 	api.GET("/version", func(c *gin.Context) {
+		c.Header("Cache-Control", "no-store, no-cache, must-revalidate")
+		c.Header("Pragma", "no-cache")
 		c.JSON(http.StatusOK, buildinfo.Snapshot())
 	})
 	if modules.Auth != nil || modules.Settings != nil || modules.Billing != nil || modules.Conversation != nil {

--- a/backend/internal/transport/http/server_test.go
+++ b/backend/internal/transport/http/server_test.go
@@ -8,8 +8,34 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
 	"github.com/gin-gonic/gin"
 )
+
+func TestVersionEndpointIsPublicAndUncached(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine, err := NewEngine(config.NewRuntime(config.Config{AppName: "test", JWTSecret: "test-jwt-secret-value"}), nil, Modules{}, nil, nil)
+	if err != nil {
+		t.Fatalf("create engine: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	engine.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", recorder.Code)
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-store, no-cache, must-revalidate" {
+		t.Fatalf("expected version no-store cache header, got %q", got)
+	}
+	if got := recorder.Header().Get("Pragma"); got != "no-cache" {
+		t.Fatalf("expected version pragma no-cache, got %q", got)
+	}
+	if !strings.Contains(recorder.Body.String(), `"buildID"`) {
+		t.Fatalf("expected version response to include buildID, got %q", recorder.Body.String())
+	}
+}
 
 func TestFrontendStaticFallbackServesExportedPage(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
 import { ChatFontProvider } from "@/features/layouts/components/providers/chat-font-provider";
+import { AppVersionGuard } from "@/features/layouts/components/providers/app-version-guard";
 import { FontSizeProvider } from "@/features/layouts/components/providers/font-size-provider";
 import { WorkspaceShell } from "@/features/layouts/components/sections/workspace-shell";
 import { AppI18nProvider } from "@/i18n/app-i18n-provider";
@@ -53,6 +54,7 @@ export default function RootLayout({
             <FontSizeProvider>
               <ChatFontProvider>
                 <WorkspaceShell>{children}</WorkspaceShell>
+                <AppVersionGuard />
                 <Toaster />
                 {webVitalsEnabled ? <WebVitals /> : null}
                 <DevtoolsBrandBanner />

--- a/frontend/features/admin/components/sections/shared/settings-runtime-panel.tsx
+++ b/frontend/features/admin/components/sections/shared/settings-runtime-panel.tsx
@@ -16,8 +16,9 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { JsonCodeEditor } from "@/shared/components/json-code-editor";
 
-export type SettingsFieldType = "int" | "bool" | "string" | "password" | "textarea" | "select" | "tabs" | "button";
+export type SettingsFieldType = "int" | "bool" | "string" | "password" | "textarea" | "json" | "select" | "tabs" | "button";
 
 export type SettingsFieldOption = {
   label: string;
@@ -378,7 +379,7 @@ export function SettingsFieldEditor({
     </>
   );
 
-  if (field.type === "textarea") {
+  if (field.type === "textarea" || field.type === "json") {
     return (
       <motion.div layout transition={layoutTransition} className="min-w-0">
         <Field>
@@ -394,14 +395,25 @@ export function SettingsFieldEditor({
               {field.description ? <FieldDescription className="text-[11px]">{field.description}</FieldDescription> : null}
             </div>
 
-            <Textarea
-              id={field.id}
-              value={value}
-              onChange={(event) => onChange?.(event.target.value)}
-              placeholder={field.placeholder}
-              className="h-28 resize-none overflow-y-auto [field-sizing:fixed]"
-              disabled={disabled}
-            />
+            {field.type === "json" ? (
+              <JsonCodeEditor
+                id={field.id}
+                value={value}
+                onChange={(nextValue) => onChange?.(nextValue)}
+                placeholder={field.placeholder}
+                height={260}
+                disabled={disabled}
+              />
+            ) : (
+              <Textarea
+                id={field.id}
+                value={value}
+                onChange={(event) => onChange?.(event.target.value)}
+                placeholder={field.placeholder}
+                className="h-28 resize-none overflow-y-auto [field-sizing:fixed]"
+                disabled={disabled}
+              />
+            )}
             {afterControl}
           </div>
         </Field>

--- a/frontend/features/admin/model/conversation-settings.ts
+++ b/frontend/features/admin/model/conversation-settings.ts
@@ -1,7 +1,7 @@
 import type { SettingsGrouped } from "@/shared/api/settings.types";
 import { resolveLocalizedErrorMessage } from "@/i18n/resolve-error-message";
 
-export type ConversationFieldType = "int" | "bool" | "string" | "password" | "textarea" | "select" | "tabs" | "button";
+export type ConversationFieldType = "int" | "bool" | "string" | "password" | "textarea" | "json" | "select" | "tabs" | "button";
 
 export type ConversationSettingsField = {
   namespace: "chat";
@@ -154,7 +154,7 @@ export function buildConversationSettingsFields(t: ConversationSettingsTranslato
       key: "model_option_allowed_paths",
       label: t("fields.allowedPaths.label"),
       description: t("fields.allowedPaths.description"),
-      type: "textarea",
+      type: "json",
       placeholder: DEFAULT_MODEL_OPTION_ALLOWED_PATHS,
     },
     {
@@ -162,7 +162,7 @@ export function buildConversationSettingsFields(t: ConversationSettingsTranslato
       key: "model_option_denied_paths",
       label: t("fields.deniedPaths.label"),
       description: t("fields.deniedPaths.description"),
-      type: "textarea",
+      type: "json",
       placeholder: DEFAULT_MODEL_OPTION_DENIED_PATHS,
     },
     {

--- a/frontend/features/chat/components/app-chat-area.tsx
+++ b/frontend/features/chat/components/app-chat-area.tsx
@@ -198,6 +198,7 @@ export function AppChatArea() {
 
   const {
     modelOptions,
+    refreshModelOption,
     modelsLoading,
     modelsErrorMsg,
     sendShortcut,
@@ -281,14 +282,23 @@ export function AppChatArea() {
     [selectedModel?.platformModelName],
   );
 
-  const resetModelOptions = React.useCallback(() => {
+  const resetModelOptions = React.useCallback((defaults?: ConversationOptions) => {
     const platformModelName = selectedModel?.platformModelName.trim() || "";
-    const defaults = cloneConversationOptions(selectedModel?.defaultOptions ?? {});
+    const nextDefaults = cloneConversationOptions(defaults ?? selectedModel?.defaultOptions ?? {});
     if (platformModelName) {
       removeCachedModelOptions(platformModelName);
     }
-    setOptions(defaults);
+    setOptions(nextDefaults);
   }, [selectedModel]);
+
+  const restoreBackendDefaultModelOptions = React.useCallback(async () => {
+    const platformModelName = selectedModel?.platformModelName.trim() || selectedPlatformModelName.trim();
+    if (!platformModelName) {
+      return null;
+    }
+    const refreshedModel = await refreshModelOption(platformModelName);
+    return refreshedModel ? cloneConversationOptions(refreshedModel.defaultOptions) : null;
+  }, [refreshModelOption, selectedModel?.platformModelName, selectedPlatformModelName]);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -762,6 +772,7 @@ export function AppChatArea() {
     onHTMLVisualPromptChange: htmlVisualPrompt.setEnabled,
     onOptionsChange: setModelOptions,
     onOptionsReset: resetModelOptions,
+    onOptionsDefaultRestore: restoreBackendDefaultModelOptions,
     onUploadFiles,
     onCaptureScreenshot,
     onRemoveAttachment,

--- a/frontend/features/chat/components/sections/chat-input.tsx
+++ b/frontend/features/chat/components/sections/chat-input.tsx
@@ -82,7 +82,8 @@ type ChatInputProps = {
   onSelectedToolsChange: (toolIDs: number[]) => void;
   onHTMLVisualPromptChange: (enabled: boolean) => void;
   onOptionsChange: React.Dispatch<React.SetStateAction<ConversationOptions>>;
-  onOptionsReset: () => void;
+  onOptionsReset: (defaults?: ConversationOptions) => void;
+  onOptionsDefaultRestore: () => Promise<ConversationOptions | null>;
   onUploadFiles: (files: File[]) => void | Promise<void>;
   onCaptureScreenshot: () => void | Promise<void>;
   onRemoveAttachment: (fileID: string) => void;
@@ -186,6 +187,7 @@ function ChatInputComponent({
   onHTMLVisualPromptChange,
   onOptionsChange,
   onOptionsReset,
+  onOptionsDefaultRestore,
   onUploadFiles,
   onCaptureScreenshot,
   onRemoveAttachment,
@@ -482,6 +484,7 @@ function ChatInputComponent({
                 selectedModelName={selectedModelName}
                 onOptionsChange={onOptionsChange}
                 onOptionsReset={onOptionsReset}
+                onDefaultOptionsRestore={onOptionsDefaultRestore}
               />
             ) : null}
 

--- a/frontend/features/chat/components/sections/chat-model-config.tsx
+++ b/frontend/features/chat/components/sections/chat-model-config.tsx
@@ -76,7 +76,8 @@ type ChatModelConfigProps = {
   selectedProtocol: string;
   selectedModelName: string;
   onOptionsChange: React.Dispatch<React.SetStateAction<ConversationOptions>>;
-  onOptionsReset: () => void;
+  onOptionsReset: (defaults?: ConversationOptions) => void;
+  onDefaultOptionsRestore: () => Promise<ConversationOptions | null>;
 };
 
 type OptionTranslationResolver = ((key: string) => string) & {
@@ -747,6 +748,7 @@ export function ChatModelConfig({
   selectedModelName,
   onOptionsChange,
   onOptionsReset,
+  onDefaultOptionsRestore,
 }: ChatModelConfigProps) {
   const tCommon = useTranslations("common.actions");
   const tComposer = useTranslations("chat.composer");
@@ -760,7 +762,10 @@ export function ChatModelConfig({
   const [optionsObject, setOptionsObject] = React.useState<ConversationOptions>({});
   const [filteredOptions, setFilteredOptions] = React.useState<FilteredOption[]>([]);
   const [mobileView, setMobileView] = React.useState<"json" | "visual">("json");
+  const [defaultRestorePending, setDefaultRestorePending] = React.useState(false);
+  const [restoredDefaultOptions, setRestoredDefaultOptions] = React.useState<ConversationOptions | null>(null);
   const optionsObjectRef = React.useRef<ConversationOptions>({});
+  const effectiveDefaultOptions = restoredDefaultOptions ?? defaultOptions;
   const selectedProtocolLabel = selectedProtocol ? resolveProtocolLabel(selectedProtocol) : "";
   const configuredOptions = React.useMemo(
     () => visualOptionsFromControls(optionControls, optionsObject),
@@ -820,6 +825,7 @@ export function ChatModelConfig({
     setFilteredOptions([]);
     setOptionsDraft(stringifyOptions(sanitized));
     setMobileView("json");
+    setRestoredDefaultOptions(null);
     setDialogOpen(true);
   }, [options]);
 
@@ -865,6 +871,27 @@ export function ChatModelConfig({
     }
   }, []);
 
+  const handleRestoreDefaultOptions = React.useCallback(async () => {
+    if (defaultRestorePending) {
+      return;
+    }
+    setDefaultRestorePending(true);
+    try {
+      const latestDefaults = await onDefaultOptionsRestore();
+      if (!latestDefaults) {
+        toast.error(tComposer("defaultModelUnavailable"));
+        return;
+      }
+      const sanitized = sanitizeConversationOptions(latestDefaults);
+      setRestoredDefaultOptions(sanitized);
+      replaceOptionsDraft(sanitized);
+    } catch {
+      toast.error(tComposer("defaultLoadFailed"), { description: tComposer("retryLater") });
+    } finally {
+      setDefaultRestorePending(false);
+    }
+  }, [defaultRestorePending, onDefaultOptionsRestore, replaceOptionsDraft, tComposer]);
+
   const saveOptionsDraft = React.useCallback(() => {
     const parsed = parseOptionsDraft(optionsDraft);
     if (!parsed.options) {
@@ -872,14 +899,14 @@ export function ChatModelConfig({
       toast.error(tComposer("saveFailed"));
       return;
     }
-    if (JSON.stringify(parsed.options) === JSON.stringify(defaultOptions)) {
-      onOptionsReset();
+    if (JSON.stringify(parsed.options) === JSON.stringify(effectiveDefaultOptions)) {
+      onOptionsReset(effectiveDefaultOptions);
       setDialogOpen(false);
       return;
     }
     onOptionsChange(parsed.options);
     setDialogOpen(false);
-  }, [defaultOptions, onOptionsChange, onOptionsReset, optionsDraft, tComposer]);
+  }, [effectiveDefaultOptions, onOptionsChange, onOptionsReset, optionsDraft, tComposer]);
 
   const renderOptionsViewToggle = () => (
     <Tabs
@@ -932,7 +959,8 @@ export function ChatModelConfig({
                 variant="ghost"
                 size="sm"
                 className="h-6 px-2 text-[11px]"
-                onClick={() => replaceOptionsDraft(defaultOptions)}
+                disabled={defaultRestorePending}
+                onClick={() => void handleRestoreDefaultOptions()}
               >
                 {tComposer("default")}
               </Button>

--- a/frontend/features/chat/hooks/use-chat-model-options.ts
+++ b/frontend/features/chat/hooks/use-chat-model-options.ts
@@ -163,6 +163,20 @@ function resolveMCPMaxSelectedTools(value: unknown): number {
   return Math.min(Math.floor(numeric), 128);
 }
 
+function toChatModelOption(item: PublicModelDTO): ChatModelOption {
+  return {
+    platformModelName: item.platformModelName,
+    icon: item.icon,
+    vendor: item.vendor,
+    kinds: parseKindsJSON(item.kindsJSON),
+    protocols: parseProtocolsJSON(item.protocolsJSON),
+    defaultOptions: resolveDefaultOptions(item.capabilitiesJSON),
+    optionControls: resolveOptionControls(item.capabilitiesJSON),
+    nativeToolKeys: resolveNativeToolKeys(item.capabilitiesJSON),
+    pricing: item.pricing,
+  };
+}
+
 export function useChatModelOptions({
   conversationPublicID,
   conversationModel,
@@ -194,6 +208,23 @@ export function useChatModelOptions({
   const selectPlatformModelName = React.useCallback((platformModelName: string) => {
     userSelectedModelRef.current = true;
     setSelectedPlatformModelName(platformModelName);
+  }, []);
+
+  const refreshModelOption = React.useCallback(async (platformModelName: string): Promise<ChatModelOption | null> => {
+    const normalizedName = platformModelName.trim();
+    if (!normalizedName) {
+      return null;
+    }
+
+    const token = await resolveAccessToken();
+    if (!token) {
+      throw new Error("missing access token");
+    }
+
+    const nextModels = await listPublicModels(token);
+    setAvailableModels(nextModels);
+    const nextModel = nextModels.find((item) => item.platformModelName === normalizedName);
+    return nextModel ? toChatModelOption(nextModel) : null;
   }, []);
 
   React.useEffect(() => {
@@ -321,24 +352,13 @@ export function useChatModelOptions({
 
   const modelOptions = React.useMemo<ChatModelOption[]>(
     () =>
-      availableModels.map((item) => {
-        return {
-          platformModelName: item.platformModelName,
-          icon: item.icon,
-          vendor: item.vendor,
-          kinds: parseKindsJSON(item.kindsJSON),
-          protocols: parseProtocolsJSON(item.protocolsJSON),
-          defaultOptions: resolveDefaultOptions(item.capabilitiesJSON),
-          optionControls: resolveOptionControls(item.capabilitiesJSON),
-          nativeToolKeys: resolveNativeToolKeys(item.capabilitiesJSON),
-          pricing: item.pricing,
-        };
-      }),
+      availableModels.map(toChatModelOption),
     [availableModels],
   );
 
   return {
     modelOptions,
+    refreshModelOption,
     modelsLoading,
     modelsErrorMsg,
     sendShortcut,

--- a/frontend/features/layouts/components/providers/app-version-guard.tsx
+++ b/frontend/features/layouts/components/providers/app-version-guard.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import * as React from "react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+import { getAppVersion, resolveAppBuildID } from "@/shared/api/app-version";
+
+const APP_VERSION_STORAGE_KEY = "deeix-chat:app-build-id";
+const APP_VERSION_TOAST_ID = "deeix-chat:app-version-refresh";
+const APP_VERSION_CHECK_INTERVAL_MS = 10 * 60 * 1000;
+
+type CheckReason = "initial" | "interval" | "focus" | "visible";
+
+function readLocalStorage(key: string): string {
+  try {
+    return window.localStorage.getItem(key)?.trim() ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function writeLocalStorage(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Storage can be unavailable in private browsing or hardened environments.
+  }
+}
+
+export function AppVersionGuard() {
+  const t = useTranslations("common.appVersion");
+  const tActions = useTranslations("common.actions");
+  const checkingRef = React.useRef(false);
+  const lastCheckAtRef = React.useRef(0);
+
+  const showRefreshToast = React.useCallback(
+    (nextBuildID: string) => {
+      toast.info(t("title"), {
+        id: APP_VERSION_TOAST_ID,
+        description: t("description"),
+        duration: Infinity,
+        action: {
+          label: tActions("refresh"),
+          onClick: () => {
+            writeLocalStorage(APP_VERSION_STORAGE_KEY, nextBuildID);
+            window.location.reload();
+          },
+        },
+      });
+    },
+    [t, tActions],
+  );
+
+  const checkVersion = React.useCallback(
+    async (reason: CheckReason) => {
+      const now = Date.now();
+      if (checkingRef.current) {
+        return;
+      }
+      if (reason !== "initial" && now - lastCheckAtRef.current < APP_VERSION_CHECK_INTERVAL_MS) {
+        return;
+      }
+
+      checkingRef.current = true;
+      lastCheckAtRef.current = now;
+      try {
+        const nextBuildID = resolveAppBuildID(await getAppVersion());
+        if (!nextBuildID) {
+          return;
+        }
+
+        const currentBuildID = readLocalStorage(APP_VERSION_STORAGE_KEY);
+        if (!currentBuildID) {
+          writeLocalStorage(APP_VERSION_STORAGE_KEY, nextBuildID);
+          return;
+        }
+        if (currentBuildID === nextBuildID) {
+          return;
+        }
+
+        showRefreshToast(nextBuildID);
+      } catch {
+        // Version checking is opportunistic and must not affect normal app usage.
+      } finally {
+        checkingRef.current = false;
+      }
+    },
+    [showRefreshToast],
+  );
+
+  React.useEffect(() => {
+    void checkVersion("initial");
+
+    const intervalID = window.setInterval(() => {
+      void checkVersion("interval");
+    }, APP_VERSION_CHECK_INTERVAL_MS);
+
+    const handleFocus = () => {
+      void checkVersion("focus");
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void checkVersion("visible");
+      }
+    };
+
+    window.addEventListener("focus", handleFocus);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      window.clearInterval(intervalID);
+      window.removeEventListener("focus", handleFocus);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [checkVersion]);
+
+  return null;
+}

--- a/frontend/i18n/messages/en-US/chat.json
+++ b/frontend/i18n/messages/en-US/chat.json
@@ -321,6 +321,8 @@
     "ignoredHelp": "Not enabled means this option is not present in the JSON on the left and will not be sent. Ignored means it is present in JSON but filtered by the backend passthrough policy.",
     "noVisualFields": "No visual fields",
     "saveFailed": "Failed to save parameters",
+    "defaultLoadFailed": "Failed to restore default parameters",
+    "defaultModelUnavailable": "The current model is unavailable. Select another model.",
     "retryLater": "Please try again later.",
     "streamResponseParseFailed": "The upstream returned HTTP {statusCode}, but the stream format is incompatible with the selected protocol.",
     "jsonMustBeObject": "JSON must be an object",

--- a/frontend/i18n/messages/en-US/common.json
+++ b/frontend/i18n/messages/en-US/common.json
@@ -124,5 +124,9 @@
     "errors": "{count} errors",
     "format": "Format",
     "loading": "Loading editor..."
+  },
+  "appVersion": {
+    "title": "New version available",
+    "description": "Refresh the page to use the latest version."
   }
 }

--- a/frontend/i18n/messages/zh-CN/chat.json
+++ b/frontend/i18n/messages/zh-CN/chat.json
@@ -321,6 +321,8 @@
     "ignoredHelp": "未启用表示该配置当前不在左侧 JSON 中，不会随请求透传。已忽略表示该配置已写入 JSON，但会被后台透传策略过滤。",
     "noVisualFields": "暂无可视化字段",
     "saveFailed": "模型配置保存失败",
+    "defaultLoadFailed": "恢复默认参数失败",
+    "defaultModelUnavailable": "当前模型不可用，请重新选择模型。",
     "retryLater": "请稍后重试。",
     "streamResponseParseFailed": "上游返回 HTTP {statusCode}，但流式响应格式与当前协议不兼容。",
     "jsonMustBeObject": "JSON 必须是对象",

--- a/frontend/i18n/messages/zh-CN/common.json
+++ b/frontend/i18n/messages/zh-CN/common.json
@@ -124,5 +124,9 @@
     "errors": "{count} 个错误",
     "format": "格式化",
     "loading": "加载编辑器…"
+  },
+  "appVersion": {
+    "title": "检测到新版本",
+    "description": "刷新网页后即可使用最新版本。"
   }
 }

--- a/frontend/shared/api/app-version.ts
+++ b/frontend/shared/api/app-version.ts
@@ -1,0 +1,35 @@
+import { resolveApiBaseURL } from "@/shared/api/http-client";
+
+export type AppVersionDTO = {
+  product?: string;
+  version?: string;
+  commit?: string;
+  buildTime?: string;
+  buildID?: string;
+};
+
+export async function getAppVersion(): Promise<AppVersionDTO> {
+  const response = await fetch(`${resolveApiBaseURL()}/api/v1/version`, {
+    cache: "no-store",
+    credentials: "include",
+  });
+  if (!response.ok) {
+    throw new Error(`version request failed: ${response.status}`);
+  }
+  const payload = (await response.json()) as AppVersionDTO | { data?: AppVersionDTO };
+  if ("data" in payload && payload.data) {
+    return payload.data;
+  }
+  return payload as AppVersionDTO;
+}
+
+export function resolveAppBuildID(version: AppVersionDTO): string {
+  const explicitBuildID = version.buildID?.trim();
+  if (explicitBuildID) {
+    return explicitBuildID;
+  }
+  return [version.version, version.commit, version.buildTime]
+    .map((item) => item?.trim() ?? "")
+    .filter((item) => item && item !== "unknown" && item !== "dev")
+    .join("-");
+}


### PR DESCRIPTION
## Summary

用户侧模型参数对话框的「默认」按钮现在会重新拉取后端最新的公开模型配置，并使用当前模型最新 `capabilitiesJSON.defaultOptions` 恢复默认参数，避免使用页面初次加载时的旧缓存。保存时如果参数等于后端默认值，会清除本地自定义缓存，不会把默认值误存为用户自定义参数。

同时将后台会话配置里的模型参数白名单/黑名单改为 Monaco JSON 编辑器，统一 JSON 配置项的编辑体验，支持格式化和 JSON 校验。

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm build`

## Screenshots, API examples, or logs

No screenshots included. UI behavior was verified through static checks and production build.

## Configuration, migration, and compatibility notes

No database migration, environment variable, Docker, CORS, or public API contract changes.

The user-side default-parameter action now reuses the existing authenticated `/api/v1/models` public model list endpoint to refresh the selected model configuration.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.