### PR TITLE
Recovery code copy fails during onboarding 2FA setup

### DIFF
--- a/frontend/features/layouts/components/sections/initial-security-guard.tsx
+++ b/frontend/features/layouts/components/sections/initial-security-guard.tsx
@@ -36,6 +36,7 @@ import { AppLogo } from "@/shared/components/app-logo";
 import { TimeZoneSelect } from "@/shared/components/time-zone-select";
 import { useTheme, type ThemePreset } from "@/shared/components/theme-provider";
 import { lobehubIconManifest } from "@/shared/generated/lobehub-icon-manifest";
+import { writeClipboardText } from "@/shared/lib/clipboard";
 import { createQRCodeSVG } from "@/shared/lib/qr-code";
 import { detectCurrentTimeZone } from "@/shared/lib/time-zone";
 import { cn } from "@/lib/utils";
@@ -408,7 +409,7 @@ export function InitialSecurityGuard() {
 
   const copyText = React.useCallback(async (value: string, label: string) => {
     try {
-      await navigator.clipboard.writeText(value);
+      await writeClipboardText(value);
       toast.success(t("toasts.copied", { label }));
     } catch {
       toast.error(t("toasts.copyFailed"), { description: t("toasts.manualCopy") });
@@ -556,7 +557,7 @@ export function InitialSecurityGuard() {
 
   const copyRecoveryCodes = React.useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(recoveryCodes.join("\n"));
+      await writeClipboardText(recoveryCodes.join("\n"));
       toast.success(t("toasts.recoveryCodesCopied"));
     } catch {
       toast.error(t("toasts.copyFailed"));

--- a/frontend/shared/lib/clipboard.ts
+++ b/frontend/shared/lib/clipboard.ts
@@ -1,0 +1,51 @@
+export async function writeClipboardText(value: string): Promise<void> {
+  let clipboardError: unknown;
+
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(value);
+      return;
+    } catch (error) {
+      clipboardError = error;
+    }
+  }
+
+  if (typeof document === "undefined" || !document.body) {
+    throw clipboardError ?? new Error("Clipboard is unavailable");
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "0";
+  textarea.style.opacity = "0";
+
+  const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const selection = document.getSelection();
+  const selectedRange = selection?.rangeCount ? selection.getRangeAt(0) : null;
+
+  document.body.appendChild(textarea);
+  textarea.focus({ preventScroll: true });
+  textarea.select();
+  textarea.setSelectionRange(0, value.length);
+
+  try {
+    const copied = document.execCommand("copy");
+    if (!copied) {
+      throw clipboardError ?? new Error("Copy command failed");
+    }
+  } finally {
+    textarea.remove();
+    try {
+      if (selectedRange && selection) {
+        selection.removeAllRanges();
+        selection.addRange(selectedRange);
+      }
+      activeElement?.focus({ preventScroll: true });
+    } catch {
+      // Restoring focus or selection must not turn a successful copy into a failed one.
+    }
+  }
+}


### PR DESCRIPTION
## Summary

When a newly registered user enables two-factor authentication during the onboarding flow, the final "Ready" step shows the generated recovery codes. Clicking the recovery code copy icon displays a "Copy failed" toast instead of copying the codes.

## Steps to Reproduce

1. Register a new user.
2. Complete onboarding until the two-factor authentication step.
3. Enable 2FA with an authenticator code.
4. Continue to the final "Ready" step.
5. Click the copy icon next to the recovery codes.

## Expected Behavior

The recovery codes are copied to the clipboard and the UI shows a success toast.

## Actual Behavior

The UI shows a "Copy failed" toast.

## Technical Notes

The onboarding component called `navigator.clipboard.writeText` directly. This API can fail or be unavailable in restricted browser contexts, insecure contexts, WebViews, Safari edge cases, or environments with clipboard permission limitations. There was no fallback copy path, so any Clipboard API rejection surfaced as a copy failure.

## Fix

Add a shared `writeClipboardText` helper that first uses the Clipboard API and falls back to a temporary textarea plus `document.execCommand("copy")`. Update the onboarding 2FA secret and recovery code copy actions to use the shared helper.

## Validation

- `pnpm --pm-on-fail=ignore --dir frontend lint`
- `pnpm --pm-on-fail=ignore --dir frontend exec tsc --noEmit --pretty false`