### PR TITLE
Register link descender is clipped on the login page

### DIFF
--- a/frontend/features/auth/components/login-page.tsx
+++ b/frontend/features/auth/components/login-page.tsx
@@ -322,7 +322,7 @@ export function LoginPage({ nextPath }: LoginPageProps) {
             ) : null}
 
             {canShowRegisterSwitch ? (
-              <div className="mt-6 text-center text-sm font-normal leading-none text-muted-foreground">
+              <div className="mt-6 text-center text-sm font-normal leading-5 text-muted-foreground">
                 {mode === "register" ? t("alreadyHaveAccount") : t("noAccount")}{" "}
                 <button
                   type="button"


### PR DESCRIPTION
## Summary

On the `/login` page, the bottom account switcher text shows "No account? Register". In a 1920x1080 fullscreen viewport, the lowercase `g` in `Register` can appear partially clipped.

## Steps to Reproduce

1. Start the frontend application.
2. Open `/login` in a 1920x1080 fullscreen browser viewport.
3. Wait for the login configuration to finish loading.
4. Inspect the bottom account switcher text: `No account? Register`.

## Expected Behavior

The `Register` text is fully visible, including the descender of the lowercase `g`.

## Actual Behavior

The lowercase `g` in `Register` is partially clipped or rendered too tightly against the bottom edge.

## Technical Notes

The account switcher row used `text-sm leading-none`, causing the inline button to inherit a `14px` font size with a `14px` line height. The row sits at the bottom of an ancestor with `overflow-hidden`, which is used for the login configuration reveal transition.

Measured before the fix:

- `Register` computed line height: `14px`
- `Register` button height: `14px`
- Nearest clipping ancestor: `.min-h-0.overflow-hidden.px-2`
- Distance from clipping ancestor bottom to button bottom: `0px`

This leaves no room for the glyph descender, so the painted overflow of the lowercase `g` can be clipped by the ancestor.

## Fix

Change the account switcher row from `leading-none` to `leading-5`. This keeps the reveal animation clipping behavior intact while giving the `text-sm` row a `20px` line box so descenders render inside the visible area.

## Validation

- Verified the `/login` page in a 1920x1080 viewport with Chrome DevTools Protocol.
- Confirmed the `Register` computed line height changed from `14px` to `20px`.
- Captured a post-fix 1920x1080 screenshot and confirmed the lowercase `g` is fully visible.
- Ran `pnpm lint`.

before
<img width="554" height="356" alt="Screenshot 2026-06-06 at 11 04 08 AM" src="https://github.com/user-attachments/assets/5a22a5c7-1fa6-49db-b2b2-d5176bacaff0" />

after
<img width="554" height="356" alt="Screenshot 2026-06-06 at 11 37 39 AM" src="https://github.com/user-attachments/assets/02ea87b2-f460-4864-8869-d489149f1f7a" />
