### PR TITLE
refactor: update button styles in chat components for improved responsiveness and consistency

### DIFF
--- a/frontend/features/chat/components/sections/chat-input.tsx
+++ b/frontend/features/chat/components/sections/chat-input.tsx
@@ -420,7 +420,7 @@ function ChatInputComponent({
         />
 
         <InputGroupAddon align="block-end" className="items-center justify-between pt-2">
-          <div className="flex items-center gap-1">
+          <div className="flex shrink-0 items-center gap-0.5 sm:gap-1">
             <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>
                 <InputGroupButton
@@ -428,7 +428,7 @@ function ChatInputComponent({
                   type="button"
                   variant="ghost"
                   size="icon-sm"
-                  className="rounded-md text-muted-foreground hover:text-foreground"
+                  className="size-7 rounded-md text-muted-foreground hover:text-foreground sm:size-8"
                   disabled={sending || loading || uploading}
                   aria-label={tComposer("openTools")}
                   onMouseEnter={() => setIsPlusHovered(true)}
@@ -502,7 +502,7 @@ function ChatInputComponent({
                     variant="ghost"
                     size="icon-sm"
                     className={cn(
-                      "rounded-md text-muted-foreground hover:text-foreground",
+                      "size-7 rounded-md text-muted-foreground hover:text-foreground sm:size-8",
                       htmlVisualPromptEnabled && "bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary",
                     )}
                     disabled={sending || loading || uploading}
@@ -528,7 +528,7 @@ function ChatInputComponent({
             ) : null}
           </div>
 
-          <div className="flex min-w-0 flex-1 items-center justify-end gap-1.5">
+          <div className="flex min-w-0 flex-1 items-center justify-end gap-1 overflow-hidden sm:gap-1.5">
             {composerModeIndicator && ComposerModeIcon ? (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -561,7 +561,7 @@ function ChatInputComponent({
               type="button"
               variant="ghost"
               size="icon-sm"
-              className="rounded-md text-muted-foreground hover:text-foreground"
+              className="size-7 rounded-md text-muted-foreground hover:text-foreground sm:size-8"
               disabled={loading || uploading || (!sending && !hasDraftText && !speechInput.supported)}
               onClick={sending ? onStopMessage : hasDraftText ? onSendMessage : speechInput.toggle}
               onMouseEnter={() => setIsVoiceHovered(true)}

--- a/frontend/features/chat/components/sections/chat-mcp.tsx
+++ b/frontend/features/chat/components/sections/chat-mcp.tsx
@@ -211,7 +211,7 @@ export function ChatMCP({
           type="button"
           variant="ghost"
           size="icon-sm"
-          className="relative rounded-md text-muted-foreground hover:text-foreground"
+          className="relative size-7 rounded-md text-muted-foreground hover:text-foreground sm:size-8"
           disabled={disabled}
           aria-label={tComposer("mcpTools")}
           title={selectedToolCount > 0 ? tComposer("mcpToolsSelected", { count: selectedToolCount }) : tComposer("mcpTools")}

--- a/frontend/features/chat/components/sections/chat-model-config.tsx
+++ b/frontend/features/chat/components/sections/chat-model-config.tsx
@@ -1376,7 +1376,7 @@ export function ChatModelConfig({
         type="button"
         variant="ghost"
         size="icon-sm"
-        className="rounded-md text-muted-foreground hover:text-foreground"
+        className="size-7 rounded-md text-muted-foreground hover:text-foreground sm:size-8"
         disabled={disabled}
         onClick={openOptionsDialog}
         aria-label={tComposer("modelOptions")}

--- a/frontend/features/chat/components/sections/chat-model-picker.tsx
+++ b/frontend/features/chat/components/sections/chat-model-picker.tsx
@@ -740,6 +740,7 @@ export function ChatModelPicker({
 
   return (
     <>
+      <div className="min-w-0 max-w-[min(320px,100%)] shrink">
       <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
           <InputGroupButton
@@ -747,7 +748,7 @@ export function ChatModelPicker({
             type="button"
             variant="ghost"
             size="sm"
-            className="min-w-0 max-w-[min(320px,100%)] rounded-lg px-2 hover:bg-accent focus-visible:bg-accent data-[state=open]:bg-accent"
+            className="w-full min-w-0 max-w-[min(320px,100%)] rounded-lg px-1.5 hover:bg-accent focus-visible:bg-accent data-[state=open]:bg-accent sm:px-2"
             disabled={disabled || loading || modelOptions.length === 0}
             aria-label={t("selectModel")}
           >
@@ -887,6 +888,7 @@ export function ChatModelPicker({
           )}
         </PopoverContent>
       </Popover>
+      </div>
       {open
       && !isMobile
       && activeDesktopVendorGroup


### PR DESCRIPTION
## Summary

Fixes the mobile chat composer layout when the selected model ID is long.

The model picker now keeps its natural right-aligned width for short model names, truncates long model IDs within the available space, and no longer overlaps adjacent composer action buttons. Mobile composer action buttons also use tighter spacing and smaller button dimensions to preserve enough room on narrow screens.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`

## Screenshots, API examples, or logs

N/A

## Configuration, migration, and compatibility notes

No configuration, migration, Docker, database, or API contract changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed; this change is limited to frontend chat composer layout.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented where needed.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.