### PR TITLE
Prevent upstream form sheet from closing on outside click

### DIFF
--- a/frontend/features/admin/components/sections/upstreams/upstream-sheet.tsx
+++ b/frontend/features/admin/components/sections/upstreams/upstream-sheet.tsx
@@ -457,7 +457,12 @@ export function UpstreamSheet({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="flex flex-col gap-0 sm:max-w-[460px]">
+      <SheetContent
+        className="flex flex-col gap-0 sm:max-w-[460px]"
+        onInteractOutside={(event) => {
+          event.preventDefault();
+        }}
+      >
         <SheetHeader className="px-4 pb-4">
           <SheetTitle>{mode === "create" ? t("sheet.createTitle") : t("sheet.editTitle")}</SheetTitle>
         </SheetHeader>


### PR DESCRIPTION
## Summary

This PR prevents the upstream create/edit form sheet from being dismissed when users accidentally click outside the floating panel.

## Problem

On the `/admin/channels` page, when opening:

Admin > Upstreams > Upstream management > Add > Create upstream

the form sheet was dismissed as soon as the user clicked outside the panel. This could cause partially entered upstream configuration to be lost unintentionally.

## Changes

- Added an `onInteractOutside` handler to `UpstreamSheet`.
- Prevented the default outside-interaction dismiss behavior for the upstream form sheet.
- Kept explicit close flows unchanged:
  - Cancel button
  - Close button
  - Successful create/update submission

## Verification

- Ran `pnpm lint`
- Ran `git diff --check`