### PR TITLE
Disable spellcheck for upstream API key textarea

### DIFF
--- a/frontend/features/admin/components/sections/upstreams/upstream-sheet.tsx
+++ b/frontend/features/admin/components/sections/upstreams/upstream-sheet.tsx
@@ -495,6 +495,7 @@ export function UpstreamSheet({
                 className={`h-24 resize-none overflow-auto whitespace-pre [field-sizing:fixed] ${CODE_TEXTAREA_CLASS}`}
                 placeholder={mode === "create" ? t("sheet.apiKeysPlaceholder") : t("sheet.apiKeysAddPlaceholder")}
                 required={mode === "create"}
+                spellCheck={false}
                 value={form.apiKeysLines}
                 wrap="off"
                 onChange={(e) => setField("apiKeysLines", e.target.value)}


### PR DESCRIPTION
Summary
- Disable browser spellcheck for the upstream API key textarea in the admin upstream sheet.
- Prevent API keys from being visually marked as misspelled text.
- Preserve the existing form behavior, validation, layout, and submission flow.

Problem
The API key textarea in the admin upstream creation flow triggers browser spellcheck. API keys are not natural language words, so spellcheck adds distracting and unnecessary visual markers while administrators enter credentials.

Solution
Add `spellCheck={false}` to the upstream API key textarea.

Testing
- Ran `pnpm lint`.