### PR TITLE
feat: add Redis username configuration option in YAML and Docker Compose files

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ cp config.full.example.yaml config.yaml
 docker compose -f docker-compose.full.yml up -d
 ```
 
-`docker-compose.full.yml` sets `POSTGRES_DSN`, `REDIS_ADDR`, and `REDIS_PASSWORD` in compose `environment`, so those values override the database and Redis values in `config.yaml`.
+`docker-compose.full.yml` sets `POSTGRES_DSN`, `REDIS_ADDR`, `REDIS_USERNAME`, and `REDIS_PASSWORD` in compose `environment`, so those values override the database and Redis values in `config.yaml`.
 
 #### Configuration, Persistence, and Image
 
@@ -348,6 +348,7 @@ Static configuration environment variables:
 | SQLite | `SQLITE_TEMP_STORE` | Temporary storage: `DEFAULT`, `FILE`, or `MEMORY`. |
 | Cache | `CACHE_DRIVER` | `redis` or `memory`; `memory` is single-process only. |
 | Redis | `REDIS_ADDR` | Redis address. |
+| Redis | `REDIS_USERNAME` | Redis ACL username; leave empty for password-only/default-user Redis. |
 | Redis | `REDIS_PASSWORD` | Redis password. |
 | Redis | `REDIS_DB` | Redis DB number. |
 | Storage | `STORAGE_BACKEND` | `local` or `s3`. |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -201,7 +201,7 @@ cp config.full.example.yaml config.yaml
 docker compose -f docker-compose.full.yml up -d
 ```
 
-`docker-compose.full.yml` 会在 compose `environment` 中设置 `POSTGRES_DSN`、`REDIS_ADDR` 和 `REDIS_PASSWORD`，因此这些值会覆盖 `config.yaml` 里的数据库和 Redis 配置。
+`docker-compose.full.yml` 会在 compose `environment` 中设置 `POSTGRES_DSN`、`REDIS_ADDR`、`REDIS_USERNAME` 和 `REDIS_PASSWORD`，因此这些值会覆盖 `config.yaml` 里的数据库和 Redis 配置。
 
 #### 配置、持久化和镜像
 
@@ -348,6 +348,7 @@ docker compose logs app
 | SQLite | `SQLITE_TEMP_STORE` | 临时存储：`DEFAULT`、`FILE`、`MEMORY`。 |
 | 缓存 | `CACHE_DRIVER` | `redis` 或 `memory`；`memory` 仅适用于单进程。 |
 | Redis | `REDIS_ADDR` | Redis 地址。 |
+| Redis | `REDIS_USERNAME` | Redis ACL 用户名；使用仅密码或默认用户 Redis 时留空。 |
 | Redis | `REDIS_PASSWORD` | Redis 密码。 |
 | Redis | `REDIS_DB` | Redis DB 编号。 |
 | 存储 | `STORAGE_BACKEND` | `local` 或 `s3`。 |

--- a/backend/internal/infra/cache/redis/redis.go
+++ b/backend/internal/infra/cache/redis/redis.go
@@ -14,6 +14,7 @@ import (
 func NewRedis(cfg config.Config) (*redis.Client, error) {
 	client := redis.NewClient(&redis.Options{
 		Addr:     cfg.RedisAddr,
+		Username: cfg.RedisUsername,
 		Password: cfg.RedisPassword,
 		DB:       cfg.RedisDB,
 	})

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -191,6 +191,7 @@ type yamlConfig struct {
 		} `yaml:"sqlite"`
 		Redis struct {
 			Addr     string `yaml:"addr"`
+			Username string `yaml:"username"`
 			Password string `yaml:"password"`
 			DB       int    `yaml:"db"`
 		} `yaml:"redis"`
@@ -269,6 +270,7 @@ type Config struct {
 	SQLiteTempStore              string
 	CacheDriver                  string
 	RedisAddr                    string
+	RedisUsername                string
 	RedisPassword                string
 	RedisDB                      int
 	StorageBackend               string
@@ -483,6 +485,7 @@ func Load() Config {
 		SQLiteTempStore:              normalizeSQLiteTempStore(envOr("SQLITE_TEMP_STORE", yc.Database.SQLite.TempStore, "MEMORY")),
 		CacheDriver:                  normalizeCacheDriver(envOr("CACHE_DRIVER", yc.Cache.Driver, "redis")),
 		RedisAddr:                    envOr("REDIS_ADDR", yc.Database.Redis.Addr, "127.0.0.1:6379"),
+		RedisUsername:                envOr("REDIS_USERNAME", yc.Database.Redis.Username, ""),
 		RedisPassword:                envOr("REDIS_PASSWORD", yc.Database.Redis.Password, ""),
 		RedisDB:                      envOrInt("REDIS_DB", yc.Database.Redis.DB, 0),
 		StorageBackend:               envOr("STORAGE_BACKEND", yc.Storage.Backend, "local"),

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -39,6 +39,8 @@ database:
   redis:
     # Required when cache.driver is redis.
     addr: "127.0.0.1:6379"
+    # Optional. Set when Redis ACL requires a username.
+    username: ""
     password: "deeix_chat_redis_dev"
     db: 0
 

--- a/config.full.example.yaml
+++ b/config.full.example.yaml
@@ -46,6 +46,8 @@ database:
     # Required when cache.driver is redis.
     # Optional. docker-compose.full.yml overrides this value with the bundled Redis service.
     addr: "redis:6379"
+    # Optional. Set when Redis ACL requires a username.
+    username: ""
     password: "deeix_chat_2026"
     db: 0
 

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -15,6 +15,7 @@ services:
       # These environment variables override database and Redis values in config.yaml.
       POSTGRES_DSN: "postgres://deeix_chat:deeix_chat_2026@postgres:5432/deeix_chat?sslmode=disable&TimeZone=Asia%2FShanghai"
       REDIS_ADDR: "redis:6379"
+      REDIS_USERNAME: ""
       REDIS_PASSWORD: "deeix_chat_2026"
     ports:
       # Optional. Localhost-only by default. Put a reverse proxy in front for public access.


### PR DESCRIPTION
## Summary

Adds Redis ACL username support for deployments that connect DEEIX Chat to externally managed Redis instances requiring username-based authentication.

The Redis configuration now supports `database.redis.username` and the `REDIS_USERNAME` environment variable, and passes the value to the Redis client. Existing password-only/default-user Redis deployments remain unchanged because the username defaults to empty.

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Refactor
- [x] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [x] Deployment / Docker / configuration
- [x] Documentation

## Verification

- [x] `cd backend && go test ./internal/infra/config ./internal/infra/cache/redis ./internal/app`

## Screenshots, API examples, or logs

N/A

## Configuration, migration, and compatibility notes

Adds optional Redis username configuration:

```yaml
database:
  redis:
    username: ""
```

Adds matching environment variable:

```bash
REDIS_USERNAME
```

Backward compatibility:
- Existing Redis deployments without ACL usernames continue to work.
- Password-only Redis remains unchanged.
- `REDIS_USERNAME` defaults to empty.
- No database migration or API contract change is required.

## Documentation

- [ ] Documentation is not needed for this change.
- [x] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including Redis authentication configuration and backward compatibility.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.