### PR TITLE
Fix pointer cursor for admin action buttons

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1008,6 +1008,10 @@
   [role="button"] {
     touch-action: manipulation;
   }
+  button:not(:disabled):not([aria-disabled="true"]),
+  [role="button"]:not([aria-disabled="true"]) {
+    cursor: pointer;
+  }
   body {
     @apply bg-background text-foreground;
   }

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-xs font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 rounded-md text-xs font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary

This PR fixes an incorrect cursor style on admin action buttons.

On `/admin/channels`, the "Refresh" and "Add" buttons under the upstream management page displayed the default arrow cursor on hover instead of the expected pointer cursor. The same issue could also affect other admin content-area action buttons.

## Root Cause

The admin sidebar uses `Link`/`a` elements, which naturally render a pointer cursor in browsers.

However, the admin content-area actions rely on the shared `Button` component or native `button` elements. With Tailwind CSS v4, buttons no longer implicitly receive a pointer cursor from preflight styles. Since the shared `Button` component did not explicitly include `cursor-pointer`, these buttons rendered with the default arrow cursor.

## Changes

- Added `cursor-pointer` to the shared `Button` component base styles.
- Added a global base rule for enabled native `button` elements and `[role="button"]` elements to use `cursor: pointer`.
- Preserved disabled-state behavior and existing custom cursor utility overrides.

## Verification

- Ran `pnpm lint`.
- Ran `git diff --check`.
- Verified on `/admin/channels` that the "Refresh" and "Add" buttons now compute `cursor: pointer` at runtime.