### PR TITLE
fix: add support for OpenRouter responses in various components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ data/*
 backend/docs/rules/*
 frontend/public/vendor/lobehub-icons/
 frontend/public/pwa/generated/
+docker-compose.local.yml
 
 .DS_Store
 .idea

--- a/backend/internal/application/channel/model_catalog.go
+++ b/backend/internal/application/channel/model_catalog.go
@@ -136,8 +136,8 @@ func systemFallbackProtocols(compatible string) map[string]string {
 		}
 	case compatibleOpenRouter:
 		return map[string]string{
-			modelKindChat:      llm.AdapterOpenAIResponses,
-			modelKindAudio:     llm.AdapterOpenAIResponses,
+			modelKindChat:      llm.AdapterOpenRouterResponses,
+			modelKindAudio:     llm.AdapterOpenRouterResponses,
 			modelKindImageGen:  protocolOpenAIImageGenerations,
 			modelKindImageEdit: protocolOpenAIImageEdits,
 			modelKindVideoGen:  protocolOpenAIVideoGenerations,
@@ -157,6 +157,7 @@ func systemFallbackProtocols(compatible string) map[string]string {
 func isKnownProtocol(raw string) bool {
 	switch strings.TrimSpace(strings.ToLower(raw)) {
 	case llm.AdapterOpenAIResponses,
+		llm.AdapterOpenRouterResponses,
 		llm.AdapterOpenAIChatCompletions,
 		llm.AdapterAnthropicMessages,
 		llm.AdapterGoogleGenerateContent,
@@ -331,6 +332,7 @@ func isProtocolAllowedForKind(kind string, protocol string) bool {
 	case modelKindChat, modelKindAudio:
 		switch protocol {
 		case llm.AdapterOpenAIResponses,
+			llm.AdapterOpenRouterResponses,
 			llm.AdapterOpenAIChatCompletions,
 			llm.AdapterAnthropicMessages,
 			llm.AdapterGoogleGenerateContent,

--- a/backend/internal/application/channel/model_catalog_test.go
+++ b/backend/internal/application/channel/model_catalog_test.go
@@ -58,7 +58,7 @@ func TestProtocolDefaultsForXAIUsesXAIResponsesForConversationKinds(t *testing.T
 	}
 }
 
-func TestProtocolDefaultsForOpenRouterUsesOpenAIResponsesForConversationKinds(t *testing.T) {
+func TestProtocolDefaultsForOpenRouterUsesOpenRouterResponsesForConversationKinds(t *testing.T) {
 	raw := protocolDefaultsForCompatible(compatibleOpenRouter)
 
 	var defaults map[string]string
@@ -66,10 +66,10 @@ func TestProtocolDefaultsForOpenRouterUsesOpenAIResponsesForConversationKinds(t 
 		t.Fatalf("unmarshal defaults: %v", err)
 	}
 
-	if defaults[modelKindChat] != "openai_responses" {
+	if defaults[modelKindChat] != "openrouter_responses" {
 		t.Fatalf("expected OpenRouter chat default, got %q in %s", defaults[modelKindChat], raw)
 	}
-	if defaults[modelKindAudio] != "openai_responses" {
+	if defaults[modelKindAudio] != "openrouter_responses" {
 		t.Fatalf("expected OpenRouter audio default, got %q in %s", defaults[modelKindAudio], raw)
 	}
 	expectedMediaDefaults := map[string]string{

--- a/backend/internal/application/conversation/model_option_policy.go
+++ b/backend/internal/application/conversation/model_option_policy.go
@@ -434,7 +434,7 @@ func sanitizeModelOptionValues(options map[string]interface{}, protocolKey strin
 		return
 	}
 	switch protocolKey {
-	case "openai_chat_completions", "openai_responses":
+	case "openai_chat_completions", "openai_responses", "openrouter_responses":
 		serviceTier, ok := options["service_tier"]
 		if !ok {
 			return
@@ -479,6 +479,8 @@ func modelOptionPolicyProtocolKey(protocol string) string {
 	switch llm.NormalizeAdapter(protocol) {
 	case "openai":
 		return "openai_responses"
+	case "openrouter":
+		return "openrouter_responses"
 	case "anthropic", "claude":
 		return "anthropic_messages"
 	case "xai", "grok":
@@ -491,6 +493,8 @@ func modelOptionPolicyProtocolKey(protocol string) string {
 		return "google_image_generation"
 	case llm.AdapterOpenAIChatCompletions:
 		return "openai_chat_completions"
+	case llm.AdapterOpenRouterResponses:
+		return "openrouter_responses"
 	case llm.AdapterOpenAIImageGenerations:
 		return "openai_image_generations"
 	case llm.AdapterOpenAIImageEdits:

--- a/backend/internal/application/settings/model_option_policy.go
+++ b/backend/internal/application/settings/model_option_policy.go
@@ -14,6 +14,7 @@ var validModelOptionProtocolKeys = map[string]struct{}{
 	"openai_image_generations": {},
 	"openai_image_edits":       {},
 	"openai_responses":         {},
+	"openrouter_responses":     {},
 	"anthropic_messages":       {},
 	"xai_responses":            {},
 	"xai_image":                {},

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -62,6 +62,10 @@ func DefaultModelOptionAllowedPathsJSON() string {
     "reasoning.summary",
     "text.verbosity"
   ],
+  "openrouter_responses": [
+    "reasoning.effort",
+    "reasoning.summary"
+  ],
   "openai_image_generations": [
     "background",
     "moderation",

--- a/backend/internal/infra/llm/adapter.go
+++ b/backend/internal/infra/llm/adapter.go
@@ -10,6 +10,7 @@ import (
 // 已支持的协议常量。每个协议固定对应一个 HTTP 端点，任务能力由模型类别和路由规则约束。
 const (
 	AdapterOpenAIResponses        = "openai_responses"         // POST /v1/responses
+	AdapterOpenRouterResponses    = "openrouter_responses"     // POST /v1/responses（OpenRouter Responses Beta）
 	AdapterOpenAIChatCompletions  = "openai_chat_completions"  // POST /v1/chat/completions
 	AdapterOpenAIImageGenerations = "openai_image_generations" // POST /v1/images/generations
 	AdapterOpenAIImageEdits       = "openai_image_edits"       // POST /v1/images/edits
@@ -48,6 +49,7 @@ func NormalizeAdapter(raw string) string {
 func IsKnownAdapter(raw string) bool {
 	switch NormalizeAdapter(raw) {
 	case AdapterOpenAIResponses,
+		AdapterOpenRouterResponses,
 		AdapterOpenAIChatCompletions,
 		AdapterOpenAIImageGenerations,
 		AdapterOpenAIImageEdits,
@@ -66,7 +68,7 @@ func IsKnownAdapter(raw string) bool {
 // IsImplementedAdapter 返回协议是否已有可用的传输层实现。
 func IsImplementedAdapter(raw string) bool {
 	switch NormalizeAdapter(raw) {
-	case AdapterOpenAIResponses, AdapterOpenAIChatCompletions, AdapterOpenAIImageGenerations, AdapterOpenAIImageEdits, AdapterXAIResponses,
+	case AdapterOpenAIResponses, AdapterOpenRouterResponses, AdapterOpenAIChatCompletions, AdapterOpenAIImageGenerations, AdapterOpenAIImageEdits, AdapterXAIResponses,
 		AdapterAnthropicMessages, AdapterGoogleGenerateContent, AdapterGoogleImageGeneration, AdapterXAIImage, AdapterXAIImageEdits:
 		return true
 	default:
@@ -78,6 +80,7 @@ func IsImplementedAdapter(raw string) bool {
 func SupportsStreamingAdapter(raw string) bool {
 	switch NormalizeAdapter(raw) {
 	case AdapterOpenAIResponses,
+		AdapterOpenRouterResponses,
 		AdapterOpenAIChatCompletions,
 		AdapterOpenAIImageGenerations,
 		AdapterOpenAIImageEdits,
@@ -135,7 +138,7 @@ func DefaultEndpointForAdapter(adapter string) string {
 	case AdapterOpenAIImageEdits, AdapterXAIImageEdits:
 		return EndpointImageEdits
 	default:
-		// openai_responses、xai_responses 及所有未知值均使用 Responses 端点。
+		// openai_responses、openrouter_responses、xai_responses 及所有未知值均使用 Responses 端点。
 		return EndpointResponses
 	}
 }

--- a/backend/internal/infra/llm/client.go
+++ b/backend/internal/infra/llm/client.go
@@ -648,6 +648,7 @@ func NewClientWithEnv(env string, ssrfProtectionEnabled bool) *Client {
 	}
 	client.adapters = map[string]transportAdapter{
 		AdapterOpenAIResponses:        &openAIResponsesAdapter{client: client},
+		AdapterOpenRouterResponses:    &openRouterResponsesAdapter{client: client},
 		AdapterOpenAIChatCompletions:  &openAIChatCompletionsAdapter{client: client},
 		AdapterOpenAIImageGenerations: &openAIImageGenerationsAdapter{client: client},
 		AdapterOpenAIImageEdits:       &openAIImageEditsAdapter{client: client},

--- a/backend/internal/infra/llm/openai_responses.go
+++ b/backend/internal/infra/llm/openai_responses.go
@@ -38,6 +38,9 @@ func buildResponsesRequestBody(
 	providerStreamOptions map[string]interface{},
 	stream bool,
 ) map[string]interface{} {
+	if adapter == AdapterOpenRouterResponses {
+		return buildOpenRouterResponsesRequestBody(model, input, messages, providerTools, toolDefinitions, providerStreamOptions, stream)
+	}
 	items := buildResponsesAPIInput(messages)
 	payload := map[string]interface{}{
 		"model":  strings.TrimSpace(model),

--- a/backend/internal/infra/llm/openrouter_responses.go
+++ b/backend/internal/infra/llm/openrouter_responses.go
@@ -1,0 +1,156 @@
+package llm
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// openRouterResponsesAdapter 实现 OpenRouter Responses API Beta。
+// OpenRouter 的历史 input item schema 与官方 OpenAI Responses 有差异：
+// assistant message 和 tool output 历史需要稳定的 id/status 字段。
+type openRouterResponsesAdapter struct {
+	client *Client
+}
+
+func (a *openRouterResponsesAdapter) Name() string { return AdapterOpenRouterResponses }
+
+// Generate 调用 OpenRouter Responses 非流式接口。
+func (a *openRouterResponsesAdapter) Generate(ctx context.Context, route RouteConfig, input GenerateInput) (*GenerateOutput, error) {
+	route = normalizeOpenRouterResponsesRoute(route)
+	return a.client.generateOpenAICompatible(ctx, route, input)
+}
+
+// GenerateStream 调用 OpenRouter Responses 流式接口。
+func (a *openRouterResponsesAdapter) GenerateStream(ctx context.Context, route RouteConfig, input GenerateInput, onEvent func(GenerateStreamEvent) error) (*GenerateOutput, error) {
+	route = normalizeOpenRouterResponsesRoute(route)
+	return a.client.generateStreamOpenAICompatible(ctx, route, input, onEvent)
+}
+
+// ListModels 按 OpenRouter OpenAI-compatible 模型列表协议查询模型。
+func (a *openRouterResponsesAdapter) ListModels(ctx context.Context, route RouteConfig) ([]ModelItem, error) {
+	route = normalizeOpenRouterResponsesRoute(route)
+	return a.client.listModelsOpenAICompatible(ctx, route)
+}
+
+// normalizeOpenRouterResponsesRoute 固定 OpenRouter Responses 的协议和端点。
+func normalizeOpenRouterResponsesRoute(route RouteConfig) RouteConfig {
+	route.Protocol = AdapterOpenRouterResponses
+	route.Endpoint = EndpointResponses
+	return route
+}
+
+// buildOpenRouterResponsesRequestBody 构造 OpenRouter Responses Beta 请求体。
+func buildOpenRouterResponsesRequestBody(
+	model string,
+	input GenerateInput,
+	messages []Message,
+	providerTools []map[string]interface{},
+	toolDefinitions []ToolDefinition,
+	providerStreamOptions map[string]interface{},
+	stream bool,
+) map[string]interface{} {
+	payload := map[string]interface{}{
+		"model":  strings.TrimSpace(model),
+		"input":  buildOpenRouterResponsesAPIInput(messages),
+		"stream": stream,
+	}
+	if maxTokens := modelParamInt(input.Options, "max_output_tokens"); maxTokens > 0 {
+		payload["max_output_tokens"] = maxTokens
+	}
+	applyOpenAICompatibleSamplingParams(payload, input.Options, false)
+	applyOpenAIResponsesReasoningParams(payload, input.Options)
+	applyOpenAIResponsesTextParams(payload, input.Options, false)
+	appendToolDeclarations(payload, providerTools, buildOpenAITools(toolDefinitions, false))
+	if streamOptions := responsesStreamOptions(providerStreamOptions); stream && len(streamOptions) > 0 {
+		payload["stream_options"] = streamOptions
+	}
+	applyProviderOptions(payload, input.Options, responsesProtectedProviderOptionKeys(AdapterOpenRouterResponses)...)
+	if include := responseIncludeValues(input.Options); len(include) > 0 {
+		appendResponseInclude(payload, include...)
+	}
+	return payload
+}
+
+// buildOpenRouterResponsesAPIInput 将内部消息转换为 OpenRouter Responses input items。
+func buildOpenRouterResponsesAPIInput(messages []Message) []map[string]interface{} {
+	items := make([]map[string]interface{}, 0, len(messages))
+	for _, msg := range messages {
+		if len(msg.ToolCalls) > 0 {
+			for _, item := range msg.ToolCalls {
+				index := len(items)
+				args := strings.TrimSpace(item.ArgumentsJSON)
+				if args == "" {
+					args = "{}"
+				}
+				callID := strings.TrimSpace(item.ToolCallID)
+				items = append(items, map[string]interface{}{
+					"type":      "function_call",
+					"id":        openRouterResponsesItemID("fc", index, callID),
+					"call_id":   callID,
+					"name":      strings.TrimSpace(item.ToolName),
+					"arguments": args,
+				})
+			}
+			continue
+		}
+		if len(msg.ToolResults) > 0 {
+			for _, item := range msg.ToolResults {
+				index := len(items)
+				callID := strings.TrimSpace(item.ToolCallID)
+				items = append(items, map[string]interface{}{
+					"type":    "function_call_output",
+					"id":      openRouterResponsesItemID("fc_output", index, callID),
+					"call_id": callID,
+					"output":  buildToolResultContent(item),
+				})
+			}
+			continue
+		}
+		index := len(items)
+		role := normalizeRole(msg.Role)
+		item := map[string]interface{}{
+			"type":    "message",
+			"role":    role,
+			"content": buildResponsesAPIContent(msg),
+		}
+		if role == "assistant" {
+			item["id"] = openRouterResponsesItemID("msg_deeix", index, msg.Content)
+			item["status"] = "completed"
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+// openRouterResponsesItemID 为 OpenRouter 历史 item 生成请求内稳定 ID。
+func openRouterResponsesItemID(prefix string, index int, seed string) string {
+	token := sanitizeOpenRouterResponsesItemID(seed)
+	if token == "" {
+		token = strconv.Itoa(index + 1)
+	}
+	return strings.TrimSpace(prefix) + "_" + token
+}
+
+// sanitizeOpenRouterResponsesItemID 清理 OpenRouter item id 中不适合直接透传的字符。
+func sanitizeOpenRouterResponsesItemID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	var builder strings.Builder
+	lastUnderscore := false
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' {
+			builder.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			builder.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(builder.String(), "_")
+}

--- a/backend/internal/infra/llm/request_params_test.go
+++ b/backend/internal/infra/llm/request_params_test.go
@@ -70,6 +70,38 @@ func TestBuildOpenAIResponsesUsesOutputTextForAssistantHistory(t *testing.T) {
 	}
 }
 
+func TestBuildOpenRouterResponsesAddsRequiredHistoryMessageFields(t *testing.T) {
+	payload := mustBuildRequestBody(t, AdapterOpenRouterResponses, "openai/gpt-oss-120b:free", EndpointResponses, GenerateInput{
+		Messages: []Message{
+			{Role: "user", Content: "你好"},
+			{Role: "assistant", Content: "你好！有什么我可以帮忙的吗？"},
+			{Role: "user", Content: "你是谁？"},
+		},
+	}, true)
+
+	inputItems, ok := payload["input"].([]map[string]interface{})
+	if !ok || len(inputItems) != 3 {
+		t.Fatalf("expected three openrouter responses input items, got %#v", payload["input"])
+	}
+	if inputItems[0]["type"] != "message" || inputItems[0]["role"] != "user" {
+		t.Fatalf("expected user message item, got %#v", inputItems[0])
+	}
+	assistant := inputItems[1]
+	if assistant["type"] != "message" || assistant["role"] != "assistant" {
+		t.Fatalf("expected assistant message item, got %#v", assistant)
+	}
+	if assistant["id"] == "" || assistant["status"] != "completed" {
+		t.Fatalf("expected assistant id/status for openrouter history, got %#v", assistant)
+	}
+	content := assistant["content"].([]map[string]interface{})
+	if content[0]["type"] != "output_text" {
+		t.Fatalf("expected output_text content, got %#v", content[0])
+	}
+	if _, ok := payload["include"]; ok {
+		t.Fatalf("expected no openai-only default include for openrouter responses, got %#v", payload["include"])
+	}
+}
+
 func TestBuildOpenAIResponsesPlaylistHistoryMatchesOfficialContentTypes(t *testing.T) {
 	payload := mustBuildRequestBody(t, AdapterOpenAIResponses, "gpt-5.5", EndpointResponses, GenerateInput{
 		Messages: []Message{

--- a/backend/internal/infra/llm/request_tools_test.go
+++ b/backend/internal/infra/llm/request_tools_test.go
@@ -170,6 +170,26 @@ func TestBuildResponsesToolInputItems(t *testing.T) {
 	}
 }
 
+func TestBuildOpenRouterResponsesToolHistoryAddsItemIDs(t *testing.T) {
+	payload := mustBuildRequestBody(t, AdapterOpenRouterResponses, "openai/o4-mini", EndpointResponses, GenerateInput{
+		Messages: []Message{
+			{Role: "assistant", ToolCalls: []ToolCall{{ToolCallID: "call_123", ToolName: "get_weather", ArgumentsJSON: `{"location":"Boston, MA"}`}}},
+			{Role: "tool", ToolResults: []ToolResult{{ToolCallID: "call_123", ToolName: "get_weather", OutputJSON: `{"temperature":"72F"}`, Status: "success"}}},
+		},
+	}, false)
+
+	items := payload["input"].([]map[string]interface{})
+	if len(items) != 2 {
+		t.Fatalf("expected two tool history items, got %#v", items)
+	}
+	if items[0]["type"] != "function_call" || items[0]["id"] == "" || items[0]["call_id"] != "call_123" {
+		t.Fatalf("expected function_call item id and call_id, got %#v", items[0])
+	}
+	if items[1]["type"] != "function_call_output" || items[1]["id"] == "" || items[1]["call_id"] != "call_123" {
+		t.Fatalf("expected function_call_output item id and call_id, got %#v", items[1])
+	}
+}
+
 func TestBuildOpenAIToolsKeepsInputSchema(t *testing.T) {
 	schema := json.RawMessage(`{"type":"object","properties":{"query":{"type":"string"},"count":{"type":"number"}},"required":["query"]}`)
 	payload := mustBuildRequestBody(t, AdapterOpenAIChatCompletions, "gpt-5", EndpointChatCompletions, GenerateInput{

--- a/frontend/features/admin/api/llm.types.ts
+++ b/frontend/features/admin/api/llm.types.ts
@@ -4,6 +4,7 @@ export type AdminLLMStatus = "active" | "inactive";
 export type AdminLLMModelAccessScope = "public" | "internal";
 export type AdminLLMAdapter =
   | "openai_responses"
+  | "openrouter_responses"
   | "openai_chat_completions"
   | "openai_image_generations"
   | "openai_image_edits"

--- a/frontend/features/admin/components/sections/conversation/admin-conversation.tsx
+++ b/frontend/features/admin/components/sections/conversation/admin-conversation.tsx
@@ -223,6 +223,10 @@ generationConfig.safetySettings.threshold`}
     "reasoning.effort",
     "text.verbosity"
   ],
+  "openrouter_responses": [
+    "reasoning.effort",
+    "reasoning.summary"
+  ],
   "openai_image_generations": [
     "background",
     "moderation",
@@ -302,7 +306,7 @@ generationConfig.safetySettings.threshold`}
             <h4 className="text-sm font-medium text-foreground">{t("guide.protocolTitle")}</h4>
             <p className="text-xs">{t("guide.protocolDescription")}</p>
             <div className="flex flex-wrap gap-1.5">
-              {["default", "openai_chat_completions", "openai_responses", "openai_image_generations", "openai_image_edits", "google_image_generation", "xai_image", "xai_image_edits", "anthropic_messages", "xai_responses", "gemini_generate_content"].map((item) => (
+              {["default", "openai_chat_completions", "openai_responses", "openrouter_responses", "openai_image_generations", "openai_image_edits", "google_image_generation", "xai_image", "xai_image_edits", "anthropic_messages", "xai_responses", "gemini_generate_content"].map((item) => (
                 <code key={item} className="rounded-md bg-muted/60 px-2 py-1 text-xs text-foreground">{item}</code>
               ))}
             </div>

--- a/frontend/features/admin/components/sections/upstreams/upstream-sheet.tsx
+++ b/frontend/features/admin/components/sections/upstreams/upstream-sheet.tsx
@@ -74,6 +74,7 @@ const NO_PROTOCOL_DEFAULT = "__system_default__";
 const PROTOCOL_OPTIONS_BY_KIND: Record<(typeof PROTOCOL_DEFAULT_KINDS)[number], string[]> = {
   chat: [
     "openai_responses",
+    "openrouter_responses",
     "openai_chat_completions",
     "anthropic_messages",
     "google_generate_content",
@@ -81,6 +82,7 @@ const PROTOCOL_OPTIONS_BY_KIND: Record<(typeof PROTOCOL_DEFAULT_KINDS)[number], 
   ],
   audio: [
     "openai_responses",
+    "openrouter_responses",
     "openai_chat_completions",
     "anthropic_messages",
     "google_generate_content",

--- a/frontend/features/admin/types/llm.ts
+++ b/frontend/features/admin/types/llm.ts
@@ -26,6 +26,7 @@ export type ModelSortValue = (typeof MODEL_SORT_OPTIONS)[number]["value"];
 
 export const ADAPTER_LABELS: Record<string, string> = {
   openai_responses:         resolveProtocolLabel("openai_responses"),
+  openrouter_responses:     resolveProtocolLabel("openrouter_responses"),
   openai_chat_completions:  resolveProtocolLabel("openai_chat_completions"),
   openai_image_generations: resolveProtocolLabel("openai_image_generations"),
   openai_image_edits:       resolveProtocolLabel("openai_image_edits"),

--- a/frontend/features/admin/utils/llm-display.ts
+++ b/frontend/features/admin/utils/llm-display.ts
@@ -36,6 +36,7 @@ type ProtocolOption = {
 
 export const PROTOCOL_OPTIONS: ReadonlyArray<ProtocolOption> = [
   { value: "openai_responses", label: "Responses API (OpenAI)", kinds: ["chat"] },
+  { value: "openrouter_responses", label: "Responses (OpenRouter)", kinds: ["chat"] },
   { value: "openai_chat_completions", label: "Chat Completions (OpenAI)", kinds: ["chat"] },
   { value: "openai_image_generations", label: "Images Generations (OpenAI)", kinds: ["image_gen"] },
   { value: "openai_image_edits", label: "Images Edits (OpenAI)", kinds: ["image_edit"] },

--- a/frontend/features/chat/components/sections/chat-model-config.tsx
+++ b/frontend/features/chat/components/sections/chat-model-config.tsx
@@ -391,6 +391,7 @@ const PROTOCOL_LABELS: Record<string, string> = {
   openai_image_edits: "Images Edits",
   openai_image_generations: "Images Generations",
   openai_responses: "Responses",
+  openrouter_responses: "OpenRouter Responses",
   openai_video_generations: "Video Generations",
   replicate_predictions: "Predictions",
   stability_ai_generate: "Image Generation",

--- a/frontend/shared/lib/model-option-policy.ts
+++ b/frontend/shared/lib/model-option-policy.ts
@@ -2,6 +2,7 @@ export const MODEL_OPTION_POLICY_PROTOCOLS = [
   "default",
   "openai_chat_completions",
   "openai_responses",
+  "openrouter_responses",
   "openai_image_generations",
   "openai_image_edits",
   "anthropic_messages",
@@ -59,6 +60,7 @@ export const MODEL_OPTION_POLICY_PROTOCOL_LABELS: Record<ModelOptionPolicyProtoc
   default: "Default",
   openai_chat_completions: "OpenAI（Chat Completions）",
   openai_responses: "OpenAI（Responses）",
+  openrouter_responses: "OpenRouter（Responses）",
   openai_image_generations: "OpenAI（Images Generations）",
   openai_image_edits: "OpenAI（Images Edits）",
   anthropic_messages: "Anthropic（Messages）",
@@ -114,6 +116,9 @@ export function resolveModelOptionPolicyProtocol(protocol: string): ModelOptionP
     case "openai":
     case "openai_responses":
       return "openai_responses";
+    case "openrouter":
+    case "openrouter_responses":
+      return "openrouter_responses";
     case "openai_chat_completions":
       return "openai_chat_completions";
     case "openai_image_generations":


### PR DESCRIPTION
## Summary

Fix OpenRouter Responses API multi-turn requests by adding a dedicated `openrouter_responses` protocol adapter. OpenRouter’s Responses Beta requires history items to include fields that differ from the official OpenAI Responses serializer, especially `type`, assistant `id/status`, and tool history `id` fields.

This change keeps the existing OpenAI Responses and Chat Completions paths unchanged, while routing OpenRouter-compatible chat/audio defaults to the new protocol.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [x] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./internal/...`
- [x] `cd frontend && pnpm lint`
- [ ] Not run; reason:

## Screenshots, API examples, or logs

Sanitized failing shape before:

```json
{
  "model": "openai/gpt-oss-120b:free",
  "input": [
    { "role": "user", "content": [{ "type": "input_text", "text": "你好" }] },
    { "role": "assistant", "content": [{ "type": "output_text", "text": "你好！有什么我可以帮忙的吗？" }] },
    { "role": "user", "content": [{ "type": "input_text", "text": "你是谁？" }] }
  ],
  "stream": true
}
```

OpenRouter-compatible history shape now includes required item metadata:

```json
{
  "type": "message",
  "role": "assistant",
  "id": "msg_deeix_...",
  "status": "completed",
  "content": [{ "type": "output_text", "text": "..." }]
}
```

## Configuration, migration, and compatibility notes

No database migration or environment variable changes are required.

New OpenRouter-compatible route defaults use `openrouter_responses` for chat/audio models. Existing OpenRouter routes already stored as `openai_responses` will continue using the old serializer until the route protocol is updated to `openrouter_responses`.

Official OpenAI Responses, OpenAI Chat Completions, Anthropic Messages, xAI Responses, and Gemini paths remain unchanged.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.