### PR TITLE
Return onboarding to password step on bootstrap password reuse error

### DIFF
--- a/frontend/features/layouts/components/sections/initial-security-guard.tsx
+++ b/frontend/features/layouts/components/sections/initial-security-guard.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/features/settings/utils/appearance-preferences";
 import { cancelCurrentTwoFactorSetup, completeOnboarding, confirmCurrentTwoFactorSetup, patchMe, patchUsername, startCurrentTwoFactorSetup } from "@/shared/api/auth";
 import type { TwoFactorSetupStartData, UserDTO } from "@/shared/api/auth.types";
+import { ApiError } from "@/shared/api/http-client";
 import {
   DISPLAY_NAME_MAX_LENGTH,
   PASSWORD_MIN_LENGTH,
@@ -126,6 +127,10 @@ const onboardingThemePresets: ThemePreset[] = [
   "ochre",
   "sepia",
 ];
+
+function isPasswordReuseError(error: unknown) {
+  return error instanceof ApiError && error.errorCode === "auth.password_reuse_not_allowed";
+}
 
 function OnboardingFeatureCarousel({
   activeIndex,
@@ -547,6 +552,9 @@ export function InitialSecurityGuard() {
       }
       toast.success(t("toasts.complete"));
     } catch (error) {
+      if (isPasswordReuseError(error)) {
+        setStep(2);
+      }
       toast.error(t("toasts.completeFailed"), {
         description: resolveErrorMessage(error, tCommonErrors("unknown")),
       });


### PR DESCRIPTION
## Summary

This change improves the bootstrap super admin onboarding recovery flow.

When the backend rejects initial setup completion because the new password matches the bootstrap password, the frontend now returns the onboarding dialog to the account/password step so the user can enter a different password immediately.

## Problem

During first-time bootstrap super admin setup, users can enter the generated bootstrap password as the new password. The backend correctly rejects this during onboarding completion with `auth.password_reuse_not_allowed`.

Previously, the user saw the error toast at the final step but could not conveniently return to the password input step to fix it.

## Solution

- Detect `auth.password_reuse_not_allowed` from the completion API error.
- Move the onboarding dialog back to step 2 when this error occurs.
- Keep the existing backend validation as the source of truth.
- Do not store passwords or password fingerprints on the frontend.
- Do not change the login flow or backend behavior.

## Testing

- `pnpm exec tsc --noEmit`
- `pnpm lint`
