### PR TITLE
Fix clipped model names in chat model picker

### DIFF
--- a/frontend/features/chat/components/sections/chat-model-picker.tsx
+++ b/frontend/features/chat/components/sections/chat-model-picker.tsx
@@ -419,7 +419,7 @@ function ChatModelMenuItem({
         onClick={onSelect}
       >
         <LobeHubIcon iconUrl={iconURL} label={platformModelName} />
-        <span className="min-w-0 flex-1 truncate">
+        <span className="min-w-0 flex-1 truncate leading-4">
           {platformModelName}
         </span>
         <span className="flex size-3 shrink-0 items-center justify-center">


### PR DESCRIPTION
### Summary

This PR fixes clipped model names in the chat model picker menu. Model labels such as `gpt-5.5` could appear vertically cut off because the label text inherited `leading-none` from the menu item button while also using `truncate`, which applies `overflow: hidden`.

The fix is intentionally small: apply `leading-4` directly to the model label span. This gives the text a sufficient line box while preserving the existing single-line truncation and menu layout.

### Changes

- Add `leading-4` to the chat model picker menu item label.
- Keep the existing row height, menu sizing constants, truncation behavior, and interaction layout unchanged.

### Root Cause

The model item button used `text-[11px] leading-none`. The model name span used `truncate`, which clips overflowing content. Because the inherited line-height was only 11px, glyph descenders such as the `g` in `gpt-5.5` could be clipped.

### Verification

- Ran `pnpm lint`.
- Ran `git diff --check`.
- Confirmed computed styles changed from an 11px label line-height to a 16px label line-height while preserving `overflow: hidden` and `white-space: nowrap`.

before
<img width="1103" height="309" alt="Screenshot 2026-06-08 at 3 08 02 PM" src="https://github.com/user-attachments/assets/5890861e-65d2-437c-8123-b091c3044c3d" />
after
<img width="1203" height="314" alt="Screenshot 2026-06-08 at 3 17 02 PM" src="https://github.com/user-attachments/assets/432290df-1b61-4a3a-a6e4-301ab3ff2073" />

