### PR TITLE
fix: load long conversation history incrementally

### DIFF
--- a/backend/internal/application/conversation/service_conversation.go
+++ b/backend/internal/application/conversation/service_conversation.go
@@ -14,6 +14,7 @@ import (
 const (
 	defaultPageSize             = 20
 	maxPageSize                 = 100
+	maxMessagePageSize          = 1000
 	conversationExportVersion   = 1
 	conversationExportScopeFull = "full"
 )
@@ -99,8 +100,31 @@ func (s *Service) ListMessages(ctx context.Context, userID uint, conversationID 
 		return nil, 0, ErrConversationNotFound
 	}
 
-	offset, limit := normalizePage(page, pageSize)
+	offset, limit := normalizeMessagePage(page, pageSize)
 	items, total, err := s.repo.ListMessages(ctx, conversationID, offset, limit)
+	if err != nil {
+		return nil, 0, err
+	}
+	if err = s.hydrateMessageFeedback(ctx, userID, items); err != nil {
+		return nil, 0, err
+	}
+	if err = s.hydrateMessageProcessTraces(ctx, items); err != nil {
+		return nil, 0, err
+	}
+	return items, total, nil
+}
+
+// ListMessagesBeforeID 查询指定消息 ID 之前的一页会话消息。
+func (s *Service) ListMessagesBeforeID(ctx context.Context, userID uint, conversationID uint, beforeID uint, pageSize int) ([]model.Message, int64, error) {
+	if beforeID == 0 {
+		return []model.Message{}, 0, nil
+	}
+	if _, err := s.repo.GetConversationByUser(ctx, conversationID, userID); err != nil {
+		return nil, 0, ErrConversationNotFound
+	}
+
+	_, limit := normalizeMessagePage(1, pageSize)
+	items, total, err := s.repo.ListMessagesBeforeID(ctx, conversationID, beforeID, limit)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -176,7 +200,7 @@ func (s *Service) ListRecentMessages(ctx context.Context, userID uint, conversat
 		return nil, 0, ErrConversationNotFound
 	}
 
-	_, normalizedLimit := normalizePage(1, limit)
+	normalizedLimit := normalizeRecentMessageLimit(limit)
 	items, total, err := s.repo.ListRecentMessages(ctx, conversationID, normalizedLimit)
 	if err != nil {
 		return nil, 0, err
@@ -400,14 +424,27 @@ func (s *Service) ListConversationRunsByRunIDs(
 }
 
 func normalizePage(page int, pageSize int) (int, int) {
+	return normalizePageWithMax(page, pageSize, maxPageSize)
+}
+
+func normalizeMessagePage(page int, pageSize int) (int, int) {
+	return normalizePageWithMax(page, pageSize, maxMessagePageSize)
+}
+
+func normalizeRecentMessageLimit(limit int) int {
+	_, normalizedLimit := normalizeMessagePage(1, limit)
+	return normalizedLimit
+}
+
+func normalizePageWithMax(page int, pageSize int, maxAllowedPageSize int) (int, int) {
 	if page <= 0 {
 		page = 1
 	}
 	if pageSize <= 0 {
 		pageSize = defaultPageSize
 	}
-	if pageSize > maxPageSize {
-		pageSize = maxPageSize
+	if maxAllowedPageSize > 0 && pageSize > maxAllowedPageSize {
+		pageSize = maxAllowedPageSize
 	}
 	offset := (page - 1) * pageSize
 	if offset < 0 {

--- a/backend/internal/application/conversation/service_conversation_export_test.go
+++ b/backend/internal/application/conversation/service_conversation_export_test.go
@@ -39,3 +39,21 @@ func TestCollectExportMessageRunIDsTrimsAndDeduplicates(t *testing.T) {
 		t.Fatalf("unexpected export run ids: got %#v want %#v", got, want)
 	}
 }
+
+func TestNormalizeMessagePageAllowsRestoreWindow(t *testing.T) {
+	_, generalLimit := normalizePage(1, 1000)
+	if generalLimit != maxPageSize {
+		t.Fatalf("expected normal page limit to stay capped at %d, got %d", maxPageSize, generalLimit)
+	}
+
+	_, messageLimit := normalizeMessagePage(1, 1000)
+	if messageLimit != 1000 {
+		t.Fatalf("expected message page limit to allow 1000, got %d", messageLimit)
+	}
+}
+
+func TestNormalizeRecentMessageLimitUsesMessageWindow(t *testing.T) {
+	if got := normalizeRecentMessageLimit(5000); got != maxMessagePageSize {
+		t.Fatalf("expected recent message limit capped at %d, got %d", maxMessagePageSize, got)
+	}
+}

--- a/backend/internal/infra/persistence/postgres/conversation/repository.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository.go
@@ -1176,6 +1176,40 @@ func (r *Repo) ListMessages(ctx context.Context, conversationID uint, offset int
 	return toMessageDomains(items), total, nil
 }
 
+// ListMessagesBeforeID 查询指定消息 ID 之前的一页会话消息（按时间升序返回）。
+func (r *Repo) ListMessagesBeforeID(ctx context.Context, conversationID uint, beforeID uint, limit int) ([]domainconversation.Message, int64, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	items := make([]models.Message, 0, limit)
+	var total int64
+
+	if err := r.db.WithContext(ctx).
+		Model(&models.Message{}).
+		Where("conversation_id = ?", conversationID).
+		Count(&total).Error; err != nil {
+		return nil, 0, translateError(err)
+	}
+
+	if err := r.db.WithContext(ctx).
+		Where("conversation_id = ? AND id < ?", conversationID, beforeID).
+		Order("id DESC").
+		Limit(limit).
+		Find(&items).Error; err != nil {
+		return nil, 0, translateError(err)
+	}
+	for left, right := 0, len(items)-1; left < right; left, right = left+1, right-1 {
+		items[left], items[right] = items[right], items[left]
+	}
+	if err := r.hydrateMessageRefs(ctx, items); err != nil {
+		return nil, 0, err
+	}
+	if err := r.hydrateMessageAttachments(ctx, items); err != nil {
+		return nil, 0, err
+	}
+	return toMessageDomains(items), total, nil
+}
+
 // ListMessagesForShare 查询分享快照可公开展示的消息。
 func (r *Repo) ListMessagesForShare(ctx context.Context, conversationID uint, publicIDs []string) ([]domainconversation.Message, error) {
 	items := make([]models.Message, 0)

--- a/backend/internal/infra/persistence/postgres/conversation/repository_test.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository_test.go
@@ -1,9 +1,91 @@
 package conversation
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
 
 func TestTranslateErrorAllowsNil(t *testing.T) {
 	if err := translateError(nil); err != nil {
 		t.Fatalf("translateError(nil) = %v, want nil", err)
 	}
+}
+
+func TestListMessagesBeforeIDReturnsPreviousWindowAscending(t *testing.T) {
+	db := openConversationRepositoryTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	conversation := model.Conversation{
+		UserID:     1,
+		PublicID:   "conv_before",
+		Title:      "before window",
+		LabelsJSON: "[]",
+		SessionKey: "session_before",
+		Status:     "active",
+	}
+	if err := db.Create(&conversation).Error; err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	messages := make([]model.Message, 0, 5)
+	var parentID *uint
+	for index := 1; index <= 5; index++ {
+		message := model.Message{
+			ConversationID:  conversation.ID,
+			UserID:          1,
+			PublicID:        fmt.Sprintf("msg_%d", index),
+			ParentMessageID: parentID,
+			Role:            "user",
+			ContentType:     "text",
+			Content:         fmt.Sprintf("message %d", index),
+			BranchReason:    "default",
+			Status:          "success",
+		}
+		if err := db.Create(&message).Error; err != nil {
+			t.Fatalf("create message %d: %v", index, err)
+		}
+		messages = append(messages, message)
+		nextParentID := message.ID
+		parentID = &nextParentID
+	}
+
+	got, total, err := repo.ListMessagesBeforeID(ctx, conversation.ID, messages[4].ID, 2)
+	if err != nil {
+		t.Fatalf("ListMessagesBeforeID() error = %v", err)
+	}
+	if total != int64(len(messages)) {
+		t.Fatalf("total = %d, want %d", total, len(messages))
+	}
+	if len(got) != 2 || got[0].PublicID != "msg_3" || got[1].PublicID != "msg_4" {
+		t.Fatalf("unexpected previous window: %#v", got)
+	}
+	if got[1].ParentPublicID != "msg_3" {
+		t.Fatalf("expected parent public id hydrated, got %q", got[1].ParentPublicID)
+	}
+}
+
+func openConversationRepositoryTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	name := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	db, err := gorm.Open(sqlite.Open("file:"+name+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		sqlDB, dbErr := db.DB()
+		if dbErr == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	if err := db.AutoMigrate(&model.Conversation{}, &model.Message{}, &model.Attachment{}, &model.FileObject{}); err != nil {
+		t.Fatalf("migrate models: %v", err)
+	}
+	return db
 }

--- a/backend/internal/repository/conversation_core.go
+++ b/backend/internal/repository/conversation_core.go
@@ -78,6 +78,7 @@ type MessageRepository interface {
 	UpdateMessageBilling(ctx context.Context, messageID uint, billedCurrency string, billedNanousd int64, pricingSnapshot string) error
 	SumMessageTokens(ctx context.Context, conversationID uint) (int64, error)
 	ListMessages(ctx context.Context, conversationID uint, offset int, limit int) ([]domainconversation.Message, int64, error)
+	ListMessagesBeforeID(ctx context.Context, conversationID uint, beforeID uint, limit int) ([]domainconversation.Message, int64, error)
 	ListAllMessages(ctx context.Context, conversationID uint) ([]domainconversation.Message, error)
 	ListMessagesForShare(ctx context.Context, conversationID uint, publicIDs []string) ([]domainconversation.Message, error)
 	ListRecentMessages(ctx context.Context, conversationID uint, limit int) ([]domainconversation.Message, int64, error)

--- a/backend/internal/transport/http/conversation/handler.go
+++ b/backend/internal/transport/http/conversation/handler.go
@@ -68,9 +68,23 @@ func (h *Handler) recordAudit(c *gin.Context, action string, resource string, re
 	})
 }
 
+const (
+	defaultHTTPPageSize = 20
+	maxHTTPPageSize     = 100
+	maxMessagePageSize  = 1000
+)
+
 func pageParams(c *gin.Context) (int, int) {
+	return pageParamsWithMax(c, maxHTTPPageSize)
+}
+
+func messagePageParams(c *gin.Context) (int, int) {
+	return pageParamsWithMax(c, maxMessagePageSize)
+}
+
+func pageParamsWithMax(c *gin.Context, maxPageSize int) (int, int) {
 	page := 1
-	pageSize := 20
+	pageSize := defaultHTTPPageSize
 
 	if raw := c.Query("page"); raw != "" {
 		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
@@ -79,8 +93,8 @@ func pageParams(c *gin.Context) (int, int) {
 	}
 	if raw := c.Query("page_size"); raw != "" {
 		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
-			if parsed > 100 {
-				parsed = 100
+			if maxPageSize > 0 && parsed > maxPageSize {
+				parsed = maxPageSize
 			}
 			pageSize = parsed
 		}

--- a/backend/internal/transport/http/conversation/handler_message_query.go
+++ b/backend/internal/transport/http/conversation/handler_message_query.go
@@ -3,6 +3,7 @@ package conversation
 import (
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 
 	appconversation "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/conversation"
@@ -161,7 +162,16 @@ func (h *Handler) ListMessages(c *gin.Context) {
 		return
 	}
 
-	page, pageSize := pageParams(c)
+	page, pageSize := messagePageParams(c)
+	var beforeID uint
+	if rawBeforeID := strings.TrimSpace(c.Query("before_id")); rawBeforeID != "" {
+		parsed, parseErr := strconv.ParseUint(rawBeforeID, 10, 64)
+		if parseErr != nil || parsed == 0 {
+			response.Error(c, http.StatusBadRequest, "invalid before message id")
+			return
+		}
+		beforeID = uint(parsed)
+	}
 	conversation, err := h.service.GetConversationByPublicID(c.Request.Context(), userID, publicID)
 	if err != nil {
 		if errors.Is(err, appconversation.ErrConversationNotFound) {
@@ -174,7 +184,9 @@ func (h *Handler) ListMessages(c *gin.Context) {
 
 	var items []model.Message
 	var total int64
-	if c.Query("tail") == "true" {
+	if beforeID > 0 {
+		items, total, err = h.service.ListMessagesBeforeID(c.Request.Context(), userID, conversation.ID, beforeID, pageSize)
+	} else if c.Query("tail") == "true" {
 		items, total, err = h.service.ListRecentMessages(c.Request.Context(), userID, conversation.ID, pageSize)
 	} else {
 		items, total, err = h.service.ListMessages(c.Request.Context(), userID, conversation.ID, page, pageSize)

--- a/backend/internal/transport/http/conversation/handler_test.go
+++ b/backend/internal/transport/http/conversation/handler_test.go
@@ -2,10 +2,12 @@ package conversation
 
 import (
 	"errors"
+	"net/http/httptest"
 	"testing"
 
 	appconversation "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/conversation"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/llm"
+	"github.com/gin-gonic/gin"
 )
 
 func TestSafeFileContentTypeDowngradesActiveContent(t *testing.T) {
@@ -22,6 +24,23 @@ func TestSafeFileContentTypeDowngradesActiveContent(t *testing.T) {
 		if got := safeFileContentType(tt.contentType); got != tt.want {
 			t.Fatalf("safeFileContentType(%q) = %q, want %q", tt.contentType, got, tt.want)
 		}
+	}
+}
+
+func TestMessagePageParamsAllowsRestoreWindow(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/messages?page=1&page_size=1000", nil)
+
+	_, pageSize := messagePageParams(c)
+	if pageSize != 1000 {
+		t.Fatalf("messagePageParams page size = %d, want 1000", pageSize)
+	}
+
+	_, normalPageSize := pageParams(c)
+	if normalPageSize != maxHTTPPageSize {
+		t.Fatalf("pageParams page size = %d, want %d", normalPageSize, maxHTTPPageSize)
 	}
 }
 

--- a/frontend/features/chat/components/app-chat-area.tsx
+++ b/frontend/features/chat/components/app-chat-area.tsx
@@ -44,9 +44,10 @@ import {
 import { useSidebarRecents } from "@/features/recent/context/sidebar-recents-context";
 import { useChatData } from "@/features/chat/hooks/use-chat-data";
 import { toPendingAttachment } from "@/features/chat/model/message-submit";
+import { getConversation } from "@/shared/api/conversation";
 import { listAvailableMCPTools } from "@/shared/api/mcp";
 import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
-import type { ConversationOptions } from "@/shared/api/conversation.types";
+import type { ConversationDTO, ConversationOptions } from "@/shared/api/conversation.types";
 import type { MCPToolDTO } from "@/shared/api/mcp.types";
 import { useTheme } from "@/shared/components/theme-provider";
 import { cn } from "@/lib/utils";
@@ -167,7 +168,10 @@ export function AppChatArea() {
   const {
     cancelResumedGeneration,
     loading,
+    loadingOlder,
     errorMsg,
+    hasOlder,
+    loadOlderMessages,
     messages,
     reload,
     replaceMessage,
@@ -188,6 +192,38 @@ export function AppChatArea() {
     }
     return items.find((item) => item.publicID === conversationID) ?? null;
   }, [conversationID, items]);
+  const [loadedConversation, setLoadedConversation] = React.useState<ConversationDTO | null>(null);
+  React.useEffect(() => {
+    const normalizedConversationID = conversationID?.trim() || "";
+    if (!normalizedConversationID || activeConversation?.publicID === normalizedConversationID) {
+      setLoadedConversation(null);
+      return;
+    }
+
+    let cancelled = false;
+    async function loadConversation() {
+      const token = await resolveAccessToken();
+      if (!token) {
+        return;
+      }
+      const item = await getConversation(token, normalizedConversationID);
+      if (cancelled) {
+        return;
+      }
+      setLoadedConversation(item);
+    }
+
+    void loadConversation().catch(() => {
+      if (!cancelled) {
+        setLoadedConversation(null);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeConversation?.publicID, conversationID]);
+  const currentConversation =
+    activeConversation ?? (loadedConversation?.publicID === conversationID ? loadedConversation : null);
   const activeRouteProject = React.useMemo(() => {
     if (!routeProjectID || conversationID) {
       return null;
@@ -220,7 +256,7 @@ export function AppChatArea() {
     setSelectedPlatformModelName,
   } = useChatModelOptions({
     conversationPublicID: conversationID,
-    conversationModel: activeConversation?.model ?? null,
+    conversationModel: currentConversation?.model ?? null,
   });
   const {
     conversationKey,
@@ -380,7 +416,7 @@ export function AppChatArea() {
     conversationID,
     resetToken: newConversationRevision,
     messages,
-    activeConversation,
+    activeConversation: currentConversation,
     selectedPlatformModelName,
     modelOptions,
     selectedToolIDs,
@@ -432,6 +468,9 @@ export function AppChatArea() {
     showPendingAssistant: showLiveAssistant,
     streamingText,
     streamingTraceText,
+    hasOlderMessages: hasOlder,
+    loadingOlderMessages: loadingOlder,
+    onLoadOlderMessages: loadOlderMessages,
   });
 
   const onEditGeneratedImageAttachment = React.useCallback(
@@ -483,20 +522,20 @@ export function AppChatArea() {
   }, [conversationID]);
 
   React.useEffect(() => {
-    const nextTitle = activeConversation?.title?.trim();
+    const nextTitle = currentConversation?.title?.trim();
     if (nextTitle) {
       setManualConversationTitle(nextTitle);
     }
-  }, [activeConversation?.publicID, activeConversation?.title]);
+  }, [currentConversation?.publicID, currentConversation?.title]);
 
   const actionConversationID = React.useMemo(() => (conversationID || "").trim(), [conversationID]);
   const canOperateConversation = actionConversationID.length > 0;
   const activeConversationTitle = React.useMemo(
-    () => manualConversationTitle || activeConversation?.title?.trim() || t("untitledConversation"),
-    [activeConversation?.title, manualConversationTitle, t],
+    () => manualConversationTitle || currentConversation?.title?.trim() || t("untitledConversation"),
+    [currentConversation?.title, manualConversationTitle, t],
   );
-  const activeConversationStarred = Boolean(activeConversation?.isStarred);
-  const activeConversationShared = activeConversation?.shareStatus === "active" && Boolean(activeConversation.shareID?.trim());
+  const activeConversationStarred = Boolean(currentConversation?.isStarred);
+  const activeConversationShared = currentConversation?.shareStatus === "active" && Boolean(currentConversation.shareID?.trim());
   const shareDefaultMessagePublicIDs = React.useMemo(
     () =>
       visibleMessages
@@ -855,7 +894,7 @@ export function AppChatArea() {
                   projectMenu={{
                     label: t("labelMenu.moveToProject"),
                     unassignedLabel: t("labelMenu.unassignedProject"),
-                    currentProjectID: activeConversation?.projectID,
+                    currentProjectID: currentConversation?.projectID,
                     projects,
                     onSelect: onSetActiveConversationProject,
                   }}

--- a/frontend/features/chat/hooks/use-chat-data.ts
+++ b/frontend/features/chat/hooks/use-chat-data.ts
@@ -4,14 +4,19 @@ import * as React from "react";
 import { useTranslations } from "next-intl";
 
 import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
-import { cancelMessageGeneration, listMessages, resumeMessageGenerationStream } from "@/shared/api/conversation";
+import { cancelMessageGeneration, listMessagesPage, resumeMessageGenerationStream } from "@/shared/api/conversation";
 import { buildMediaImagePreviewMarkdown } from "@/features/chat/model/media-image-preview";
 import type { MessageDTO } from "@/shared/api/conversation.types";
 
+const MESSAGE_PAGE_SIZE = 100;
+
 type ChatDataState = {
   loading: boolean;
+  loadingOlder: boolean;
   errorMsg: string;
   messages: MessageDTO[];
+  total: number;
+  hasOlder: boolean;
 };
 
 type ActiveResumeStream = {
@@ -34,8 +39,11 @@ export function useChatData(
   const tSubmit = useTranslations("chat.submit");
   const [state, setState] = React.useState<ChatDataState>({
     loading: Boolean(conversationID),
+    loadingOlder: false,
     errorMsg: "",
     messages: [],
+    total: 0,
+    hasOlder: false,
   });
   const [reloadToken, setReloadToken] = React.useState(0);
   const [resumingRunID, setResumingRunID] = React.useState("");
@@ -50,8 +58,11 @@ export function useChatData(
       if (!conversationID) {
         setState({
           loading: false,
+          loadingOlder: false,
           errorMsg: "",
           messages: [],
+          total: 0,
+          hasOlder: false,
         });
         return;
       }
@@ -60,8 +71,11 @@ export function useChatData(
       previousConversationIDRef.current = conversationID;
       setState((prev) => ({
         loading: isConversationSwitch || prev.messages.length === 0,
+        loadingOlder: false,
         errorMsg: "",
         messages: isConversationSwitch ? [] : prev.messages,
+        total: isConversationSwitch ? 0 : prev.total,
+        hasOlder: isConversationSwitch ? false : prev.hasOlder,
       }));
       try {
         const token = await resolveAccessToken();
@@ -69,28 +83,39 @@ export function useChatData(
           if (!cancelled) {
             setState({
               loading: false,
+              loadingOlder: false,
               errorMsg: t("signInRequired"),
               messages: [],
+              total: 0,
+              hasOlder: false,
             });
           }
           return;
         }
 
-        const messages = await listMessages(token, conversationID);
+        const data = await listMessagesPage(token, conversationID, {
+          page: 1,
+          pageSize: MESSAGE_PAGE_SIZE,
+          tail: true,
+        });
         if (cancelled) {
           return;
         }
 
         setState({
           loading: false,
+          loadingOlder: false,
           errorMsg: "",
-          messages,
+          messages: data.results,
+          total: data.total,
+          hasOlder: data.results.length < data.total,
         });
       } catch {
         if (!cancelled) {
           setState((prev) => ({
             ...prev,
             loading: false,
+            loadingOlder: false,
             errorMsg: t("loadFailed"),
           }));
         }
@@ -115,6 +140,53 @@ export function useChatData(
       ),
     }));
   }, []);
+
+  const loadOlderMessages = React.useCallback(async () => {
+    if (!conversationID || state.loading || state.loadingOlder || !state.hasOlder || state.messages.length === 0) {
+      return false;
+    }
+
+    const beforeID = state.messages[0]?.id ?? 0;
+    if (beforeID <= 0) {
+      setState((prev) => ({ ...prev, hasOlder: false }));
+      return false;
+    }
+
+    setState((prev) => ({ ...prev, loadingOlder: true }));
+    try {
+      const token = await resolveAccessToken();
+      if (!token) {
+        setState((prev) => ({ ...prev, loadingOlder: false, hasOlder: false }));
+        return false;
+      }
+
+      const data = await listMessagesPage(token, conversationID, {
+        pageSize: MESSAGE_PAGE_SIZE,
+        beforeID,
+      });
+      if (previousConversationIDRef.current !== conversationID) {
+        return false;
+      }
+      let loaded = false;
+      setState((prev) => {
+        const existingPublicIDs = new Set(prev.messages.map((message) => message.publicID));
+        const olderMessages = data.results.filter((message) => !existingPublicIDs.has(message.publicID));
+        const messages = [...olderMessages, ...prev.messages];
+        loaded = olderMessages.length > 0;
+        return {
+          ...prev,
+          loadingOlder: false,
+          messages,
+          total: data.total,
+          hasOlder: loaded && messages.length < data.total,
+        };
+      });
+      return loaded;
+    } catch {
+      setState((prev) => ({ ...prev, loadingOlder: false }));
+      return false;
+    }
+  }, [conversationID, state.hasOlder, state.loading, state.loadingOlder, state.messages]);
 
   const cancelResumedGeneration = React.useCallback(async () => {
     const active = activeResumeStreamRef.current;
@@ -320,6 +392,7 @@ export function useChatData(
   return {
     ...state,
     cancelResumedGeneration,
+    loadOlderMessages,
     reload,
     replaceMessage,
     resumingRunID,

--- a/frontend/features/chat/hooks/use-chat-scroll-controller.ts
+++ b/frontend/features/chat/hooks/use-chat-scroll-controller.ts
@@ -4,6 +4,7 @@ import * as React from "react";
 
 const CHAT_SCROLL_STORAGE_KEY = "deeix-chat:chat-scroll:v1";
 const BOTTOM_THRESHOLD_PX = 96;
+const TOP_LOAD_THRESHOLD_PX = 48;
 const SCROLL_POSITION_PERSIST_DELAY_MS = 180;
 const RESTORE_RETRY_FRAMES = 3;
 
@@ -85,6 +86,9 @@ export function useChatScrollController({
   showPendingAssistant,
   streamingText,
   streamingTraceText,
+  hasOlderMessages = false,
+  loadingOlderMessages = false,
+  onLoadOlderMessages,
 }: {
   conversationID: string | null;
   loading: boolean;
@@ -94,6 +98,9 @@ export function useChatScrollController({
   showPendingAssistant: boolean;
   streamingText: string;
   streamingTraceText: string;
+  hasOlderMessages?: boolean;
+  loadingOlderMessages?: boolean;
+  onLoadOlderMessages?: () => Promise<boolean> | boolean;
 }) {
   const messageViewportRef = React.useRef<HTMLDivElement | null>(null);
   const messageContentRef = React.useRef<HTMLDivElement | null>(null);
@@ -106,6 +113,11 @@ export function useChatScrollController({
   const currentConversationIDRef = React.useRef<string | null>(conversationID);
   const handledConversationIDRef = React.useRef<string | null | undefined>(undefined);
   const wasStreamingRef = React.useRef(false);
+  const hasOlderMessagesRef = React.useRef(hasOlderMessages);
+  const loadingOlderMessagesRef = React.useRef(loadingOlderMessages);
+  const onLoadOlderMessagesRef = React.useRef(onLoadOlderMessages);
+  const loadingOlderInFlightRef = React.useRef(false);
+  const olderScrollRestoreRef = React.useRef<{ scrollHeight: number; scrollTop: number } | null>(null);
   const [showScrollToLatestButton, setShowScrollToLatestButton] = React.useState(false);
 
   const hasLiveStreamingContent = showPendingAssistant || streamingText.length > 0 || streamingTraceText.length > 0;
@@ -134,6 +146,18 @@ export function useChatScrollController({
   const setFollowMode = React.useCallback((mode: FollowMode) => {
     followModeRef.current = mode;
   }, []);
+
+  React.useEffect(() => {
+    hasOlderMessagesRef.current = hasOlderMessages;
+  }, [hasOlderMessages]);
+
+  React.useEffect(() => {
+    loadingOlderMessagesRef.current = loadingOlderMessages;
+  }, [loadingOlderMessages]);
+
+  React.useEffect(() => {
+    onLoadOlderMessagesRef.current = onLoadOlderMessages;
+  }, [onLoadOlderMessages]);
 
   const scrollViewportToBottom = React.useCallback(
     (viewport: HTMLDivElement | null = messageViewportRef.current) => {
@@ -204,6 +228,40 @@ export function useChatScrollController({
     [persistViewportPosition],
   );
 
+  const triggerLoadOlderMessages = React.useCallback(() => {
+    const viewport = messageViewportRef.current;
+    const loadOlder = onLoadOlderMessagesRef.current;
+    if (
+      !viewport ||
+      !loadOlder ||
+      !hasOlderMessagesRef.current ||
+      loadingOlderMessagesRef.current ||
+      loadingOlderInFlightRef.current
+    ) {
+      return;
+    }
+
+    setFollowMode("manual");
+    loadingOlderInFlightRef.current = true;
+    olderScrollRestoreRef.current = {
+      scrollHeight: viewport.scrollHeight,
+      scrollTop: viewport.scrollTop,
+    };
+
+    Promise.resolve(loadOlder())
+      .then((loaded) => {
+        if (!loaded) {
+          olderScrollRestoreRef.current = null;
+        }
+      })
+      .catch(() => {
+        olderScrollRestoreRef.current = null;
+      })
+      .finally(() => {
+        loadingOlderInFlightRef.current = false;
+      });
+  }, [setFollowMode]);
+
   const restoreViewportPosition = React.useCallback(() => {
     const viewport = messageViewportRef.current;
     if (!viewport) {
@@ -231,8 +289,11 @@ export function useChatScrollController({
     }
 
     setFollowMode(updateScrollAffordance(viewport) ? "follow" : "manual");
+    if (viewport.scrollTop <= TOP_LOAD_THRESHOLD_PX) {
+      triggerLoadOlderMessages();
+    }
     schedulePersistViewportPosition(currentConversationIDRef.current);
-  }, [schedulePersistViewportPosition, setFollowMode, updateScrollAffordance]);
+  }, [schedulePersistViewportPosition, setFollowMode, triggerLoadOlderMessages, updateScrollAffordance]);
 
   const onScrollToLatest = React.useCallback(() => {
     const viewport = messageViewportRef.current;
@@ -252,6 +313,8 @@ export function useChatScrollController({
     currentConversationIDRef.current = conversationID;
     restoreStateRef.current = conversationID ? "pending" : "idle";
     wasStreamingRef.current = false;
+    olderScrollRestoreRef.current = null;
+    loadingOlderInFlightRef.current = false;
     setFollowMode("follow");
     setShowScrollToLatestButton(false);
 
@@ -297,6 +360,24 @@ export function useChatScrollController({
   }, [loading, restoreViewportPosition, visibleMessageCount]);
 
   React.useLayoutEffect(() => {
+    if (loadingOlderMessages) {
+      return;
+    }
+
+    const restore = olderScrollRestoreRef.current;
+    const viewport = messageViewportRef.current;
+    if (!restore || !viewport) {
+      return;
+    }
+
+    const heightDelta = viewport.scrollHeight - restore.scrollHeight;
+    setFollowMode("manual");
+    viewport.scrollTop = restore.scrollTop + Math.max(0, heightDelta);
+    olderScrollRestoreRef.current = null;
+    updateScrollAffordance(viewport);
+  }, [loadingOlderMessages, setFollowMode, updateScrollAffordance, visibleMessageCount]);
+
+  React.useLayoutEffect(() => {
     if (restoreStateRef.current === "pending") {
       return;
     }
@@ -322,6 +403,16 @@ export function useChatScrollController({
     updateScrollAffordance,
     visibleMessageCount,
   ]);
+
+  React.useEffect(() => {
+    const viewport = messageViewportRef.current;
+    if (!viewport || restoreStateRef.current === "pending" || loading || loadingOlderMessages) {
+      return;
+    }
+    if (viewport.scrollTop <= TOP_LOAD_THRESHOLD_PX) {
+      triggerLoadOlderMessages();
+    }
+  }, [hasOlderMessages, loading, loadingOlderMessages, triggerLoadOlderMessages, visibleMessageCount]);
 
   React.useEffect(() => {
     const content = messageContentRef.current;

--- a/frontend/features/chat/model/chat-thread.ts
+++ b/frontend/features/chat/model/chat-thread.ts
@@ -338,7 +338,7 @@ export function buildVisibleMessages(
   selections: Record<string, string>,
 ): ChatAreaMessage[] {
   const children = buildChildrenIndex(messages);
-  const visible: ChatAreaMessage[] = [];
+  let visible: ChatAreaMessage[] = [];
   const visited = new Set<string>();
   let parentKey = ROOT_BRANCH_KEY;
 
@@ -357,6 +357,10 @@ export function buildVisibleMessages(
     visited.add(selected.publicID);
     visible.push(selected);
     parentKey = selected.publicID;
+  }
+
+  if (visible.length === 0 && messages.length > 0) {
+    visible = buildTailVisibleMessages(messages);
   }
 
   const withUserNavigators = visible.map((item) => {
@@ -399,4 +403,20 @@ export function buildVisibleMessages(
       branchNavigator: previous.branchNavigator ?? item.branchNavigator,
     };
   });
+}
+
+function buildTailVisibleMessages(messages: ChatAreaMessage[]): ChatAreaMessage[] {
+  const byPublicID = new Map(messages.map((item) => [item.publicID, item]));
+  const visible: ChatAreaMessage[] = [];
+  const visited = new Set<string>();
+  let current = messages.at(-1) ?? null;
+
+  while (current && !visited.has(current.publicID)) {
+    visited.add(current.publicID);
+    visible.push(current);
+    const parentPublicID = current.parentPublicID?.trim() || "";
+    current = parentPublicID ? byPublicID.get(parentPublicID) ?? null : null;
+  }
+
+  return visible.reverse();
 }

--- a/frontend/features/layouts/components/sections/initial-security-guard.tsx
+++ b/frontend/features/layouts/components/sections/initial-security-guard.tsx
@@ -17,9 +17,16 @@ import {
   readLocalAppearancePreferences,
   serializeAppearancePreferences,
 } from "@/features/settings/utils/appearance-preferences";
-import { cancelCurrentTwoFactorSetup, completeOnboarding, confirmCurrentTwoFactorSetup, patchMe, patchUsername, startCurrentTwoFactorSetup } from "@/shared/api/auth";
+import {
+  cancelCurrentTwoFactorSetup,
+  completeOnboarding,
+  confirmCurrentTwoFactorSetup,
+  isPasswordReuseNotAllowedError,
+  patchMe,
+  patchUsername,
+  startCurrentTwoFactorSetup,
+} from "@/shared/api/auth";
 import type { TwoFactorSetupStartData, UserDTO } from "@/shared/api/auth.types";
-import { ApiError } from "@/shared/api/http-client";
 import {
   DISPLAY_NAME_MAX_LENGTH,
   PASSWORD_MIN_LENGTH,
@@ -127,10 +134,6 @@ const onboardingThemePresets: ThemePreset[] = [
   "ochre",
   "sepia",
 ];
-
-function isPasswordReuseError(error: unknown) {
-  return error instanceof ApiError && error.errorCode === "auth.password_reuse_not_allowed";
-}
 
 function OnboardingFeatureCarousel({
   activeIndex,
@@ -552,7 +555,7 @@ export function InitialSecurityGuard() {
       }
       toast.success(t("toasts.complete"));
     } catch (error) {
-      if (isPasswordReuseError(error)) {
+      if (isPasswordReuseNotAllowedError(error)) {
         setStep(2);
       }
       toast.error(t("toasts.completeFailed"), {

--- a/frontend/shared/api/auth.ts
+++ b/frontend/shared/api/auth.ts
@@ -1,4 +1,4 @@
-import { apiRequest, pathParam } from "@/shared/api/http-client";
+import { ApiError, apiRequest, pathParam } from "@/shared/api/http-client";
 import { authedRequest } from "@/shared/api/authed-client";
 import type {
   ActiveSessionListData,
@@ -29,6 +29,14 @@ import type {
   UserIdentityData,
   UserIdentityListData,
 } from "@/shared/api/auth.types";
+
+export const AUTH_ERROR_CODES = {
+  passwordReuseNotAllowed: "auth.password_reuse_not_allowed",
+} as const;
+
+export function isPasswordReuseNotAllowedError(error: unknown): boolean {
+  return error instanceof ApiError && error.errorCode === AUTH_ERROR_CODES.passwordReuseNotAllowed;
+}
 
 export async function login(username: string, password: string): Promise<LoginData> {
   return apiRequest<LoginData>("/api/v1/auth/login", {

--- a/frontend/shared/api/conversation.ts
+++ b/frontend/shared/api/conversation.ts
@@ -717,21 +717,55 @@ export async function getContextArtifact(
 }
 
 // Messages
-export async function listMessages(
+type ListMessagesOptions = {
+  page?: number;
+  pageSize?: number;
+  tail?: boolean;
+  beforeID?: number;
+};
+
+export async function listMessagesPage(
   accessToken: string,
   conversationPublicID: string,
-  page = 1,
-  pageSize = 1000,
-): Promise<MessageDTO[]> {
-  const tailQuery = page === 1 ? "&tail=true" : "";
+  options: ListMessagesOptions = {},
+): Promise<PagePayload<MessageDTO>> {
+  const page = options.page && options.page > 0 ? options.page : 1;
+  const pageSize = options.pageSize && options.pageSize > 0 ? options.pageSize : 100;
+  const params = new URLSearchParams({
+    page: String(page),
+    page_size: String(pageSize),
+  });
+  if (options.tail) {
+    params.set("tail", "true");
+  }
+  if (options.beforeID && options.beforeID > 0) {
+    params.set("before_id", String(options.beforeID));
+  }
   const data = await authedRequest<PagePayload<MessageDTO>>(
-    `/api/v1/conversations/${pathParam(conversationPublicID)}/messages?page=${page}&page_size=${pageSize}${tailQuery}`,
+    `/api/v1/conversations/${pathParam(conversationPublicID)}/messages?${params.toString()}`,
     {
       accessToken,
     },
     true,
   );
-  return data.results ?? [];
+  return {
+    total: data.total ?? 0,
+    results: data.results ?? [],
+  };
+}
+
+export async function listMessages(
+  accessToken: string,
+  conversationPublicID: string,
+  page = 1,
+  pageSize = 100,
+): Promise<MessageDTO[]> {
+  const data = await listMessagesPage(accessToken, conversationPublicID, {
+    page,
+    pageSize,
+    tail: page === 1,
+  });
+  return data.results;
 }
 
 export async function sendMessage(


### PR DESCRIPTION
## Summary

Fix long conversation history loading when reopening a conversation after moving it to another project.

The project move flow only updates the conversation `project_id`; it does not modify message records. The issue was caused by long conversation reload behavior: the frontend requested a large tail window, while backend pagination could cap message results too aggressively, and the frontend could lose the visible branch chain when the loaded tail window did not include enough parent messages.

This PR adds message-specific pagination, supports `before_id` loading for older messages, loads the latest 100 messages first, and automatically fetches older history when scrolling to the top.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && GOCACHE=/private/tmp/deeix-go-build-cache go test ./internal/application/conversation`
- [x] `cd backend && GOCACHE=/private/tmp/deeix-go-build-cache go test ./internal/transport/http/conversation`
- [x] `cd backend && GOCACHE=/private/tmp/deeix-go-build-cache go test ./internal/infra/persistence/postgres/conversation`
- [x] `cd frontend && pnpm lint`
- [x] `git diff --check`
- [ ] `cd backend && go test ./...`; reason: the full backend suite is blocked in this sandbox by unrelated tests that require local `httptest` server listeners.

## Screenshots, API examples, or logs

No screenshots included. Relevant API behavior:

- Initial message load requests the latest message window.
- Older history is loaded with `before_id` when the user scrolls to the top.
- Loading stops silently when there are no older messages.

## Configuration, migration, and compatibility notes

No configuration or database migration changes.

The conversation messages API now supports optional `before_id` pagination for loading older messages. Existing message list behavior remains compatible.

## Documentation

- [ ] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [x] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.