### PR TITLE
Hide project creation action until Projects header hover

### DIFF
--- a/frontend/features/layouts/components/navigation/nav-projects.tsx
+++ b/frontend/features/layouts/components/navigation/nav-projects.tsx
@@ -105,11 +105,36 @@ const PROJECT_TREE_ACCORDION_MASK_STYLE = {
   WebkitMaskImage: "linear-gradient(black var(--mask-stop), transparent var(--mask-stop))",
   overflow: "hidden",
 } satisfies React.CSSProperties
-const PROJECT_CREATE_ACTION_CLASS = "right-2 top-2.5 size-7"
+const PROJECT_CREATE_ACTION_CLASS =
+  "right-0 top-0.5 size-7 opacity-100 transition-[background-color,color,opacity,transform] duration-150 md:pointer-events-none md:opacity-0 md:group-hover/project-create:pointer-events-auto md:group-hover/project-create:opacity-100 md:group-focus-within/project-create:pointer-events-auto md:group-focus-within/project-create:opacity-100"
 
 type ProjectFolderIconHandle = {
   startAnimation: () => void
   stopAnimation: () => void
+}
+
+function ProjectGroupHeader({
+  title,
+  createLabel,
+  onCreate,
+}: {
+  title: string
+  createLabel: string
+  onCreate: () => void
+}) {
+  return (
+    <div className="group/project-create relative h-8">
+      <SidebarGroupLabel className="pr-9">{title}</SidebarGroupLabel>
+      <SidebarGroupAction
+        type="button"
+        aria-label={createLabel}
+        className={PROJECT_CREATE_ACTION_CLASS}
+        onClick={onCreate}
+      >
+        <Plus />
+      </SidebarGroupAction>
+    </div>
+  )
 }
 
 function ProjectTreeButton({
@@ -615,14 +640,11 @@ export function NavProjects() {
       <>
         <div className="relative z-10 group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:opacity-0">
           <SidebarGroup>
-            <SidebarGroupLabel>{t("title")}</SidebarGroupLabel>
-            <SidebarGroupAction
-              aria-label={t("create")}
-              className={PROJECT_CREATE_ACTION_CLASS}
-              onClick={() => setDraft({ name: "", systemPrompt: "" })}
-            >
-              <Plus />
-            </SidebarGroupAction>
+            <ProjectGroupHeader
+              title={t("title")}
+              createLabel={t("create")}
+              onCreate={() => setDraft({ name: "", systemPrompt: "" })}
+            />
             <div className="px-2 py-1 text-xs text-sidebar-foreground/55">{t("empty")}</div>
           </SidebarGroup>
         </div>
@@ -635,14 +657,11 @@ export function NavProjects() {
     <>
       <div className="relative z-10 group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:opacity-0">
         <SidebarGroup>
-          <SidebarGroupLabel>{t("title")}</SidebarGroupLabel>
-          <SidebarGroupAction
-            aria-label={t("create")}
-            className={PROJECT_CREATE_ACTION_CLASS}
-            onClick={() => setDraft({ name: "", systemPrompt: "" })}
-          >
-            <Plus />
-          </SidebarGroupAction>
+          <ProjectGroupHeader
+            title={t("title")}
+            createLabel={t("create")}
+            onCreate={() => setDraft({ name: "", systemPrompt: "" })}
+          />
           <SidebarMenu>
             {projects.map((project) => {
               const expanded = expandedProjectIDs.has(project.publicID)


### PR DESCRIPTION
### Summary

This PR reduces accidental project creation from the sidebar by hiding the project create `+` action until the user intentionally hovers or focuses the Projects header on desktop.

### Problem

The `+` icon next to the Projects sidebar heading was always visible. Because users commonly associate a sidebar `+` action with creating a new chat, the always-visible project creation button could be clicked by mistake. Project creation is a low-frequency action compared with starting a new chat, so keeping the action permanently visible created unnecessary friction.

### Changes

- Added a shared `ProjectGroupHeader` component for the Projects section header.
- Hid the project create action by default on desktop using opacity and pointer-event controls.
- Revealed the action when the Projects header is hovered or receives focus.
- Kept the action visible on mobile so touch users still have access to project creation.
- Applied the same behavior to both empty and populated project lists.

### Testing

- `pnpm lint`
- `pnpm exec tsc --noEmit`

### Build Note

`pnpm build` was attempted, but `next build --turbopack` did not produce further output for an extended period and was stopped manually with exit code 143. The build attempt is not listed as a passing verification.

### Risk

Low. The change is limited to sidebar Projects header rendering and CSS interaction states. It does not change project creation logic, routing, API calls, or conversation behavior.