### PR TITLE
Fix Chinese page size label in admin pagination

### DIFF
--- a/frontend/i18n/messages/zh-CN/common.json
+++ b/frontend/i18n/messages/zh-CN/common.json
@@ -75,7 +75,7 @@
     "refresh": "刷新",
     "selectedItems": "已选 {count} 项",
     "pagination": "共 {total} 条，第 {page} / {pageCount} 页",
-    "pageSize": "{size} / 页",
+    "pageSize": "{size} 条 / 页",
     "previousPage": "上一页",
     "nextPage": "下一页"
   },


### PR DESCRIPTION
## Summary
This PR updates the Simplified Chinese pagination page-size label used by shared table pagination components.

## Changes
- Changed the Chinese `common.table.pageSize` translation from `{size} / 页` to `{size} 条 / 页`.
- This fixes the page-size label in the admin channel upstream route binding dialog, so `25 / 页` is displayed as `25 条 / 页`.

## Validation
- Verified the updated translation in `frontend/i18n/messages/zh-CN/common.json`.
- Confirmed the JSON file parses successfully.

## Impact
This affects shared table pagination labels in the Simplified Chinese locale only.