### PR TITLE
Fix JSON editor placeholder alignment

### DIFF
--- a/frontend/shared/components/json-code-editor.tsx
+++ b/frontend/shared/components/json-code-editor.tsx
@@ -126,6 +126,7 @@ export function JsonCodeEditor({
   const mountDisabledRef = React.useRef(disabled);
   const mountThemeRef = React.useRef(resolvedTheme);
   const mountAutoFocusRef = React.useRef(autoFocus);
+  const placeholderRef = React.useRef(placeholder);
   const [loading, setLoading] = React.useState(true);
   const [markerCount, setMarkerCount] = React.useState(0);
 
@@ -171,6 +172,11 @@ export function JsonCodeEditor({
   }, [autoFocus]);
 
   React.useEffect(() => {
+    placeholderRef.current = placeholder;
+    editorRef.current?.updateOptions({ placeholder: placeholder || undefined });
+  }, [placeholder]);
+
+  React.useEffect(() => {
     let disposed = false;
     let contentSubscription: Monaco.IDisposable | null = null;
     let markerSubscription: Monaco.IDisposable | null = null;
@@ -195,6 +201,7 @@ export function JsonCodeEditor({
       const editor = monaco.editor.create(containerRef.current, {
         value: mountValueRef.current,
         language: "json",
+        placeholder: placeholderRef.current || undefined,
         readOnly: mountDisabledRef.current,
         theme: mountThemeRef.current === "dark" ? "vs-dark" : "vs",
         automaticLayout: true,
@@ -346,11 +353,6 @@ export function JsonCodeEditor({
       {loading ? (
         <div className="absolute inset-x-0 bottom-0 top-8 flex items-center px-3 font-mono text-xs text-muted-foreground">
           {t("loading")}
-        </div>
-      ) : null}
-      {!loading && value.trim() === "" && placeholder ? (
-        <div className="pointer-events-none absolute left-[58px] top-[39px] font-mono text-xs text-muted-foreground/70">
-          {placeholder}
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary

This change fixes placeholder alignment in the shared JSON code editor by using Monaco Editor's built-in `placeholder` option instead of rendering a manually positioned overlay.

## Problem

On `/admin/channels`, in the upstream request headers editor, the placeholder text:

```json
{"X-Custom-Header": "value"}
```

was visually misaligned with Monaco's actual first code line. The placeholder appeared slightly higher than the current-line highlight and had a larger left offset than real JSON content.

## Root Cause

`JsonCodeEditor` rendered the placeholder as a custom absolutely positioned `div`:

```tsx
left-[58px] top-[39px] font-mono text-xs
```

Those hard-coded coordinates did not match Monaco's internal layout. Monaco computes its own content left offset, line top, font metrics, and line height based on gutter settings, padding, and editor options.

## Solution

- Pass `placeholder` directly to `monaco.editor.create(...)`
- Sync placeholder changes with `editor.updateOptions(...)`
- Remove the custom absolute placeholder overlay

This lets Monaco render the placeholder using the same layout system as real editor content.

## Validation

- Ran `pnpm exec eslint shared/components/json-code-editor.tsx`
- Verified in browser that the legacy absolute placeholder layer is removed
- Verified Monaco `.editorPlaceholder` aligns with `.view-line` and `.current-line`

before
<img width="547" height="360" alt="Screenshot 2026-06-09 at 12 11 23 PM" src="https://github.com/user-attachments/assets/b2a1a0cc-76d2-4191-8dbb-9a965c13dcb3" />
after
<img width="519" height="356" alt="Screenshot 2026-06-09 at 12 37 14 PM" src="https://github.com/user-attachments/assets/781db7b4-f0f2-459c-9afe-0b80a5521267" />