### PR TITLE
Fix upstream model count aggregation

### DIFF
--- a/backend/internal/infra/persistence/postgres/channel/repository.go
+++ b/backend/internal/infra/persistence/postgres/channel/repository.go
@@ -174,8 +174,8 @@ func (r *Repo) ListUpstreams(ctx context.Context, input repository.ListChannelUp
 		Joins(
 			`LEFT JOIN (
 				SELECT um.upstream_id,
-					COUNT(r.id) AS models_count,
-					SUM(CASE WHEN r.status = 'active' AND um.status = 'active' THEN 1 ELSE 0 END) AS active_models_count
+					COUNT(DISTINCT um.id) AS models_count,
+					COUNT(DISTINCT CASE WHEN r.status = 'active' AND um.status = 'active' THEN um.id END) AS active_models_count
 				FROM llm_upstream_models um
 				LEFT JOIN llm_model_routes r ON r.upstream_model_id = um.id
 				GROUP BY um.upstream_id


### PR DESCRIPTION
## Summary

This PR fixes the model count shown in the admin upstream list.

The upstream list previously counted route bindings from `llm_model_routes`, which caused a single upstream model with multiple protocol routes to be counted multiple times. The aggregation now counts distinct upstream model records from `llm_upstream_models`.

## Root Cause

The `/api/v1/admin/llm/upstreams` query used:

```sql
COUNT(r.id)
```

where `r` is `llm_model_routes`.

For models that support multiple protocols, such as an image model bound to both image generation and image edit routes, this counted one real upstream model more than once.

## Changes

- Updated the upstream list aggregation to use `COUNT(DISTINCT um.id)`.
- Updated the active count aggregation to deduplicate upstream models while preserving the existing active route and active upstream model checks.
- No frontend, DTO, or API response shape changes.

## Testing

```bash
go test ./internal/infra/persistence/postgres/channel
```

## Risk

Low. The change is limited to the admin upstream list count aggregation. Existing response fields are preserved.