### PR TITLE
fix: prevent SQLite streams from being canceled immediately

### DIFF
--- a/backend/internal/application/conversation/service_helpers.go
+++ b/backend/internal/application/conversation/service_helpers.go
@@ -217,6 +217,20 @@ func messageErrorSummary(err error) string {
 	return value
 }
 
+func isMessageGenerationCanceledError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrMessageGenerationCanceled) {
+		return true
+	}
+	var upstreamErr *llm.UpstreamError
+	if !errors.As(err, &upstreamErr) || !isSuccessfulUpstreamStatus(upstreamErr.StatusCode) {
+		return false
+	}
+	return strings.TrimSpace(upstreamErr.Message) == ErrMessageGenerationCanceled.Error()
+}
+
 func messageErrorDebug(err error) *llm.UpstreamDebugSnapshot {
 	if err == nil {
 		return nil

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -917,7 +917,7 @@ func (s *Service) sendMessageInternal(
 	}
 
 	handleCanceledGeneration := func(generateErr error) bool {
-		if generateErr == nil || (ctx.Err() == nil && !errors.Is(generateErr, ErrMessageGenerationCanceled)) {
+		if generateErr == nil || (ctx.Err() == nil && !isMessageGenerationCanceledError(generateErr)) {
 			return false
 		}
 		partialText := strings.TrimSpace(streamedText.String())

--- a/backend/internal/application/conversation/service_stream_fallback_test.go
+++ b/backend/internal/application/conversation/service_stream_fallback_test.go
@@ -88,6 +88,16 @@ func TestMessageErrorSummaryHidesRawSSEForSuccessfulHTTPStatus(t *testing.T) {
 	}
 }
 
+func TestMessageGenerationCanceledDetectsWrappedSuccessfulUpstreamError(t *testing.T) {
+	err := &llm.UpstreamError{
+		StatusCode: 200,
+		Message:    ErrMessageGenerationCanceled.Error(),
+	}
+	if !isMessageGenerationCanceledError(err) {
+		t.Fatalf("expected wrapped HTTP 200 cancellation to be recognized")
+	}
+}
+
 func TestMessageErrorSummarySuggestsDisablingImageStreamForParseFailure(t *testing.T) {
 	err := wrapUpstreamRequestError(&llm.UpstreamError{
 		StatusCode: 500,

--- a/backend/internal/infra/cache/memory/generation_stream.go
+++ b/backend/internal/infra/cache/memory/generation_stream.go
@@ -35,7 +35,8 @@ func (c *Cache) GetGenerationStreamOwner(ctx context.Context, runID string) (uin
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	stream := c.streams[strings.TrimSpace(runID)]
-	if stream == nil || stream.ownerID == 0 || expired(stream.ownerExpiresAt) {
+	now := time.Now()
+	if stream == nil || stream.ownerID == 0 || stream.ownerExpired(now) {
 		return 0, false, nil
 	}
 	return stream.ownerID, true, nil
@@ -63,7 +64,8 @@ func (c *Cache) IsGenerationStreamActive(ctx context.Context, runID string) (boo
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	stream := c.streams[strings.TrimSpace(runID)]
-	return stream != nil && !expired(stream.activeExpiresAt), nil
+	now := time.Now()
+	return stream != nil && !stream.activeExpired(now), nil
 }
 
 func (c *Cache) RequestGenerationStreamCancel(ctx context.Context, runID string, ttl time.Duration) error {
@@ -80,7 +82,8 @@ func (c *Cache) IsGenerationStreamCanceled(ctx context.Context, runID string) (b
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	stream := c.streams[strings.TrimSpace(runID)]
-	return stream != nil && !expired(stream.cancelExpiresAt), nil
+	now := time.Now()
+	return stream != nil && !stream.cancelExpired(now), nil
 }
 
 func (c *Cache) AppendGenerationStreamEvent(ctx context.Context, runID string, payloadJSON string, maxEvents int64, ttl time.Duration) (repository.GenerationStreamMessage, error) {
@@ -110,7 +113,8 @@ func (c *Cache) ListGenerationStreamEvents(ctx context.Context, runID string, li
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	stream := c.streams[strings.TrimSpace(runID)]
-	if stream == nil || expired(stream.eventsExpiresAt) {
+	now := time.Now()
+	if stream == nil || stream.eventsExpired(now) {
 		return nil, nil
 	}
 	if limit <= 0 || int(limit) >= len(stream.events) {
@@ -131,7 +135,8 @@ func (c *Cache) ReadGenerationStreamEvents(ctx context.Context, runID string, af
 	for {
 		c.mu.Lock()
 		stream := c.streams[strings.TrimSpace(runID)]
-		if stream == nil || expired(stream.eventsExpiresAt) {
+		now := time.Now()
+		if stream == nil || stream.eventsExpired(now) {
 			c.mu.Unlock()
 			return nil, nil
 		}
@@ -156,9 +161,10 @@ func (c *Cache) ExpireGenerationStream(ctx context.Context, runID string, ttl ti
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if stream := c.streams[strings.TrimSpace(runID)]; stream != nil {
+		now := time.Now()
 		stream.eventsExpiresAt = ttlFromNow(ttl)
 		stream.ownerExpiresAt = ttlFromNow(ttl)
-		if !stream.cancelExpiresAt.IsZero() && !expired(stream.cancelExpiresAt) {
+		if !stream.cancelExpired(now) {
 			stream.cancelExpiresAt = ttlFromNow(ttl)
 		}
 		stream.notifyLocked()

--- a/backend/internal/infra/cache/memory/generation_stream_test.go
+++ b/backend/internal/infra/cache/memory/generation_stream_test.go
@@ -1,0 +1,64 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestGenerationStreamRegisterDoesNotMarkCanceled(t *testing.T) {
+	cache := New()
+	ctx := context.Background()
+	runID := "run_memory_cancel_state"
+
+	if err := cache.RegisterGenerationStream(ctx, runID, 7, time.Minute); err != nil {
+		t.Fatalf("register generation stream: %v", err)
+	}
+
+	if canceled, err := cache.IsGenerationStreamCanceled(ctx, runID); err != nil || canceled {
+		t.Fatalf("newly registered stream canceled=%v err=%v, want false nil", canceled, err)
+	}
+	if active, err := cache.IsGenerationStreamActive(ctx, runID); err != nil || active {
+		t.Fatalf("newly registered stream active=%v err=%v, want false nil", active, err)
+	}
+	if ownerID, ok, err := cache.GetGenerationStreamOwner(ctx, runID); err != nil || !ok || ownerID != 7 {
+		t.Fatalf("owner=(%d,%v) err=%v, want (7,true) nil", ownerID, ok, err)
+	}
+
+	if err := cache.RequestGenerationStreamCancel(ctx, runID, time.Minute); err != nil {
+		t.Fatalf("request cancel: %v", err)
+	}
+	if canceled, err := cache.IsGenerationStreamCanceled(ctx, runID); err != nil || !canceled {
+		t.Fatalf("requested stream canceled=%v err=%v, want true nil", canceled, err)
+	}
+
+	if err := cache.RegisterGenerationStream(ctx, runID, 7, time.Minute); err != nil {
+		t.Fatalf("register generation stream after cancel: %v", err)
+	}
+	if canceled, err := cache.IsGenerationStreamCanceled(ctx, runID); err != nil || canceled {
+		t.Fatalf("re-registered stream canceled=%v err=%v, want false nil", canceled, err)
+	}
+}
+
+func TestGenerationStreamClearActiveMarksInactive(t *testing.T) {
+	cache := New()
+	ctx := context.Background()
+	runID := "run_memory_active_state"
+
+	if err := cache.RegisterGenerationStream(ctx, runID, 7, time.Minute); err != nil {
+		t.Fatalf("register generation stream: %v", err)
+	}
+	if err := cache.TouchGenerationStreamActive(ctx, runID, time.Minute); err != nil {
+		t.Fatalf("touch active stream: %v", err)
+	}
+	if active, err := cache.IsGenerationStreamActive(ctx, runID); err != nil || !active {
+		t.Fatalf("touched stream active=%v err=%v, want true nil", active, err)
+	}
+
+	if err := cache.ClearGenerationStreamActive(ctx, runID); err != nil {
+		t.Fatalf("clear active stream: %v", err)
+	}
+	if active, err := cache.IsGenerationStreamActive(ctx, runID); err != nil || active {
+		t.Fatalf("cleared stream active=%v err=%v, want false nil", active, err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes SQLite/local chat streams being interrupted immediately with a misleading upstream protocol incompatibility error. The root cause was the in-memory generation stream cache treating unset zero timestamps as active cancel/active markers, while Redis-backed Postgres deployments did not have this behavior.

The fix makes generation stream state checks treat zero timestamps as unset, and also classifies wrapped HTTP 200 `message generation canceled` callback errors as generation cancellations instead of upstream response-format failures.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/infra/cache/memory`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/application/conversation`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/infra/persistence/sqlite ./internal/infra/persistence/postgres/...`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./...`

## Screenshots, API examples, or logs

Observed SQLite/local failure before the fix:

```text
upstream request failed: status=200 message=message generation canceled
```

This was surfaced to users as:

```text
模型响应格式不兼容（HTTP 200）
错误：上游返回成功状态码，但响应格式与当前协议不兼容
```

## Configuration, migration, and compatibility notes

No configuration or database migration changes are required.

This fixes single-process SQLite/local deployments that use the in-memory generation stream cache. Existing failed messages already written to a local SQLite database are not retroactively repaired.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.