### PR TITLE
feat: improve chat message handling and state management

### DIFF
--- a/frontend/features/chat/hooks/use-chat-branch-state.ts
+++ b/frontend/features/chat/hooks/use-chat-branch-state.ts
@@ -40,7 +40,13 @@ function buildPendingMessages({
   const nextMessages = [...serverTreeMessages];
   const activePublicID = conversationID?.trim() || null;
   const pendingConversationPublicID = pendingExchange?.conversationPublicID?.trim() || null;
-  if (!pendingExchange || (activePublicID && pendingConversationPublicID !== activePublicID)) {
+  if (!pendingExchange) {
+    return nextMessages;
+  }
+  if (pendingConversationPublicID && pendingConversationPublicID !== activePublicID) {
+    return nextMessages;
+  }
+  if (!pendingConversationPublicID && activePublicID) {
     return nextMessages;
   }
   const pendingRunID = pendingExchange.runID?.trim() || "";

--- a/frontend/features/chat/hooks/use-chat-data.ts
+++ b/frontend/features/chat/hooks/use-chat-data.ts
@@ -25,6 +25,50 @@ type ActiveResumeStream = {
   accessToken: string | null;
 };
 
+type ResumeTextReplayState = {
+  baseContent: string;
+  replayedContent: string;
+  visibleContent: string;
+};
+
+function appendResumedTextDelta(state: ResumeTextReplayState, delta: string): string {
+  if (!delta) {
+    return state.visibleContent;
+  }
+
+  state.replayedContent += delta;
+  const { baseContent, replayedContent } = state;
+  if (!baseContent) {
+    state.visibleContent = replayedContent;
+    return state.visibleContent;
+  }
+
+  if (
+    replayedContent === baseContent ||
+    baseContent.startsWith(replayedContent) ||
+    baseContent.includes(replayedContent)
+  ) {
+    state.visibleContent = baseContent;
+    return state.visibleContent;
+  }
+
+  if (replayedContent.startsWith(baseContent)) {
+    state.visibleContent = replayedContent;
+    return state.visibleContent;
+  }
+
+  const maxOverlapLength = Math.min(baseContent.length, replayedContent.length);
+  for (let length = maxOverlapLength; length > 0; length -= 1) {
+    if (baseContent.endsWith(replayedContent.slice(0, length))) {
+      state.visibleContent = `${baseContent}${replayedContent.slice(length)}`;
+      return state.visibleContent;
+    }
+  }
+
+  state.visibleContent = `${state.visibleContent}${delta}`;
+  return state.visibleContent;
+}
+
 export function useChatData(
   conversationID: string | null,
   {
@@ -49,6 +93,8 @@ export function useChatData(
   const [resumingRunID, setResumingRunID] = React.useState("");
   const previousConversationIDRef = React.useRef<string | null>(conversationID);
   const resumeSeqByRunRef = React.useRef<Record<string, number>>({});
+  const pendingAssistantContentRef = React.useRef("");
+  const resumeTextReplayByRunRef = React.useRef<Record<string, ResumeTextReplayState>>({});
   const activeResumeStreamRef = React.useRef<ActiveResumeStream | null>(null);
 
   React.useEffect(() => {
@@ -220,6 +266,10 @@ export function useChatData(
   const pendingRunID = pendingAssistant?.runID?.trim() || "";
 
   React.useEffect(() => {
+    pendingAssistantContentRef.current = pendingAssistant?.content ?? "";
+  }, [pendingAssistant?.content]);
+
+  React.useEffect(() => {
     if (
       !conversationID ||
       !pendingRunID ||
@@ -233,6 +283,16 @@ export function useChatData(
     const controller = new AbortController();
     let closed = false;
     const afterSeq = resumeSeqByRunRef.current[pendingRunID] ?? 0;
+    const baseContent = pendingAssistantContentRef.current;
+    const resumeTextReplayByRun = resumeTextReplayByRunRef.current;
+    const clearResumeTextReplay = () => {
+      delete resumeTextReplayByRun[pendingRunID];
+    };
+    resumeTextReplayByRun[pendingRunID] = {
+      baseContent,
+      replayedContent: afterSeq > 0 ? baseContent : "",
+      visibleContent: baseContent,
+    };
     activeResumeStreamRef.current = {
       controller,
       runID: pendingRunID,
@@ -275,6 +335,7 @@ export function useChatData(
             }));
           },
           onMediaImageDelta: (event) => {
+            clearResumeTextReplay();
             const previewMarkdown = buildMediaImagePreviewMarkdown(event, tSubmit("imagePreviewAlt"));
             if (!previewMarkdown) {
               return;
@@ -289,11 +350,19 @@ export function useChatData(
             }));
           },
           onDelta: (delta) => {
+            const replayState =
+              resumeTextReplayByRun[pendingRunID] ??
+              (resumeTextReplayByRun[pendingRunID] = {
+                baseContent: "",
+                replayedContent: "",
+                visibleContent: "",
+              });
+            const nextContent = appendResumedTextDelta(replayState, delta);
             setState((prev) => ({
               ...prev,
               messages: prev.messages.map((message) =>
                 message.runID === pendingRunID && message.role === "assistant" && message.status === "pending"
-                  ? { ...message, content: `${message.content}${delta}` }
+                  ? { ...message, content: nextContent }
                   : message,
               ),
             }));
@@ -340,14 +409,17 @@ export function useChatData(
           },
         });
         if (!controller.signal.aborted && completed === null) {
+          clearResumeTextReplay();
           reload();
         }
         if (!controller.signal.aborted && completed) {
           delete resumeSeqByRunRef.current[pendingRunID];
+          clearResumeTextReplay();
           reload();
         }
       } catch (error) {
         if (!controller.signal.aborted && error instanceof Error && error.name !== "AbortError") {
+          clearResumeTextReplay();
           setResumingRunID("");
           reload();
         }
@@ -365,6 +437,7 @@ export function useChatData(
     return () => {
       closed = true;
       controller.abort();
+      clearResumeTextReplay();
       if (activeResumeStreamRef.current?.controller === controller) {
         activeResumeStreamRef.current = null;
       }

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -284,9 +284,8 @@ export function useChatMessageSubmit({
 
     const active = activeStreamRef.current;
     if (active) {
-      if (active.accessToken) {
-        void cancelMessageGeneration(active.accessToken, active.runID).catch(() => undefined);
-      }
+      // A new chat navigation should detach this view from the active stream without
+      // canceling the server-side run. Reopening the conversation can resume it.
       active.controller.abort();
       activeGenerationRunsRefRef.current?.current.delete(active.runID);
       activeStreamRef.current = null;


### PR DESCRIPTION
## Summary

Fixes streaming state loss when users navigate away from an active generation, especially when switching to a new chat inside another project and then returning.

The frontend now detaches the current view from an active generation without canceling the server-side run, scopes pending local messages to the active conversation, and reconciles resumed text stream replay with the persisted pending assistant content. This keeps image loading state visible after returning and prevents intermediate streaming text from appearing duplicated, skipped, or misaligned while the final server result remains unchanged.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm build`

## Screenshots, API examples, or logs

Not applicable. This is a frontend streaming state fix.

## Configuration, migration, and compatibility notes

No configuration, migration, API contract, or deployment changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.