### PR TITLE
fix: refresh MCP server list after sync failure

### DIFF
--- a/frontend/features/admin/components/sections/tools/admin-tools.tsx
+++ b/frontend/features/admin/components/sections/tools/admin-tools.tsx
@@ -423,20 +423,22 @@ export function AdminToolsPage() {
   const syncTools = React.useCallback(
     async (serverID: number) => {
       setSyncingServerID(serverID);
+      const token = await resolveAccessToken();
+      if (!token) {
+        toast.error(t("toast.sessionExpired"), { description: t("toast.sessionExpiredDescription") });
+        setSyncingServerID(null);
+        return;
+      }
+
       try {
-        const token = await resolveAccessToken();
-        if (!token) {
-          toast.error(t("toast.sessionExpired"), { description: t("toast.sessionExpiredDescription") });
-          return;
-        }
         const nextTools = await syncAdminMCPServerTools(token, serverID);
         setToolSheetServerID(serverID);
         setTools(nextTools);
-        await loadServers();
         toast.success(t("toast.toolsSynced"));
       } catch (error) {
         toast.error(t("toast.toolsSyncFailed"), { description: resolveToolSettingsErrorMessage(error, t("toast.unknownError")) });
       } finally {
+        await loadServers();
         setSyncingServerID(null);
       }
     },


### PR DESCRIPTION
## Summary

This change ensures the admin MCP server table refreshes after an automatic tool sync attempt, even when the sync request fails.

When a user creates a new MCP server from `/admin/tools`, the frontend creates the server and then attempts to sync its tools. Previously, if the sync request failed, the server list was not reloaded. As a result, the newly created but misconfigured server was not visible in the table, preventing users from editing, retrying, or deleting it immediately.

## Changes

- Move access token resolution outside the sync request `try/catch/finally` block.
- Keep the sync request error handling focused on `syncAdminMCPServerTools`.
- Always call `loadServers()` in `finally` after a sync attempt has started.
- Preserve the existing session-expired behavior when no token is available.

## Verification

- `pnpm lint`
- `pnpm exec tsc --noEmit`