### PR TITLE
Keep MCP admin management available when runtime MCP is disabled

### DIFF
--- a/frontend/features/admin/components/sections/tools/admin-tools.tsx
+++ b/frontend/features/admin/components/sections/tools/admin-tools.tsx
@@ -199,15 +199,6 @@ export function AdminToolsPage() {
   );
   const activeToolCount = React.useMemo(() => countActiveTools(tools), [tools]);
 
-  React.useEffect(() => {
-    if (mcpEnabled) {
-      return;
-    }
-    setToolSheetServerID(null);
-    setToolForm(null);
-    setSchemaTool(null);
-  }, [mcpEnabled]);
-
   const filteredServers = React.useMemo(() => {
     const query = serverQuery.trim().toLowerCase();
     return servers.filter((server) => {
@@ -705,7 +696,7 @@ export function AdminToolsPage() {
           </SettingsCollapsibleContent>
         </SettingsFieldList>
 
-        <SettingsCollapsibleContent open={mcpEnabled}>
+        <SettingsCollapsibleContent open>
           <Field className="gap-2">
             <div className="flex items-center">
               <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Summary

This change decouples MCP admin management visibility from the global MCP runtime toggle.

Administrators can now manage MCP servers and tools even when `mcp_enable` is set to `false`, while chat-side MCP usage remains disabled as before.

## Problem

The admin tools page used the `mcp_enable` setting for two different purposes:

- Controlling whether chat users can select and use MCP tools.
- Controlling whether administrators can see and manage MCP servers and tools.

This caused the MCP management UI to disappear when runtime MCP usage was disabled.

That behavior is inconvenient because administrators often need to configure, sync, edit, enable, disable, or delete MCP tools before enabling MCP access for chat users.

## Root Cause

The MCP server/tool management section was wrapped in a collapsible block controlled by `mcpEnabled`:

```tsx
<SettingsCollapsibleContent open={mcpEnabled}>
```

The page also cleared the active tool management sheet and related dialogs when `mcpEnabled` became false.

## Changes

- Keep the MCP server/tool management section visible regardless of `mcp_enable`.
- Remove the effect that forced MCP tool management panels to close when runtime MCP was disabled.
- Leave the global MCP runtime switch behavior unchanged.
- Leave backend settings behavior unchanged.

## User Impact

When `mcp_enable` is off:

- Chat users still cannot use MCP tools.
- Admin users can still manage MCP servers and tools.

This makes it possible to prepare or maintain MCP configuration while keeping runtime access disabled.

## Testing

Ran targeted ESLint for the modified frontend file:

```bash
cd frontend
node_modules/.bin/eslint features/admin/components/sections/tools/admin-tools.tsx
```

Result: passed.

## Risk

Low. The change is limited to admin UI visibility and does not modify backend settings, API contracts, or chat-side runtime MCP enforcement.

## Notes

The `configured` field in the settings response means that a setting has a non-empty stored value. It does not mean the boolean setting is enabled. For `mcp_enable`, the boolean state is determined by the `value` field.