### PR TITLE
chore: remove local build context from Docker Compose files

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,18 +39,37 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Normalize image name
+      - name: Resolve image names
         id: image
         shell: bash
+        env:
+          DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           image_name=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
-          echo "name=ghcr.io/$image_name" >> "$GITHUB_OUTPUT"
+          ghcr_image="ghcr.io/$image_name"
+          dockerhub_image="${DOCKERHUB_IMAGE:-${DOCKERHUB_USERNAME}/deeix-chat}"
+
+          {
+            echo "ghcr_image=$ghcr_image"
+            echo "images<<EOF"
+            echo "$ghcr_image"
+            if [[ -n "$DOCKERHUB_USERNAME" && -n "$DOCKERHUB_TOKEN" ]]; then
+              echo "$dockerhub_image"
+              dockerhub_enabled=true
+            else
+              dockerhub_enabled=false
+            fi
+            echo "EOF"
+            echo "dockerhub_enabled=$dockerhub_enabled"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ steps.image.outputs.name }}
+          images: ${{ steps.image.outputs.images }}
           tags: |
             type=ref,event=branch,suffix=-${{ matrix.arch }}
             type=ref,event=tag,suffix=-${{ matrix.arch }}
@@ -63,6 +82,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request' && steps.image.outputs.dockerhub_enabled == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and publish
         uses: docker/build-push-action@v6
@@ -89,18 +115,37 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Normalize image name
+      - name: Resolve image names
         id: image
         shell: bash
+        env:
+          DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           image_name=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
-          echo "name=ghcr.io/$image_name" >> "$GITHUB_OUTPUT"
+          ghcr_image="ghcr.io/$image_name"
+          dockerhub_image="${DOCKERHUB_IMAGE:-${DOCKERHUB_USERNAME}/deeix-chat}"
+
+          {
+            echo "ghcr_image=$ghcr_image"
+            echo "images<<EOF"
+            echo "$ghcr_image"
+            if [[ -n "$DOCKERHUB_USERNAME" && -n "$DOCKERHUB_TOKEN" ]]; then
+              echo "$dockerhub_image"
+              dockerhub_enabled=true
+            else
+              dockerhub_enabled=false
+            fi
+            echo "EOF"
+            echo "dockerhub_enabled=$dockerhub_enabled"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ steps.image.outputs.name }}
+          images: ${{ steps.image.outputs.images }}
           tags: |
             type=ref,event=branch
             type=ref,event=tag
@@ -113,6 +158,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        if: steps.image.outputs.dockerhub_enabled == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Create manifest list
         run: |
           jq -cr '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON" | while read -r tag; do
@@ -123,4 +175,4 @@ jobs:
           done
 
       - name: Inspect image
-        run: docker buildx imagetools inspect "${{ steps.image.outputs.name }}:${{ steps.meta.outputs.version }}"
+        run: docker buildx imagetools inspect "${{ steps.image.outputs.ghcr_image }}:${{ steps.meta.outputs.version }}"

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,8 @@
+name: deeix-chat
+
+services:
+  app:
+    image: ${DEEIX_CHAT_LOCAL_IMAGE:-deeix-chat:local}
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -3,9 +3,6 @@ name: deeix-chat
 services:
   app:
     image: ${DEEIX_CHAT_IMAGE:-ghcr.io/deeix-ai/deeix-chat:latest}
-    build:
-      context: .
-      dockerfile: Dockerfile
     container_name: deeix-chat-app
     depends_on:
       postgres:

--- a/docker-compose.sqlite.yml
+++ b/docker-compose.sqlite.yml
@@ -3,9 +3,6 @@ name: deeix-chat
 services:
   app:
     image: ${DEEIX_CHAT_IMAGE:-ghcr.io/deeix-ai/deeix-chat:latest}
-    build:
-      context: .
-      dockerfile: Dockerfile
     container_name: deeix-chat-app
     ports:
       # Optional. Localhost-only by default. Put a reverse proxy in front for public access.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,6 @@ name: deeix-chat
 services:
   app:
     image: ${DEEIX_CHAT_IMAGE:-ghcr.io/deeix-ai/deeix-chat:latest}
-    build:
-      context: .
-      dockerfile: Dockerfile
     container_name: deeix-chat-app
     ports:
       # Optional. Localhost-only by default. Put a reverse proxy in front for public access.


### PR DESCRIPTION
## Summary

This PR updates Docker deployment and publishing behavior.

Default compose deployments now use the published application image instead of building from local source. Local source builds remain available through an explicit `docker-compose.build.yml` override.

The Docker image workflow also mirrors published image tags to Docker Hub when `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are configured, while preserving the existing GHCR publishing flow, branch/tag rules, PR behavior, architecture matrix, and manifest merge process.

## Change type

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [x] Deployment / Docker / configuration
- [x] Documentation

## Verification

- [x] `docker compose -f docker-compose.yml config`
- [x] `docker compose -f docker-compose.sqlite.yml config`
- [x] `docker compose -f docker-compose.full.yml config`
- [x] `docker compose -f docker-compose.yml -f docker-compose.build.yml config`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-image.yml"); puts "ok"'`
- [x] `git diff --check`

## Screenshots, API examples, or logs

N/A. This change affects Docker compose configuration and CI image publishing.

## Configuration, migration, and compatibility notes

Default compose files no longer build the application image from local source. They use `ghcr.io/deeix-ai/deeix-chat:latest` by default and can still be overridden with `DEEIX_CHAT_IMAGE`.

Local source builds now require the explicit build override:

```bash
docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
```

Docker Hub mirroring is enabled when the following GitHub Actions secrets are configured:

- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`

By default, Docker Hub images are published to `${DOCKERHUB_USERNAME}/deeix-chat`. Set the optional repository variable `DOCKERHUB_IMAGE` to publish to a different Docker Hub namespace or repository.

## Documentation

- [ ] Documentation is not needed for this change.
- [x] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.