### PR TITLE
feat: improve SQLite title handling

### DIFF
--- a/backend/internal/infra/persistence/postgres/conversation/repository.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository.go
@@ -74,6 +74,13 @@ func (r *Repo) sqliteDialect() bool {
 	return r != nil && r.db != nil && r.db.Dialector != nil && r.db.Dialector.Name() == "sqlite"
 }
 
+func (r *Repo) trimFunctionName() string {
+	if r.sqliteDialect() {
+		return "trim"
+	}
+	return "btrim"
+}
+
 // CreateConversation 创建会话。
 func (r *Repo) CreateConversation(ctx context.Context, item *domainconversation.Conversation) error {
 	entity := toConversationModel(item)
@@ -457,7 +464,7 @@ func (r *Repo) UpdateConversationMetadata(ctx context.Context, conversationID ui
 	updates := map[string]interface{}{}
 	if strings.TrimSpace(title) != "" {
 		updates["title"] = gorm.Expr(
-			"CASE WHEN lower(btrim(title)) IN ? THEN ? ELSE title END",
+			fmt.Sprintf("CASE WHEN lower(%s(title)) IN ? THEN ? ELSE title END", r.trimFunctionName()),
 			[]string{"", "new conversation", "new chat", "untitled", "新会话", "新对话", "新的对话"},
 			strings.TrimSpace(title),
 		)

--- a/backend/internal/infra/persistence/postgres/conversation/repository_test.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository_test.go
@@ -71,6 +71,35 @@ func TestListMessagesBeforeIDReturnsPreviousWindowAscending(t *testing.T) {
 	}
 }
 
+func TestUpdateConversationMetadataSQLiteUsesPortableTrim(t *testing.T) {
+	db := openConversationRepositoryTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	conversation := model.Conversation{
+		UserID:     1,
+		PublicID:   "conv_metadata_sqlite",
+		Title:      " 新对话 ",
+		LabelsJSON: "[]",
+		SessionKey: "session_metadata_sqlite",
+		Status:     "active",
+	}
+	if err := db.Create(&conversation).Error; err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	updated, err := repo.UpdateConversationMetadata(ctx, conversation.ID, "SQLite 标题", `["技术"]`)
+	if err != nil {
+		t.Fatalf("UpdateConversationMetadata() error = %v", err)
+	}
+	if updated.Title != "SQLite 标题" {
+		t.Fatalf("updated title = %q, want %q", updated.Title, "SQLite 标题")
+	}
+	if updated.LabelsJSON != `["技术"]` {
+		t.Fatalf("updated labels = %q, want %q", updated.LabelsJSON, `["技术"]`)
+	}
+}
+
 func openConversationRepositoryTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	name := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -54,7 +54,10 @@ import type {
 } from "@/shared/api/conversation.types";
 import { ApiError } from "@/shared/api/http-client";
 
-const CONVERSATION_METADATA_REFRESH_DELAYS = [800, 1200, 1800, 2600, 3500, 5000] as const;
+const CONVERSATION_METADATA_REFRESH_MAX_WAIT_MS = 45_000;
+const CONVERSATION_METADATA_REFRESH_INITIAL_DELAY_MS = 800;
+const CONVERSATION_METADATA_REFRESH_MAX_DELAY_MS = 5_000;
+const CONVERSATION_METADATA_REFRESH_BACKOFF = 1.5;
 
 function resolveSubmitBlockDescription(
   reason: ChatSubmitBlockReason,
@@ -150,8 +153,12 @@ function isPlaceholderConversationTitle(title: string): boolean {
   return ["", "new conversation", "new chat", "untitled", "新会话", "新对话", "新的对话"].includes(value);
 }
 
-function shouldRefreshGeneratedConversationMetadata(item: ConversationDTO | null, visibleMessageCount: number): boolean {
-  return visibleMessageCount === 0 || item?.messageCount === 0;
+function hasPendingGeneratedConversationMetadata(item: ConversationDTO | null): boolean {
+  return (
+    !item ||
+    isPlaceholderConversationTitle(item.title) ||
+    normalizeLabelsJSON(item.labelsJSON) === "[]"
+  );
 }
 
 function hasGeneratedConversationMetadataChanged(
@@ -172,8 +179,14 @@ async function refreshGeneratedConversationMetadata(
   previous: ConversationDTO | null,
   touchByPublicID: (publicID: string, patch?: Partial<ConversationDTO>) => void,
 ): Promise<void> {
-  for (const delay of CONVERSATION_METADATA_REFRESH_DELAYS) {
-    await sleep(delay);
+  let elapsedMS = 0;
+  let delayMS = CONVERSATION_METADATA_REFRESH_INITIAL_DELAY_MS;
+
+  while (elapsedMS < CONVERSATION_METADATA_REFRESH_MAX_WAIT_MS) {
+    const nextDelayMS = Math.min(delayMS, CONVERSATION_METADATA_REFRESH_MAX_WAIT_MS - elapsedMS);
+    await sleep(nextDelayMS);
+    elapsedMS += nextDelayMS;
+
     let latest: ConversationDTO;
     try {
       latest = await getConversation(accessToken, conversationPublicID);
@@ -184,6 +197,11 @@ async function refreshGeneratedConversationMetadata(
       touchByPublicID(conversationPublicID, latest);
       return;
     }
+
+    delayMS = Math.min(
+      Math.round(delayMS * CONVERSATION_METADATA_REFRESH_BACKOFF),
+      CONVERSATION_METADATA_REFRESH_MAX_DELAY_MS,
+    );
   }
 }
 
@@ -487,7 +505,7 @@ export function useChatMessageSubmit({
           window.history.replaceState(null, "", `/chat?conversation_id=${created.publicID}`);
           onConversationCreated?.(created.publicID);
         }
-        const shouldRefreshConversationMetadata = shouldRefreshGeneratedConversationMetadata(targetConversation, visibleMessageCount);
+        const shouldRefreshConversationMetadata = hasPendingGeneratedConversationMetadata(targetConversation);
 
         const commonStreamPayload = {
           model: requestPlatformModelName,


### PR DESCRIPTION
## Summary

Fix conversation title metadata updates for SQLite deployments.

The title/label metadata task was being invoked successfully, but SQLite could fail when persisting generated conversation metadata because the shared repository SQL used PostgreSQL-specific `btrim(title)`. This caused conversations to remain titled `New chat` / `新对话` even after the title model call completed.

This PR makes the metadata title update SQL dialect-aware: PostgreSQL continues to use `btrim`, while SQLite uses `trim`. It also adds SQLite coverage for metadata updates and keeps the frontend conversation metadata refresh path active while generated metadata is still pending, so newly generated titles and labels can appear in the sidebar without requiring a manual reload.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/infra/persistence/postgres/conversation`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/infra/persistence/postgres/conversation ./internal/infra/persistence/postgres/billing ./internal/infra/persistence/postgres/channel ./internal/infra/persistence/postgres/announcement ./internal/infra/persistence/sqlite`
- [x] `cd frontend && pnpm lint`
- [x] `git diff --check`

## Screenshots, API examples, or logs

N/A. This change fixes persistence and sidebar metadata refresh behavior for generated conversation titles.

## Configuration, migration, and compatibility notes

No configuration or database migration is required.

SQLite deployments now use SQLite-compatible `trim(title)` when conditionally replacing placeholder conversation titles. PostgreSQL behavior is unchanged and continues to use `btrim(title)`.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.