### PR TITLE
feat: implement model shortcut menu in chat input component

### DIFF
--- a/frontend/features/chat/components/sections/chat-input.tsx
+++ b/frontend/features/chat/components/sections/chat-input.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { createPortal } from "react-dom";
 import dynamic from "next/dynamic";
 import { Check, Image, ImageOff, ImagePlus } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -19,6 +20,7 @@ import type {
   UploadingAttachment,
 } from "@/features/chat/types/chat-runtime";
 import { useSpeechInput } from "@/features/chat/hooks/use-speech-input";
+import { useModelShortcutMenu } from "@/features/chat/hooks/use-model-shortcut-menu";
 import { ChatMCP } from "@/features/chat/components/sections/chat-mcp";
 import { ChatModelPicker } from "@/features/chat/components/sections/chat-model-picker";
 import { ChatModelConfig } from "@/features/chat/components/sections/chat-model-config";
@@ -100,51 +102,6 @@ type ComposerModeIndicator = {
   icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
   tone: "default" | "warning";
 };
-
-const MODEL_SHORTCUT_MENU_MAX_HEIGHT = 280;
-const MODEL_SHORTCUT_MENU_MIN_HEIGHT = 32;
-const MODEL_SHORTCUT_MENU_MIN_WIDTH = 232;
-const MODEL_SHORTCUT_MENU_MAX_WIDTH = 420;
-const MODEL_SHORTCUT_MENU_TEXT_WIDTH_UNIT = 7;
-const MODEL_SHORTCUT_MENU_CONTENT_GAP_WIDTH = 64;
-const MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER = 12;
-const MODEL_SHORTCUT_MENU_OFFSET = 8;
-
-function resolveModelShortcutQuery(value: string): string | null {
-  if (!value.startsWith("@")) {
-    return null;
-  }
-  return value.slice(1).match(/^\S*/)?.[0]?.trim().toLowerCase() ?? "";
-}
-
-function removeModelShortcutTrigger(value: string): string {
-  return value.replace(/^@\S*\s?/, "");
-}
-
-function filterModelShortcutOptions(modelOptions: ChatModelOption[], query: string): ChatModelOption[] {
-  const normalizedQuery = query.trim().toLowerCase();
-  return normalizedQuery
-    ? modelOptions.filter((model) => {
-      const platformModelName = model.platformModelName.toLowerCase();
-      const vendor = model.vendor.toLowerCase();
-      return platformModelName.includes(normalizedQuery) || vendor.includes(normalizedQuery);
-    })
-    : modelOptions;
-}
-
-function resolveModelShortcutMenuWidth(modelOptions: ChatModelOption[], viewportWidth: number): number {
-  const availableWidth = Math.max(0, viewportWidth - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER * 2);
-  const longestLabelLength = modelOptions.reduce(
-    (maxLength, model) => Math.max(maxLength, model.platformModelName.length),
-    0,
-  );
-  const contentWidth = longestLabelLength * MODEL_SHORTCUT_MENU_TEXT_WIDTH_UNIT + MODEL_SHORTCUT_MENU_CONTENT_GAP_WIDTH;
-  return Math.min(
-    Math.max(contentWidth, MODEL_SHORTCUT_MENU_MIN_WIDTH),
-    MODEL_SHORTCUT_MENU_MAX_WIDTH,
-    availableWidth,
-  );
-}
 
 function ModelShortcutMenuItem({
   model,
@@ -297,13 +254,7 @@ function ChatInputComponent({
   const [previewAttachment, setPreviewAttachment] = React.useState<PendingAttachment | null>(null);
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
-  const modelShortcutMenuRef = React.useRef<HTMLDivElement | null>(null);
   const composingRef = React.useRef(false);
-  const modelShortcutMenuID = React.useId();
-  const [inputFocused, setInputFocused] = React.useState(false);
-  const [modelShortcutActiveIndex, setModelShortcutActiveIndex] = React.useState(0);
-  const [dismissedModelShortcutDraft, setDismissedModelShortcutDraft] = React.useState<string | null>(null);
-  const [modelShortcutMenuStyle, setModelShortcutMenuStyle] = React.useState<React.CSSProperties>({});
   const hasDraftText = draft.trim().length > 0;
   const canSend = (draft.trim().length > 0 || attachments.length > 0) && !sending && !loading && !uploading;
   const inputHeightClassName =
@@ -337,128 +288,27 @@ function ChatInputComponent({
   const modelOptionPolicyDisabled = modelOptionPolicy?.mode?.trim() === "disabled";
   const showMCPToolsButton = availableTools.length > 0 && !isMediaMode;
   const showHTMLVisualPromptButton = !isMediaMode;
-  const modelShortcutQuery = resolveModelShortcutQuery(draft);
-  const modelShortcutOptions = React.useMemo(
-    () => (modelShortcutQuery === null ? [] : filterModelShortcutOptions(modelOptions, modelShortcutQuery)),
-    [modelOptions, modelShortcutQuery],
-  );
-  const showModelShortcutMenu =
-    inputFocused &&
-    modelShortcutQuery !== null &&
-    dismissedModelShortcutDraft !== draft &&
-    !sending &&
-    !loading &&
-    !uploading &&
-    !modelLoading &&
-    !modelDisabled &&
-    modelShortcutOptions.length > 0;
-  const activeModelShortcutOption = showModelShortcutMenu
-    ? modelShortcutOptions[Math.min(modelShortcutActiveIndex, modelShortcutOptions.length - 1)]
-    : null;
-
-  const selectedModelShortcutIndex = React.useMemo(
-    () => modelShortcutOptions.findIndex((model) => model.platformModelName === selectedPlatformModelName),
-    [modelShortcutOptions, selectedPlatformModelName],
-  );
-
-  React.useEffect(() => {
-    setModelShortcutActiveIndex(selectedModelShortcutIndex >= 0 ? selectedModelShortcutIndex : 0);
-  }, [modelShortcutQuery, selectedModelShortcutIndex]);
-
-  React.useEffect(() => {
-    setModelShortcutActiveIndex((current) => {
-      if (modelShortcutOptions.length === 0) {
-        return 0;
-      }
-      return Math.min(current, modelShortcutOptions.length - 1);
-    });
-  }, [modelShortcutOptions.length]);
-
-  React.useEffect(() => {
-    if (!showModelShortcutMenu) {
-      return;
-    }
-    const activeItem = modelShortcutMenuRef.current?.querySelector<HTMLElement>('[data-active="true"]');
-    activeItem?.scrollIntoView({ block: "nearest" });
-  }, [modelShortcutActiveIndex, showModelShortcutMenu]);
-
-  const updateModelShortcutMenuLayout = React.useCallback(() => {
-    if (!showModelShortcutMenu || typeof window === "undefined") {
-      return;
-    }
-
-    const textarea = textareaRef.current;
-    const inputGroup = textarea?.closest('[data-slot="input-group"]') as HTMLElement | null;
-    if (!textarea || !inputGroup) {
-      return;
-    }
-
-    const textareaRect = textarea.getBoundingClientRect();
-    const inputGroupRect = inputGroup.getBoundingClientRect();
-    const computed = window.getComputedStyle(textarea);
-    const paddingLeft = Number.parseFloat(computed.paddingLeft) || 20;
-    const paddingTop = Number.parseFloat(computed.paddingTop) || 16;
-    const lineHeight = Number.parseFloat(computed.lineHeight) || 24;
-    const preferredTop = textareaRect.top - inputGroupRect.top + paddingTop + lineHeight + MODEL_SHORTCUT_MENU_OFFSET;
-    const viewportBottomInGroup = window.innerHeight - inputGroupRect.top - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER;
-    const top = Math.min(
-      preferredTop,
-      Math.max(MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER, viewportBottomInGroup - MODEL_SHORTCUT_MENU_MIN_HEIGHT),
-    );
-    const preferredWidth = resolveModelShortcutMenuWidth(modelShortcutOptions, window.innerWidth);
-    const preferredLeft = textareaRect.left - inputGroupRect.left + paddingLeft - MODEL_SHORTCUT_MENU_OFFSET;
-    const maxLeft = Math.max(
-      MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER,
-      window.innerWidth - inputGroupRect.left - preferredWidth - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER,
-    );
-    const left = Math.min(Math.max(preferredLeft, MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER), maxLeft);
-    const width = Math.min(
-      preferredWidth,
-      Math.max(0, window.innerWidth - (inputGroupRect.left + left) - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER),
-    );
-    const availableHeight = window.innerHeight - (inputGroupRect.top + top) - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER;
-    const maxHeight = Math.max(
-      MODEL_SHORTCUT_MENU_MIN_HEIGHT,
-      Math.min(MODEL_SHORTCUT_MENU_MAX_HEIGHT, availableHeight),
-    );
-
-    setModelShortcutMenuStyle({
-      left,
-      top,
-      width,
-      maxHeight,
-    });
-  }, [modelShortcutOptions, showModelShortcutMenu]);
-
-  React.useLayoutEffect(() => {
-    if (!showModelShortcutMenu) {
-      return;
-    }
-    let frameID = window.requestAnimationFrame(updateModelShortcutMenuLayout);
-    const update = () => {
-      window.cancelAnimationFrame(frameID);
-      frameID = window.requestAnimationFrame(updateModelShortcutMenuLayout);
-    };
-    window.addEventListener("resize", update);
-    window.addEventListener("scroll", update, true);
-    return () => {
-      window.cancelAnimationFrame(frameID);
-      window.removeEventListener("resize", update);
-      window.removeEventListener("scroll", update, true);
-    };
-  }, [showModelShortcutMenu, updateModelShortcutMenuLayout]);
-
-  const selectModelShortcut = React.useCallback(
-    (model: ChatModelOption) => {
-      onModelChange(model.platformModelName);
-      onDraftChange(removeModelShortcutTrigger(draft));
-      setDismissedModelShortcutDraft(null);
-      window.requestAnimationFrame(() => {
-        textareaRef.current?.focus();
-      });
-    },
-    [draft, onDraftChange, onModelChange],
-  );
+  const {
+    activeIndex: modelShortcutActiveIndex,
+    handleBlur: handleModelShortcutBlur,
+    handleChange: handleModelShortcutChange,
+    handleFocus: handleModelShortcutFocus,
+    handleKeyDown: handleModelShortcutKeyDown,
+    menuID: modelShortcutMenuID,
+    menuRef: modelShortcutMenuRef,
+    menuStyle: modelShortcutMenuStyle,
+    open: showModelShortcutMenu,
+    options: modelShortcutOptions,
+    select: selectModelShortcut,
+  } = useModelShortcutMenu({
+    disabled: sending || loading || uploading || modelLoading || modelDisabled,
+    draft,
+    modelOptions,
+    onDraftChange,
+    onModelChange,
+    selectedPlatformModelName,
+    textareaRef,
+  });
   const onSelectUploadTool = React.useCallback(() => {
     fileInputRef.current?.click();
   }, []);
@@ -595,12 +445,12 @@ function ChatInputComponent({
           </div>
         ) : null}
 
-        {showModelShortcutMenu ? (
+        {showModelShortcutMenu && typeof document !== "undefined" ? createPortal(
           <div
             ref={modelShortcutMenuRef}
             id={modelShortcutMenuID}
             role="listbox"
-            className="absolute z-40 overflow-y-auto rounded-xl border-[0.5px] border-border bg-popover p-1.5 text-popover-foreground shadow-lg"
+            className="fixed z-[60] overflow-y-auto rounded-xl border-[0.5px] border-border bg-popover p-1.5 text-popover-foreground shadow-lg"
             style={modelShortcutMenuStyle}
           >
             <div className="flex flex-col gap-0.5">
@@ -614,7 +464,8 @@ function ChatInputComponent({
                 />
               ))}
             </div>
-          </div>
+          </div>,
+          document.body,
         ) : null}
 
         <InputGroupTextarea
@@ -632,14 +483,9 @@ function ChatInputComponent({
             inputHeightClassName,
             speechInput.active ? "placeholder:font-normal placeholder:text-muted-foreground" : "",
           )}
-          onFocus={() => setInputFocused(true)}
-          onBlur={() => setInputFocused(false)}
-          onChange={(event) => {
-            if (dismissedModelShortcutDraft !== null && event.target.value !== dismissedModelShortcutDraft) {
-              setDismissedModelShortcutDraft(null);
-            }
-            onDraftChange(event.target.value);
-          }}
+          onFocus={handleModelShortcutFocus}
+          onBlur={handleModelShortcutBlur}
+          onChange={(event) => handleModelShortcutChange(event.target.value)}
           onPaste={(event) => {
             const files = clipboardFilesFromPaste(event);
             if (files.length === 0) {
@@ -662,27 +508,8 @@ function ChatInputComponent({
             }
             const shouldSend = isSendShortcutEvent(sendShortcut, event);
 
-            if (showModelShortcutMenu) {
-              if (event.key === "ArrowDown") {
-                event.preventDefault();
-                setModelShortcutActiveIndex((current) => (current + 1) % modelShortcutOptions.length);
-                return;
-              }
-              if (event.key === "ArrowUp") {
-                event.preventDefault();
-                setModelShortcutActiveIndex((current) => (current - 1 + modelShortcutOptions.length) % modelShortcutOptions.length);
-                return;
-              }
-              if ((event.key === "Enter" || event.key === "Tab") && activeModelShortcutOption) {
-                event.preventDefault();
-                selectModelShortcut(activeModelShortcutOption);
-                return;
-              }
-              if (event.key === "Escape") {
-                event.preventDefault();
-                setDismissedModelShortcutDraft(draft);
-                return;
-              }
+            if (handleModelShortcutKeyDown(event)) {
+              return;
             }
 
             if (shouldSend) {

--- a/frontend/features/chat/components/sections/chat-input.tsx
+++ b/frontend/features/chat/components/sections/chat-input.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import dynamic from "next/dynamic";
-import { Image, ImageOff, ImagePlus } from "lucide-react";
+import { Check, Image, ImageOff, ImagePlus } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { AudioLines } from "@/components/animate-ui/icons/audio-lines";
@@ -41,6 +41,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { resolveFileProcessingBadge, resolveFileProcessingToneClass } from "@/shared/lib/file-processing";
 import { cn } from "@/lib/utils";
+import { LobeHubIcon } from "@/shared/components/lobehub-icon";
+import { resolveLobeHubIconURL, resolveModelIdentity } from "@/shared/lib/model-identity";
 import type { ConversationOptions } from "@/shared/api/conversation.types";
 import type { MCPToolDTO } from "@/shared/api/mcp.types";
 import type { ModelOptionPolicy } from "@/shared/lib/model-option-policy";
@@ -98,6 +100,95 @@ type ComposerModeIndicator = {
   icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
   tone: "default" | "warning";
 };
+
+const MODEL_SHORTCUT_MENU_MAX_HEIGHT = 280;
+const MODEL_SHORTCUT_MENU_MIN_HEIGHT = 32;
+const MODEL_SHORTCUT_MENU_MIN_WIDTH = 232;
+const MODEL_SHORTCUT_MENU_MAX_WIDTH = 420;
+const MODEL_SHORTCUT_MENU_TEXT_WIDTH_UNIT = 7;
+const MODEL_SHORTCUT_MENU_CONTENT_GAP_WIDTH = 64;
+const MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER = 12;
+const MODEL_SHORTCUT_MENU_OFFSET = 8;
+
+function resolveModelShortcutQuery(value: string): string | null {
+  if (!value.startsWith("@")) {
+    return null;
+  }
+  return value.slice(1).match(/^\S*/)?.[0]?.trim().toLowerCase() ?? "";
+}
+
+function removeModelShortcutTrigger(value: string): string {
+  return value.replace(/^@\S*\s?/, "");
+}
+
+function filterModelShortcutOptions(modelOptions: ChatModelOption[], query: string): ChatModelOption[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  return normalizedQuery
+    ? modelOptions.filter((model) => {
+      const platformModelName = model.platformModelName.toLowerCase();
+      const vendor = model.vendor.toLowerCase();
+      return platformModelName.includes(normalizedQuery) || vendor.includes(normalizedQuery);
+    })
+    : modelOptions;
+}
+
+function resolveModelShortcutMenuWidth(modelOptions: ChatModelOption[], viewportWidth: number): number {
+  const availableWidth = Math.max(0, viewportWidth - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER * 2);
+  const longestLabelLength = modelOptions.reduce(
+    (maxLength, model) => Math.max(maxLength, model.platformModelName.length),
+    0,
+  );
+  const contentWidth = longestLabelLength * MODEL_SHORTCUT_MENU_TEXT_WIDTH_UNIT + MODEL_SHORTCUT_MENU_CONTENT_GAP_WIDTH;
+  return Math.min(
+    Math.max(contentWidth, MODEL_SHORTCUT_MENU_MIN_WIDTH),
+    MODEL_SHORTCUT_MENU_MAX_WIDTH,
+    availableWidth,
+  );
+}
+
+function ModelShortcutMenuItem({
+  model,
+  active,
+  selected,
+  onSelect,
+}: {
+  model: ChatModelOption;
+  active: boolean;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const platformModelName = model.platformModelName.trim();
+  const identity = React.useMemo(
+    () =>
+      resolveModelIdentity({
+        code: model.platformModelName,
+        vendor: model.vendor,
+        icon: model.icon,
+      }),
+    [model.icon, model.platformModelName, model.vendor],
+  );
+  const iconURL = React.useMemo(() => resolveLobeHubIconURL(identity.modelIcon), [identity.modelIcon]);
+
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={active}
+      data-active={active}
+      className="flex h-7 w-full min-w-0 items-center gap-2 rounded-md px-2 text-left text-[11px] font-medium text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground data-[active=true]:bg-accent data-[active=true]:text-accent-foreground"
+      onMouseDown={(event) => {
+        event.preventDefault();
+        onSelect();
+      }}
+    >
+      <LobeHubIcon iconUrl={iconURL} label={platformModelName} />
+      <span className="min-w-0 flex-1 truncate">{platformModelName}</span>
+      <span className="flex size-3.5 shrink-0 items-center justify-center">
+        {selected ? <Check className="size-3.5 text-current" strokeWidth={1.8} /> : null}
+      </span>
+    </button>
+  );
+}
 
 function resolveComposerModeIndicator(
   decision: ChatSubmitDecision,
@@ -205,7 +296,14 @@ function ChatInputComponent({
   const [ragWarnDismissed, setRagWarnDismissed] = React.useState(false);
   const [previewAttachment, setPreviewAttachment] = React.useState<PendingAttachment | null>(null);
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const modelShortcutMenuRef = React.useRef<HTMLDivElement | null>(null);
   const composingRef = React.useRef(false);
+  const modelShortcutMenuID = React.useId();
+  const [inputFocused, setInputFocused] = React.useState(false);
+  const [modelShortcutActiveIndex, setModelShortcutActiveIndex] = React.useState(0);
+  const [dismissedModelShortcutDraft, setDismissedModelShortcutDraft] = React.useState<string | null>(null);
+  const [modelShortcutMenuStyle, setModelShortcutMenuStyle] = React.useState<React.CSSProperties>({});
   const hasDraftText = draft.trim().length > 0;
   const canSend = (draft.trim().length > 0 || attachments.length > 0) && !sending && !loading && !uploading;
   const inputHeightClassName =
@@ -239,6 +337,128 @@ function ChatInputComponent({
   const modelOptionPolicyDisabled = modelOptionPolicy?.mode?.trim() === "disabled";
   const showMCPToolsButton = availableTools.length > 0 && !isMediaMode;
   const showHTMLVisualPromptButton = !isMediaMode;
+  const modelShortcutQuery = resolveModelShortcutQuery(draft);
+  const modelShortcutOptions = React.useMemo(
+    () => (modelShortcutQuery === null ? [] : filterModelShortcutOptions(modelOptions, modelShortcutQuery)),
+    [modelOptions, modelShortcutQuery],
+  );
+  const showModelShortcutMenu =
+    inputFocused &&
+    modelShortcutQuery !== null &&
+    dismissedModelShortcutDraft !== draft &&
+    !sending &&
+    !loading &&
+    !uploading &&
+    !modelLoading &&
+    !modelDisabled &&
+    modelShortcutOptions.length > 0;
+  const activeModelShortcutOption = showModelShortcutMenu
+    ? modelShortcutOptions[Math.min(modelShortcutActiveIndex, modelShortcutOptions.length - 1)]
+    : null;
+
+  const selectedModelShortcutIndex = React.useMemo(
+    () => modelShortcutOptions.findIndex((model) => model.platformModelName === selectedPlatformModelName),
+    [modelShortcutOptions, selectedPlatformModelName],
+  );
+
+  React.useEffect(() => {
+    setModelShortcutActiveIndex(selectedModelShortcutIndex >= 0 ? selectedModelShortcutIndex : 0);
+  }, [modelShortcutQuery, selectedModelShortcutIndex]);
+
+  React.useEffect(() => {
+    setModelShortcutActiveIndex((current) => {
+      if (modelShortcutOptions.length === 0) {
+        return 0;
+      }
+      return Math.min(current, modelShortcutOptions.length - 1);
+    });
+  }, [modelShortcutOptions.length]);
+
+  React.useEffect(() => {
+    if (!showModelShortcutMenu) {
+      return;
+    }
+    const activeItem = modelShortcutMenuRef.current?.querySelector<HTMLElement>('[data-active="true"]');
+    activeItem?.scrollIntoView({ block: "nearest" });
+  }, [modelShortcutActiveIndex, showModelShortcutMenu]);
+
+  const updateModelShortcutMenuLayout = React.useCallback(() => {
+    if (!showModelShortcutMenu || typeof window === "undefined") {
+      return;
+    }
+
+    const textarea = textareaRef.current;
+    const inputGroup = textarea?.closest('[data-slot="input-group"]') as HTMLElement | null;
+    if (!textarea || !inputGroup) {
+      return;
+    }
+
+    const textareaRect = textarea.getBoundingClientRect();
+    const inputGroupRect = inputGroup.getBoundingClientRect();
+    const computed = window.getComputedStyle(textarea);
+    const paddingLeft = Number.parseFloat(computed.paddingLeft) || 20;
+    const paddingTop = Number.parseFloat(computed.paddingTop) || 16;
+    const lineHeight = Number.parseFloat(computed.lineHeight) || 24;
+    const preferredTop = textareaRect.top - inputGroupRect.top + paddingTop + lineHeight + MODEL_SHORTCUT_MENU_OFFSET;
+    const viewportBottomInGroup = window.innerHeight - inputGroupRect.top - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER;
+    const top = Math.min(
+      preferredTop,
+      Math.max(MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER, viewportBottomInGroup - MODEL_SHORTCUT_MENU_MIN_HEIGHT),
+    );
+    const preferredWidth = resolveModelShortcutMenuWidth(modelShortcutOptions, window.innerWidth);
+    const preferredLeft = textareaRect.left - inputGroupRect.left + paddingLeft - MODEL_SHORTCUT_MENU_OFFSET;
+    const maxLeft = Math.max(
+      MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER,
+      window.innerWidth - inputGroupRect.left - preferredWidth - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER,
+    );
+    const left = Math.min(Math.max(preferredLeft, MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER), maxLeft);
+    const width = Math.min(
+      preferredWidth,
+      Math.max(0, window.innerWidth - (inputGroupRect.left + left) - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER),
+    );
+    const availableHeight = window.innerHeight - (inputGroupRect.top + top) - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER;
+    const maxHeight = Math.max(
+      MODEL_SHORTCUT_MENU_MIN_HEIGHT,
+      Math.min(MODEL_SHORTCUT_MENU_MAX_HEIGHT, availableHeight),
+    );
+
+    setModelShortcutMenuStyle({
+      left,
+      top,
+      width,
+      maxHeight,
+    });
+  }, [modelShortcutOptions, showModelShortcutMenu]);
+
+  React.useLayoutEffect(() => {
+    if (!showModelShortcutMenu) {
+      return;
+    }
+    let frameID = window.requestAnimationFrame(updateModelShortcutMenuLayout);
+    const update = () => {
+      window.cancelAnimationFrame(frameID);
+      frameID = window.requestAnimationFrame(updateModelShortcutMenuLayout);
+    };
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.cancelAnimationFrame(frameID);
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [showModelShortcutMenu, updateModelShortcutMenuLayout]);
+
+  const selectModelShortcut = React.useCallback(
+    (model: ChatModelOption) => {
+      onModelChange(model.platformModelName);
+      onDraftChange(removeModelShortcutTrigger(draft));
+      setDismissedModelShortcutDraft(null);
+      window.requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+      });
+    },
+    [draft, onDraftChange, onModelChange],
+  );
   const onSelectUploadTool = React.useCallback(() => {
     fileInputRef.current?.click();
   }, []);
@@ -375,19 +595,51 @@ function ChatInputComponent({
           </div>
         ) : null}
 
+        {showModelShortcutMenu ? (
+          <div
+            ref={modelShortcutMenuRef}
+            id={modelShortcutMenuID}
+            role="listbox"
+            className="absolute z-40 overflow-y-auto rounded-xl border-[0.5px] border-border bg-popover p-1.5 text-popover-foreground shadow-lg"
+            style={modelShortcutMenuStyle}
+          >
+            <div className="flex flex-col gap-0.5">
+              {modelShortcutOptions.map((model, index) => (
+                <ModelShortcutMenuItem
+                  key={model.platformModelName}
+                  model={model}
+                  active={index === modelShortcutActiveIndex}
+                  selected={model.platformModelName === selectedPlatformModelName}
+                  onSelect={() => selectModelShortcut(model)}
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
+
         <InputGroupTextarea
+          ref={textareaRef}
           value={draft}
           disabled={sending || loading || uploading}
           readOnly={speechInput.active}
           placeholder={dropActive ? tChat("attachments.dropTitle") : speechInput.placeholder}
           rows={1}
+          aria-controls={showModelShortcutMenu ? modelShortcutMenuID : undefined}
+          aria-expanded={showModelShortcutMenu ? true : undefined}
           style={{ fontFamily: "var(--font-chat)", fontWeight: "var(--font-chat-weight)" }}
           className={cn(
             "rounded-3xl min-h-12 overflow-y-auto px-5 pt-4 text-[15px] leading-6 placeholder:text-muted-foreground placeholder:font-[inherit] placeholder:leading-[inherit]",
             inputHeightClassName,
             speechInput.active ? "placeholder:font-normal placeholder:text-muted-foreground" : "",
           )}
-          onChange={(event) => onDraftChange(event.target.value)}
+          onFocus={() => setInputFocused(true)}
+          onBlur={() => setInputFocused(false)}
+          onChange={(event) => {
+            if (dismissedModelShortcutDraft !== null && event.target.value !== dismissedModelShortcutDraft) {
+              setDismissedModelShortcutDraft(null);
+            }
+            onDraftChange(event.target.value);
+          }}
           onPaste={(event) => {
             const files = clipboardFilesFromPaste(event);
             if (files.length === 0) {
@@ -409,6 +661,29 @@ function ChatInputComponent({
               return;
             }
             const shouldSend = isSendShortcutEvent(sendShortcut, event);
+
+            if (showModelShortcutMenu) {
+              if (event.key === "ArrowDown") {
+                event.preventDefault();
+                setModelShortcutActiveIndex((current) => (current + 1) % modelShortcutOptions.length);
+                return;
+              }
+              if (event.key === "ArrowUp") {
+                event.preventDefault();
+                setModelShortcutActiveIndex((current) => (current - 1 + modelShortcutOptions.length) % modelShortcutOptions.length);
+                return;
+              }
+              if ((event.key === "Enter" || event.key === "Tab") && activeModelShortcutOption) {
+                event.preventDefault();
+                selectModelShortcut(activeModelShortcutOption);
+                return;
+              }
+              if (event.key === "Escape") {
+                event.preventDefault();
+                setDismissedModelShortcutDraft(draft);
+                return;
+              }
+            }
 
             if (shouldSend) {
               event.preventDefault();

--- a/frontend/features/chat/components/sections/chat-model-picker.tsx
+++ b/frontend/features/chat/components/sections/chat-model-picker.tsx
@@ -18,10 +18,13 @@ import { resolveLobeHubIconURL, resolveModelIdentity } from "@/shared/lib/model-
 import { cn } from "@/lib/utils";
 
 const MODEL_MENU_MAX_HEIGHT = 400;
+const MODEL_MENU_MODEL_PANEL_MAX_HEIGHT = 280;
+const MODEL_MENU_HEADER_HEIGHT = 28;
+const MODEL_MENU_POPOVER_CHROME_HEIGHT = 12;
+const MODEL_MENU_SAFE_INSET = 16;
 const MODEL_MENU_VENDOR_ROW_HEIGHT = 28;
 const MODEL_MENU_MODEL_ROW_HEIGHT = 28;
 const MODEL_MENU_ROW_GAP = 2;
-const MODEL_MENU_LIST_PADDING_BOTTOM = 4;
 const MODEL_MENU_MODEL_PANEL_CHROME_HEIGHT = 12;
 const MODEL_MENU_TEXT_WIDTH_UNIT = 7;
 const MODEL_MENU_CONTENT_GAP_WIDTH = 56;
@@ -48,21 +51,30 @@ type ChatModelPickerProps = {
   onModelChange: (platformModelName: string) => void;
 };
 
+function resolveModelMenuContentHeight(
+  itemCount: number,
+  rowHeight: number,
+  maxContentHeight = MODEL_MENU_MAX_HEIGHT,
+): number {
+  const actualContentHeight = itemCount > 0
+    ? itemCount * rowHeight + Math.max(0, itemCount - 1) * MODEL_MENU_ROW_GAP
+    : 0;
+  return Math.min(actualContentHeight, maxContentHeight);
+}
+
 function resolveModelMenuMaxHeight(
   itemCount: number,
   rowHeight: number,
   chromeHeight: number,
   availablePanelHeight?: number | null,
+  maxContentHeight = MODEL_MENU_MAX_HEIGHT,
 ): string {
-  const actualContentHeight = itemCount > 0
-    ? itemCount * rowHeight + Math.max(0, itemCount - 1) * MODEL_MENU_ROW_GAP + MODEL_MENU_LIST_PADDING_BOTTOM
-    : 0;
-  const contentHeight = Math.min(actualContentHeight, MODEL_MENU_MAX_HEIGHT);
+  const contentHeight = resolveModelMenuContentHeight(itemCount, rowHeight, maxContentHeight);
   if (availablePanelHeight && availablePanelHeight > 0) {
     const availableListHeight = Math.max(rowHeight, Math.floor(availablePanelHeight - chromeHeight));
     return `${Math.min(contentHeight, availableListHeight)}px`;
   }
-  return `min(${contentHeight}px, calc(100vh - ${96 + chromeHeight}px))`;
+  return `min(${contentHeight}px, max(${rowHeight}px, calc(var(--radix-popover-content-available-height, calc(100vh - 96px)) - ${chromeHeight}px)))`;
 }
 
 function resolveAdaptiveMenuWidthValue(labels: string[], minWidth: number, maxWidth: number, viewportWidth?: number): number {
@@ -78,6 +90,86 @@ function resolveAdaptiveMenuWidthValue(labels: string[], minWidth: number, maxWi
 function resolveAdaptiveMenuWidth(labels: string[], minWidth: number, maxWidth: number): string {
   const preferredWidth = resolveAdaptiveMenuWidthValue(labels, minWidth, maxWidth);
   return `min(${preferredWidth}px, calc(100vw - ${MODEL_MENU_VIEWPORT_GUTTER}px))`;
+}
+
+function resolveVendorGroups(modelOptions: ChatModelOption[]) {
+  const groupMap = new Map<string, ChatModelOption[]>();
+  for (const item of modelOptions) {
+    const identity = resolveModelIdentity({
+      code: item.platformModelName,
+      vendor: item.vendor,
+      icon: item.icon,
+    });
+    const group = groupMap.get(identity.vendorKey) ?? [];
+    group.push(item);
+    groupMap.set(identity.vendorKey, group);
+  }
+
+  return Array.from(groupMap.entries()).map(([vendor, items]) => ({
+    vendor,
+    label: resolveModelIdentity({ vendor }).vendorLabel,
+    icon: resolveModelIdentity({ vendor }).vendorIcon,
+    items,
+  }));
+}
+
+function resolveDesktopModelPanelLayout({
+  activeVendorRowRect,
+  itemCount,
+  key,
+  menuRect,
+  preferredWidth,
+  viewportHeight,
+  viewportWidth,
+}: {
+  activeVendorRowRect?: DOMRect;
+  itemCount: number;
+  key: number;
+  menuRect: DOMRect;
+  preferredWidth: number;
+  viewportHeight: number;
+  viewportWidth: number;
+}): FloatingModelPanelLayout {
+  const width = Math.min(preferredWidth, Math.max(0, viewportWidth - MODEL_MENU_COLLISION_GUTTER * 2));
+  const panelChromeHeight = MODEL_MENU_MODEL_PANEL_CHROME_HEIGHT;
+  const contentHeight = resolveModelMenuContentHeight(
+    itemCount,
+    MODEL_MENU_MODEL_ROW_HEIGHT,
+    MODEL_MENU_MODEL_PANEL_MAX_HEIGHT,
+  );
+  const maxListHeight = Math.max(
+    MODEL_MENU_MODEL_ROW_HEIGHT,
+    viewportHeight - MODEL_MENU_SAFE_INSET - MODEL_MENU_COLLISION_GUTTER - panelChromeHeight,
+  );
+  const initialListHeight = Math.min(contentHeight, maxListHeight);
+  const initialPanelHeight = panelChromeHeight + initialListHeight;
+  const preferredY = activeVendorRowRect
+    ? activeVendorRowRect.top
+    : menuRect.top + initialPanelHeight <= viewportHeight - MODEL_MENU_COLLISION_GUTTER
+      ? menuRect.top
+      : menuRect.bottom - initialPanelHeight;
+  const y = Math.min(
+    Math.max(preferredY, MODEL_MENU_SAFE_INSET),
+    Math.max(MODEL_MENU_SAFE_INSET, viewportHeight - initialPanelHeight - MODEL_MENU_COLLISION_GUTTER),
+  );
+  const listMaxHeight = Math.min(
+    contentHeight,
+    Math.max(
+      MODEL_MENU_MODEL_ROW_HEIGHT,
+      Math.min(maxListHeight, viewportHeight - y - MODEL_MENU_COLLISION_GUTTER - panelChromeHeight),
+    ),
+  );
+  const rightX = menuRect.right + MODEL_MENU_PANEL_GAP;
+  const leftX = menuRect.left - MODEL_MENU_PANEL_GAP - width;
+  const rightFits = rightX + width <= viewportWidth - MODEL_MENU_COLLISION_GUTTER;
+  const leftFits = leftX >= MODEL_MENU_COLLISION_GUTTER;
+  const preferredX = rightFits || !leftFits ? rightX : leftX;
+  const x = Math.min(
+    Math.max(preferredX, MODEL_MENU_COLLISION_GUTTER),
+    Math.max(MODEL_MENU_COLLISION_GUTTER, viewportWidth - width - MODEL_MENU_COLLISION_GUTTER),
+  );
+
+  return { key, x, y, width, listMaxHeight };
 }
 
 function ChatModelIdentity({
@@ -174,9 +266,7 @@ function ModelMenuScrollContainer({
         style={{ maxHeight }}
         onScroll={updateScrollHints}
       >
-        <div className="pb-1">
-          {children}
-        </div>
+        {children}
       </div>
       {hasMoreAbove ? (
         <div className="pointer-events-none absolute inset-x-0 top-0 flex h-4 items-start justify-center rounded-t-lg bg-gradient-to-b from-popover via-popover/80 to-transparent pt-px">
@@ -497,28 +587,14 @@ export function ChatModelPicker({
       icon: selectedModel.icon,
     }).vendorLabel;
   }, [selectedModel]);
-  const vendorGroups = React.useMemo(() => {
-    const groupMap = new Map<string, ChatModelOption[]>();
-    for (const item of modelOptions) {
-      const identity = resolveModelIdentity({
-        code: item.platformModelName,
-        vendor: item.vendor,
-        icon: item.icon,
-      });
-      const group = groupMap.get(identity.vendorKey) ?? [];
-      group.push(item);
-      groupMap.set(identity.vendorKey, group);
-    }
-
-    return Array.from(groupMap.entries()).map(([vendor, items]) => ({
-      vendor,
-      label: resolveModelIdentity({ vendor }).vendorLabel,
-      icon: resolveModelIdentity({ vendor }).vendorIcon,
-      items,
-    }));
-  }, [modelOptions]);
+  const vendorGroups = React.useMemo(() => resolveVendorGroups(modelOptions), [modelOptions]);
   const vendorMenuMaxHeight = React.useMemo(
-    () => resolveModelMenuMaxHeight(vendorGroups.length, MODEL_MENU_VENDOR_ROW_HEIGHT, 12),
+    () =>
+      resolveModelMenuMaxHeight(
+        vendorGroups.length,
+        MODEL_MENU_VENDOR_ROW_HEIGHT,
+        MODEL_MENU_HEADER_HEIGHT + MODEL_MENU_POPOVER_CHROME_HEIGHT + MODEL_MENU_SAFE_INSET,
+      ),
     [vendorGroups.length],
   );
   const vendorMenuWidth = React.useMemo(
@@ -539,6 +615,8 @@ export function ChatModelPicker({
         activeDesktopVendorGroup?.items.length ?? 0,
         MODEL_MENU_MODEL_ROW_HEIGHT,
         MODEL_MENU_MODEL_PANEL_CHROME_HEIGHT,
+        null,
+        MODEL_MENU_MODEL_PANEL_MAX_HEIGHT,
       );
     },
     [activeDesktopVendorGroup, desktopModelPanelLayout],
@@ -571,7 +649,7 @@ export function ChatModelPicker({
       resolveModelMenuMaxHeight(
         mobileVendorGroup ? mobileVendorGroup.items.length : vendorGroups.length,
         MODEL_MENU_VENDOR_ROW_HEIGHT,
-        56,
+        MODEL_MENU_HEADER_HEIGHT + MODEL_MENU_POPOVER_CHROME_HEIGHT + MODEL_MENU_SAFE_INSET,
       ),
     [mobileVendorGroup, vendorGroups.length],
   );
@@ -647,58 +725,16 @@ export function ChatModelPicker({
     if (menuRect.width <= 0 || menuRect.height <= 0) {
       return;
     }
-    const panelWidth = Math.min(
-      desktopModelMenuWidthValue,
-      Math.max(0, window.innerWidth - MODEL_MENU_COLLISION_GUTTER * 2),
-    );
-    const panelChromeHeight = MODEL_MENU_MODEL_PANEL_CHROME_HEIGHT;
-    const actualContentHeight = activeDesktopVendorGroup.items.length > 0
-      ? activeDesktopVendorGroup.items.length * MODEL_MENU_MODEL_ROW_HEIGHT
-        + Math.max(0, activeDesktopVendorGroup.items.length - 1) * MODEL_MENU_ROW_GAP
-        + MODEL_MENU_LIST_PADDING_BOTTOM
-      : 0;
-    const contentHeight = Math.min(actualContentHeight, MODEL_MENU_MAX_HEIGHT);
-    const maxListHeight = Math.max(
-      MODEL_MENU_MODEL_ROW_HEIGHT,
-      window.innerHeight - MODEL_MENU_COLLISION_GUTTER * 2 - panelChromeHeight,
-    );
-    const initialListHeight = Math.min(
-      contentHeight,
-      maxListHeight,
-    );
-    const initialPanelHeight = panelChromeHeight + initialListHeight;
     const activeVendorRow = menu.querySelector<HTMLElement>('[data-active-vendor="true"]');
-    const activeVendorRowRect = activeVendorRow?.getBoundingClientRect();
-    const preferredY = activeVendorRowRect
-      ? activeVendorRowRect.top
-      : menuRect.top + initialPanelHeight <= window.innerHeight - MODEL_MENU_COLLISION_GUTTER
-        ? menuRect.top
-        : menuRect.bottom - initialPanelHeight;
-    const y = Math.min(
-      Math.max(preferredY, MODEL_MENU_COLLISION_GUTTER),
-      Math.max(MODEL_MENU_COLLISION_GUTTER, window.innerHeight - initialPanelHeight - MODEL_MENU_COLLISION_GUTTER),
-    );
-    const listMaxHeight = Math.min(
-      contentHeight,
-      Math.max(
-        MODEL_MENU_MODEL_ROW_HEIGHT,
-        Math.min(
-          maxListHeight,
-          window.innerHeight - y - MODEL_MENU_COLLISION_GUTTER - panelChromeHeight,
-        ),
-      ),
-    );
-    const rightX = menuRect.right + MODEL_MENU_PANEL_GAP;
-    const leftX = menuRect.left - MODEL_MENU_PANEL_GAP - panelWidth;
-    const rightFits = rightX + panelWidth <= window.innerWidth - MODEL_MENU_COLLISION_GUTTER;
-    const leftFits = leftX >= MODEL_MENU_COLLISION_GUTTER;
-    const preferredX = rightFits || !leftFits ? rightX : leftX;
-    const x = Math.min(
-      Math.max(preferredX, MODEL_MENU_COLLISION_GUTTER),
-      Math.max(MODEL_MENU_COLLISION_GUTTER, window.innerWidth - panelWidth - MODEL_MENU_COLLISION_GUTTER),
-    );
-
-    setDesktopModelPanelLayout({ key: layoutKey, x, y, width: panelWidth, listMaxHeight });
+    setDesktopModelPanelLayout(resolveDesktopModelPanelLayout({
+      activeVendorRowRect: activeVendorRow?.getBoundingClientRect(),
+      itemCount: activeDesktopVendorGroup.items.length,
+      key: layoutKey,
+      menuRect,
+      preferredWidth: desktopModelMenuWidthValue,
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
+    }));
   }, [activeDesktopVendorGroup, desktopModelMenuWidthValue, isMobile, open]);
 
   React.useLayoutEffect(() => {
@@ -776,7 +812,10 @@ export function ChatModelPicker({
           sideOffset={8}
           className="relative overflow-visible rounded-xl p-1.5"
           ref={desktopPopoverContentRef}
-          style={{ width: isMobile ? mobileMenuWidth : vendorMenuWidth }}
+          style={{
+            width: isMobile ? mobileMenuWidth : vendorMenuWidth,
+            maxHeight: "var(--radix-popover-content-available-height)",
+          }}
           onInteractOutside={(event) => {
             const target = event.target;
             if (target instanceof Node && desktopModelPanelRef.current?.contains(target)) {

--- a/frontend/features/chat/components/sections/chat-model-picker.tsx
+++ b/frontend/features/chat/components/sections/chat-model-picker.tsx
@@ -667,9 +667,13 @@ export function ChatModelPicker({
       maxListHeight,
     );
     const initialPanelHeight = panelChromeHeight + initialListHeight;
-    const preferredY = menuRect.top + initialPanelHeight <= window.innerHeight - MODEL_MENU_COLLISION_GUTTER
-      ? menuRect.top
-      : menuRect.bottom - initialPanelHeight;
+    const activeVendorRow = menu.querySelector<HTMLElement>('[data-active-vendor="true"]');
+    const activeVendorRowRect = activeVendorRow?.getBoundingClientRect();
+    const preferredY = activeVendorRowRect
+      ? activeVendorRowRect.top
+      : menuRect.top + initialPanelHeight <= window.innerHeight - MODEL_MENU_COLLISION_GUTTER
+        ? menuRect.top
+        : menuRect.bottom - initialPanelHeight;
     const y = Math.min(
       Math.max(preferredY, MODEL_MENU_COLLISION_GUTTER),
       Math.max(MODEL_MENU_COLLISION_GUTTER, window.innerHeight - initialPanelHeight - MODEL_MENU_COLLISION_GUTTER),
@@ -864,6 +868,7 @@ export function ChatModelPicker({
                       <button
                         type="button"
                         key={group.vendor}
+                        data-active-vendor={activeVendor ? "true" : undefined}
                         className={cn(
                           "flex h-7 w-full items-center gap-2 rounded-md px-2 py-0 text-left text-[11px] font-medium outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground",
                           activeVendor ? "bg-accent text-accent-foreground" : "text-muted-foreground",

--- a/frontend/features/chat/hooks/use-model-shortcut-menu.ts
+++ b/frontend/features/chat/hooks/use-model-shortcut-menu.ts
@@ -1,0 +1,258 @@
+"use client";
+
+import * as React from "react";
+
+import type { ChatModelOption } from "@/features/chat/types/chat-runtime";
+
+const MODEL_SHORTCUT_MENU_MAX_HEIGHT = 280;
+const MODEL_SHORTCUT_MENU_MIN_HEIGHT = 32;
+const MODEL_SHORTCUT_MENU_MIN_WIDTH = 232;
+const MODEL_SHORTCUT_MENU_MAX_WIDTH = 420;
+const MODEL_SHORTCUT_MENU_ROW_HEIGHT = 28;
+const MODEL_SHORTCUT_MENU_ROW_GAP = 2;
+const MODEL_SHORTCUT_MENU_CHROME_HEIGHT = 12;
+const MODEL_SHORTCUT_MENU_TEXT_WIDTH_UNIT = 7;
+const MODEL_SHORTCUT_MENU_CONTENT_GAP_WIDTH = 64;
+const MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER = 16;
+const MODEL_SHORTCUT_MENU_OFFSET = 8;
+
+type ModelShortcutMenuControllerArgs = {
+  draft: string;
+  modelOptions: ChatModelOption[];
+  selectedPlatformModelName: string;
+  disabled: boolean;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  onDraftChange: (value: string) => void;
+  onModelChange: (platformModelName: string) => void;
+};
+
+function resolveModelShortcutQuery(value: string): string | null {
+  if (!value.startsWith("@")) {
+    return null;
+  }
+  return value.slice(1).match(/^\S*/)?.[0]?.trim().toLowerCase() ?? "";
+}
+
+function removeModelShortcutTrigger(value: string): string {
+  return value.replace(/^@\S*\s?/, "");
+}
+
+function filterModelShortcutOptions(modelOptions: ChatModelOption[], query: string): ChatModelOption[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  return normalizedQuery
+    ? modelOptions.filter((model) => {
+      const platformModelName = model.platformModelName.toLowerCase();
+      const vendor = model.vendor.toLowerCase();
+      return platformModelName.includes(normalizedQuery) || vendor.includes(normalizedQuery);
+    })
+    : modelOptions;
+}
+
+function resolveModelShortcutMenuWidth(modelOptions: ChatModelOption[], viewportWidth: number): number {
+  const availableWidth = Math.max(0, viewportWidth - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER * 2);
+  const longestLabelLength = modelOptions.reduce(
+    (maxLength, model) => Math.max(maxLength, model.platformModelName.length),
+    0,
+  );
+  const contentWidth = longestLabelLength * MODEL_SHORTCUT_MENU_TEXT_WIDTH_UNIT + MODEL_SHORTCUT_MENU_CONTENT_GAP_WIDTH;
+  return Math.min(
+    Math.max(contentWidth, MODEL_SHORTCUT_MENU_MIN_WIDTH),
+    MODEL_SHORTCUT_MENU_MAX_WIDTH,
+    availableWidth,
+  );
+}
+
+function resolveModelShortcutMenuContentHeight(modelOptions: ChatModelOption[]): number {
+  if (modelOptions.length === 0) {
+    return MODEL_SHORTCUT_MENU_MIN_HEIGHT;
+  }
+  return Math.min(
+    MODEL_SHORTCUT_MENU_MAX_HEIGHT,
+    modelOptions.length * MODEL_SHORTCUT_MENU_ROW_HEIGHT
+      + Math.max(0, modelOptions.length - 1) * MODEL_SHORTCUT_MENU_ROW_GAP
+      + MODEL_SHORTCUT_MENU_CHROME_HEIGHT,
+  );
+}
+
+function resolveModelShortcutMenuLayout(
+  textarea: HTMLTextAreaElement,
+  modelOptions: ChatModelOption[],
+  viewportWidth: number,
+  viewportHeight: number,
+): React.CSSProperties {
+  const textareaRect = textarea.getBoundingClientRect();
+  const computed = window.getComputedStyle(textarea);
+  const paddingLeft = Number.parseFloat(computed.paddingLeft) || 20;
+  const paddingTop = Number.parseFloat(computed.paddingTop) || 16;
+  const lineHeight = Number.parseFloat(computed.lineHeight) || 24;
+  const preferredTop = textareaRect.top + paddingTop + lineHeight + MODEL_SHORTCUT_MENU_OFFSET;
+  const preferredBottom = textareaRect.top + paddingTop - MODEL_SHORTCUT_MENU_OFFSET;
+  const desiredHeight = resolveModelShortcutMenuContentHeight(modelOptions);
+  const availableBelow = viewportHeight - preferredTop - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER;
+  const availableAbove = preferredBottom - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER;
+  const openBelow =
+    availableBelow >= Math.min(desiredHeight, MODEL_SHORTCUT_MENU_MIN_HEIGHT)
+    || availableBelow >= availableAbove;
+  const availableHeight = Math.max(0, openBelow ? availableBelow : availableAbove);
+  const maxHeight = Math.max(
+    Math.min(MODEL_SHORTCUT_MENU_MIN_HEIGHT, availableHeight),
+    Math.min(desiredHeight, availableHeight),
+  );
+  const top = openBelow
+    ? preferredTop
+    : Math.max(MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER, preferredBottom - maxHeight);
+  const preferredWidth = resolveModelShortcutMenuWidth(modelOptions, viewportWidth);
+  const preferredLeft = textareaRect.left + paddingLeft - MODEL_SHORTCUT_MENU_OFFSET;
+  const maxLeft = Math.max(
+    MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER,
+    viewportWidth - preferredWidth - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER,
+  );
+  const left = Math.min(Math.max(preferredLeft, MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER), maxLeft);
+  const width = Math.min(
+    preferredWidth,
+    Math.max(0, viewportWidth - left - MODEL_SHORTCUT_MENU_VIEWPORT_GUTTER),
+  );
+
+  return { left, top, width, maxHeight };
+}
+
+export function useModelShortcutMenu({
+  draft,
+  modelOptions,
+  selectedPlatformModelName,
+  disabled,
+  textareaRef,
+  onDraftChange,
+  onModelChange,
+}: ModelShortcutMenuControllerArgs) {
+  const menuRef = React.useRef<HTMLDivElement | null>(null);
+  const menuID = React.useId();
+  const [inputFocused, setInputFocused] = React.useState(false);
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const [dismissedDraft, setDismissedDraft] = React.useState<string | null>(null);
+  const [menuStyle, setMenuStyle] = React.useState<React.CSSProperties>({});
+  const query = resolveModelShortcutQuery(draft);
+  const options = React.useMemo(
+    () => (query === null ? [] : filterModelShortcutOptions(modelOptions, query)),
+    [modelOptions, query],
+  );
+  const open = inputFocused && query !== null && dismissedDraft !== draft && !disabled && options.length > 0;
+  const activeOption = open ? options[Math.min(activeIndex, options.length - 1)] : null;
+  const selectedIndex = React.useMemo(
+    () => options.findIndex((model) => model.platformModelName === selectedPlatformModelName),
+    [options, selectedPlatformModelName],
+  );
+
+  React.useEffect(() => {
+    setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
+  }, [query, selectedIndex]);
+
+  React.useEffect(() => {
+    setActiveIndex((current) => (options.length === 0 ? 0 : Math.min(current, options.length - 1)));
+  }, [options.length]);
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const activeItem = menuRef.current?.querySelector<HTMLElement>('[data-active="true"]');
+    activeItem?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, open]);
+
+  const updateLayout = React.useCallback(() => {
+    if (!open || typeof window === "undefined") {
+      return;
+    }
+
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    setMenuStyle(resolveModelShortcutMenuLayout(textarea, options, window.innerWidth, window.innerHeight));
+  }, [open, options, textareaRef]);
+
+  React.useLayoutEffect(() => {
+    if (!open) {
+      return;
+    }
+    let frameID = window.requestAnimationFrame(updateLayout);
+    const update = () => {
+      window.cancelAnimationFrame(frameID);
+      frameID = window.requestAnimationFrame(updateLayout);
+    };
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.cancelAnimationFrame(frameID);
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [open, updateLayout]);
+
+  const select = React.useCallback(
+    (model: ChatModelOption) => {
+      onModelChange(model.platformModelName);
+      onDraftChange(removeModelShortcutTrigger(draft));
+      setDismissedDraft(null);
+      window.requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+      });
+    },
+    [draft, onDraftChange, onModelChange, textareaRef],
+  );
+
+  const handleChange = React.useCallback(
+    (value: string) => {
+      if (dismissedDraft !== null && value !== dismissedDraft) {
+        setDismissedDraft(null);
+      }
+      onDraftChange(value);
+    },
+    [dismissedDraft, onDraftChange],
+  );
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>): boolean => {
+      if (!open) {
+        return false;
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActiveIndex((current) => (current + 1) % options.length);
+        return true;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActiveIndex((current) => (current - 1 + options.length) % options.length);
+        return true;
+      }
+      if ((event.key === "Enter" || event.key === "Tab") && activeOption) {
+        event.preventDefault();
+        select(activeOption);
+        return true;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setDismissedDraft(draft);
+        return true;
+      }
+      return false;
+    },
+    [activeOption, draft, open, options.length, select],
+  );
+
+  return {
+    activeIndex,
+    handleBlur: () => setInputFocused(false),
+    handleChange,
+    handleFocus: () => setInputFocused(true),
+    handleKeyDown,
+    menuID,
+    menuRef,
+    menuStyle,
+    open,
+    options,
+    select,
+  };
+}


### PR DESCRIPTION
## Summary

Improve the chat model selection experience and clean up the related frontend code.

This adds a first-character `@` shortcut in the chat composer for quickly selecting models, with mouse and keyboard navigation, viewport-safe floating layout, adaptive width/height, and proper dismissal behavior. It also improves the existing model picker panels so vendor/model lists use adaptive sizing, avoid viewport clipping, and keep consistent spacing.

The implementation was refactored to keep the chat input component focused: the `@` shortcut controller now lives in `frontend/features/chat/hooks/use-model-shortcut-menu.ts`, while model picker grouping and floating panel layout calculations are kept as local helpers in `chat-model-picker.tsx`.

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `git diff --check`

## Screenshots, API examples, or logs

UI-only change. Manual visual checks covered the composer `@` shortcut menu and the model picker vendor/model panels.

## Configuration, migration, and compatibility notes

No configuration, database migration, deployment, or API contract changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.