### PR TITLE
feat: update mobile view logic in ChatModelConfig

### DIFF
--- a/frontend/features/chat/components/sections/chat-model-config.tsx
+++ b/frontend/features/chat/components/sections/chat-model-config.tsx
@@ -802,6 +802,31 @@ function visualOptionsFromControls(
   });
 }
 
+function hasVisualConfigurationContent({
+  nativeToolDefinitions,
+  optionControls,
+  options,
+  policy,
+  protocol,
+}: {
+  nativeToolDefinitions: NativeToolDefinition[];
+  optionControls: ModelOptionControl[];
+  options: ConversationOptions;
+  policy: ModelOptionPolicy | null;
+  protocol: string;
+}): boolean {
+  if (nativeToolDefinitions.length > 0) {
+    return true;
+  }
+  const configuredOptions = visualOptionsFromControls(optionControls, options);
+  if (configuredOptions.length > 0) {
+    return true;
+  }
+  const configuredKeys = new Set(configuredOptions.map((item) => item.key));
+  return visualOptionsFromOptions(options, policy, protocol, nativeToolDefinitions)
+    .some((item) => !configuredKeys.has(item.key));
+}
+
 function resolveOptionTitle(key: string, configuredLabel: string | undefined, translate: OptionTranslationResolver): string {
   const translationKey = key.replaceAll(".", "__");
   if (OPTION_LABEL_KEYS.has(key) && translate.has?.(translationKey)) {
@@ -949,7 +974,7 @@ export function ChatModelConfig({
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [optionsDraft, setOptionsDraft] = React.useState("");
   const [optionsObject, setOptionsObject] = React.useState<ConversationOptions>({});
-  const [mobileView, setMobileView] = React.useState<"json" | "visual">("json");
+  const [mobileView, setMobileView] = React.useState<"json" | "visual">("visual");
   const [defaultRestorePending, setDefaultRestorePending] = React.useState(false);
   const [restoredDefaultOptions, setRestoredDefaultOptions] = React.useState<ConversationOptions | null>(null);
   const optionsObjectRef = React.useRef<ConversationOptions>({});
@@ -999,13 +1024,20 @@ export function ChatModelConfig({
 
   const openOptionsDialog = React.useCallback(() => {
     const sanitized = sanitizeConversationOptions(options);
+    const hasVisualContent = hasVisualConfigurationContent({
+      nativeToolDefinitions,
+      optionControls,
+      options: sanitized,
+      policy: modelOptionPolicy,
+      protocol: selectedProtocol,
+    });
     optionsObjectRef.current = sanitized;
     setOptionsObject(sanitized);
     setOptionsDraft(stringifyOptions(sanitized));
-    setMobileView("json");
+    setMobileView(hasVisualContent ? "visual" : "json");
     setRestoredDefaultOptions(null);
     setDialogOpen(true);
-  }, [options]);
+  }, [modelOptionPolicy, nativeToolDefinitions, optionControls, options, selectedProtocol]);
 
   const replaceOptionsDraft = React.useCallback((next: ConversationOptions) => {
     const sanitized = sanitizeConversationOptions(next);
@@ -1090,8 +1122,8 @@ export function ChatModelConfig({
       className="w-fit gap-0"
     >
       <TabsList className="h-7">
-        <TabsTrigger value="json">JSON</TabsTrigger>
         <TabsTrigger value="visual">{tComposer("visual")}</TabsTrigger>
+        <TabsTrigger value="json">JSON</TabsTrigger>
       </TabsList>
     </Tabs>
   );
@@ -1113,9 +1145,10 @@ export function ChatModelConfig({
       </div>
       <div className="min-h-0 flex-1 p-0.5">
         <JsonCodeEditor
+          key={mobileView === "json" ? "json-visible" : "json-hidden"}
           value={optionsDraft}
           onChange={handleOptionsJSONChange}
-          autoFocus
+          autoFocus={mobileView === "json"}
           height="100%"
           className="h-full min-h-0"
           actions={

--- a/frontend/shared/components/json-code-editor.tsx
+++ b/frontend/shared/components/json-code-editor.tsx
@@ -66,6 +66,14 @@ function getEditorFontSize() {
   return BASE_EDITOR_FONT_SIZE * readUIFontScale();
 }
 
+function preservePlaceholderIndentation(value: string | undefined): string | undefined {
+  return value?.replace(/^[ \t]+/gm, (indent) =>
+    indent
+      .replaceAll(" ", "\u00A0")
+      .replaceAll("\t", "\u00A0\u00A0"),
+  );
+}
+
 function configureMonacoWorkers() {
   if (typeof window === "undefined") {
     return;
@@ -126,7 +134,7 @@ export function JsonCodeEditor({
   const mountDisabledRef = React.useRef(disabled);
   const mountThemeRef = React.useRef(resolvedTheme);
   const mountAutoFocusRef = React.useRef(autoFocus);
-  const placeholderRef = React.useRef(placeholder);
+  const placeholderRef = React.useRef(preservePlaceholderIndentation(placeholder));
   const [loading, setLoading] = React.useState(true);
   const [markerCount, setMarkerCount] = React.useState(0);
 
@@ -172,8 +180,19 @@ export function JsonCodeEditor({
   }, [autoFocus]);
 
   React.useEffect(() => {
-    placeholderRef.current = placeholder;
-    editorRef.current?.updateOptions({ placeholder: placeholder || undefined });
+    if (!autoFocus) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      editorRef.current?.focus();
+    }, 50);
+    return () => window.clearTimeout(timer);
+  }, [autoFocus]);
+
+  React.useEffect(() => {
+    const formattedPlaceholder = preservePlaceholderIndentation(placeholder);
+    placeholderRef.current = formattedPlaceholder;
+    editorRef.current?.updateOptions({ placeholder: formattedPlaceholder || undefined });
   }, [placeholder]);
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary

Improve the mobile model configuration dialog so users land on the most useful configuration view by default.

On mobile, the dialog now opens the visual configuration view when visual controls or native tool options are available, and falls back to JSON when there is no visual content to edit. The tab order was updated to show Visual before JSON. JSON editor focus behavior was also fixed so switching into JSON reliably focuses Monaco, restores select-all behavior, and keeps formatted placeholder indentation.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `git diff --check`

## Screenshots, API examples, or logs

UI-only change. No API examples or logs.

## Configuration, Migration, And Compatibility Notes

No configuration, migration, deployment, database schema, or API contract changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.