### PR TITLE
feat: implement RawUsageJSON handling in billing

### DIFF
--- a/backend/internal/application/billing/service.go
+++ b/backend/internal/application/billing/service.go
@@ -98,6 +98,26 @@ type UsagePricingInput struct {
 	LatencyMS           int64
 	ServerSideToolUsage map[string]int64
 	ServiceItems        []ServiceUsageInput
+	RawUsageJSON        string
+}
+
+func upstreamUsageSnapshot(input UsagePricingInput) interface{} {
+	raw := strings.TrimSpace(input.RawUsageJSON)
+	if raw == "" {
+		return map[string]interface{}{}
+	}
+	var decoded interface{}
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return map[string]interface{}{}
+	}
+	switch value := decoded.(type) {
+	case map[string]interface{}:
+		return value
+	case []interface{}:
+		return value
+	default:
+		return map[string]interface{}{}
+	}
 }
 
 // PlatformModelIdentity 描述一次计费需要用到的平台模型身份。
@@ -1514,6 +1534,7 @@ func (s *Service) BuildUsageLedger(ctx context.Context, input UsagePricingInput)
 		"output_billed_nanousd":                    outputBilledNanousd,
 		"call_billed_nanousd":                      callBilledNanousd,
 		"duration_billed_nanousd":                  durationBilledNanousd,
+		"upstream_usage":                           upstreamUsageSnapshot(input),
 		"server_side_tool_usage":                   normalizeUsageCountMap(input.ServerSideToolUsage),
 		"native_tool_billing_enabled":              nativeToolBillingEnabled,
 		"native_tool_pricing_source":               nativeToolPricingSourceForSnapshot(nativeToolPricingJSON, nativeToolDefinitions),

--- a/backend/internal/application/billing/service_model_identity_test.go
+++ b/backend/internal/application/billing/service_model_identity_test.go
@@ -18,6 +18,16 @@ func (s modelIdentityResolverStub) ResolvePlatformModelIdentity(context.Context,
 	return s.identity, nil
 }
 
+func TestUpstreamUsageSnapshotReturnsEmptyObjectWhenRawUsageIsMissing(t *testing.T) {
+	snapshot, ok := upstreamUsageSnapshot(UsagePricingInput{
+		InputTokens:  10,
+		OutputTokens: 20,
+	}).(map[string]interface{})
+	if !ok || len(snapshot) != 0 {
+		t.Fatalf("expected empty upstream usage snapshot, got %#v", snapshot)
+	}
+}
+
 type billingRepositoryStub struct {
 	mode                       string
 	pricing                    *domainbilling.ModelPricing
@@ -238,6 +248,7 @@ func TestBuildUsageLedgerSnapshotsModelIdentity(t *testing.T) {
 		UpstreamModelName: "gpt-5.5-upstream",
 		InputTokens:       1_000_000,
 		OutputTokens:      1_000_000,
+		RawUsageJSON:      `{"input_tokens":1000000,"output_tokens":1000000,"vendor_extra":"kept"}`,
 		ServerSideToolUsage: map[string]int64{
 			"web_search": 2,
 			"ignored":    0,
@@ -272,6 +283,10 @@ func TestBuildUsageLedgerSnapshotsModelIdentity(t *testing.T) {
 	}
 	if snapshot["routed_binding_code"] != "upm_gpt55_20260514" || snapshot["upstream_model_name"] != "gpt-5.5-upstream" {
 		t.Fatalf("expected routed binding/upstream snapshot, got routed=%#v upstream_model=%#v", snapshot["routed_binding_code"], snapshot["upstream_model_name"])
+	}
+	upstreamUsage, ok := snapshot["upstream_usage"].(map[string]interface{})
+	if !ok || upstreamUsage["vendor_extra"] != "kept" || upstreamUsage["input_tokens"] != float64(1_000_000) {
+		t.Fatalf("expected raw upstream usage snapshot, got %#v", snapshot["upstream_usage"])
 	}
 	if _, ok := snapshot["billing_multiplier"]; ok {
 		t.Fatalf("did not expect billing multiplier snapshot, got %#v", snapshot["billing_multiplier"])

--- a/backend/internal/application/conversation/service.go
+++ b/backend/internal/application/conversation/service.go
@@ -157,6 +157,7 @@ type SendMessageResult struct {
 	EffectiveOptions    map[string]interface{}
 	UsageSpeed          string
 	UsageServiceTier    string
+	RawUsageJSON        string
 	CacheWrite5mTokens  int64
 	CacheWrite1hTokens  int64
 	ServerSideToolUsage map[string]int64

--- a/backend/internal/application/conversation/service_billing.go
+++ b/backend/internal/application/conversation/service_billing.go
@@ -182,6 +182,7 @@ func (s *Service) buildSendMessageUsageLedger(ctx context.Context, input SendMes
 		CallCount:           1,
 		LatencyMS:           latencyMS,
 		ServerSideToolUsage: result.ServerSideToolUsage,
+		RawUsageJSON:        result.RawUsageJSON,
 	})
 }
 

--- a/backend/internal/application/conversation/service_generation_support.go
+++ b/backend/internal/application/conversation/service_generation_support.go
@@ -241,6 +241,7 @@ func (s *Service) recordBasicServiceUsage(
 		CallCount:          item.CallCount,
 		LatencyMS:          latencyMS,
 		ServiceItems:       []appbilling.ServiceUsageInput{item},
+		RawUsageJSON:       usage.RawUsageJSON,
 	})
 	if err != nil {
 		if s.logger != nil {

--- a/backend/internal/application/conversation/service_media_generation.go
+++ b/backend/internal/application/conversation/service_media_generation.go
@@ -442,6 +442,7 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 		EffectiveOptions:   filteredOptions,
 		UsageSpeed:         usage.Speed,
 		UsageServiceTier:   usage.ServiceTier,
+		RawUsageJSON:       usage.RawUsageJSON,
 		CacheWrite5mTokens: usage.CacheWrite5mTokens,
 		CacheWrite1hTokens: usage.CacheWrite1hTokens,
 		LatencyMS:          latencyMS,

--- a/backend/internal/application/conversation/service_message_completion.go
+++ b/backend/internal/application/conversation/service_message_completion.go
@@ -329,6 +329,7 @@ func buildInterruptedSendMessageResult(input persistInterruptedMessageGeneration
 		EffectiveOptions:    input.EffectiveOptions,
 		UsageSpeed:          input.Usage.Speed,
 		UsageServiceTier:    input.Usage.ServiceTier,
+		RawUsageJSON:        input.Usage.RawUsageJSON,
 		CacheWrite5mTokens:  input.Usage.CacheWrite5mTokens,
 		CacheWrite1hTokens:  input.Usage.CacheWrite1hTokens,
 		ServerSideToolUsage: input.ServerSideToolUsage,

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -1336,6 +1336,7 @@ func (s *Service) sendMessageInternal(
 		EffectiveOptions:    filteredOptions,
 		UsageSpeed:          totalUsage.Speed,
 		UsageServiceTier:    totalUsage.ServiceTier,
+		RawUsageJSON:        totalUsage.RawUsageJSON,
 		CacheWrite5mTokens:  totalUsage.CacheWrite5mTokens,
 		CacheWrite1hTokens:  totalUsage.CacheWrite1hTokens,
 		ServerSideToolUsage: totalServerSideToolUsage,

--- a/backend/internal/application/conversation/service_tool_loop.go
+++ b/backend/internal/application/conversation/service_tool_loop.go
@@ -166,6 +166,7 @@ func addLLMUsage(left llm.Usage, right llm.Usage) llm.Usage {
 		ReasoningTokens:    left.ReasoningTokens + right.ReasoningTokens,
 		Speed:              mergeLLMUsageSpeed(left.Speed, right.Speed),
 		ServiceTier:        mergeLLMUsageServiceTier(left.ServiceTier, right.ServiceTier),
+		RawUsageJSON:       llm.MergeRawUsageJSON(left.RawUsageJSON, right.RawUsageJSON),
 	}
 }
 
@@ -180,6 +181,7 @@ func diffLLMUsage(current llm.Usage, previous llm.Usage) llm.Usage {
 		ReasoningTokens:    nonNegativeTokenDelta(current.ReasoningTokens, previous.ReasoningTokens),
 		Speed:              strings.TrimSpace(current.Speed),
 		ServiceTier:        strings.TrimSpace(current.ServiceTier),
+		RawUsageJSON:       diffLLMUsageRawJSON(current.RawUsageJSON, previous.RawUsageJSON),
 	}
 }
 
@@ -224,6 +226,14 @@ func addServerSideToolUsage(left map[string]int64, right map[string]int64) map[s
 		return nil
 	}
 	return result
+}
+
+func diffLLMUsageRawJSON(current string, previous string) string {
+	current = strings.TrimSpace(current)
+	if current == "" || current == strings.TrimSpace(previous) {
+		return ""
+	}
+	return current
 }
 
 func mergeLLMUsageSpeed(left string, right string) string {

--- a/backend/internal/infra/llm/anthropic.go
+++ b/backend/internal/infra/llm/anthropic.go
@@ -866,6 +866,7 @@ func parseAnthropicUsage(parsed map[string]interface{}) Usage {
 		CacheWrite5mTokens: cacheCreation5mInputTokens,
 		CacheWrite1hTokens: cacheCreation1hInputTokens,
 		Speed:              strings.TrimSpace(getStringFromPath(parsed, "usage", "speed")),
+		RawUsageJSON:       rawUsageJSONFromPath(parsed, "usage"),
 	}
 }
 
@@ -1318,6 +1319,7 @@ func applyAnthropicStreamEvent(
 		deltaUsage := asMap(parsed["usage"])
 		if out := toInt64(deltaUsage["output_tokens"]); out > 0 {
 			result.Usage.OutputTokens = out
+			result.Usage.RawUsageJSON = MergeRawUsageJSON(result.Usage.RawUsageJSON, rawUsageJSONFromPath(parsed, "usage"))
 			if onEvent != nil {
 				return onEvent(GenerateStreamEvent{
 					Usage:      result.Usage,

--- a/backend/internal/infra/llm/client.go
+++ b/backend/internal/infra/llm/client.go
@@ -491,6 +491,7 @@ type Usage struct {
 	ReasoningTokens    int64
 	Speed              string
 	ServiceTier        string
+	RawUsageJSON       string
 }
 
 func nonCachedInputTokens(totalInputTokens int64, cacheReadTokens int64) int64 {
@@ -505,6 +506,88 @@ func nonCachedInputTokens(totalInputTokens int64, cacheReadTokens int64) int64 {
 		return 0
 	}
 	return remaining
+}
+
+func rawUsageJSONFromPath(payload map[string]interface{}, keys ...string) string {
+	if len(payload) == 0 || len(keys) == 0 {
+		return ""
+	}
+	var current interface{} = payload
+	for _, key := range keys {
+		currentMap, ok := current.(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		current, ok = currentMap[key]
+		if !ok {
+			return ""
+		}
+	}
+	switch value := current.(type) {
+	case map[string]interface{}:
+		if len(value) == 0 {
+			return ""
+		}
+	case []interface{}:
+		if len(value) == 0 {
+			return ""
+		}
+	default:
+		return ""
+	}
+	raw, err := json.Marshal(current)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
+func MergeRawUsageJSON(left string, right string) string {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" {
+		return right
+	}
+	if right == "" || right == left {
+		return left
+	}
+	items := make([]interface{}, 0, 2)
+	items = appendRawUsageJSON(items, left)
+	items = appendRawUsageJSON(items, right)
+	if len(items) == 0 {
+		return ""
+	}
+	if len(items) == 1 {
+		raw, err := json.Marshal(items[0])
+		if err != nil {
+			return ""
+		}
+		return string(raw)
+	}
+	raw, err := json.Marshal(items)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
+func appendRawUsageJSON(items []interface{}, raw string) []interface{} {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return items
+	}
+	var decoded interface{}
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return items
+	}
+	switch value := decoded.(type) {
+	case []interface{}:
+		return append(items, value...)
+	case map[string]interface{}:
+		return append(items, value)
+	default:
+		return items
+	}
 }
 
 // ToolCall 记录上游返回的工具调用请求。

--- a/backend/internal/infra/llm/gemini.go
+++ b/backend/internal/infra/llm/gemini.go
@@ -793,6 +793,7 @@ func parseGeminiUsage(parsed map[string]interface{}) Usage {
 		OutputTokens:    getInt64FromPath(parsed, "usageMetadata", "candidatesTokenCount"),
 		CacheReadTokens: cacheReadTokens,
 		ReasoningTokens: getInt64FromPath(parsed, "usageMetadata", "thoughtsTokenCount"),
+		RawUsageJSON:    rawUsageJSONFromPath(parsed, "usageMetadata"),
 	}
 }
 

--- a/backend/internal/infra/llm/openai_chat_completions.go
+++ b/backend/internal/infra/llm/openai_chat_completions.go
@@ -548,6 +548,7 @@ func parseOpenAICompatibleUsageForAdapter(adapter string, parsed map[string]inte
 		),
 		ReasoningTokens: reasoningTokens,
 		ServiceTier:     strings.TrimSpace(getString(parsed["service_tier"])),
+		RawUsageJSON:    rawUsageJSONFromPath(parsed, "usage"),
 	}
 }
 

--- a/backend/internal/infra/llm/usage_test.go
+++ b/backend/internal/infra/llm/usage_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -12,6 +13,21 @@ func mustDecodeObject(t *testing.T, raw string) map[string]interface{} {
 		t.Fatalf("decode usage fixture: %v", err)
 	}
 	return payload
+}
+
+func assertJSONEqual(t *testing.T, actual string, expected string) {
+	t.Helper()
+	var actualPayload interface{}
+	if err := json.Unmarshal([]byte(actual), &actualPayload); err != nil {
+		t.Fatalf("decode actual json: %v; raw=%s", err, actual)
+	}
+	var expectedPayload interface{}
+	if err := json.Unmarshal([]byte(expected), &expectedPayload); err != nil {
+		t.Fatalf("decode expected json: %v; raw=%s", err, expected)
+	}
+	if !reflect.DeepEqual(actualPayload, expectedPayload) {
+		t.Fatalf("json mismatch:\nactual:   %s\nexpected: %s", actual, expected)
+	}
 }
 
 func TestParseChatCompletionsUsage(t *testing.T) {
@@ -28,6 +44,12 @@ func TestParseChatCompletionsUsage(t *testing.T) {
 	if usage.InputTokens != 84 || usage.OutputTokens != 16 || usage.CacheReadTokens != 17 || usage.ReasoningTokens != 7 {
 		t.Fatalf("unexpected chat completions usage: %+v", usage)
 	}
+	assertJSONEqual(t, usage.RawUsageJSON, `{
+		"prompt_tokens": 101,
+		"completion_tokens": 23,
+		"prompt_tokens_details": {"cached_tokens": 17},
+		"completion_tokens_details": {"reasoning_tokens": 7}
+	}`)
 }
 
 func TestParseChatStreamUsageIgnoresServiceTierOnlyChunks(t *testing.T) {
@@ -184,6 +206,17 @@ func TestParseAnthropicMessagesUsage(t *testing.T) {
 	if usage.InputTokens != 101 || usage.OutputTokens != 23 || usage.CacheReadTokens != 17 || usage.CacheWriteTokens != 8 || usage.CacheWrite5mTokens != 5 || usage.CacheWrite1hTokens != 3 || usage.ReasoningTokens != 0 || usage.Speed != "fast" {
 		t.Fatalf("unexpected anthropic usage: %+v", usage)
 	}
+	assertJSONEqual(t, usage.RawUsageJSON, `{
+		"input_tokens": 101,
+		"output_tokens": 23,
+		"cache_creation_input_tokens": 11,
+		"cache_read_input_tokens": 17,
+		"speed": "fast",
+		"cache_creation": {
+			"ephemeral_1h_input_tokens": 3,
+			"ephemeral_5m_input_tokens": 5
+		}
+	}`)
 }
 
 func TestParseAnthropicMessagesUsageFallsBackToLegacyCacheCreation(t *testing.T) {
@@ -200,6 +233,44 @@ func TestParseAnthropicMessagesUsageFallsBackToLegacyCacheCreation(t *testing.T)
 	if usage.CacheWriteTokens != 11 {
 		t.Fatalf("unexpected anthropic legacy cache write usage: %+v", usage)
 	}
+}
+
+func TestApplyAnthropicStreamEventKeepsSplitRawUsage(t *testing.T) {
+	result := &GenerateOutput{}
+	start := mustDecodeObject(t, `{
+		"type": "message_start",
+		"message": {
+			"id": "msg_1",
+			"usage": {
+				"input_tokens": 101,
+				"cache_read_input_tokens": 17
+			}
+		}
+	}`)
+	if err := applyAnthropicStreamEvent(start, "", result, nil, anthropicToolClassifier{}); err != nil {
+		t.Fatalf("apply message_start: %v", err)
+	}
+	delta := mustDecodeObject(t, `{
+		"type": "message_delta",
+		"usage": {
+			"output_tokens": 23
+		}
+	}`)
+	if err := applyAnthropicStreamEvent(delta, "", result, nil, anthropicToolClassifier{}); err != nil {
+		t.Fatalf("apply message_delta: %v", err)
+	}
+	if result.Usage.InputTokens != 101 || result.Usage.OutputTokens != 23 || result.Usage.CacheReadTokens != 17 {
+		t.Fatalf("unexpected anthropic stream usage: %+v", result.Usage)
+	}
+	assertJSONEqual(t, result.Usage.RawUsageJSON, `[
+		{
+			"input_tokens": 101,
+			"cache_read_input_tokens": 17
+		},
+		{
+			"output_tokens": 23
+		}
+	]`)
 }
 
 func TestParseAnthropicServerSideToolUsage(t *testing.T) {
@@ -257,6 +328,12 @@ func TestParseGoogleGenerateContentUsage(t *testing.T) {
 	if usage.InputTokens != 84 || usage.OutputTokens != 23 || usage.CacheReadTokens != 17 || usage.ReasoningTokens != 7 {
 		t.Fatalf("unexpected google generateContent usage: %+v", usage)
 	}
+	assertJSONEqual(t, usage.RawUsageJSON, `{
+		"promptTokenCount": 101,
+		"candidatesTokenCount": 23,
+		"cachedContentTokenCount": 17,
+		"thoughtsTokenCount": 7
+	}`)
 }
 
 func TestNonCachedInputTokensNeverNegative(t *testing.T) {

--- a/frontend/features/admin/components/sections/logs/admin-logs.tsx
+++ b/frontend/features/admin/components/sections/logs/admin-logs.tsx
@@ -102,6 +102,21 @@ function formatJSON(raw: string | null | undefined): string {
   }
 }
 
+function parseJSONRecord(raw: string | null | undefined): Record<string, unknown> | null {
+  const value = raw?.trim();
+  if (!value) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 function formatCount(value: number | null | undefined, locale: string): string {
   return new Intl.NumberFormat(locale).format(value ?? 0);
 }
@@ -134,7 +149,16 @@ type UsagePricingSnapshot = {
   duration_billed_nanousd?: number;
   tiered_from_tokens?: number;
   tiered_up_to_tokens?: number | null;
+  upstream_usage?: unknown;
 };
+
+function usageLogRawUsageJSON(item: AdminUsageLogDTO): string {
+  const upstreamUsage = parseJSONRecord(item.pricingSnapshotJSON)?.upstream_usage;
+  if (upstreamUsage && typeof upstreamUsage === "object") {
+    return JSON.stringify(upstreamUsage, null, 2);
+  }
+  return "{}";
+}
 
 type UsageBillingLabels = {
   input: string;
@@ -666,11 +690,12 @@ function LogDetailSheet({ detail, onClose }: { detail: LogDetail | null; onClose
         : detail?.kind === "conversation"
           ? detail.item.payloadJSON || detail.item.inputJSON || detail.item.outputJSON || detail.item.errorJSON
           : detail?.item.detailJSON;
+  const rawUsageJSON = detail?.kind === "usage" ? usageLogRawUsageJSON(detail.item) : "";
   const formattedJSON = formatJSON(detailJSON);
 
   return (
     <Sheet open={Boolean(detail)} onOpenChange={(open) => !open && onClose()}>
-      <SheetContent className="sm:max-w-[720px]">
+      <SheetContent className="sm:max-w-[480px]">
         <SheetHeader>
           <SheetTitle>{title}</SheetTitle>
           <SheetDescription>{description}</SheetDescription>
@@ -768,6 +793,28 @@ function LogDetailSheet({ detail, onClose }: { detail: LogDetail | null; onClose
                 <DetailRow label={t("fields.latency")} value={`${formatCount(detail.item.latencyMS, locale)} ms`} mono />
               </DetailBlock>
             </>
+          ) : null}
+
+          {detail?.kind === "usage" ? (
+            <section className="space-y-2">
+              <div className="flex items-center justify-between gap-3 px-1">
+                <h4 className="text-xs font-medium text-foreground/88">{t("rawUsageJsonTitle")}</h4>
+                <CopyActionButton
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs shadow-none"
+                  value={rawUsageJSON}
+                  messages={copyMessages}
+                  copyOptions={{ copied: t("copied", { label: t("rawUsageJsonTitle") }) }}
+                >
+                  JSON
+                </CopyActionButton>
+              </div>
+              <pre className="max-h-[240px] overflow-auto rounded-lg border border-border/60 bg-muted/35 p-3 text-xs leading-5 text-foreground/86">
+                <code>{rawUsageJSON}</code>
+              </pre>
+            </section>
           ) : null}
 
           {detail?.kind === "order" ? (

--- a/frontend/i18n/messages/en-US/admin-logs.json
+++ b/frontend/i18n/messages/en-US/admin-logs.json
@@ -319,6 +319,7 @@
       "failure": "Failed",
       "blocked": "Blocked"
     },
+    "rawUsageJsonTitle": "Raw Usage JSON",
     "jsonTitle": "Detail JSON",
     "copied": "{label} copied",
     "copyFailed": "Copy failed"

--- a/frontend/i18n/messages/zh-CN/admin-logs.json
+++ b/frontend/i18n/messages/zh-CN/admin-logs.json
@@ -319,6 +319,7 @@
       "failure": "失败",
       "blocked": "阻断"
     },
+    "rawUsageJsonTitle": "原始 Usage JSON",
     "jsonTitle": "详情 JSON",
     "copied": "{label}已复制",
     "copyFailed": "复制失败"


### PR DESCRIPTION
## Summary

Add raw upstream usage visibility to admin usage log details.

This change captures provider-native usage payloads when available and stores them in the billing pricing snapshot as `upstream_usage`. The admin log detail sheet now shows a dedicated “Raw Usage JSON” section so billing, cache, reasoning, and provider-specific token behavior can be inspected directly.

The implementation reads usage from each protocol’s native location:

- OpenAI / OpenAI-compatible / xAI: top-level `usage`
- Anthropic Messages: top-level `usage`
- Anthropic streaming: `message_start.message.usage` and `message_delta.usage`
- Gemini: top-level `usageMetadata`

If no upstream usage is present, the UI shows `{}` and the existing token estimation and billing flow continues unchanged.

The usage log detail sheet width was also reduced to `480px`.

## Change type

- [x] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [x] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/infra/llm ./internal/application/billing ./internal/transport/http/admin`
- [x] `cd frontend && pnpm lint`

## Screenshots, API examples, or logs

Admin usage log detail sheet now includes a “Raw Usage JSON” block.

Missing upstream usage is displayed as:

```json
{}
```

## Configuration, migration, and compatibility notes

No configuration, migration, deployment, or API contract changes are required.

Existing usage logs that do not contain `upstream_usage` remain compatible and display `{}`.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.