### PR TITLE
fix: broken GitHub 404 link

### DIFF
--- a/frontend/shared/components/about-settings-content.tsx
+++ b/frontend/shared/components/about-settings-content.tsx
@@ -101,7 +101,7 @@ export function AboutSettingsContent({
     {
       label: labels.official,
       value: "DEEIX",
-      href: "https://github.com/DEEIX-AI/DEEIX",
+      href: "https://github.com/DEEIX-AI",
       providerIcon: { name: "GitHub", slug: "github" },
     },
     {


### PR DESCRIPTION
GitHub 404 link `https://github.com/DEEIX-AI/DEEIX`
Replace it with `https://github.com/DEEIX-AI`