### PR TITLE
Improve model ordering and availability states across admin and chat selectors

### DIFF
--- a/backend/internal/application/channel/service_model.go
+++ b/backend/internal/application/channel/service_model.go
@@ -20,25 +20,28 @@ const maxSystemPromptChars = 20000
 
 // ListModelsInput 定义模型列表筛选排序条件。
 type ListModelsInput struct {
-	Query    string
-	Status   string
-	Vendor   string
-	Protocol string
-	Sort     string
+	OnlyActive    bool
+	OnlyAvailable bool
+	Query         string
+	Status        string
+	Vendor        string
+	Protocol      string
+	Sort          string
 }
 
 // ListModels 分页查询模型目录。
-func (s *Service) ListModels(ctx context.Context, page int, pageSize int, onlyActive bool, input ListModelsInput) ([]ModelView, int64, error) {
+func (s *Service) ListModels(ctx context.Context, page int, pageSize int, input ListModelsInput) ([]ModelView, int64, error) {
 	offset, limit := normalizePage(page, pageSize)
 	items, total, err := s.repo.ListModels(ctx, repository.ListChannelModelsInput{
-		Offset:     offset,
-		Limit:      limit,
-		OnlyActive: onlyActive,
-		Query:      input.Query,
-		Status:     input.Status,
-		Vendor:     input.Vendor,
-		Protocol:   input.Protocol,
-		Sort:       input.Sort,
+		Offset:        offset,
+		Limit:         limit,
+		OnlyActive:    input.OnlyActive,
+		OnlyAvailable: input.OnlyAvailable,
+		Query:         input.Query,
+		Status:        input.Status,
+		Vendor:        input.Vendor,
+		Protocol:      input.Protocol,
+		Sort:          input.Sort,
 	})
 	if err != nil {
 		return nil, 0, err

--- a/backend/internal/infra/persistence/postgres/channel/repository.go
+++ b/backend/internal/infra/persistence/postgres/channel/repository.go
@@ -299,25 +299,21 @@ func (r *Repo) UpdateModel(ctx context.Context, modelID uint, input repository.U
 	return nil
 }
 
-// ReorderModels 按指定子序列调整模型顺序，并归一化全量 sort_order。
+// ReorderModels 按指定子序列调整模型顺序，仅更新提交的模型。
 func (r *Repo) ReorderModels(ctx context.Context, orderedModelIDs []uint) error {
 	if len(orderedModelIDs) == 0 {
 		return repository.ErrInvalidInput
 	}
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var rows []model.LLMPlatformModel
+		var existingRows []model.LLMPlatformModel
 		if err := tx.
-			Table("llm_platform_models AS m").
-			Select("m.id").
-			Order(modelDisplayOrder("m", "ASC")).
-			Find(&rows).Error; err != nil {
+			Select("id").
+			Where("id IN ?", orderedModelIDs).
+			Find(&existingRows).Error; err != nil {
 			return translateError(err)
 		}
-
-		allIDs := make([]uint, 0, len(rows))
-		existingIDs := make(map[uint]struct{}, len(rows))
-		for _, row := range rows {
-			allIDs = append(allIDs, row.ID)
+		existingIDs := make(map[uint]struct{}, len(existingRows))
+		for _, row := range existingRows {
 			existingIDs[row.ID] = struct{}{}
 		}
 
@@ -332,21 +328,7 @@ func (r *Repo) ReorderModels(ctx context.Context, orderedModelIDs []uint) error 
 			reorderedIDs[modelID] = struct{}{}
 		}
 
-		nextIDs := make([]uint, 0, len(allIDs))
-		reorderedIndex := 0
-		for _, modelID := range allIDs {
-			if _, exists := reorderedIDs[modelID]; exists {
-				nextIDs = append(nextIDs, orderedModelIDs[reorderedIndex])
-				reorderedIndex++
-				continue
-			}
-			nextIDs = append(nextIDs, modelID)
-		}
-		if reorderedIndex != len(orderedModelIDs) {
-			return repository.ErrInvalidInput
-		}
-
-		for index, modelID := range nextIDs {
+		for index, modelID := range orderedModelIDs {
 			sortOrder := (index + 1) * 100
 			if err := tx.
 				Model(&model.LLMPlatformModel{}).
@@ -515,7 +497,22 @@ func (r *Repo) applyModelListProtocols(ctx context.Context, items []ModelListRow
 }
 
 func applyModelListFilters(query *gorm.DB, input repository.ListChannelModelsInput) *gorm.DB {
-	if input.OnlyActive {
+	if input.OnlyAvailable {
+		query = query.Where("m.status = ?", "active")
+		query = query.Where("COALESCE(NULLIF(TRIM(m.access_scope), ''), 'public') = ?", "public")
+		query = query.Where(
+			`EXISTS (
+				SELECT 1
+				FROM llm_model_routes r
+				JOIN llm_upstream_models um ON um.id = r.upstream_model_id
+				JOIN llm_upstreams u ON u.id = um.upstream_id
+				WHERE r.platform_model_id = m.id
+					AND r.status = 'active'
+					AND um.status = 'active'
+					AND u.status = 'active'
+			)`,
+		)
+	} else if input.OnlyActive {
 		query = query.Where("m.status = ?", "active")
 	} else if status := strings.TrimSpace(input.Status); status == "active" || status == "inactive" {
 		query = query.Where("m.status = ?", status)
@@ -555,26 +552,26 @@ func modelListOrder(sort string) string {
 	case "sourceCount_desc":
 		return "source_count DESC, m.id DESC"
 	case "sortOrder_asc":
-		return modelDisplayOrder("m", "ASC")
+		return modelDefaultDisplayOrder()
 	case "updated_desc":
 		return "m.updated_at DESC, m.id DESC"
 	default:
-		return modelDisplayOrder("m", "ASC")
+		return modelDefaultDisplayOrder()
 	}
 }
 
-func modelDisplayOrder(alias string, direction string) string {
-	prefix := ""
-	if strings.TrimSpace(alias) != "" {
-		prefix = strings.TrimSpace(alias) + "."
-	}
-	sortDirection := "ASC"
-	if strings.EqualFold(strings.TrimSpace(direction), "DESC") {
-		sortDirection = "DESC"
-	}
-	vendorKey := modelVendorOrderKey(prefix)
-	groupOrder := "(SELECT MIN(anchor.sort_order) FROM llm_platform_models AS anchor WHERE " + modelVendorOrderKey("anchor.") + " = " + vendorKey + ")"
-	return groupOrder + " " + sortDirection + ", " + vendorKey + " ASC, " + prefix + "sort_order " + sortDirection + ", " + prefix + "id ASC"
+func modelDefaultDisplayOrder() string {
+	availabilityRank := modelAvailabilityRankExpression()
+	vendorKey := modelVendorOrderKey("m.")
+	vendorGroupOrder := "MIN(m.sort_order) OVER (PARTITION BY " + availabilityRank + ", " + vendorKey + ")"
+	return availabilityRank + " ASC, " +
+		vendorGroupOrder + " ASC, " +
+		vendorKey + " ASC, " +
+		"m.sort_order ASC, m.id ASC"
+}
+
+func modelAvailabilityRankExpression() string {
+	return "CASE WHEN m.status = 'active' AND COALESCE(stats.active_source_count, 0) > 0 THEN 0 WHEN COALESCE(stats.source_count, 0) > 0 THEN 1 ELSE 2 END"
 }
 
 func modelVendorOrderKey(prefix string) string {

--- a/backend/internal/infra/persistence/postgres/channel/repository.go
+++ b/backend/internal/infra/persistence/postgres/channel/repository.go
@@ -307,8 +307,9 @@ func (r *Repo) ReorderModels(ctx context.Context, orderedModelIDs []uint) error 
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var rows []model.LLMPlatformModel
 		if err := tx.
-			Select("id").
-			Order("sort_order ASC, id ASC").
+			Table("llm_platform_models AS m").
+			Select("m.id").
+			Order(modelDisplayOrder("m", "ASC")).
 			Find(&rows).Error; err != nil {
 			return translateError(err)
 		}
@@ -554,12 +555,30 @@ func modelListOrder(sort string) string {
 	case "sourceCount_desc":
 		return "source_count DESC, m.id DESC"
 	case "sortOrder_asc":
-		return "m.sort_order ASC, m.id ASC"
+		return modelDisplayOrder("m", "ASC")
 	case "updated_desc":
 		return "m.updated_at DESC, m.id DESC"
 	default:
-		return "m.sort_order ASC, m.id ASC"
+		return modelDisplayOrder("m", "ASC")
 	}
+}
+
+func modelDisplayOrder(alias string, direction string) string {
+	prefix := ""
+	if strings.TrimSpace(alias) != "" {
+		prefix = strings.TrimSpace(alias) + "."
+	}
+	sortDirection := "ASC"
+	if strings.EqualFold(strings.TrimSpace(direction), "DESC") {
+		sortDirection = "DESC"
+	}
+	vendorKey := modelVendorOrderKey(prefix)
+	groupOrder := "(SELECT MIN(anchor.sort_order) FROM llm_platform_models AS anchor WHERE " + modelVendorOrderKey("anchor.") + " = " + vendorKey + ")"
+	return groupOrder + " " + sortDirection + ", " + vendorKey + " ASC, " + prefix + "sort_order " + sortDirection + ", " + prefix + "id ASC"
+}
+
+func modelVendorOrderKey(prefix string) string {
+	return "COALESCE(NULLIF(TRIM(LOWER(" + prefix + "vendor)), ''), LOWER(" + prefix + "name))"
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/infra/persistence/postgres/channel/repository_sqlite_test.go
+++ b/backend/internal/infra/persistence/postgres/channel/repository_sqlite_test.go
@@ -86,6 +86,7 @@ func TestListModelsSQLiteUsesPortableRouteStats(t *testing.T) {
 func TestListModelsSQLiteSortOrderKeepsVendorGroups(t *testing.T) {
 	db := openChannelSQLiteTestDB(t)
 	ctx := context.Background()
+	upstreamModel := createActiveRouteTarget(t, db)
 
 	models := []model.LLMPlatformModel{
 		{Name: "claude-sonnet-4.6", Vendor: "anthropic", Status: "active", SortOrder: 100},
@@ -97,6 +98,7 @@ func TestListModelsSQLiteSortOrderKeepsVendorGroups(t *testing.T) {
 	if err := db.Create(&models).Error; err != nil {
 		t.Fatalf("create platform models: %v", err)
 	}
+	createActiveRoutes(t, db, upstreamModel.ID, models...)
 
 	items, total, err := NewRepo(db).ListModels(ctx, repository.ListChannelModelsInput{
 		Limit: 10,
@@ -121,9 +123,10 @@ func TestListModelsSQLiteSortOrderKeepsVendorGroups(t *testing.T) {
 	}
 }
 
-func TestListModelsSQLiteSortOrderUsesAllModelsForVendorGroupAnchor(t *testing.T) {
+func TestListModelsSQLiteSortOrderIgnoresHiddenDisabledVendorAnchors(t *testing.T) {
 	db := openChannelSQLiteTestDB(t)
 	ctx := context.Background()
+	upstreamModel := createActiveRouteTarget(t, db)
 
 	models := []model.LLMPlatformModel{
 		{Name: "claude-sonnet-4.6", Vendor: "anthropic", Status: "inactive", SortOrder: 100},
@@ -134,6 +137,7 @@ func TestListModelsSQLiteSortOrderUsesAllModelsForVendorGroupAnchor(t *testing.T
 	if err := db.Create(&models).Error; err != nil {
 		t.Fatalf("create platform models: %v", err)
 	}
+	createActiveRoutes(t, db, upstreamModel.ID, models...)
 
 	items, _, err := NewRepo(db).ListModels(ctx, repository.ListChannelModelsInput{
 		Limit:      10,
@@ -145,21 +149,99 @@ func TestListModelsSQLiteSortOrderUsesAllModelsForVendorGroupAnchor(t *testing.T
 	}
 	got := modelNames(items)
 	want := []string{
-		"claude-fable-5",
 		"gpt-5.5",
 		"gemini-3.1-pro",
+		"claude-fable-5",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected model order %v, got %v", want, got)
 	}
 }
 
-func TestReorderModelsSQLiteUsesVendorGroupDisplayOrder(t *testing.T) {
+func TestListModelsSQLiteSortOrderGroupsByAvailability(t *testing.T) {
 	db := openChannelSQLiteTestDB(t)
 	ctx := context.Background()
+	upstreamModel := createActiveRouteTarget(t, db)
 
 	models := []model.LLMPlatformModel{
-		{Name: "claude-sonnet-4.6", Vendor: "anthropic", Status: "active", SortOrder: 100},
+		{Name: "disabled-claude", Vendor: "anthropic", Status: "inactive", SortOrder: 100},
+		{Name: "unrouted-gpt", Vendor: "openai", Status: "active", SortOrder: 200},
+		{Name: "available-gemini", Vendor: "google", Status: "active", SortOrder: 300},
+	}
+	if err := db.Create(&models).Error; err != nil {
+		t.Fatalf("create platform models: %v", err)
+	}
+	createActiveRoutes(t, db, upstreamModel.ID, models[0], models[2])
+
+	repo := NewRepo(db)
+	items, _, err := repo.ListModels(ctx, repository.ListChannelModelsInput{
+		Limit: 10,
+		Sort:  "sortOrder_asc",
+	})
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	got := modelNames(items)
+	want := []string{
+		"available-gemini",
+		"disabled-claude",
+		"unrouted-gpt",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected model order %v, got %v", want, got)
+	}
+}
+
+func TestListModelsSQLiteOnlyAvailableReturnsPublicRoutableModels(t *testing.T) {
+	db := openChannelSQLiteTestDB(t)
+	ctx := context.Background()
+	upstreamModel := createActiveRouteTarget(t, db)
+
+	models := []model.LLMPlatformModel{
+		{Name: "available-gpt", Vendor: "openai", AccessScope: "public", Status: "active", SortOrder: 100},
+		{Name: "internal-gemini", Vendor: "google", AccessScope: "internal", Status: "active", SortOrder: 200},
+		{Name: "unrouted-claude", Vendor: "anthropic", AccessScope: "public", Status: "active", SortOrder: 300},
+		{Name: "disabled-grok", Vendor: "xai", AccessScope: "public", Status: "inactive", SortOrder: 400},
+		{Name: "inactive-route", Vendor: "openai", AccessScope: "public", Status: "active", SortOrder: 500},
+	}
+	if err := db.Create(&models).Error; err != nil {
+		t.Fatalf("create platform models: %v", err)
+	}
+	createActiveRoutes(t, db, upstreamModel.ID, models[0], models[1])
+	if err := db.Create(&model.LLMPlatformModelRoute{
+		PlatformModelID: models[4].ID,
+		UpstreamModelID: upstreamModel.ID,
+		Protocol:        "openai_responses",
+		Status:          "inactive",
+	}).Error; err != nil {
+		t.Fatalf("create inactive route: %v", err)
+	}
+
+	items, total, err := NewRepo(db).ListModels(ctx, repository.ListChannelModelsInput{
+		Limit:         10,
+		OnlyAvailable: true,
+		Sort:          "sortOrder_asc",
+	})
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("expected total 1, got %d", total)
+	}
+	got := modelNames(items)
+	want := []string{"available-gpt"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected model order %v, got %v", want, got)
+	}
+}
+
+func TestReorderModelsSQLiteUpdatesSubmittedModelsOnly(t *testing.T) {
+	db := openChannelSQLiteTestDB(t)
+	ctx := context.Background()
+	upstreamModel := createActiveRouteTarget(t, db)
+
+	models := []model.LLMPlatformModel{
+		{Name: "disabled-claude", Vendor: "anthropic", Status: "inactive", SortOrder: 100},
 		{Name: "gpt-5.5", Vendor: "openai", Status: "active", SortOrder: 200},
 		{Name: "gemini-3.1-pro", Vendor: "google", Status: "active", SortOrder: 300},
 		{Name: "claude-fable-5", Vendor: "anthropic", Status: "active", SortOrder: 1000},
@@ -167,9 +249,10 @@ func TestReorderModelsSQLiteUsesVendorGroupDisplayOrder(t *testing.T) {
 	if err := db.Create(&models).Error; err != nil {
 		t.Fatalf("create platform models: %v", err)
 	}
+	createActiveRoutes(t, db, upstreamModel.ID, models[1], models[2], models[3])
 
 	repo := NewRepo(db)
-	if err := repo.ReorderModels(ctx, []uint{models[1].ID, models[0].ID, models[3].ID, models[2].ID}); err != nil {
+	if err := repo.ReorderModels(ctx, []uint{models[1].ID, models[3].ID, models[2].ID}); err != nil {
 		t.Fatalf("ReorderModels() error = %v", err)
 	}
 	items, _, err := repo.ListModels(ctx, repository.ListChannelModelsInput{
@@ -182,12 +265,19 @@ func TestReorderModelsSQLiteUsesVendorGroupDisplayOrder(t *testing.T) {
 	got := modelNames(items)
 	want := []string{
 		"gpt-5.5",
-		"claude-sonnet-4.6",
 		"claude-fable-5",
 		"gemini-3.1-pro",
+		"disabled-claude",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected model order %v, got %v", want, got)
+	}
+	var disabled model.LLMPlatformModel
+	if err := db.First(&disabled, models[0].ID).Error; err != nil {
+		t.Fatalf("load disabled model: %v", err)
+	}
+	if disabled.SortOrder != 100 {
+		t.Fatalf("expected disabled model sort order to remain 100, got %d", disabled.SortOrder)
 	}
 }
 
@@ -224,6 +314,42 @@ func modelNames(items []ModelListRow) []string {
 		results = append(results, item.PlatformModelName)
 	}
 	return results
+}
+
+func createActiveRouteTarget(t *testing.T, db *gorm.DB) model.LLMUpstreamModel {
+	t.Helper()
+
+	upstream := model.LLMUpstream{Name: "active-upstream", Status: "active"}
+	if err := db.Create(&upstream).Error; err != nil {
+		t.Fatalf("create active upstream: %v", err)
+	}
+	upstreamModel := model.LLMUpstreamModel{
+		UpstreamID:        upstream.ID,
+		BindingCode:       "active-route-target",
+		UpstreamModelName: "active-route-target",
+		Status:            "active",
+	}
+	if err := db.Create(&upstreamModel).Error; err != nil {
+		t.Fatalf("create active upstream model: %v", err)
+	}
+	return upstreamModel
+}
+
+func createActiveRoutes(t *testing.T, db *gorm.DB, upstreamModelID uint, models ...model.LLMPlatformModel) {
+	t.Helper()
+
+	routes := make([]model.LLMPlatformModelRoute, 0, len(models))
+	for _, item := range models {
+		routes = append(routes, model.LLMPlatformModelRoute{
+			PlatformModelID: item.ID,
+			UpstreamModelID: upstreamModelID,
+			Protocol:        "openai_responses",
+			Status:          "active",
+		})
+	}
+	if err := db.Create(&routes).Error; err != nil {
+		t.Fatalf("create active routes: %v", err)
+	}
 }
 
 func assertProtocolsJSON(t *testing.T, raw string, expected []string) {

--- a/backend/internal/infra/persistence/postgres/channel/repository_sqlite_test.go
+++ b/backend/internal/infra/persistence/postgres/channel/repository_sqlite_test.go
@@ -83,6 +83,114 @@ func TestListModelsSQLiteUsesPortableRouteStats(t *testing.T) {
 	assertProtocolsJSON(t, items[1].ProtocolsJSON, []string{})
 }
 
+func TestListModelsSQLiteSortOrderKeepsVendorGroups(t *testing.T) {
+	db := openChannelSQLiteTestDB(t)
+	ctx := context.Background()
+
+	models := []model.LLMPlatformModel{
+		{Name: "claude-sonnet-4.6", Vendor: "anthropic", Status: "active", SortOrder: 100},
+		{Name: "gpt-5.5", Vendor: "openai", Status: "active", SortOrder: 200},
+		{Name: "gemini-3.1-pro", Vendor: "google", Status: "active", SortOrder: 300},
+		{Name: "grok-4.3", Vendor: "xai", Status: "active", SortOrder: 400},
+		{Name: "claude-fable-5", Vendor: "anthropic", Status: "active", SortOrder: 1000},
+	}
+	if err := db.Create(&models).Error; err != nil {
+		t.Fatalf("create platform models: %v", err)
+	}
+
+	items, total, err := NewRepo(db).ListModels(ctx, repository.ListChannelModelsInput{
+		Limit: 10,
+		Sort:  "sortOrder_asc",
+	})
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if total != int64(len(models)) {
+		t.Fatalf("expected total %d, got %d", len(models), total)
+	}
+	got := modelNames(items)
+	want := []string{
+		"claude-sonnet-4.6",
+		"claude-fable-5",
+		"gpt-5.5",
+		"gemini-3.1-pro",
+		"grok-4.3",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected model order %v, got %v", want, got)
+	}
+}
+
+func TestListModelsSQLiteSortOrderUsesAllModelsForVendorGroupAnchor(t *testing.T) {
+	db := openChannelSQLiteTestDB(t)
+	ctx := context.Background()
+
+	models := []model.LLMPlatformModel{
+		{Name: "claude-sonnet-4.6", Vendor: "anthropic", Status: "inactive", SortOrder: 100},
+		{Name: "gpt-5.5", Vendor: "openai", Status: "active", SortOrder: 200},
+		{Name: "gemini-3.1-pro", Vendor: "google", Status: "active", SortOrder: 300},
+		{Name: "claude-fable-5", Vendor: "anthropic", Status: "active", SortOrder: 1000},
+	}
+	if err := db.Create(&models).Error; err != nil {
+		t.Fatalf("create platform models: %v", err)
+	}
+
+	items, _, err := NewRepo(db).ListModels(ctx, repository.ListChannelModelsInput{
+		Limit:      10,
+		OnlyActive: true,
+		Sort:       "sortOrder_asc",
+	})
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	got := modelNames(items)
+	want := []string{
+		"claude-fable-5",
+		"gpt-5.5",
+		"gemini-3.1-pro",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected model order %v, got %v", want, got)
+	}
+}
+
+func TestReorderModelsSQLiteUsesVendorGroupDisplayOrder(t *testing.T) {
+	db := openChannelSQLiteTestDB(t)
+	ctx := context.Background()
+
+	models := []model.LLMPlatformModel{
+		{Name: "claude-sonnet-4.6", Vendor: "anthropic", Status: "active", SortOrder: 100},
+		{Name: "gpt-5.5", Vendor: "openai", Status: "active", SortOrder: 200},
+		{Name: "gemini-3.1-pro", Vendor: "google", Status: "active", SortOrder: 300},
+		{Name: "claude-fable-5", Vendor: "anthropic", Status: "active", SortOrder: 1000},
+	}
+	if err := db.Create(&models).Error; err != nil {
+		t.Fatalf("create platform models: %v", err)
+	}
+
+	repo := NewRepo(db)
+	if err := repo.ReorderModels(ctx, []uint{models[1].ID, models[0].ID, models[3].ID, models[2].ID}); err != nil {
+		t.Fatalf("ReorderModels() error = %v", err)
+	}
+	items, _, err := repo.ListModels(ctx, repository.ListChannelModelsInput{
+		Limit: 10,
+		Sort:  "sortOrder_asc",
+	})
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	got := modelNames(items)
+	want := []string{
+		"gpt-5.5",
+		"claude-sonnet-4.6",
+		"claude-fable-5",
+		"gemini-3.1-pro",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected model order %v, got %v", want, got)
+	}
+}
+
 func openChannelSQLiteTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 
@@ -108,6 +216,14 @@ func openChannelSQLiteTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("migrate channel tables: %v", err)
 	}
 	return db
+}
+
+func modelNames(items []ModelListRow) []string {
+	results := make([]string, 0, len(items))
+	for _, item := range items {
+		results = append(results, item.PlatformModelName)
+	}
+	return results
 }
 
 func assertProtocolsJSON(t *testing.T, raw string, expected []string) {

--- a/backend/internal/repository/channel.go
+++ b/backend/internal/repository/channel.go
@@ -196,14 +196,15 @@ type ListChannelUpstreamsInput struct {
 
 // ListChannelModelsInput 定义模型列表查询条件。
 type ListChannelModelsInput struct {
-	Offset     int
-	Limit      int
-	OnlyActive bool
-	Query      string
-	Status     string
-	Vendor     string
-	Protocol   string
-	Sort       string
+	Offset        int
+	Limit         int
+	OnlyActive    bool
+	OnlyAvailable bool
+	Query         string
+	Status        string
+	Vendor        string
+	Protocol      string
+	Sort          string
 }
 
 // UpdateChannelModelInput 定义平台模型更新字段。

--- a/backend/internal/transport/http/channel/handler.go
+++ b/backend/internal/transport/http/channel/handler.go
@@ -901,6 +901,7 @@ func (h *Handler) ImportUpstreamModels(c *gin.Context) {
 // @Param page query int false "页码"
 // @Param page_size query int false "每页数量"
 // @Param only_active query bool false "仅查询启用模型"
+// @Param only_available query bool false "仅查询公开且可路由模型"
 // @Param q query string false "搜索关键词"
 // @Param status query string false "状态：active/inactive"
 // @Param vendor query string false "模型厂商"
@@ -912,12 +913,15 @@ func (h *Handler) ImportUpstreamModels(c *gin.Context) {
 func (h *Handler) ListModels(c *gin.Context) {
 	page, pageSize := pageParams(c)
 	onlyActive := c.Query("only_active") == "true"
-	items, total, err := h.service.ListModels(c.Request.Context(), page, pageSize, onlyActive, appchannel.ListModelsInput{
-		Query:    c.Query("q"),
-		Status:   c.Query("status"),
-		Vendor:   c.Query("vendor"),
-		Protocol: c.Query("protocol"),
-		Sort:     c.Query("sort"),
+	onlyAvailable := c.Query("only_available") == "true"
+	items, total, err := h.service.ListModels(c.Request.Context(), page, pageSize, appchannel.ListModelsInput{
+		OnlyActive:    onlyActive,
+		OnlyAvailable: onlyAvailable,
+		Query:         c.Query("q"),
+		Status:        c.Query("status"),
+		Vendor:        c.Query("vendor"),
+		Protocol:      c.Query("protocol"),
+		Sort:          c.Query("sort"),
 	})
 	if err != nil {
 		response.Error(c, http.StatusInternalServerError, "list models failed")

--- a/frontend/features/admin/api/llm.ts
+++ b/frontend/features/admin/api/llm.ts
@@ -37,6 +37,7 @@ type ListAdminLLMUpstreamsOptions = AdminListQueryOptions & {
 
 type ListAdminLLMModelsOptions = AdminListQueryOptions & {
   onlyActive?: boolean;
+  onlyAvailable?: boolean;
   vendor?: string;
   protocol?: string;
 };
@@ -311,6 +312,9 @@ export async function listAdminLLMModels(
     page_size: String(pageSize),
     only_active: options.onlyActive ? "true" : "false",
   });
+  if (options.onlyAvailable) {
+    params.set("only_available", "true");
+  }
   if (options.query?.trim()) {
     params.set("q", options.query.trim());
   }

--- a/frontend/features/admin/components/sections/models/admin-models.tsx
+++ b/frontend/features/admin/components/sections/models/admin-models.tsx
@@ -474,7 +474,12 @@ export function AdminModelsPage() {
         <ModelOrderSheet
           open
           onClose={() => setOrderOpen(false)}
-          onSaved={() => void models.loadModels(models.page, models.pageSize)}
+          onSaved={() => {
+            models.setSortValue("sortOrder_asc");
+            if (models.sortValue === "sortOrder_asc") {
+              void models.loadModels(models.page, models.pageSize);
+            }
+          }}
         />
       ) : null}
 

--- a/frontend/features/admin/components/sections/models/model-order-sheet.tsx
+++ b/frontend/features/admin/components/sections/models/model-order-sheet.tsx
@@ -26,7 +26,7 @@ import { listAllAdminPages } from "@/features/admin/api/shared";
 import type { AdminLLMModelDTO } from "@/features/admin/api/llm.types";
 import { resolveErrorMessage } from "@/features/admin/types/llm";
 import { LobeHubIcon } from "@/shared/components/lobehub-icon";
-import { resolveLobeHubIconURL, resolveModelIdentity } from "@/shared/lib/model-identity";
+import { resolveLobeHubIconURL, resolveModelIdentity, resolveVendorIdentity } from "@/shared/lib/model-identity";
 import { parseKindsJSON } from "@/shared/model/llm-schema";
 import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
 
@@ -46,11 +46,7 @@ type ModelOrderGroup = {
 function buildModelOrderGroups(models: AdminLLMModelDTO[]): ModelOrderGroup[] {
   const groups = new Map<string, ModelOrderGroup>();
   for (const model of models) {
-    const identity = resolveModelIdentity({
-      code: model.platformModelName,
-      vendor: model.vendor,
-      icon: model.icon,
-    });
+    const identity = resolveVendorIdentity(model.vendor);
     const current = groups.get(identity.vendorKey);
     if (current) {
       current.items.push(model);
@@ -179,7 +175,7 @@ export function ModelOrderSheet({
       const results = await listAllAdminPages((options) =>
         listAdminLLMModels(token, {
           ...options,
-          onlyActive: false,
+          onlyAvailable: true,
           sort: "sortOrder_asc",
         }),
       );
@@ -491,13 +487,8 @@ export function ModelOrderSheet({
                             <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
                               {model.platformModelName}
                             </span>
-                            <div className="ml-auto flex max-w-[45%] shrink-0 items-center justify-end gap-1 overflow-hidden">
+                            <div className="ml-auto flex max-w-[45%] shrink-0 items-center justify-end overflow-hidden">
                               <KindBadges kindsJSON={model.kindsJSON} />
-                              {model.status === "inactive" ? (
-                                <Badge variant="outline" className="h-5 shrink-0 rounded-md px-1.5 py-0">
-                                  {t("inactive")}
-                                </Badge>
-                              ) : null}
                             </div>
                           </div>
                         );

--- a/frontend/features/admin/components/sections/models/model-sheet.tsx
+++ b/frontend/features/admin/components/sections/models/model-sheet.tsx
@@ -60,7 +60,7 @@ import {
   updateAdminLLMModel,
 } from "@/features/admin/api";
 import { LobeHubIcon } from "@/shared/components/lobehub-icon";
-import { KNOWN_VENDOR_OPTIONS, resolveLobeHubIconURL, resolveModelIdentity } from "@/shared/lib/model-identity";
+import { KNOWN_VENDOR_OPTIONS, resolveLobeHubIconURL, resolveModelIdentity, resolveVendorIdentity } from "@/shared/lib/model-identity";
 import type {
   AdminLLMModelDTO,
   AdminLLMModelAccessScope,
@@ -132,7 +132,7 @@ const UNKNOWN_VENDOR = "unknown";
 const MODEL_SHEET_VENDOR_OPTIONS: VendorOption[] = [
   { value: UNKNOWN_VENDOR, label: "Unknown", iconUrl: null },
   ...KNOWN_VENDOR_OPTIONS.map(({ value, label }) => {
-    const identity = resolveModelIdentity({ vendor: value });
+    const identity = resolveVendorIdentity(value);
     return {
       value,
       label,
@@ -187,7 +187,7 @@ function normalizeSupportedVendor(value: string | null | undefined): AdminLLMMod
   if (MODEL_SHEET_VENDOR_OPTIONS.some((item) => item.value === normalized)) {
     return normalized;
   }
-  const identity = resolveModelIdentity({ vendor: normalized });
+  const identity = resolveVendorIdentity(normalized);
   return MODEL_SHEET_VENDOR_OPTIONS.some((item) => item.value === identity.vendorKey)
     ? identity.vendorKey
     : UNKNOWN_VENDOR;

--- a/frontend/features/admin/components/sections/models/models-table.tsx
+++ b/frontend/features/admin/components/sections/models/models-table.tsx
@@ -69,7 +69,7 @@ import {
   updateAdminLLMModelUpstreamSource,
 } from "@/features/admin/api";
 import { LobeHubIcon } from "@/shared/components/lobehub-icon";
-import { resolveLobeHubIconURL, resolveModelIdentity } from "@/shared/lib/model-identity";
+import { resolveLobeHubIconURL, resolveModelIdentity, resolveVendorIdentity } from "@/shared/lib/model-identity";
 import type {
   AdminLLMModelAccessScope,
   AdminLLMModelDTO,
@@ -172,6 +172,38 @@ function KindsBadges({ kindsJson }: { kindsJson: string | null | undefined }) {
         </Badge>
       ))}
     </div>
+  );
+}
+
+type ModelAvailability = "available" | "notEnabled" | "noSource";
+
+function resolveModelAvailability(item: AdminLLMModelDTO): ModelAvailability {
+  if (item.sourceCount <= 0) {
+    return "noSource";
+  }
+  if (item.status !== "active") {
+    return "notEnabled";
+  }
+  return item.activeSourceCount > 0 ? "available" : "notEnabled";
+}
+
+function ModelAvailabilityBadge({ availability }: { availability: ModelAvailability }) {
+  const t = useTranslations("adminModels");
+  if (availability === "available") {
+    return null;
+  }
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "h-5 rounded-md px-1.5 py-0 text-[10px]",
+        "shrink-0",
+        availability === "noSource" && "border-border/70 text-muted-foreground",
+        availability === "notEnabled" && "border-border/50 text-muted-foreground/80",
+      )}
+    >
+      {availability === "noSource" ? t("availability.noSource") : t("availability.notEnabled")}
+    </Badge>
   );
 }
 
@@ -297,14 +329,18 @@ const ModelTableRow = React.memo(function ModelTableRow({
     icon: item.icon,
   });
   const iconURL = resolveLobeHubIconURL(identity.modelIcon);
-  const vendorIconURL = resolveLobeHubIconURL(identity.vendorIcon);
+  const vendorIdentity = resolveVendorIdentity(item.vendor);
+  const vendorIconURL = resolveLobeHubIconURL(vendorIdentity.vendorIcon);
   const titleText = item.platformModelName.trim();
   const protocols = resolveModelProtocols(item);
+  const availability = resolveModelAvailability(item);
+  const muted = availability !== "available";
 
   return (
     <React.Fragment>
       <TableRow
-        className="cursor-pointer"
+        className={cn("cursor-pointer", muted && "text-muted-foreground")}
+        tone={muted ? "muted" : undefined}
         selected={selected}
         aria-expanded={expanded && !collapsing}
         onClick={() => onToggleRow(item)}
@@ -321,12 +357,11 @@ const ModelTableRow = React.memo(function ModelTableRow({
 
         <TableCell className="py-1.5">
           <div className="flex min-w-0 items-center gap-2">
+            <ModelAvailabilityBadge availability={availability} />
             <LobeHubIcon iconUrl={iconURL} label={titleText} />
-            <div className="flex min-w-0 flex-1">
-              <span className="truncate text-xs font-medium leading-5 text-foreground">
-                {titleText}
-              </span>
-            </div>
+            <span className={cn("min-w-0 flex-1 truncate text-xs font-medium leading-5", muted ? "text-muted-foreground" : "text-foreground")}>
+              {titleText}
+            </span>
           </div>
         </TableCell>
 
@@ -339,11 +374,11 @@ const ModelTableRow = React.memo(function ModelTableRow({
         </TableCell>
 
         <TableCell className="w-[120px] py-1.5">
-          {identity.vendorKey !== "unknown" ? (
+          {vendorIdentity.vendorKey !== "unknown" ? (
             <div className="flex min-w-0 items-center gap-1.5">
-              {vendorIconURL ? <LobeHubIcon iconUrl={vendorIconURL} label={identity.vendorLabel} size={14} /> : null}
+              {vendorIconURL ? <LobeHubIcon iconUrl={vendorIconURL} label={vendorIdentity.vendorLabel} size={14} /> : null}
               <span className="block max-w-[92px] truncate text-xs text-muted-foreground">
-                {identity.vendorLabel}
+                {vendorIdentity.vendorLabel}
               </span>
             </div>
           ) : (
@@ -352,7 +387,10 @@ const ModelTableRow = React.memo(function ModelTableRow({
         </TableCell>
 
         <TableCell className="whitespace-nowrap py-1.5 text-center">
-          <span className="text-xs text-muted-foreground">
+          <span className={cn(
+            "text-xs",
+            item.activeSourceCount > 0 ? "text-muted-foreground" : "text-muted-foreground/75",
+          )}>
             {item.activeSourceCount}/{item.sourceCount}
           </span>
         </TableCell>

--- a/frontend/features/chat/components/sections/chat-model-picker.tsx
+++ b/frontend/features/chat/components/sections/chat-model-picker.tsx
@@ -14,7 +14,7 @@ import { useIsMobile } from "@/shared/hooks/use-mobile";
 import { LobeHubIcon } from "@/shared/components/lobehub-icon";
 import { cacheWritePricingLabel, cacheWritePricingNote, resolveCacheWritePricingUSD } from "@/shared/lib/billing-display";
 import type { BillingDisplayLabels } from "@/shared/lib/billing-display";
-import { resolveLobeHubIconURL, resolveModelIdentity } from "@/shared/lib/model-identity";
+import { resolveLobeHubIconURL, resolveModelIdentity, resolveVendorIdentity } from "@/shared/lib/model-identity";
 import { cn } from "@/lib/utils";
 
 const MODEL_MENU_MAX_HEIGHT = 400;
@@ -96,22 +96,21 @@ function resolveAdaptiveMenuWidth(labels: string[], minWidth: number, maxWidth: 
 function resolveVendorGroups(modelOptions: ChatModelOption[]) {
   const groupMap = new Map<string, ChatModelOption[]>();
   for (const item of modelOptions) {
-    const identity = resolveModelIdentity({
-      code: item.platformModelName,
-      vendor: item.vendor,
-      icon: item.icon,
-    });
+    const identity = resolveVendorIdentity(item.vendor);
     const group = groupMap.get(identity.vendorKey) ?? [];
     group.push(item);
     groupMap.set(identity.vendorKey, group);
   }
 
-  return Array.from(groupMap.entries()).map(([vendor, items]) => ({
-    vendor,
-    label: resolveModelIdentity({ vendor }).vendorLabel,
-    icon: resolveModelIdentity({ vendor }).vendorIcon,
-    items,
-  }));
+  return Array.from(groupMap.entries()).map(([vendor, items]) => {
+    const identity = resolveVendorIdentity(vendor);
+    return {
+      vendor,
+      label: identity.vendorLabel,
+      icon: identity.vendorIcon,
+      items,
+    };
+  });
 }
 
 function resolveDesktopModelPanelLayout({
@@ -573,21 +572,13 @@ export function ChatModelPicker({
     if (!selectedModel) {
       return "";
     }
-    return resolveModelIdentity({
-      code: selectedModel.platformModelName,
-      vendor: selectedModel.vendor,
-      icon: selectedModel.icon,
-    }).vendorKey;
+    return resolveVendorIdentity(selectedModel.vendor).vendorKey;
   }, [selectedModel]);
   const selectedVendorLabel = React.useMemo(() => {
     if (!selectedModel) {
       return "none";
     }
-    return resolveModelIdentity({
-      code: selectedModel.platformModelName,
-      vendor: selectedModel.vendor,
-      icon: selectedModel.icon,
-    }).vendorLabel;
+    return resolveVendorIdentity(selectedModel.vendor).vendorLabel;
   }, [selectedModel]);
   const vendorGroups = React.useMemo(() => resolveVendorGroups(modelOptions), [modelOptions]);
   const vendorMenuMaxHeight = React.useMemo(

--- a/frontend/features/chat/hooks/use-chat-model-options.ts
+++ b/frontend/features/chat/hooks/use-chat-model-options.ts
@@ -28,6 +28,20 @@ type ModelCatalogRefreshResult = {
   modelOptionPolicy: ModelOptionPolicy | null;
 };
 
+function normalizeModelSortOrder(value: number): number {
+  return Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER;
+}
+
+function sortPublicModelsBySortOrder(models: PublicModelDTO[]): PublicModelDTO[] {
+  return models
+    .map((model, index) => ({ model, index }))
+    .sort((left, right) => {
+      const sortDiff = normalizeModelSortOrder(left.model.sortOrder) - normalizeModelSortOrder(right.model.sortOrder);
+      return sortDiff || left.index - right.index;
+    })
+    .map(({ model }) => model);
+}
+
 function parseJSONObject(raw: string): Record<string, unknown> | null {
   const normalized = raw.trim();
   if (!normalized) {
@@ -335,7 +349,7 @@ export function useChatModelOptions({
         listPublicModels(token),
         getModelOptionPolicy(token).catch(() => null),
       ]);
-      return { models, modelOptionPolicy };
+      return { models: sortPublicModelsBySortOrder(models), modelOptionPolicy };
     })().finally(() => {
       if (modelCatalogRequestRef.current === request) {
         modelCatalogRequestRef.current = null;

--- a/frontend/features/chat/hooks/use-chat-model-options.ts
+++ b/frontend/features/chat/hooks/use-chat-model-options.ts
@@ -28,20 +28,6 @@ type ModelCatalogRefreshResult = {
   modelOptionPolicy: ModelOptionPolicy | null;
 };
 
-function normalizeModelSortOrder(value: number): number {
-  return Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER;
-}
-
-function sortPublicModelsBySortOrder(models: PublicModelDTO[]): PublicModelDTO[] {
-  return models
-    .map((model, index) => ({ model, index }))
-    .sort((left, right) => {
-      const sortDiff = normalizeModelSortOrder(left.model.sortOrder) - normalizeModelSortOrder(right.model.sortOrder);
-      return sortDiff || left.index - right.index;
-    })
-    .map(({ model }) => model);
-}
-
 function parseJSONObject(raw: string): Record<string, unknown> | null {
   const normalized = raw.trim();
   if (!normalized) {
@@ -349,7 +335,7 @@ export function useChatModelOptions({
         listPublicModels(token),
         getModelOptionPolicy(token).catch(() => null),
       ]);
-      return { models: sortPublicModelsBySortOrder(models), modelOptionPolicy };
+      return { models, modelOptionPolicy };
     })().finally(() => {
       if (modelCatalogRequestRef.current === request) {
         modelCatalogRequestRef.current = null;

--- a/frontend/i18n/messages/en-US/admin-models.json
+++ b/frontend/i18n/messages/en-US/admin-models.json
@@ -15,6 +15,10 @@
     "inactive": "Disabled",
     "circuitOpen": "Circuit open"
   },
+  "availability": {
+    "notEnabled": "Not enabled",
+    "noSource": "No upstream"
+  },
   "accessScope": {
     "public": "Platform-wide",
     "internal": "Internal tasks"
@@ -233,7 +237,6 @@
     "vendorHeader": "Vendors",
     "modelHeader": "Models",
     "itemCount": "{count}",
-    "inactive": "Inactive",
     "dragVendor": "Drag to reorder vendor {name}",
     "dragModel": "Drag to reorder model {name}"
   },

--- a/frontend/i18n/messages/zh-CN/admin-models.json
+++ b/frontend/i18n/messages/zh-CN/admin-models.json
@@ -15,6 +15,10 @@
     "inactive": "停用",
     "circuitOpen": "熔断中"
   },
+  "availability": {
+    "notEnabled": "未启用",
+    "noSource": "无上游"
+  },
   "accessScope": {
     "public": "全平台",
     "internal": "内部任务"
@@ -233,7 +237,6 @@
     "vendorHeader": "厂商",
     "modelHeader": "模型",
     "itemCount": "{count} 个",
-    "inactive": "停用",
     "dragVendor": "拖拽调整厂商 {name} 的顺序",
     "dragModel": "拖拽调整模型 {name} 的顺序"
   },

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/shared/lib/model-identity.ts
+++ b/frontend/shared/lib/model-identity.ts
@@ -14,7 +14,7 @@ type VendorCatalogItem = {
   patterns: readonly RegExp[];
 };
 
-type ResolvedModelIdentity = {
+export type ResolvedModelIdentity = {
   vendorKey: string;
   vendorLabel: string;
   vendorIcon: string;
@@ -347,8 +347,39 @@ export function resolveModelIdentity(input: ModelIdentityInput): ResolvedModelId
   };
 }
 
+export function resolveVendorIdentity(vendor: string | null | undefined): ResolvedModelIdentity {
+  const rawVendor = vendor?.trim() ?? "";
+  const normalizedVendor = normalizeValue(rawVendor);
+  const resolvedVendor = findVendorByExactValue(normalizedVendor) ?? findVendorByText(normalizedVendor);
+
+  if (resolvedVendor) {
+    return {
+      vendorKey: resolvedVendor.key,
+      vendorLabel: resolvedVendor.label,
+      vendorIcon: resolvedVendor.vendorIcon,
+      modelIcon: resolvedVendor.modelIcon,
+    };
+  }
+
+  if (!normalizedVendor) {
+    return {
+      vendorKey: "unknown",
+      vendorLabel: "Unknown",
+      vendorIcon: "",
+      modelIcon: "",
+    };
+  }
+
+  return {
+    vendorKey: normalizedVendor,
+    vendorLabel: rawVendor,
+    vendorIcon: "",
+    modelIcon: "",
+  };
+}
+
 export function resolveVendorLabel(vendor: string): string {
-  return resolveModelIdentity({ vendor }).vendorLabel;
+  return resolveVendorIdentity(vendor).vendorLabel;
 }
 
 export function resolveLobeHubIconURL(icon: string): string | null {


### PR DESCRIPTION
## Summary

This PR aligns model ordering across the admin console, chat model picker, and `@` model selector.

It updates model list queries to preserve configured display order, groups models by the configured vendor instead of inferred model names, and separates model availability states into clear UI categories:

- Available models are shown normally.
- Models with upstream bindings but no usable active route are marked as `Not enabled`.
- Models without upstream bindings are marked as `No upstream`.

The model display order editor now only includes models that are public, enabled, and routable, so admins adjust the same model order users actually see.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/infra/persistence/postgres/channel`
- [x] `cd frontend && pnpm exec eslint features/admin/components/sections/models/model-sheet.tsx features/admin/components/sections/models/model-order-sheet.tsx features/admin/components/sections/models/models-table.tsx features/admin/api/llm.ts features/chat/components/sections/chat-model-picker.tsx shared/lib/model-identity.ts`
- [x] `cd frontend && node -e "JSON.parse(require('node:fs').readFileSync('i18n/messages/zh-CN/admin-models.json','utf8')); JSON.parse(require('node:fs').readFileSync('i18n/messages/en-US/admin-models.json','utf8'));"`
- [x] `git diff --check`

## Screenshots, API examples, or logs

No screenshots included.

## Configuration, migration, and compatibility notes

Adds an `only_available` query option for admin model listing. No database migration or deployment configuration change is required.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.