### PR TITLE
refactor: simplify hover state management

### DIFF
--- a/frontend/features/layouts/components/navigation/sidebar-conversation-item.tsx
+++ b/frontend/features/layouts/components/navigation/sidebar-conversation-item.tsx
@@ -70,10 +70,7 @@ export function SidebarConversationItem({
   onNavigate,
 }: SidebarConversationItemProps) {
   const t = useTranslations("recent.row")
-  const [isRowHovered, setIsRowHovered] = React.useState(false)
-  const [isMenuHovered, setIsMenuHovered] = React.useState(false)
   const [isMenuOpen, setIsMenuOpen] = React.useState(false)
-  const showMenuButton = isRowHovered || isMenuHovered || isMenuOpen || active
 
   return (
     <SidebarAnimatedItem
@@ -110,9 +107,9 @@ export function SidebarConversationItem({
         <div
           className={cn(
             "group relative flex h-8 items-center rounded-md text-sm transition-colors",
-            active || isRowHovered
+            active
               ? "bg-sidebar-accent text-sidebar-accent-foreground"
-              : "text-sidebar-foreground",
+              : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
             rowClassName,
           )}
         >
@@ -121,8 +118,6 @@ export function SidebarConversationItem({
             prefetch={false}
             className={cn("flex h-full min-w-0 flex-1 items-center pl-2 pr-9", linkClassName)}
             onClick={onNavigate}
-            onMouseEnter={() => setIsRowHovered(true)}
-            onMouseLeave={() => setIsRowHovered(false)}
           >
             <AnimatedText
               text={item.title}
@@ -136,17 +131,15 @@ export function SidebarConversationItem({
               <button
                 id={menuTriggerID}
                 className={cn(
-                  "absolute right-0 flex h-8 w-8 items-center justify-center rounded-md text-sidebar-foreground opacity-0 transition-[background-color,color,opacity] duration-150 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
-                  showMenuButton && "opacity-100",
+                  "absolute right-0 flex h-8 w-8 items-center justify-center rounded-md text-sidebar-foreground opacity-0 transition-[background-color,color,opacity] duration-150 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-hover/menu-item:opacity-100 group-focus-within/menu-item:opacity-100",
+                  isMenuOpen && "opacity-100",
                 )}
-                onMouseEnter={() => setIsMenuHovered(true)}
-                onMouseLeave={() => setIsMenuHovered(false)}
                 onClick={(event) => {
                   event.preventDefault()
                   event.stopPropagation()
                 }}
               >
-                <Ellipsis size={16} strokeWidth={1.4} animate={isMenuHovered ? "pulse" : undefined} />
+                <Ellipsis size={16} strokeWidth={1.4} animateOnHover="pulse" />
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-max min-w-36 max-w-[calc(100vw-2rem)]">


### PR DESCRIPTION
## Summary

Fixes a sidebar conversation row hover issue where the three-dot menu button could remain visible after scrolling away from the hovered row.

The menu button visibility now relies on CSS hover/focus state instead of React hover state, so scrolling correctly recalculates whether the row is hovered. The dropdown open state is still preserved separately, so the button remains visible while the menu is actually open.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm exec eslint features/layouts/components/navigation/sidebar-conversation-item.tsx`
- [x] `git diff --check`

## Screenshots, API examples, or logs

No screenshots included.

## Configuration, migration, and compatibility notes

No configuration, migration, deployment, or API changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.