### PR TITLE
feat: improve HTML normalization

### DIFF
--- a/frontend/features/chat/components/markdown/streamdown-content.ts
+++ b/frontend/features/chat/components/markdown/streamdown-content.ts
@@ -50,6 +50,8 @@ const HTML_VISUAL_STYLE_RE = /\sstyle\s*=\s*["'][^"']{8,}["']/i;
 const HTML_BLOCK_CONTAINER_OPEN_RE = /<(div|section|article|aside|main|details|table)\b[^>]*>/i;
 const HTML_BLOCK_TAG_SCAN_RE = /<\/?(div|p|section|article|aside|main|blockquote|ul|ol|li|table|thead|tbody|tr|th|td|h[1-6]|pre|details|summary|nav|header|footer|figure|figcaption)\b[^>]*>/gi;
 const HTML_BLOCK_BLANK_LINE_RE = /\n(?:[ \t]*\n)+(?=[ \t]*(?:<!--|<\/?(?:div|p|section|article|aside|main|blockquote|ul|ol|li|table|thead|tbody|tr|th|td|h[1-6]|pre|details|summary|nav|header|footer|figure|figcaption)\b))/gi;
+const HTML_VISUAL_MARKDOWN_BLOCK_START_RE =
+  /(<(?:div|section|article|aside|main|details)\b(?=[^>]*\sstyle\s*=)[^>]*>)(\n[ \t]*\n)(?=[ \t]*(?:#{1,6}\s|[-*+]\s|\d+[.)]\s|>\s|[*_]{1,3}\S|`{3,}|~{3,}|\$\$|!\[|\[[^\]\n]+\]\())/gi;
 const INLINE_DOLLAR_MATH_RE = /(^|[^\\$])\$([^$\n]{1,800})\$/g;
 const ESCAPED_INLINE_DOLLAR_MATH_RE = /\\\$([^$\n]{1,400})\\\$/g;
 const DISPLAY_DOLLAR_MATH_RE = /(\${2,})([\s\S]*?)(\1)/g;
@@ -330,7 +332,10 @@ function normalizeHTMLVisualBlankLinesInText(source: string): string {
     const blockStart = cursor + match.index;
     const blockEnd = findHTMLVisualBlockEnd(source, blockStart);
     normalized += source.slice(cursor, blockStart);
-    normalized += source.slice(blockStart, blockEnd).replace(HTML_BLOCK_BLANK_LINE_RE, "\n");
+    normalized += source
+      .slice(blockStart, blockEnd)
+      .replace(HTML_VISUAL_MARKDOWN_BLOCK_START_RE, "$1\n\n\n")
+      .replace(HTML_BLOCK_BLANK_LINE_RE, "\n");
     cursor = blockEnd;
   }
   return normalized;


### PR DESCRIPTION
## Summary

修复视觉排版场景下，HTML 容器内的 Markdown 内容可能被直接显示为原文的问题。

当带 `style` 的 HTML 块级容器开标签后直接进入 Markdown 块内容时，前端会在渲染前规范化空行边界，确保 Streamdown 能正确识别并渲染加粗、列表、标题、引用、代码块、数学公式等 Markdown 语法。

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint -- features/chat/components/markdown/streamdown-content.ts`

## Screenshots, API examples, or logs

N/A

## Configuration, migration, and compatibility notes

No configuration changes, API changes, database migrations, or deployment changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.