### PR TITLE
refactor: simplify NavigationSearch component logic

### DIFF
--- a/frontend/features/layouts/components/navigation/navigation-search.tsx
+++ b/frontend/features/layouts/components/navigation/navigation-search.tsx
@@ -92,28 +92,10 @@ export function NavigationSearch({
   onSelect: (href: string) => void
 }) {
   const [hasMounted, setHasMounted] = React.useState(false)
-  const listContentRef = React.useRef<HTMLDivElement | null>(null)
-  const [listHeight, setListHeight] = React.useState<number | null>(null)
 
   React.useEffect(() => {
     setHasMounted(true)
   }, [])
-
-  React.useLayoutEffect(() => {
-    const element = listContentRef.current
-    if (!element) {
-      return
-    }
-
-    const updateHeight = () => {
-      setListHeight(Math.min(element.scrollHeight + 16, 280))
-    }
-
-    updateHeight()
-    const observer = new ResizeObserver(updateHeight)
-    observer.observe(element)
-    return () => observer.disconnect()
-  }, [loading, results.length])
 
   if (!hasMounted) {
     return null
@@ -139,11 +121,10 @@ export function NavigationSearch({
       />
 
       <CommandList
-        scrollContainerClassName="max-h-[280px] transition-[height] duration-200 ease-out"
-        scrollContainerStyle={listHeight === null ? undefined : { height: listHeight }}
+        scrollContainerClassName="max-h-[280px] overflow-x-hidden overscroll-contain"
         className="px-2 py-2"
       >
-        <div ref={listContentRef}>
+        <div>
           <CommandEmpty className="flex min-h-32 items-center justify-center py-8 text-sm text-muted-foreground">
             {loading ? (
               <SpinnerLabel className="justify-center">


### PR DESCRIPTION
## Summary

修复侧边栏搜索弹窗在执行搜索后结果区域高度异常的问题。

本次移除了搜索结果列表的 JS 高度测量逻辑，避免 `ResizeObserver`、`scrollHeight` 与 `cmdk` 搜索状态切换互相影响，改为使用稳定的 CSS 最大高度和自然滚动行为。这样 loading、空状态、少量结果和多条结果之间切换时，列表区域不会再出现高度残留、裁切或错位。

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm exec eslint features/layouts/components/navigation/navigation-search.tsx features/layouts/hooks/use-navigation-search.ts features/layouts/components/navigation/nav-main.tsx features/layouts/components/navigation/nav-starred.tsx`

## Screenshots, API examples, or logs

_No response_

## Configuration, migration, and compatibility notes

无配置、API、数据库或部署变更。

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.