### PR TITLE
feat: enhance chat input and mention menu functionality

### DIFF
--- a/frontend/features/chat/components/app-chat-area.tsx
+++ b/frontend/features/chat/components/app-chat-area.tsx
@@ -1068,6 +1068,10 @@ export function AppChatArea() {
                   onContinueAssistantMessage={onContinueAssistantMessage}
                   onEditAssistantMessage={onEditAssistantMessage}
                   onEditUserMessage={onEditUserMessage}
+                  modelOptions={modelOptions}
+                  selectedPlatformModelName={selectedPlatformModelName}
+                  onModelChange={setSelectedPlatformModelName}
+                  onModelCatalogRefresh={refreshModelCatalogForComposer}
                   onEditImageAttachment={onEditGeneratedImageAttachment}
                   onOpenCodeArtifact={artifactWorkspace.openArtifact}
                   onCycleMessageBranch={onCycleMessageBranch}

--- a/frontend/features/chat/components/message/message-user.tsx
+++ b/frontend/features/chat/components/message/message-user.tsx
@@ -7,9 +7,15 @@ import { useTranslations } from "next-intl";
 
 import { ChevronDown } from "@/components/animate-ui/icons/chevron-down";
 import { ChevronUp } from "@/components/animate-ui/icons/chevron-up";
+import { ChatMentionMenuPortal } from "@/features/chat/components/shared/chat-mention-menu";
 import { MessageAttachmentRow } from "@/features/chat/components/message/message-attachment";
 import { UserMessageMeta } from "@/features/chat/components/message/message-meta";
 import type { ChatAreaMessage } from "@/features/chat/types/messages";
+import {
+  useChatMentionMenu,
+  type ChatMentionMenuKind,
+} from "@/features/chat/hooks/use-chat-mention-menu";
+import type { ChatModelOption } from "@/features/chat/types/chat-runtime";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import type { FileContentResult } from "@/shared/api/file";
@@ -22,12 +28,20 @@ const USER_MESSAGE_EXPAND_TRANSITION = {
   duration: 0.36,
   ease: [0.16, 1, 0.3, 1] as const,
 };
+const EDIT_MESSAGE_MENTION_KINDS: readonly ChatMentionMenuKind[] = ["model", "prompt"];
+const EDIT_MESSAGE_EMPTY_ATTACHMENTS = [];
+const EDIT_MESSAGE_EMPTY_TOOLS = [];
+const EDIT_MESSAGE_EMPTY_TOOL_IDS = [];
 
 type ChatMessageUserProps = {
   item: ChatAreaMessage;
   busy: boolean;
   onRetryUserMessage: (message: ChatAreaMessage) => Promise<void> | void;
   onEditUserMessage: (message: ChatAreaMessage, content: string) => Promise<boolean> | boolean;
+  modelOptions?: ChatModelOption[];
+  selectedPlatformModelName?: string;
+  onModelChange?: (platformModelName: string) => void;
+  onModelCatalogRefresh?: () => void | Promise<void>;
   onCycleMessageBranch: (parentPublicID: string | null, direction: "previous" | "next") => void;
   onCopy: () => void;
   copySucceeded?: boolean;
@@ -41,6 +55,10 @@ export function ChatMessageUser({
   busy,
   onRetryUserMessage,
   onEditUserMessage,
+  modelOptions = [],
+  selectedPlatformModelName = "",
+  onModelChange = () => undefined,
+  onModelCatalogRefresh,
   onCycleMessageBranch,
   onCopy,
   copySucceeded = false,
@@ -49,6 +67,7 @@ export function ChatMessageUser({
   showBranchNavigator = true,
 }: ChatMessageUserProps) {
   const tCommon = useTranslations("common.actions");
+  const tComposer = useTranslations("chat.composer");
   const tMessages = useTranslations("chat.messages");
   const [isEditing, setIsEditing] = React.useState(false);
   const [editingValue, setEditingValue] = React.useState(item.content);
@@ -59,6 +78,8 @@ export function ChatMessageUser({
   const [collapsedHeight, setCollapsedHeight] = React.useState(USER_MESSAGE_COLLAPSED_FALLBACK_HEIGHT);
   const [measuredContentKey, setMeasuredContentKey] = React.useState("");
   const contentRef = React.useRef<HTMLDivElement>(null);
+  const editInputGroupRef = React.useRef<HTMLDivElement | null>(null);
+  const editTextareaRef = React.useRef<HTMLTextAreaElement | null>(null);
   const measurementKey = React.useMemo(
     () => `${item.publicID || item.key}:${item.content}`,
     [item.content, item.key, item.publicID],
@@ -123,6 +144,48 @@ export function ChatMessageUser({
       setIsEditing(false);
     }
   }, [editingValue, item, onEditUserMessage]);
+  const {
+    activeIndex: mentionActiveIndex,
+    handleBlur: handleMentionBlur,
+    handleChange: handleMentionChange,
+    handleFocus: handleMentionFocus,
+    handleKeyDown: handleMentionKeyDown,
+    menuID: mentionMenuID,
+    menuLayout: mentionMenuLayout,
+    menuRef: mentionMenuRef,
+    menuReady: mentionMenuReady,
+    open: showMentionMenu,
+    sections: mentionSections,
+    select: selectMentionItem,
+  } = useChatMentionMenu({
+    attachments: EDIT_MESSAGE_EMPTY_ATTACHMENTS,
+    availableTools: EDIT_MESSAGE_EMPTY_TOOLS,
+    defaultFileLabel: "",
+    disabled: busy || readOnly || !isEditing,
+    draft: editingValue,
+    enabledKinds: EDIT_MESSAGE_MENTION_KINDS,
+    maxSelectedTools: 0,
+    modelOptions,
+    selectedPlatformModelName,
+    selectedToolIDs: EDIT_MESSAGE_EMPTY_TOOL_IDS,
+    anchorRef: editInputGroupRef,
+    textareaRef: editTextareaRef,
+    toolsDisabled: true,
+    onDraftChange: setEditingValue,
+    onFileSelect: () => undefined,
+    onModelCatalogRefresh,
+    onModelChange,
+    onSelectedToolsChange: () => undefined,
+  });
+  const mentionSectionOffsets = React.useMemo(() => {
+    const offsets = new Map<ChatMentionMenuKind, number>();
+    let offset = 0;
+    for (const section of mentionSections) {
+      offsets.set(section.kind, offset);
+      offset += section.items.length;
+    }
+    return offsets;
+  }, [mentionSections]);
 
   if (!readOnly && isEditing) {
     const nextContent = editingValue.trim();
@@ -131,13 +194,37 @@ export function ChatMessageUser({
     return (
       <div className="flex justify-end">
         <div className="w-full max-w-[640px] rounded-lg bg-muted/60 p-3 text-foreground">
-          <Textarea
-            autoFocus
-            value={editingValue}
-            className="chat-font-content min-h-[120px] resize-none rounded-lg border-border border-[0.5px] bg-background px-3 py-2 text-sm leading-7 shadow-none focus-visible:border-primary focus-visible:ring-0"
-            style={{ fontFamily: "var(--font-chat)", fontWeight: "var(--font-chat-weight)" }}
-            onChange={(event) => setEditingValue(event.target.value)}
-          />
+          <div ref={editInputGroupRef}>
+            <ChatMentionMenuPortal
+              activeIndex={mentionActiveIndex}
+              menuID={mentionMenuID}
+              menuLayout={mentionMenuLayout}
+              menuRef={mentionMenuRef}
+              menuReady={mentionMenuReady}
+              open={showMentionMenu}
+              sectionOffsets={mentionSectionOffsets}
+              sections={mentionSections}
+              t={tComposer}
+              onSelect={selectMentionItem}
+            />
+            <Textarea
+              ref={editTextareaRef}
+              autoFocus
+              value={editingValue}
+              className="chat-font-content min-h-[120px] resize-none rounded-lg border-border border-[0.5px] bg-background px-3 py-2 text-sm leading-7 shadow-none focus-visible:border-primary focus-visible:ring-0"
+              style={{ fontFamily: "var(--font-chat)", fontWeight: "var(--font-chat-weight)" }}
+              aria-controls={showMentionMenu ? mentionMenuID : undefined}
+              aria-expanded={showMentionMenu}
+              onBlur={handleMentionBlur}
+              onChange={(event) => handleMentionChange(event.target.value)}
+              onFocus={handleMentionFocus}
+              onKeyDown={(event) => {
+                if (handleMentionKeyDown(event)) {
+                  return;
+                }
+              }}
+            />
+          </div>
           <div className="flex items-center justify-between gap-4">
             <div className="flex gap-2 pt-2 text-xs text-muted-foreground">
               <CircleAlert className="mt-0.5 size-3 shrink-0" />

--- a/frontend/features/chat/components/sections/chat-area.tsx
+++ b/frontend/features/chat/components/sections/chat-area.tsx
@@ -22,6 +22,7 @@ import { CenteredEmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ConversationShareExportIconDropdown } from "@/shared/components/conversation-share-export-menu";
 import { useCopyAction } from "@/shared/components/copy-action";
+import type { ChatModelOption } from "@/features/chat/types/chat-runtime";
 import { cn } from "@/lib/utils";
 
 function CompactDivider({ summaryPreview }: { summaryPreview: string }) {
@@ -77,6 +78,10 @@ type ChatAreaProps = {
   onContinueAssistantMessage?: (message: ChatAreaMessage) => Promise<void> | void;
   onEditAssistantMessage: (message: ChatAreaMessage, content: string) => Promise<boolean> | boolean;
   onEditUserMessage: (message: ChatAreaMessage, content: string) => Promise<boolean> | boolean;
+  modelOptions: ChatModelOption[];
+  selectedPlatformModelName: string;
+  onModelChange: (platformModelName: string) => void;
+  onModelCatalogRefresh?: () => void | Promise<void>;
   onEditImageAttachment?: (attachment: MessageAttachment, sourceModelName?: string) => void;
   onOpenCodeArtifact?: (message: ChatAreaMessage, artifact: OpenCodeArtifactInput) => void;
   onCycleMessageBranch: (parentPublicID: string | null, direction: "previous" | "next") => void;
@@ -114,6 +119,10 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
   onContinueAssistantMessage,
   onEditAssistantMessage,
   onEditUserMessage,
+  modelOptions,
+  selectedPlatformModelName,
+  onModelChange,
+  onModelCatalogRefresh,
   onEditImageAttachment,
   onCycleMessageBranch,
   onReactAssistantMessage,
@@ -132,6 +141,10 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
   onContinueAssistantMessage?: (message: ChatAreaMessage) => Promise<void> | void;
   onEditAssistantMessage: (message: ChatAreaMessage, content: string) => Promise<boolean> | boolean;
   onEditUserMessage: (message: ChatAreaMessage, content: string) => Promise<boolean> | boolean;
+  modelOptions: ChatModelOption[];
+  selectedPlatformModelName: string;
+  onModelChange: (platformModelName: string) => void;
+  onModelCatalogRefresh?: () => void | Promise<void>;
   onEditImageAttachment?: (attachment: MessageAttachment, sourceModelName?: string) => void;
   onCycleMessageBranch: (parentPublicID: string | null, direction: "previous" | "next") => void;
   onReactAssistantMessage: (publicID: string, reaction: AssistantReaction) => void;
@@ -174,6 +187,10 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
         busy={busy}
         onRetryUserMessage={onRetryUserMessage}
         onEditUserMessage={onEditUserMessage}
+        modelOptions={modelOptions}
+        selectedPlatformModelName={selectedPlatformModelName}
+        onModelChange={onModelChange}
+        onModelCatalogRefresh={onModelCatalogRefresh}
         onCycleMessageBranch={onCycleMessageBranch}
         onCopy={() => void onCopy()}
         copySucceeded={isCopied(copyKey)}
@@ -225,6 +242,10 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
   previous.showLatency === next.showLatency &&
   previous.showTokenUsage === next.showTokenUsage &&
   previous.showBillingCost === next.showBillingCost &&
+  previous.modelOptions === next.modelOptions &&
+  previous.selectedPlatformModelName === next.selectedPlatformModelName &&
+  previous.onModelChange === next.onModelChange &&
+  previous.onModelCatalogRefresh === next.onModelCatalogRefresh &&
   previous.onEditImageAttachment === next.onEditImageAttachment &&
   previous.onOpenCodeArtifact === next.onOpenCodeArtifact &&
   areChatAreaMessagesRenderEqual(previous.item, next.item)
@@ -247,6 +268,10 @@ export function ChatArea({
   onContinueAssistantMessage,
   onEditAssistantMessage,
   onEditUserMessage,
+  modelOptions,
+  selectedPlatformModelName,
+  onModelChange,
+  onModelCatalogRefresh,
   onEditImageAttachment,
   onOpenCodeArtifact,
   onCycleMessageBranch,
@@ -272,6 +297,8 @@ export function ChatArea({
   const stableOnContinueAssistantMessage = useStableEvent(onContinueAssistantMessage ?? (() => undefined));
   const stableOnEditAssistantMessage = useStableEvent(onEditAssistantMessage);
   const stableOnEditUserMessage = useStableEvent(onEditUserMessage);
+  const stableOnModelChange = useStableEvent(onModelChange);
+  const stableOnModelCatalogRefresh = useStableEvent(onModelCatalogRefresh ?? (() => undefined));
   const stableOnEditImageAttachment = useStableEvent((attachment: MessageAttachment, sourceModelName?: string) => {
     onEditImageAttachment?.(attachment, sourceModelName);
   });
@@ -341,6 +368,10 @@ export function ChatArea({
                   onContinueAssistantMessage={onContinueAssistantMessage ? stableOnContinueAssistantMessage : undefined}
                   onEditAssistantMessage={stableOnEditAssistantMessage}
                   onEditUserMessage={stableOnEditUserMessage}
+                  modelOptions={modelOptions}
+                  selectedPlatformModelName={selectedPlatformModelName}
+                  onModelChange={stableOnModelChange}
+                  onModelCatalogRefresh={onModelCatalogRefresh ? stableOnModelCatalogRefresh : undefined}
                   onEditImageAttachment={editImageAttachmentHandler}
                   onCycleMessageBranch={stableOnCycleMessageBranch}
                   onReactAssistantMessage={stableOnReactAssistantMessage}

--- a/frontend/features/chat/components/sections/chat-input.tsx
+++ b/frontend/features/chat/components/sections/chat-input.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { createPortal } from "react-dom";
 import dynamic from "next/dynamic";
-import { AnimatePresence, motion } from "motion/react";
-import { Check, FileText, Image, ImageOff, ImagePlus, ScrollText, Wrench } from "lucide-react";
+import { Image, ImageOff, ImagePlus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
@@ -24,11 +22,9 @@ import type {
 import { useSpeechInput } from "@/features/chat/hooks/use-speech-input";
 import {
   useChatMentionMenu,
-  type ChatMentionMenuItem,
   type ChatMentionMenuKind,
-  type ChatMentionMenuLayout,
-  type ChatMentionMenuSection,
 } from "@/features/chat/hooks/use-chat-mention-menu";
+import { ChatMentionMenuPortal } from "@/features/chat/components/shared/chat-mention-menu";
 import { ChatMCP } from "@/features/chat/components/sections/chat-mcp";
 import { ChatModelPicker } from "@/features/chat/components/sections/chat-model-picker";
 import { ChatModelConfig } from "@/features/chat/components/sections/chat-model-config";
@@ -51,8 +47,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { resolveFileProcessingBadge, resolveFileProcessingToneClass } from "@/shared/lib/file-processing";
 import { cn } from "@/lib/utils";
-import { LobeHubIcon } from "@/shared/components/lobehub-icon";
-import { resolveLobeHubIconURL, resolveModelIdentity } from "@/shared/lib/model-identity";
 import type { ConversationOptions } from "@/shared/api/conversation.types";
 import type { FileObjectDTO } from "@/shared/api/file.types";
 import type { MCPToolDTO } from "@/shared/api/mcp.types";
@@ -115,127 +109,6 @@ type ComposerModeIndicator = {
   icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
   tone: "default" | "warning";
 };
-
-function MentionMenuItem({
-  item,
-  active,
-  onSelect,
-}: {
-  item: ChatMentionMenuItem;
-  active: boolean;
-  onSelect: () => void;
-}) {
-  const platformModelName = item.kind === "model" ? item.model.platformModelName.trim() : "";
-  const identity = React.useMemo(() => {
-    if (item.kind !== "model") {
-      return null;
-    }
-    return resolveModelIdentity({
-      code: item.model.platformModelName,
-      vendor: item.model.vendor,
-      icon: item.model.icon,
-    });
-  }, [item]);
-  const iconURL = React.useMemo(() => identity ? resolveLobeHubIconURL(identity.modelIcon) : "", [identity]);
-
-  return (
-    <button
-      type="button"
-      role="option"
-      aria-selected={active}
-      data-active={active}
-      className="flex h-8 w-full min-w-0 items-center gap-2 rounded-md px-2 text-left text-[11px] font-medium text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground data-[active=true]:bg-accent data-[active=true]:text-accent-foreground"
-      onMouseDown={(event) => {
-        event.preventDefault();
-        onSelect();
-      }}
-    >
-      {item.kind === "model" ? (
-        <LobeHubIcon iconUrl={iconURL} label={platformModelName} />
-      ) : item.kind === "file" ? (
-        <span className="flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground">
-          <FileText className="size-3.5" strokeWidth={1.7} />
-        </span>
-      ) : item.kind === "tool" ? (
-        <span className="flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground">
-          <Wrench className="size-3.5" strokeWidth={1.7} />
-        </span>
-      ) : (
-        <span className="flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground">
-          <ScrollText className="size-3.5" strokeWidth={1.7} />
-        </span>
-      )}
-      <span className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
-        <span
-          className={cn(
-            "text-foreground/90",
-            item.kind === "tool" ? "shrink-0 whitespace-nowrap" : "min-w-0 truncate",
-          )}
-        >
-          {item.label}
-        </span>
-        {item.description ? (
-          <span className="min-w-0 truncate font-normal text-muted-foreground/80">{item.description}</span>
-        ) : null}
-      </span>
-      <span className="flex size-3.5 shrink-0 items-center justify-center">
-        {item.selected ? <Check className="size-3.5 text-current" strokeWidth={1.8} /> : null}
-      </span>
-    </button>
-  );
-}
-
-const MentionMenuContent = React.memo(function MentionMenuContent({
-  activeIndex,
-  sectionOffsets,
-  sections,
-  t,
-  onSelect,
-}: {
-  activeIndex: number;
-  sectionOffsets: Map<ChatMentionMenuKind, number>;
-  sections: ChatMentionMenuSection[];
-  t: (key: string) => string;
-  onSelect: (item: ChatMentionMenuItem) => void;
-}) {
-  return (
-    <>
-      {sections.map((section) => {
-        const sectionOffset = sectionOffsets.get(section.kind) ?? 0;
-        return (
-          <div key={section.kind} className="space-y-0.5">
-            <div className="px-2 pb-1 pt-1.5 text-[11px] font-semibold text-muted-foreground">
-              {t(`mention.sections.${section.kind}`)}
-            </div>
-            {section.items.map((item, index) => (
-              <MentionMenuItem
-                key={item.id}
-                item={item}
-                active={sectionOffset + index === activeIndex}
-                onSelect={() => onSelect(item)}
-              />
-            ))}
-          </div>
-        );
-      })}
-    </>
-  );
-});
-
-function resolveMentionMenuMotionStyle(layout: ChatMentionMenuLayout | null): React.CSSProperties | undefined {
-  if (!layout) {
-    return undefined;
-  }
-  return {
-    bottom: layout.bottom,
-    left: layout.left,
-    top: layout.top,
-    width: layout.width,
-    contain: "layout paint",
-    transformOrigin: layout.placement === "bottom" ? "top center" : "bottom center",
-    willChange: "height, opacity, transform",
-  };
-}
 
 function resolveComposerModeIndicator(
   decision: ChatSubmitDecision,
@@ -429,18 +302,12 @@ function ChatInputComponent({
   const mentionSectionOffsets = React.useMemo(() => {
     const offsets = new Map<ChatMentionMenuKind, number>();
     let offset = 0;
-    for (const section of mentionSections) {
+  for (const section of mentionSections) {
       offsets.set(section.kind, offset);
       offset += section.items.length;
     }
     return offsets;
   }, [mentionSections]);
-  const mentionMenuMotionStyle = React.useMemo(
-    () => resolveMentionMenuMotionStyle(mentionMenuLayout),
-    [mentionMenuLayout],
-  );
-  const mentionMenuHeight = mentionMenuLayout?.height ?? 0;
-  const shouldRenderMentionMenu = showMentionMenu && mentionMenuReady && mentionMenuMotionStyle !== undefined;
   const onSelectUploadTool = React.useCallback(() => {
     fileInputRef.current?.click();
   }, []);
@@ -578,50 +445,18 @@ function ChatInputComponent({
           </div>
         ) : null}
 
-        {typeof document !== "undefined" ? createPortal(
-          <AnimatePresence initial={false}>
-            {shouldRenderMentionMenu ? (
-              <motion.div
-                ref={mentionMenuRef}
-                id={mentionMenuID}
-                key="chat-mention-menu"
-                role="listbox"
-                className="bg-pure fixed z-[60] overflow-hidden rounded-xl border-[0.5px] border-border/70 text-popover-foreground shadow-xs"
-                style={mentionMenuMotionStyle}
-                initial={{
-                  height: Math.min(mentionMenuHeight, 12),
-                  opacity: 0,
-                  scale: 0.99,
-                  y: mentionMenuLayout?.placement === "top" ? 4 : -4,
-                }}
-                animate={{ height: mentionMenuHeight, opacity: 1, scale: 1, y: 0 }}
-                exit={{
-                  height: Math.min(mentionMenuHeight, 12),
-                  opacity: 0,
-                  scale: 0.99,
-                  y: mentionMenuLayout?.placement === "top" ? 4 : -4,
-                }}
-                transition={{
-                  height: { type: "spring", stiffness: 520, damping: 42, mass: 0.75 },
-                  opacity: { duration: 0.1, ease: "easeOut" },
-                  scale: { duration: 0.12, ease: "easeOut" },
-                  y: { duration: 0.12, ease: "easeOut" },
-                }}
-              >
-                <div data-mention-menu-scroll className="h-full overflow-y-auto p-1.5">
-                  <MentionMenuContent
-                    activeIndex={mentionActiveIndex}
-                    sectionOffsets={mentionSectionOffsets}
-                    sections={mentionSections}
-                    t={tComposer}
-                    onSelect={selectMentionItem}
-                  />
-                </div>
-              </motion.div>
-            ) : null}
-          </AnimatePresence>,
-          document.body,
-        ) : null}
+        <ChatMentionMenuPortal
+          activeIndex={mentionActiveIndex}
+          menuID={mentionMenuID}
+          menuLayout={mentionMenuLayout}
+          menuRef={mentionMenuRef}
+          menuReady={mentionMenuReady}
+          open={showMentionMenu}
+          sectionOffsets={mentionSectionOffsets}
+          sections={mentionSections}
+          t={tComposer}
+          onSelect={selectMentionItem}
+        />
 
         <InputGroupTextarea
           ref={textareaRef}

--- a/frontend/features/chat/components/shared/chat-mention-menu.tsx
+++ b/frontend/features/chat/components/shared/chat-mention-menu.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import * as React from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, motion } from "motion/react";
+import { Check, FileText, ScrollText, Wrench } from "lucide-react";
+
+import type {
+  ChatMentionMenuItem,
+  ChatMentionMenuKind,
+  ChatMentionMenuLayout,
+  ChatMentionMenuSection,
+} from "@/features/chat/hooks/use-chat-mention-menu";
+import { LobeHubIcon } from "@/shared/components/lobehub-icon";
+import { resolveLobeHubIconURL, resolveModelIdentity } from "@/shared/lib/model-identity";
+import { cn } from "@/lib/utils";
+
+function ChatMentionMenuItemButton({
+  item,
+  active,
+  onSelect,
+}: {
+  item: ChatMentionMenuItem;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  const platformModelName = item.kind === "model" ? item.model.platformModelName.trim() : "";
+  const identity = React.useMemo(() => {
+    if (item.kind !== "model") {
+      return null;
+    }
+    return resolveModelIdentity({
+      code: item.model.platformModelName,
+      vendor: item.model.vendor,
+      icon: item.model.icon,
+    });
+  }, [item]);
+  const iconURL = React.useMemo(() => identity ? resolveLobeHubIconURL(identity.modelIcon) : "", [identity]);
+
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={active}
+      data-active={active}
+      className="flex h-8 w-full min-w-0 items-center gap-2 rounded-md px-2 text-left text-[11px] font-medium text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground data-[active=true]:bg-accent data-[active=true]:text-accent-foreground"
+      onMouseDown={(event) => {
+        event.preventDefault();
+        onSelect();
+      }}
+    >
+      {item.kind === "model" ? (
+        <LobeHubIcon iconUrl={iconURL} label={platformModelName} />
+      ) : item.kind === "file" ? (
+        <span className="flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground">
+          <FileText className="size-3.5" strokeWidth={1.7} />
+        </span>
+      ) : item.kind === "tool" ? (
+        <span className="flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground">
+          <Wrench className="size-3.5" strokeWidth={1.7} />
+        </span>
+      ) : (
+        <span className="flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground">
+          <ScrollText className="size-3.5" strokeWidth={1.7} />
+        </span>
+      )}
+      <span className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
+        <span
+          className={cn(
+            "text-foreground/90",
+            item.kind === "tool" ? "shrink-0 whitespace-nowrap" : "min-w-0 truncate",
+          )}
+        >
+          {item.label}
+        </span>
+        {item.description ? (
+          <span className="min-w-0 truncate font-normal text-muted-foreground/80">{item.description}</span>
+        ) : null}
+      </span>
+      <span className="flex size-3.5 shrink-0 items-center justify-center">
+        {item.selected ? <Check className="size-3.5 text-current" strokeWidth={1.8} /> : null}
+      </span>
+    </button>
+  );
+}
+
+const ChatMentionMenuContent = React.memo(function ChatMentionMenuContent({
+  activeIndex,
+  sectionOffsets,
+  sections,
+  t,
+  onSelect,
+}: {
+  activeIndex: number;
+  sectionOffsets: Map<ChatMentionMenuKind, number>;
+  sections: ChatMentionMenuSection[];
+  t: (key: string) => string;
+  onSelect: (item: ChatMentionMenuItem) => void;
+}) {
+  return (
+    <>
+      {sections.map((section) => {
+        const sectionOffset = sectionOffsets.get(section.kind) ?? 0;
+        return (
+          <div key={section.kind} className="space-y-0.5">
+            <div className="px-2 pb-1 pt-1.5 text-[11px] font-semibold text-muted-foreground">
+              {t(`mention.sections.${section.kind}`)}
+            </div>
+            {section.items.map((item, index) => (
+              <ChatMentionMenuItemButton
+                key={item.id}
+                item={item}
+                active={sectionOffset + index === activeIndex}
+                onSelect={() => onSelect(item)}
+              />
+            ))}
+          </div>
+        );
+      })}
+    </>
+  );
+});
+
+export function resolveMentionMenuMotionStyle(layout: ChatMentionMenuLayout | null): React.CSSProperties | undefined {
+  if (!layout) {
+    return undefined;
+  }
+  return {
+    bottom: layout.bottom,
+    left: layout.left,
+    top: layout.top,
+    width: layout.width,
+    contain: "layout paint",
+    transformOrigin: layout.placement === "bottom" ? "top center" : "bottom center",
+    willChange: "height, opacity, transform",
+  };
+}
+
+export function ChatMentionMenuPortal({
+  activeIndex,
+  menuID,
+  menuLayout,
+  menuRef,
+  menuReady,
+  open,
+  sectionOffsets,
+  sections,
+  t,
+  onSelect,
+}: {
+  activeIndex: number;
+  menuID: string;
+  menuLayout: ChatMentionMenuLayout | null;
+  menuRef: React.RefObject<HTMLDivElement | null>;
+  menuReady: boolean;
+  open: boolean;
+  sectionOffsets: Map<ChatMentionMenuKind, number>;
+  sections: ChatMentionMenuSection[];
+  t: (key: string) => string;
+  onSelect: (item: ChatMentionMenuItem) => void;
+}) {
+  const menuMotionStyle = React.useMemo(
+    () => resolveMentionMenuMotionStyle(menuLayout),
+    [menuLayout],
+  );
+  const menuHeight = menuLayout?.height ?? 0;
+  const shouldRender = open && menuReady && menuMotionStyle !== undefined;
+
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
+    <AnimatePresence initial={false}>
+      {shouldRender ? (
+        <motion.div
+          ref={menuRef}
+          id={menuID}
+          key="chat-mention-menu"
+          role="listbox"
+          className="bg-pure fixed z-[60] overflow-hidden rounded-xl border-[0.5px] border-border/70 text-popover-foreground shadow-xs"
+          style={menuMotionStyle}
+          initial={{
+            height: Math.min(menuHeight, 12),
+            opacity: 0,
+            scale: 0.99,
+            y: menuLayout?.placement === "top" ? 4 : -4,
+          }}
+          animate={{ height: menuHeight, opacity: 1, scale: 1, y: 0 }}
+          exit={{
+            height: Math.min(menuHeight, 12),
+            opacity: 0,
+            scale: 0.99,
+            y: menuLayout?.placement === "top" ? 4 : -4,
+          }}
+          transition={{
+            height: { type: "spring", stiffness: 520, damping: 42, mass: 0.75 },
+            opacity: { duration: 0.1, ease: "easeOut" },
+            scale: { duration: 0.12, ease: "easeOut" },
+            y: { duration: 0.12, ease: "easeOut" },
+          }}
+        >
+          <div data-mention-menu-scroll className="h-full overflow-y-auto overflow-x-hidden p-1.5">
+            <ChatMentionMenuContent
+              activeIndex={activeIndex}
+              sectionOffsets={sectionOffsets}
+              sections={sections}
+              t={t}
+              onSelect={onSelect}
+            />
+          </div>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/frontend/features/chat/hooks/use-chat-mention-menu.ts
+++ b/frontend/features/chat/hooks/use-chat-mention-menu.ts
@@ -18,12 +18,14 @@ const MENTION_MENU_MAX_HEIGHT = 280;
 const MENTION_MENU_MIN_HEIGHT = 32;
 const MENTION_MENU_ROW_HEIGHT = 32;
 const MENTION_MENU_ROW_GAP = 2;
-const MENTION_MENU_SECTION_HEADER_HEIGHT = 26;
+const MENTION_MENU_SECTION_HEADER_HEIGHT = 28;
+const MENTION_MENU_SECTION_GAP = 2;
 const MENTION_MENU_CHROME_HEIGHT = 12;
 const MENTION_MENU_VIEWPORT_GUTTER = 16;
 const MENTION_MENU_OFFSET = 8;
 const MENTION_MENU_FILE_QUERY_DELAY_MS = 180;
 const MENTION_MENU_PROMPT_QUERY_DELAY_MS = 180;
+const DEFAULT_MENTION_MENU_KINDS: readonly ChatMentionMenuKind[] = ["model", "file", "tool", "prompt"];
 
 export type ChatMentionMenuKind = "file" | "tool" | "model" | "prompt";
 
@@ -99,6 +101,7 @@ type ChatMentionMenuControllerArgs = {
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
   toolsDisabled: boolean;
   onDraftChange: (value: string) => void;
+  enabledKinds?: readonly ChatMentionMenuKind[];
   onFileSelect: (file: FileObjectDTO) => void | Promise<void>;
   onModelChange: (platformModelName: string) => void;
   placementPreference?: ChatMentionMenuPlacementPreference;
@@ -107,26 +110,124 @@ type ChatMentionMenuControllerArgs = {
   onToolLimitReached?: () => void;
 };
 
-function resolveMentionQuery(value: string): string | null {
-  if (!value.startsWith("@")) {
+type ChatMentionTriggerQuery = {
+  kind: "mention" | "prompt";
+  query: string;
+  range: {
+    start: number;
+    end: number;
+  };
+};
+
+type ChatMentionMenuAnchor = {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+};
+
+function resolveTriggerQuery(value: string, caretIndex: number): ChatMentionTriggerQuery | null {
+  const end = Math.min(Math.max(caretIndex, 0), value.length);
+  let start = end;
+  while (start > 0 && !/\s/.test(value[start - 1] ?? "")) {
+    start -= 1;
+  }
+
+  const token = value.slice(start, end);
+  const trigger = token[0];
+  if (trigger !== "@" && trigger !== "/") {
     return null;
   }
-  return value.slice(1).match(/^\S*/)?.[0]?.trim().toLowerCase() ?? "";
+
+  return {
+    kind: trigger === "@" ? "mention" : "prompt",
+    query: token.slice(1).toLowerCase(),
+    range: { start, end },
+  };
 }
 
-function resolvePromptQuery(value: string): string | null {
-  if (!value.startsWith("/")) {
-    return null;
+function createTextareaCaretMirror(textarea: HTMLTextAreaElement) {
+  const styles = window.getComputedStyle(textarea);
+  const mirror = document.createElement("div");
+  mirror.style.position = "absolute";
+  mirror.style.visibility = "hidden";
+  mirror.style.pointerEvents = "none";
+  mirror.style.whiteSpace = "pre-wrap";
+  mirror.style.overflowWrap = "break-word";
+  mirror.style.boxSizing = styles.boxSizing;
+  mirror.style.width = styles.width;
+  mirror.style.padding = styles.padding;
+  mirror.style.border = styles.border;
+  mirror.style.font = styles.font;
+  mirror.style.fontFamily = styles.fontFamily;
+  mirror.style.fontSize = styles.fontSize;
+  mirror.style.fontWeight = styles.fontWeight;
+  mirror.style.letterSpacing = styles.letterSpacing;
+  mirror.style.lineHeight = styles.lineHeight;
+  mirror.style.tabSize = styles.tabSize;
+  mirror.style.textTransform = styles.textTransform;
+  return mirror;
+}
+
+function resolveTextareaCaretAnchor(
+  textarea: HTMLTextAreaElement | null,
+  fallbackAnchor: HTMLElement,
+  caretIndex: number,
+): ChatMentionMenuAnchor {
+  const fallbackRect = fallbackAnchor.getBoundingClientRect();
+  if (!textarea || typeof document === "undefined") {
+    return fallbackRect;
   }
-  return value.slice(1).match(/^\S*/)?.[0]?.trim().toLowerCase() ?? "";
+
+  const textareaRect = textarea.getBoundingClientRect();
+  if (textareaRect.width <= 0 || textareaRect.height <= 0) {
+    return fallbackRect;
+  }
+
+  const mirror = createTextareaCaretMirror(textarea);
+  const textBeforeCaret = textarea.value.slice(0, caretIndex);
+  mirror.textContent = textBeforeCaret;
+  const marker = document.createElement("span");
+  marker.textContent = "\u200b";
+  mirror.appendChild(marker);
+  document.body.appendChild(mirror);
+
+  const markerRect = marker.getBoundingClientRect();
+  const styles = window.getComputedStyle(textarea);
+  const borderTop = Number.parseFloat(styles.borderTopWidth) || 0;
+  const mirrorRect = mirror.getBoundingClientRect();
+  const markerTop = textareaRect.top + markerRect.top - mirrorRect.top - textarea.scrollTop - borderTop;
+  const lineHeight = Number.parseFloat(styles.lineHeight) || textareaRect.height;
+  document.body.removeChild(mirror);
+
+  return {
+    height: Math.max(1, lineHeight),
+    left: fallbackRect.left,
+    top: Math.min(Math.max(markerTop, textareaRect.top), textareaRect.bottom),
+    width: fallbackRect.width,
+  };
 }
 
-function removeMentionTrigger(value: string): string {
-  return value.replace(/^@\S*\s?/, "");
+function removeTriggerRange(value: string, range: ChatMentionTriggerQuery["range"]): {
+  caretIndex: number;
+  value: string;
+} {
+  const trailingSpace = value[range.end] === " " ? 1 : 0;
+  return {
+    caretIndex: range.start,
+    value: `${value.slice(0, range.start)}${value.slice(range.end + trailingSpace)}`,
+  };
 }
 
-function replacePromptTrigger(value: string, content: string): string {
-  return value.replace(/^\/\S*/, content.trim());
+function replaceTriggerRange(value: string, range: ChatMentionTriggerQuery["range"], content: string): {
+  caretIndex: number;
+  value: string;
+} {
+  const nextContent = content.trim();
+  return {
+    caretIndex: range.start + nextContent.length,
+    value: `${value.slice(0, range.start)}${nextContent}${value.slice(range.end)}`,
+  };
 }
 
 function itemMatchesQuery(values: Array<string | undefined>, query: string): boolean {
@@ -226,6 +327,7 @@ function buildSections({
   selectedPlatformModelName,
   selectedToolIDs,
   toolsDisabled,
+  enabledKinds,
 }: {
   attachments: PendingAttachment[];
   availableTools: MCPToolDTO[];
@@ -241,6 +343,7 @@ function buildSections({
   selectedPlatformModelName: string;
   selectedToolIDs: number[];
   toolsDisabled: boolean;
+  enabledKinds: ReadonlySet<ChatMentionMenuKind>;
 }): ChatMentionMenuSection[] {
   if (query === null) {
     return [];
@@ -248,16 +351,25 @@ function buildSections({
 
   const normalizedQuery = query.trim().toLowerCase();
   if (queryKind === "prompt") {
+    if (!enabledKinds.has("prompt")) {
+      return [];
+    }
     const promptItems = promptLoading ? [] : promptsToItems(prompts);
     return promptItems.length > 0 ? [{ kind: "prompt" as const, items: promptItems }] : [];
   }
 
-  const fileItems = fileLoading || filesQuery !== normalizedQuery ? [] : filesToItems(files, attachments, defaultFileLabel);
-  const toolItems = toolsDisabled ? [] : filterTools(availableTools, query, selectedToolIDs);
-  const modelItems = filterModels(modelOptions, query).map((item) => ({
-    ...item,
-    selected: item.model.platformModelName === selectedPlatformModelName,
-  }));
+  const fileItems = enabledKinds.has("file") && !fileLoading && filesQuery === normalizedQuery
+    ? filesToItems(files, attachments, defaultFileLabel)
+    : [];
+  const toolItems = enabledKinds.has("tool") && !toolsDisabled
+    ? filterTools(availableTools, query, selectedToolIDs)
+    : [];
+  const modelItems = enabledKinds.has("model")
+    ? filterModels(modelOptions, query).map((item) => ({
+        ...item,
+        selected: item.model.platformModelName === selectedPlatformModelName,
+      }))
+    : [];
 
   return [
     { kind: "model" as const, items: modelItems },
@@ -281,40 +393,42 @@ function resolveMentionMenuContentHeight(sections: ChatMentionMenuSection[]): nu
     return MENTION_MENU_MIN_HEIGHT;
   }
   const sectionChrome = sections.length * MENTION_MENU_SECTION_HEADER_HEIGHT;
+  const sectionGaps = sections.length * MENTION_MENU_SECTION_GAP;
   return Math.min(
     MENTION_MENU_MAX_HEIGHT,
     itemCount * MENTION_MENU_ROW_HEIGHT
       + Math.max(0, itemCount - 1) * MENTION_MENU_ROW_GAP
       + sectionChrome
+      + sectionGaps
       + MENTION_MENU_CHROME_HEIGHT,
   );
 }
 
 function resolveMentionMenuLayout(
-  anchor: HTMLElement,
+  anchor: ChatMentionMenuAnchor,
   sections: ChatMentionMenuSection[],
   viewportWidth: number,
   viewportHeight: number,
   placementPreference: ChatMentionMenuPlacementPreference,
 ): ChatMentionMenuLayout {
-  const anchorRect = anchor.getBoundingClientRect();
-  const preferredTop = anchorRect.bottom + MENTION_MENU_OFFSET;
-  const preferredBottom = anchorRect.top - MENTION_MENU_OFFSET;
+  const preferredTop = anchor.top + anchor.height + MENTION_MENU_OFFSET;
+  const preferredBottom = anchor.top - MENTION_MENU_OFFSET;
   const desiredHeight = resolveMentionMenuContentHeight(sections);
   const availableBelow = viewportHeight - preferredTop - MENTION_MENU_VIEWPORT_GUTTER;
   const availableAbove = preferredBottom - MENTION_MENU_VIEWPORT_GUTTER;
-  const anchorInLowerHalf = anchorRect.top + anchorRect.height / 2 > viewportHeight / 2;
+  const anchorInLowerHalf = anchor.top + anchor.height / 2 > viewportHeight / 2;
   const openBelow =
-    (placementPreference === "bottom" || !anchorInLowerHalf) &&
-    (availableBelow >= Math.min(desiredHeight, MENTION_MENU_MIN_HEIGHT) ||
-      availableBelow >= availableAbove);
+    placementPreference === "bottom" ||
+    !anchorInLowerHalf ||
+    availableBelow >= Math.min(desiredHeight, MENTION_MENU_MIN_HEIGHT) ||
+    availableBelow >= availableAbove;
   const availableHeight = Math.max(0, openBelow ? availableBelow : availableAbove);
   const maxHeight = Math.max(
     Math.min(MENTION_MENU_MIN_HEIGHT, availableHeight),
     Math.min(desiredHeight, availableHeight),
   );
-  const preferredWidth = resolveMentionMenuWidth(anchorRect.width, viewportWidth);
-  const preferredLeft = anchorRect.left;
+  const preferredWidth = resolveMentionMenuWidth(anchor.width, viewportWidth);
+  const preferredLeft = anchor.left;
   const maxLeft = Math.max(
     MENTION_MENU_VIEWPORT_GUTTER,
     viewportWidth - preferredWidth - MENTION_MENU_VIEWPORT_GUTTER,
@@ -338,6 +452,21 @@ function resolveMentionMenuLayout(
   };
 }
 
+function mentionMenuLayoutsEqual(
+  previous: ChatMentionMenuLayout | null,
+  next: ChatMentionMenuLayout,
+): boolean {
+  return Boolean(
+    previous &&
+      previous.bottom === next.bottom &&
+      previous.height === next.height &&
+      previous.left === next.left &&
+      previous.placement === next.placement &&
+      previous.top === next.top &&
+      previous.width === next.width,
+  );
+}
+
 export function useChatMentionMenu({
   attachments,
   availableTools,
@@ -352,6 +481,7 @@ export function useChatMentionMenu({
   textareaRef,
   toolsDisabled,
   onDraftChange,
+  enabledKinds = DEFAULT_MENTION_MENU_KINDS,
   onFileSelect,
   onModelChange,
   placementPreference = "auto",
@@ -371,13 +501,15 @@ export function useChatMentionMenu({
   const [prompts, setPrompts] = React.useState<PromptPresetDTO[]>([]);
   const [promptsLoading, setPromptsLoading] = React.useState(false);
   const modelCatalogRefreshRequestedRef = React.useRef(false);
-  const mentionQuery = resolveMentionQuery(draft);
-  const promptQuery = resolvePromptQuery(draft);
+  const enabledKindSet = React.useMemo(() => new Set(enabledKinds), [enabledKinds]);
+  const triggerQuery = resolveTriggerQuery(draft, textareaRef.current?.selectionStart ?? draft.length);
+  const mentionQuery = triggerQuery?.kind === "mention" ? triggerQuery.query : null;
+  const promptQuery = triggerQuery?.kind === "prompt" ? triggerQuery.query : null;
   const query = mentionQuery ?? promptQuery;
   const queryKind = mentionQuery !== null ? "mention" : promptQuery !== null ? "prompt" : null;
 
   React.useEffect(() => {
-    if (!inputFocused || mentionQuery === null) {
+    if (!inputFocused || mentionQuery === null || !enabledKindSet.has("model")) {
       modelCatalogRefreshRequestedRef.current = false;
       return;
     }
@@ -387,10 +519,10 @@ export function useChatMentionMenu({
 
     modelCatalogRefreshRequestedRef.current = true;
     void Promise.resolve(onModelCatalogRefresh()).catch(() => undefined);
-  }, [disabled, inputFocused, mentionQuery, onModelCatalogRefresh]);
+  }, [disabled, enabledKindSet, inputFocused, mentionQuery, onModelCatalogRefresh]);
 
   React.useEffect(() => {
-    if (mentionQuery === null || disabled) {
+    if (mentionQuery === null || disabled || !enabledKindSet.has("file")) {
       setFiles([]);
       setFilesQuery("");
       setFilesLoading(false);
@@ -440,10 +572,10 @@ export function useChatMentionMenu({
       controller.abort();
       window.clearTimeout(timer);
     };
-  }, [disabled, mentionQuery]);
+  }, [disabled, enabledKindSet, mentionQuery]);
 
   React.useEffect(() => {
-    if (promptQuery === null || disabled) {
+    if (promptQuery === null || disabled || !enabledKindSet.has("prompt")) {
       setPrompts([]);
       setPromptsLoading(false);
       return;
@@ -478,7 +610,7 @@ export function useChatMentionMenu({
       controller.abort();
       window.clearTimeout(timer);
     };
-  }, [disabled, promptQuery]);
+  }, [disabled, enabledKindSet, promptQuery]);
 
   const sections = React.useMemo(
     () =>
@@ -497,6 +629,7 @@ export function useChatMentionMenu({
         selectedPlatformModelName,
         selectedToolIDs,
         toolsDisabled,
+        enabledKinds: enabledKindSet,
       }),
     [
       attachments,
@@ -513,6 +646,7 @@ export function useChatMentionMenu({
       selectedPlatformModelName,
       selectedToolIDs,
       toolsDisabled,
+      enabledKindSet,
     ],
   );
   const items = React.useMemo(() => flattenSections(sections), [sections]);
@@ -555,8 +689,10 @@ export function useChatMentionMenu({
       return;
     }
 
-    setMenuLayout(resolveMentionMenuLayout(anchor, sections, window.innerWidth, window.innerHeight, placementPreference));
-  }, [anchorRef, open, placementPreference, sections]);
+    const menuAnchor = resolveTextareaCaretAnchor(textareaRef.current, anchor, triggerQuery?.range.start ?? draft.length);
+    const nextLayout = resolveMentionMenuLayout(menuAnchor, sections, window.innerWidth, window.innerHeight, placementPreference);
+    setMenuLayout((current) => (mentionMenuLayoutsEqual(current, nextLayout) ? current : nextLayout));
+  }, [anchorRef, draft.length, open, placementPreference, sections, textareaRef, triggerQuery?.range.start]);
 
   React.useLayoutEffect(() => {
     if (!open) {
@@ -578,13 +714,23 @@ export function useChatMentionMenu({
     };
   }, [open, updateLayout]);
 
-  const finishSelection = React.useCallback(() => {
-    onDraftChange(removeMentionTrigger(draft));
-    setDismissedDraft(null);
+  const focusTextarea = React.useCallback((caretIndex: number) => {
     window.requestAnimationFrame(() => {
-      textareaRef.current?.focus();
+      const textarea = textareaRef.current;
+      textarea?.focus();
+      textarea?.setSelectionRange(caretIndex, caretIndex);
     });
-  }, [draft, onDraftChange, textareaRef]);
+  }, [textareaRef]);
+
+  const finishSelection = React.useCallback(() => {
+    if (!triggerQuery) {
+      return;
+    }
+    const nextDraft = removeTriggerRange(draft, triggerQuery.range);
+    onDraftChange(nextDraft.value);
+    setDismissedDraft(null);
+    focusTextarea(nextDraft.caretIndex);
+  }, [draft, focusTextarea, onDraftChange, triggerQuery]);
 
   const select = React.useCallback(
     (item: ChatMentionMenuItem) => {
@@ -595,11 +741,13 @@ export function useChatMentionMenu({
       }
 
       if (item.kind === "prompt") {
-        onDraftChange(replacePromptTrigger(draft, item.prompt.content));
+        if (!triggerQuery) {
+          return;
+        }
+        const nextDraft = replaceTriggerRange(draft, triggerQuery.range, item.prompt.content);
+        onDraftChange(nextDraft.value);
         setDismissedDraft(null);
-        window.requestAnimationFrame(() => {
-          textareaRef.current?.focus();
-        });
+        focusTextarea(nextDraft.caretIndex);
         return;
       }
 
@@ -631,7 +779,8 @@ export function useChatMentionMenu({
       onToolLimitReached,
       selectedToolIDs,
       draft,
-      textareaRef,
+      focusTextarea,
+      triggerQuery,
     ],
   );
 


### PR DESCRIPTION
## Summary

修复 Chat 输入与编辑场景中的 `/`、`@` 触发菜单定位问题。菜单现在会优先根据触发符所在的 caret 行定位，而不是只根据整个输入框容器定位；当触发符靠近输入框顶部且上下空间都不理想时，允许菜单展示在触发符下方并按可用高度滚动。

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm exec tsc --noEmit --pretty false`
- [x] `cd frontend && pnpm exec eslint features/chat/hooks/use-chat-mention-menu.ts features/chat/components/shared/chat-mention-menu.tsx features/chat/components/sections/chat-input.tsx features/chat/components/message/message-user.tsx`

## Screenshots, API examples, or logs

UI-only positioning fix. No API examples or logs.

## Configuration, migration, and compatibility notes

No configuration, database migration, deployment, or API contract changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.