### PR TITLE
fix: allow clearing model capabilities in model editor

### DIFF
--- a/frontend/features/admin/components/sections/models/models-sheet.tsx
+++ b/frontend/features/admin/components/sections/models/models-sheet.tsx
@@ -610,7 +610,7 @@ export function ModelSheet({ open, mode, target, models, onClose, onSuccess }: M
         vendor: form.vendor || undefined,
         kindsJSON: kindsJson,
         icon: form.icon.trim(),
-        capabilitiesJSON: normalizeModelCapabilitiesJSON(form.capabilitiesJSON, nativeTools, routeProtocols) || undefined,
+        capabilitiesJSON: normalizeModelCapabilitiesJSON(form.capabilitiesJSON, nativeTools, routeProtocols),
         systemPrompt: form.systemPrompt.trim(),
         accessScope: form.accessScope,
         status: form.status,


### PR DESCRIPTION
## Summary

Fixes #270.

This PR fixes the admin model editor so clearing the last model capability entry is sent as an explicit update. Edit-mode saves now preserve the normalized empty `capabilitiesJSON` string instead of converting it to `undefined`, which allows the backend PATCH handler to clear the existing configuration.

Create-mode behavior is unchanged: empty capability configuration is still omitted so new models can use backend defaults.

## Verification

- [x] `cd frontend && pnpm lint`
```
