### PR TITLE
feat: add currency dollar normalization to markdown processing

### DIFF
--- a/frontend/shared/components/markdown/streamdown-content.ts
+++ b/frontend/shared/components/markdown/streamdown-content.ts
@@ -55,6 +55,7 @@ const HTML_VISUAL_MARKDOWN_BLOCK_START_RE =
 const INLINE_DOLLAR_MATH_RE = /(^|[^\\$])\$([^$\n]{1,800})\$/g;
 const ESCAPED_INLINE_DOLLAR_MATH_RE = /\\\$([^$\n]{1,400})\\\$/g;
 const DISPLAY_DOLLAR_MATH_RE = /(\${2,})([\s\S]*?)(\1)/g;
+const CURRENCY_DOLLAR_RE = /(^|[^\\$])\$((?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d{1,2})?)(?!\$)(?=\b)/g;
 
 function isMarkdownLiteralFragment(fragment: string): boolean {
   return fragment.startsWith("```") || fragment.startsWith("~~~") || fragment.startsWith("`");
@@ -200,6 +201,16 @@ export function normalizeMathDelimiters(source: string): string {
     const normalizedFragment = shouldNormalizeDelimiters ? normalizeLatexDelimitersInText(fragment) : fragment;
     return normalizedFragment.includes("$") ? normalizeDollarMathSegments(normalizedFragment) : normalizedFragment;
   });
+}
+
+export function normalizeCurrencyDollars(source: string): string {
+  if (!source.includes("$")) {
+    return source;
+  }
+
+  return mapMarkdownTextFragments(source, (fragment) =>
+    fragment.replace(CURRENCY_DOLLAR_RE, (_match: string, prefix: string, amount: string) => `${prefix}&#36;${amount}`),
+  );
 }
 
 const LATEX_UNICODE_SYMBOLS: Array<[RegExp, string]> = [

--- a/frontend/shared/components/markdown/streamdown-render.tsx
+++ b/frontend/shared/components/markdown/streamdown-render.tsx
@@ -38,6 +38,7 @@ import {
 } from "./streamdown-components";
 import {
   normalizeContent,
+  normalizeCurrencyDollars,
   normalizeHTMLVisualBlankLines,
   normalizeHTMLVisualMarkdownFences,
   normalizeLatexUnicodeSymbols,
@@ -216,7 +217,9 @@ const THINKING_STREAMDOWN_COMPONENTS = {
 function normalizeStreamdownContent(content: unknown): string {
   return normalizeHTMLVisualBlankLines(
     normalizeHTMLVisualMarkdownFences(
-      normalizeMermaidBlocks(normalizeLatexUnicodeSymbols(normalizeMathDelimiters(normalizeContent(content)))),
+      normalizeMermaidBlocks(
+        normalizeLatexUnicodeSymbols(normalizeMathDelimiters(normalizeCurrencyDollars(normalizeContent(content)))),
+      ),
     ),
   );
 }


### PR DESCRIPTION
## Summary

Fix Markdown rendering where dollar-denominated prices such as `$39.99`, `$49.99`, and `$99.99` could be incorrectly parsed as inline math, causing surrounding bold text and list content to render incorrectly.

The fix adds a targeted Markdown preprocessing step for obvious USD currency amounts, converting the dollar sign to an HTML entity before Streamdown math parsing. Normal inline math such as `$x$` and `$2$` remains supported.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`

- [ ] Not run; reason:

## Screenshots, API examples, or logs

Before: dollar prices in Markdown replies could be treated as formula delimiters, breaking bold/list rendering.

After: USD price text renders as normal text while regular inline math remains supported.

## Configuration, migration, and compatibility notes

No configuration, environment variable, database schema, Docker, or API contract changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.