### PR TITLE
feat: enhance chat mention menu and update markdown regex

### DIFF
--- a/frontend/features/chat/components/message/message-user.tsx
+++ b/frontend/features/chat/components/message/message-user.tsx
@@ -175,6 +175,7 @@ export function ChatMessageUser({
     onFileSelect: () => undefined,
     onModelCatalogRefresh,
     onModelChange,
+    placementPreference: "bottom",
     onSelectedToolsChange: () => undefined,
   });
   const mentionSectionOffsets = React.useMemo(() => {

--- a/frontend/features/chat/components/sections/chat-input.tsx
+++ b/frontend/features/chat/components/sections/chat-input.tsx
@@ -293,7 +293,8 @@ function ChatInputComponent({
     onFileSelect: onAttachExistingFile,
     onModelCatalogRefresh,
     onModelChange,
-    placementPreference: isConversationMode ? "auto" : "bottom",
+    placementAnchor: "container",
+    placementPreference: isConversationMode ? "top" : "bottom",
     onSelectedToolsChange,
     onToolLimitReached: () => {
       toast.error(tComposer("mcpToolLimitTitle"), {

--- a/frontend/features/chat/hooks/use-chat-mention-menu.ts
+++ b/frontend/features/chat/hooks/use-chat-mention-menu.ts
@@ -85,7 +85,8 @@ export type ChatMentionMenuLayout = {
   width: number;
 };
 
-type ChatMentionMenuPlacementPreference = "auto" | "bottom";
+type ChatMentionMenuPlacementPreference = "auto" | "bottom" | "top";
+type ChatMentionMenuPlacementAnchor = "caret" | "container";
 
 type ChatMentionMenuControllerArgs = {
   availableTools: MCPToolDTO[];
@@ -104,6 +105,7 @@ type ChatMentionMenuControllerArgs = {
   enabledKinds?: readonly ChatMentionMenuKind[];
   onFileSelect: (file: FileObjectDTO) => void | Promise<void>;
   onModelChange: (platformModelName: string) => void;
+  placementAnchor?: ChatMentionMenuPlacementAnchor;
   placementPreference?: ChatMentionMenuPlacementPreference;
   onModelCatalogRefresh?: () => void | Promise<void>;
   onSelectedToolsChange: (toolIDs: number[]) => void;
@@ -205,6 +207,16 @@ function resolveTextareaCaretAnchor(
     left: fallbackRect.left,
     top: Math.min(Math.max(markerTop, textareaRect.top), textareaRect.bottom),
     width: fallbackRect.width,
+  };
+}
+
+function resolveContainerAnchor(anchor: HTMLElement): ChatMentionMenuAnchor {
+  const rect = anchor.getBoundingClientRect();
+  return {
+    height: rect.height,
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
   };
 }
 
@@ -417,11 +429,14 @@ function resolveMentionMenuLayout(
   const availableBelow = viewportHeight - preferredTop - MENTION_MENU_VIEWPORT_GUTTER;
   const availableAbove = preferredBottom - MENTION_MENU_VIEWPORT_GUTTER;
   const anchorInLowerHalf = anchor.top + anchor.height / 2 > viewportHeight / 2;
+  const hasUsableAbove = availableAbove >= Math.min(desiredHeight, MENTION_MENU_MIN_HEIGHT);
   const openBelow =
     placementPreference === "bottom" ||
-    !anchorInLowerHalf ||
-    availableBelow >= Math.min(desiredHeight, MENTION_MENU_MIN_HEIGHT) ||
-    availableBelow >= availableAbove;
+    (placementPreference === "top"
+      ? !hasUsableAbove
+      : !anchorInLowerHalf ||
+        availableBelow >= Math.min(desiredHeight, MENTION_MENU_MIN_HEIGHT) ||
+        availableBelow >= availableAbove);
   const availableHeight = Math.max(0, openBelow ? availableBelow : availableAbove);
   const maxHeight = Math.max(
     Math.min(MENTION_MENU_MIN_HEIGHT, availableHeight),
@@ -484,6 +499,7 @@ export function useChatMentionMenu({
   enabledKinds = DEFAULT_MENTION_MENU_KINDS,
   onFileSelect,
   onModelChange,
+  placementAnchor = "caret",
   placementPreference = "auto",
   onModelCatalogRefresh,
   onSelectedToolsChange,
@@ -689,10 +705,13 @@ export function useChatMentionMenu({
       return;
     }
 
-    const menuAnchor = resolveTextareaCaretAnchor(textareaRef.current, anchor, triggerQuery?.range.start ?? draft.length);
+    const menuAnchor =
+      placementAnchor === "container"
+        ? resolveContainerAnchor(anchor)
+        : resolveTextareaCaretAnchor(textareaRef.current, anchor, triggerQuery?.range.start ?? draft.length);
     const nextLayout = resolveMentionMenuLayout(menuAnchor, sections, window.innerWidth, window.innerHeight, placementPreference);
     setMenuLayout((current) => (mentionMenuLayoutsEqual(current, nextLayout) ? current : nextLayout));
-  }, [anchorRef, draft.length, open, placementPreference, sections, textareaRef, triggerQuery?.range.start]);
+  }, [anchorRef, draft.length, open, placementAnchor, placementPreference, sections, textareaRef, triggerQuery?.range.start]);
 
   React.useLayoutEffect(() => {
     if (!open) {

--- a/frontend/shared/components/markdown/streamdown-content.ts
+++ b/frontend/shared/components/markdown/streamdown-content.ts
@@ -55,7 +55,7 @@ const HTML_VISUAL_MARKDOWN_BLOCK_START_RE =
 const INLINE_DOLLAR_MATH_RE = /(^|[^\\$])\$([^$\n]{1,800})\$/g;
 const ESCAPED_INLINE_DOLLAR_MATH_RE = /\\\$([^$\n]{1,400})\\\$/g;
 const DISPLAY_DOLLAR_MATH_RE = /(\${2,})([\s\S]*?)(\1)/g;
-const CURRENCY_DOLLAR_RE = /(^|[^\\$])\$((?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d{1,2})?)(?!\$)(?=\b)/g;
+const CURRENCY_DOLLAR_RE = /(^|[^\\$])\$((?:\d{1,3}(?:,\d{3})+|\d+\.\d{1,2}))(?!\$)(?=\b)/g;
 
 function isMarkdownLiteralFragment(fragment: string): boolean {
   return fragment.startsWith("```") || fragment.startsWith("~~~") || fragment.startsWith("`");


### PR DESCRIPTION
## Summary

Fix mention menu placement for different chat input contexts.

The menu now uses the full input container as the anchor for the main composer, so it appears outside the input box instead of attaching to the typed `@` or `/` text line. The placement behavior is split by context:

- Centered empty-chat input: menu opens below the input box.
- Bottom conversation input: menu opens above the input box.
- Message edit input: menu opens below the edited text area.

This keeps the main composer and edit composer behavior visually consistent with their actual layout roles.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`

- [ ] Not run; reason:

## Screenshots, API examples, or logs

Before: the mention menu could open relative to the typed text line, causing incorrect placement inside or against the chat input.

After: the main composer menu anchors to the input container and opens above or below according to composer position; edit mode still opens below the edited text area.

## Configuration, migration, and compatibility notes

No configuration, database, deployment, API contract, or migration changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.