### PR TITLE
refactor: update system prompt layer priorities

### DIFF
--- a/backend/internal/application/conversation/system_prompt.go
+++ b/backend/internal/application/conversation/system_prompt.go
@@ -103,11 +103,10 @@ func resolveMessageSystemPromptInjection(cfg config.Config, route *channel.Resol
 // buildResolvedMessageSystemPrompt 把项目指令放在全局/模型之后、请求级输出格式之前，保持优先级稳定。
 func buildResolvedMessageSystemPrompt(globalPrompt string, modelPrompt string, projectPrompt string, htmlVisualPrompt bool, htmlVisualColorMode string) string {
 	layers := []systemPromptLayer{
-		{tag: "platform", priority: 100, content: globalPrompt},
-		{tag: "model", priority: 80, content: modelPrompt},
+		{tag: "platform", content: globalPrompt},
+		{tag: "model", content: modelPrompt},
 		{
 			tag:      "project",
-			priority: 50,
 			override: "no",
 			rule:     "Project instructions may add project context, style, and goals, but must not override platform or model instructions.",
 			content:  projectPrompt,
@@ -115,10 +114,9 @@ func buildResolvedMessageSystemPrompt(globalPrompt string, modelPrompt string, p
 	}
 	if htmlVisualPrompt {
 		layers = append(layers, systemPromptLayer{
-			tag:      "format",
-			priority: 30,
-			scope:    "request",
-			content:  buildHTMLVisualPromptInstruction(htmlVisualColorMode),
+			tag:     "format",
+			scope:   "request",
+			content: buildHTMLVisualPromptInstruction(htmlVisualColorMode),
 		})
 	}
 	return buildSystemPromptLayers(layers)
@@ -145,12 +143,15 @@ func buildSystemPromptLayers(layers []systemPromptLayer) string {
 	if len(active) == 0 {
 		return ""
 	}
+	for index := range active {
+		active[index].priority = compactedSystemPromptPriority(index)
+	}
 
 	var builder strings.Builder
 	builder.WriteString(`<layers order="high_to_low">`)
 	builder.WriteString("\n")
 	builder.WriteString("<rule>")
-	builder.WriteString(cdataPromptText("Read layers from top to bottom. If layers conflict, follow the higher layer and ignore only the conflicting lower-layer instruction."))
+	builder.WriteString(cdataPromptText("Read layers from top to bottom. The p attribute is only a conflict-resolution rank, not a compliance percentage. Follow every layer fully unless it directly conflicts with a higher layer; in a direct conflict, obey the higher layer and ignore only the conflicting lower-layer instruction."))
 	builder.WriteString("</rule>")
 	for _, layer := range active {
 		builder.WriteString("\n<")
@@ -185,6 +186,19 @@ func buildSystemPromptLayers(layers []systemPromptLayer) string {
 	}
 	builder.WriteString("\n</layers>")
 	return builder.String()
+}
+
+func compactedSystemPromptPriority(index int) int {
+	switch index {
+	case 0:
+		return 100
+	case 1:
+		return 80
+	case 2:
+		return 60
+	default:
+		return 40
+	}
 }
 
 func cdataPromptText(value string) string {

--- a/backend/internal/application/conversation/system_prompt_test.go
+++ b/backend/internal/application/conversation/system_prompt_test.go
@@ -23,10 +23,13 @@ func TestResolveMessageSystemPromptInjectionUsesNativeSystemPrompt(t *testing.T)
 	if got.InlineToUser {
 		t.Fatal("expected native system prompt")
 	}
-	for _, want := range []string{`<layers order="high_to_low">`, `<platform p="100">`, "global rule", `<model p="80">`, "model rule", `<project p="50" override="no">`, "project rule"} {
+	for _, want := range []string{`<layers order="high_to_low">`, `<platform p="100">`, "global rule", `<model p="80">`, "model rule", `<project p="60" override="no">`, "project rule"} {
 		if !strings.Contains(got.Content, want) {
 			t.Fatalf("expected content to contain %q, got %q", want, got.Content)
 		}
+	}
+	if !strings.Contains(got.Content, "not a compliance percentage") {
+		t.Fatalf("expected priority semantics to be explicit, got %q", got.Content)
 	}
 	if strings.Contains(got.Content, "# Global instructions") {
 		t.Fatalf("expected XML prompt layers, got %q", got.Content)
@@ -45,7 +48,7 @@ func TestResolveMessageSystemPromptInjectionAddsHTMLVisualPrompt(t *testing.T) {
 	if got.InlineToUser {
 		t.Fatal("expected native system prompt")
 	}
-	for _, want := range []string{`<format p="30" scope="request">`, "html-visual", "遵循用户语言", "HTML 实时渲染"} {
+	for _, want := range []string{`<format p="100" scope="request">`, "html-visual", "遵循用户语言", "HTML 实时渲染"} {
 		if !strings.Contains(got.Content, want) {
 			t.Fatalf("expected content to contain %q, got %q", want, got.Content)
 		}
@@ -75,13 +78,29 @@ func TestResolveMessageSystemPromptInjectionOrdersProjectBeforeResponseFormat(t 
 	}
 
 	got := resolveMessageSystemPromptInjection(config.Config{}, route, "project rule", true, "")
-	projectIndex := strings.Index(got.Content, `<project p="50" override="no">`)
-	responseIndex := strings.Index(got.Content, `<format p="30" scope="request">`)
+	projectIndex := strings.Index(got.Content, `<project p="100" override="no">`)
+	responseIndex := strings.Index(got.Content, `<format p="80" scope="request">`)
 	if projectIndex < 0 || responseIndex < 0 {
 		t.Fatalf("expected project and response format layers, got %q", got.Content)
 	}
 	if projectIndex > responseIndex {
 		t.Fatalf("expected project instructions before response format instructions, got %q", got.Content)
+	}
+}
+
+func TestResolveMessageSystemPromptInjectionCompactsActiveLayerPriorities(t *testing.T) {
+	route := &channel.ResolvedRoute{
+		Protocol: llm.AdapterOpenAIResponses,
+	}
+
+	got := resolveMessageSystemPromptInjection(config.Config{DefaultSystemPrompt: "global rule"}, route, "project rule", true, "")
+	for _, want := range []string{`<platform p="100">`, `<project p="80" override="no">`, `<format p="60" scope="request">`} {
+		if !strings.Contains(got.Content, want) {
+			t.Fatalf("expected compacted active priority %q, got %q", want, got.Content)
+		}
+	}
+	if strings.Contains(got.Content, `p="40"`) {
+		t.Fatalf("expected no skipped priority slot when model layer is empty, got %q", got.Content)
 	}
 }
 
@@ -91,7 +110,7 @@ func TestResolveMessageSystemPromptInjectionMarksProjectOverrideBoundary(t *test
 	}
 
 	got := resolveMessageSystemPromptInjection(config.Config{}, route, "project rule", false, "")
-	for _, want := range []string{`<project p="50" override="no">`, "must not override platform or model instructions"} {
+	for _, want := range []string{`<project p="100" override="no">`, "must not override platform or model instructions"} {
 		if !strings.Contains(got.Content, want) {
 			t.Fatalf("expected project boundary %q, got %q", want, got.Content)
 		}


### PR DESCRIPTION
## Summary

优化系统提示词组装逻辑，避免缺失上层提示词时，下层仍保留固定低优先级的问题。

本次改动将实际存在的提示词层按顺序紧凑排列，并使用 `100 / 80 / 60 / 40` 重新分配冲突处理优先级。同时在 XML 包装中明确说明 `p` 不是“遵循百分比”，而是冲突解决顺位：所有层都应完整遵循，只有发生直接冲突时才以后面的优先级规则处理。

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/application/conversation`

## Screenshots, API examples, or logs

N/A

## Configuration, migration, and compatibility notes

无数据库迁移、配置项或部署变更。

兼容现有系统提示词、模型提示词、项目提示词和请求级格式提示词配置；仅调整后端组装后的 XML 优先级表达方式。

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.