### PR TITLE
feat: implement provider email conflict handling

### DIFF
--- a/backend/internal/application/auth/errs.go
+++ b/backend/internal/application/auth/errs.go
@@ -2,6 +2,8 @@ package auth
 
 import "errors"
 
+const ProviderEmailConflictActionSignInThenBind = "sign_in_then_bind"
+
 var (
 	// ErrInvalidCredentials 用户名或密码错误。
 	ErrInvalidCredentials = errors.New("invalid username or password")
@@ -53,6 +55,8 @@ var (
 	ErrTwoFactorChallengeExpired = errors.New("two factor challenge expired")
 	// ErrPasswordResetFailed 表示密码重置失败，避免暴露邮箱或账号状态。
 	ErrPasswordResetFailed = errors.New("password reset failed")
+	// ErrProviderEmailConflict 表示第三方身份邮箱已存在但不能安全自动合并。
+	ErrProviderEmailConflict = errors.New("provider email conflict")
 )
 
 // IdentityProviderDeleteConflictError 携带身份源删除冲突的受影响用户数量。
@@ -66,4 +70,19 @@ func (e *IdentityProviderDeleteConflictError) Error() string {
 
 func (e *IdentityProviderDeleteConflictError) Unwrap() error {
 	return ErrIdentityProviderDeleteConflict
+}
+
+// ProviderEmailConflictError 携带第三方登录邮箱冲突的安全绑定引导信息。
+type ProviderEmailConflictError struct {
+	ProviderSlug string
+	Email        string
+	Action       string
+}
+
+func (e *ProviderEmailConflictError) Error() string {
+	return ErrProviderEmailConflict.Error()
+}
+
+func (e *ProviderEmailConflictError) Unwrap() error {
+	return ErrProviderEmailConflict
 }

--- a/backend/internal/application/auth/provider.go
+++ b/backend/internal/application/auth/provider.go
@@ -122,6 +122,12 @@ type oidcDiscoveryDocument struct {
 	UserInfoEndpoint      string
 }
 
+type githubEmailAddress struct {
+	Email    string `json:"email"`
+	Primary  bool   `json:"primary"`
+	Verified bool   `json:"verified"`
+}
+
 type providerOAuthState struct {
 	Provider      string `json:"provider"`
 	RedirectURI   string `json:"redirectURI"`
@@ -1025,7 +1031,106 @@ func (s *Service) fetchProviderUserInfo(ctx context.Context, provider domainuser
 	if err = json.Unmarshal(body, &profile); err != nil {
 		return nil, err
 	}
+	if githubEmailsURL, ok := githubEmailsEndpoint(provider, userInfoURL); ok {
+		if err = s.enrichGitHubVerifiedEmail(ctx, accessToken, profile, githubEmailsURL); err != nil {
+			return nil, err
+		}
+	}
 	return profile, nil
+}
+
+func (s *Service) enrichGitHubVerifiedEmail(ctx context.Context, accessToken string, profile map[string]interface{}, emailsURL string) error {
+	if strings.TrimSpace(accessToken) == "" || strings.TrimSpace(emailsURL) == "" {
+		return nil
+	}
+	existingEmail, _ := normalizeProviderEmail(claimString(profile, "email"))
+	if existingEmail != "" && resolveProviderEmailVerified(profile, domainuser.IdentityProvider{EmailVerifiedField: "email_verified"}) {
+		return nil
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, emailsURL, nil)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("Authorization", "Bearer "+accessToken)
+	response, err := s.providerHTTPClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("github provider emails failed: %s", response.Status)
+	}
+	var emails []githubEmailAddress
+	if err = json.Unmarshal(body, &emails); err != nil {
+		return err
+	}
+	verifiedEmail := selectGitHubVerifiedEmail(existingEmail, emails)
+	if verifiedEmail == "" {
+		return nil
+	}
+	profile["email"] = verifiedEmail
+	profile["email_verified"] = true
+	profile["verified_email"] = true
+	return nil
+}
+
+func githubEmailsEndpoint(provider domainuser.IdentityProvider, userInfoURL string) (string, bool) {
+	if !isGitHubProvider(provider, userInfoURL) {
+		return "", false
+	}
+	parsed, err := url.Parse(strings.TrimSpace(userInfoURL))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", false
+	}
+	pathValue := strings.TrimRight(parsed.Path, "/")
+	if !strings.HasSuffix(pathValue, "/user") {
+		return "", false
+	}
+	parsed.Path = pathValue + "/emails"
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), true
+}
+
+func isGitHubProvider(provider domainuser.IdentityProvider, userInfoURL string) bool {
+	if normalizeProviderSlug(provider.Slug) == "github" || normalizeProviderSlug(provider.Name) == "github" {
+		return true
+	}
+	parsed, err := url.Parse(strings.TrimSpace(userInfoURL))
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return host == "api.github.com" || strings.HasSuffix(host, ".github.com")
+}
+
+func selectGitHubVerifiedEmail(existingEmail string, emails []githubEmailAddress) string {
+	normalizedExistingEmail := strings.ToLower(strings.TrimSpace(existingEmail))
+	firstVerified := ""
+	for _, item := range emails {
+		if !item.Verified {
+			continue
+		}
+		normalizedEmail, err := normalizeProviderEmail(item.Email)
+		if err != nil || normalizedEmail == "" {
+			continue
+		}
+		if normalizedExistingEmail != "" && normalizedEmail == normalizedExistingEmail {
+			return normalizedEmail
+		}
+		if item.Primary {
+			return normalizedEmail
+		}
+		if firstVerified == "" {
+			firstVerified = normalizedEmail
+		}
+	}
+	return firstVerified
 }
 
 func (s *Service) resolveProviderEndpoints(ctx context.Context, provider domainuser.IdentityProvider) (string, string, string, error) {
@@ -1136,7 +1241,11 @@ func (s *Service) resolveProviderUser(ctx context.Context, provider domainuser.I
 		}
 	} else if normalizedEmail != "" {
 		if _, findErr := s.repo.GetByEmail(ctx, normalizedEmail); findErr == nil {
-			return nil, fmt.Errorf("email already exists; bind the provider before login")
+			return nil, &ProviderEmailConflictError{
+				ProviderSlug: provider.Slug,
+				Email:        normalizedEmail,
+				Action:       ProviderEmailConflictActionSignInThenBind,
+			}
 		} else if !errors.Is(findErr, repository.ErrNotFound) {
 			return nil, findErr
 		}
@@ -1391,7 +1500,27 @@ func resolveProviderEmailVerified(profile map[string]interface{}, provider domai
 		fields = append(fields, provider.EmailVerifiedField)
 	}
 	fields = append(fields, "email_verified", "verified_email")
+	fields = append(fields, providerSpecificEmailVerifiedFields(provider)...)
 	return claimBool(profile, uniqueClaimFields(fields)...)
+}
+
+func providerSpecificEmailVerifiedFields(provider domainuser.IdentityProvider) []string {
+	if isDiscordProvider(provider, "") {
+		return []string{"verified"}
+	}
+	return nil
+}
+
+func isDiscordProvider(provider domainuser.IdentityProvider, userInfoURL string) bool {
+	if normalizeProviderSlug(provider.Slug) == "discord" || normalizeProviderSlug(provider.Name) == "discord" {
+		return true
+	}
+	parsed, err := url.Parse(strings.TrimSpace(userInfoURL))
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return host == "discord.com" || strings.HasSuffix(host, ".discord.com") || host == "discordapp.com" || strings.HasSuffix(host, ".discordapp.com")
 }
 
 func uniqueClaimFields(fields []string) []string {

--- a/backend/internal/application/auth/provider_test.go
+++ b/backend/internal/application/auth/provider_test.go
@@ -212,6 +212,30 @@ func TestResolveProviderEmailVerifiedUsesConfiguredField(t *testing.T) {
 	}
 }
 
+func TestResolveProviderEmailVerifiedUsesDiscordVerifiedField(t *testing.T) {
+	provider := domainuser.IdentityProvider{Slug: "discord", EmailVerifiedField: "email_verified"}
+	profile := map[string]interface{}{
+		"email":    "verified@example.com",
+		"verified": true,
+	}
+
+	if !resolveProviderEmailVerified(profile, provider) {
+		t.Fatalf("expected discord verified field to be recognized as email verification")
+	}
+}
+
+func TestResolveProviderEmailVerifiedDoesNotUseGenericVerifiedField(t *testing.T) {
+	provider := domainuser.IdentityProvider{Slug: "x", EmailVerifiedField: "email_verified"}
+	profile := map[string]interface{}{
+		"email":    "verified@example.com",
+		"verified": true,
+	}
+
+	if resolveProviderEmailVerified(profile, provider) {
+		t.Fatalf("expected generic verified field to be ignored for non-discord providers")
+	}
+}
+
 func TestCompleteProviderBindAllowsSameAccountWithoutProviderEmailVerification(t *testing.T) {
 	dataKey := "test-data-key"
 	clientSecret, err := secretbox.EncryptString(dataKey, "client-secret")
@@ -285,6 +309,204 @@ func TestCompleteProviderBindAllowsSameAccountWithoutProviderEmailVerification(t
 	}
 	if len(repo.identities) != 1 || repo.identities[0].UserID != 42 || repo.identities[0].EmailVerified {
 		t.Fatalf("expected identity linked to current user without verified email, got %#v", repo.identities)
+	}
+}
+
+func TestCompleteProviderLoginAutoLinksGitHubVerifiedPrimaryEmail(t *testing.T) {
+	dataKey := "test-data-key"
+	clientSecret, err := secretbox.EncryptString(dataKey, "client-secret")
+	if err != nil {
+		t.Fatalf("encrypt client secret: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			_, _ = w.Write([]byte(`{"access_token":"access-token","token_type":"Bearer"}`))
+		case "/user":
+			if r.Header.Get("Authorization") != "Bearer access-token" {
+				t.Fatalf("unexpected user authorization header %q", r.Header.Get("Authorization"))
+			}
+			_, _ = w.Write([]byte(`{"id":123,"login":"octocat","email":null,"avatar_url":"https://example.com/avatar.png"}`))
+		case "/user/emails":
+			if r.Header.Get("Authorization") != "Bearer access-token" {
+				t.Fatalf("unexpected emails authorization header %q", r.Header.Get("Authorization"))
+			}
+			_, _ = w.Write([]byte(`[
+				{"email":"secondary@example.com","primary":false,"verified":true},
+				{"email":"Verified@Example.com","primary":true,"verified":true}
+			]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := &domainuser.IdentityProvider{
+		ID:                  10,
+		Type:                domainuser.IdentityProviderTypeOAuth2,
+		Name:                "GitHub",
+		Slug:                "github",
+		LoginEnabled:        true,
+		RegistrationEnabled: true,
+		ClientID:            "client",
+		ClientSecret:        clientSecret,
+		AuthURL:             server.URL + "/login/oauth/authorize",
+		TokenURL:            server.URL + "/login/oauth/access_token",
+		UserInfoURL:         server.URL + "/user",
+		SubjectField:        "id",
+		EmailField:          "email",
+		EmailVerifiedField:  "email_verified",
+		NameField:           "login",
+		AvatarField:         "avatar_url",
+		DefaultRole:         domainuser.RoleUser,
+	}
+	existing := &domainuser.User{
+		ID:          42,
+		Email:       "verified@example.com",
+		DisplayName: "Existing User",
+		Status:      domainuser.StatusActive,
+		Role:        domainuser.RoleUser,
+	}
+	repo := &providerLoginRepo{
+		providersBySlug: map[string]*domainuser.IdentityProvider{"github": provider},
+		usersByEmail:    map[string]*domainuser.User{existing.Email: existing},
+	}
+	service := NewService(config.Config{
+		JWTSecret:              "test-secret",
+		DataEncryptionKey:      dataKey,
+		ThirdPartyLoginEnabled: true,
+		AutoLinkVerifiedEmail:  true,
+	}, repo, nil)
+	redirectURI := "http://localhost/auth/callback?provider=github"
+	codeVerifier := strings.Repeat("a", 43)
+	state, err := service.signProviderState(providerOAuthState{
+		Provider:      "github",
+		RedirectURI:   redirectURI,
+		Intent:        providerIntentLogin,
+		CodeChallenge: providerCodeChallenge(codeVerifier),
+		ExpiresAt:     time.Now().Add(time.Minute).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("sign provider state: %v", err)
+	}
+
+	result, err := service.CompleteProviderLogin(context.Background(), "github", "code", state, redirectURI, codeVerifier, providerIntentLogin, "request-id", requestmeta.SessionAuditContext{})
+	if err != nil {
+		t.Fatalf("expected github login to auto-link existing email, got %v", err)
+	}
+	if result.User.ID != existing.ID || result.User.Email != existing.Email {
+		t.Fatalf("expected existing user login result, got %#v", result.User)
+	}
+	if repo.createUserCount != 0 {
+		t.Fatalf("expected no new user to be created, got %d", repo.createUserCount)
+	}
+	if len(repo.identities) != 1 || repo.identities[0].UserID != existing.ID || repo.identities[0].Email != existing.Email || !repo.identities[0].EmailVerified {
+		t.Fatalf("expected verified github identity linked to existing user, got %#v", repo.identities)
+	}
+	if repo.createSessionCount != 1 || repo.updateLastLoginUserID != existing.ID {
+		t.Fatalf("expected session and last login for existing user, sessions=%d lastLogin=%d", repo.createSessionCount, repo.updateLastLoginUserID)
+	}
+}
+
+func TestCompleteProviderLoginReturnsErrorWhenGitHubEmailsUnavailable(t *testing.T) {
+	dataKey := "test-data-key"
+	clientSecret, err := secretbox.EncryptString(dataKey, "client-secret")
+	if err != nil {
+		t.Fatalf("encrypt client secret: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			_, _ = w.Write([]byte(`{"access_token":"access-token","token_type":"Bearer"}`))
+		case "/user":
+			_, _ = w.Write([]byte(`{"id":123,"login":"octocat","email":null}`))
+		case "/user/emails":
+			http.Error(w, `{"message":"Requires user:email scope"}`, http.StatusForbidden)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := &domainuser.IdentityProvider{
+		ID:                  10,
+		Type:                domainuser.IdentityProviderTypeOAuth2,
+		Name:                "GitHub",
+		Slug:                "github",
+		LoginEnabled:        true,
+		RegistrationEnabled: true,
+		ClientID:            "client",
+		ClientSecret:        clientSecret,
+		AuthURL:             server.URL + "/login/oauth/authorize",
+		TokenURL:            server.URL + "/login/oauth/access_token",
+		UserInfoURL:         server.URL + "/user",
+		SubjectField:        "id",
+		EmailField:          "email",
+		EmailVerifiedField:  "email_verified",
+		NameField:           "login",
+		DefaultRole:         domainuser.RoleUser,
+	}
+	repo := &providerLoginRepo{
+		providersBySlug: map[string]*domainuser.IdentityProvider{"github": provider},
+	}
+	service := NewService(config.Config{
+		JWTSecret:              "test-secret",
+		DataEncryptionKey:      dataKey,
+		ThirdPartyLoginEnabled: true,
+		AutoLinkVerifiedEmail:  true,
+	}, repo, nil)
+	redirectURI := "http://localhost/auth/callback?provider=github"
+	codeVerifier := strings.Repeat("a", 43)
+	state, err := service.signProviderState(providerOAuthState{
+		Provider:      "github",
+		RedirectURI:   redirectURI,
+		Intent:        providerIntentLogin,
+		CodeChallenge: providerCodeChallenge(codeVerifier),
+		ExpiresAt:     time.Now().Add(time.Minute).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("sign provider state: %v", err)
+	}
+
+	_, err = service.CompleteProviderLogin(context.Background(), "github", "code", state, redirectURI, codeVerifier, providerIntentLogin, "request-id", requestmeta.SessionAuditContext{})
+	if err == nil || !strings.Contains(err.Error(), "github provider emails failed") {
+		t.Fatalf("expected github email lookup error, got %v", err)
+	}
+	if repo.createUserCount != 0 || len(repo.identities) != 0 {
+		t.Fatalf("expected no user or identity side effect, users=%d identities=%#v", repo.createUserCount, repo.identities)
+	}
+}
+
+func TestResolveProviderUserReturnsStructuredEmailConflict(t *testing.T) {
+	existing := &domainuser.User{
+		ID:     42,
+		Email:  "existing@example.com",
+		Status: domainuser.StatusActive,
+	}
+	repo := &providerLoginRepo{usersByEmail: map[string]*domainuser.User{existing.Email: existing}}
+	service := NewService(config.Config{JWTSecret: "test-secret", AutoLinkVerifiedEmail: true}, repo, nil)
+	provider := domainuser.IdentityProvider{
+		ID:                  10,
+		Type:                domainuser.IdentityProviderTypeOAuth2,
+		Name:                "Consumer OAuth",
+		Slug:                "consumer",
+		LoginEnabled:        true,
+		RegistrationEnabled: true,
+		DefaultRole:         domainuser.RoleUser,
+	}
+
+	_, err := service.resolveProviderUser(context.Background(), provider, "sub-1", existing.Email, "Consumer User", "", false, `{"sub":"sub-1"}`, providerIntentLogin)
+	var conflictErr *ProviderEmailConflictError
+	if !errors.As(err, &conflictErr) {
+		t.Fatalf("expected structured email conflict, got %v", err)
+	}
+	if conflictErr.ProviderSlug != provider.Slug || conflictErr.Email != existing.Email || conflictErr.Action != ProviderEmailConflictActionSignInThenBind {
+		t.Fatalf("unexpected conflict details: %#v", conflictErr)
+	}
+	if repo.createUserCount != 0 || len(repo.identities) != 0 {
+		t.Fatalf("expected no user or identity side effect, users=%d identities=%#v", repo.createUserCount, repo.identities)
 	}
 }
 
@@ -498,6 +720,8 @@ type providerLoginRepo struct {
 	deletedIdentityID         uint
 	createIdentityErr         error
 	duplicateUsernameAttempts int
+	createSessionCount        int
+	updateLastLoginUserID     uint
 	usersByID                 map[uint]*domainuser.User
 	usersByEmail              map[string]*domainuser.User
 	credentialsByUserID       map[uint]*domainuser.Credential
@@ -614,6 +838,16 @@ func (r *providerLoginRepo) CreateUserIdentity(ctx context.Context, identity *do
 	return identity, nil
 }
 
+func (r *providerLoginRepo) CreateSession(ctx context.Context, item *domainuser.Session) error {
+	r.createSessionCount++
+	return nil
+}
+
+func (r *providerLoginRepo) UpdateLastLogin(ctx context.Context, userID uint) error {
+	r.updateLastLoginUserID = userID
+	return nil
+}
+
 func (r *providerLoginRepo) ListUserIdentitiesByUserID(ctx context.Context, userID uint) ([]domainuser.UserIdentity, error) {
 	results := make([]domainuser.UserIdentity, 0)
 	for _, identity := range r.identities {
@@ -633,6 +867,10 @@ func (r *providerLoginRepo) GetCredentialByUserID(ctx context.Context, userID ui
 		return nil, repository.ErrNotFound
 	}
 	return credential, nil
+}
+
+func (r *providerLoginRepo) GetUserTwoFactorByUserID(ctx context.Context, userID uint) (*domainuser.UserTwoFactor, error) {
+	return nil, repository.ErrNotFound
 }
 
 func (r *providerLoginRepo) DeleteUserIdentity(ctx context.Context, userID uint, identityID uint) error {

--- a/backend/internal/shared/response/error_code.go
+++ b/backend/internal/shared/response/error_code.go
@@ -74,7 +74,6 @@ var exactErrorSpecs = map[string]errorSpec{
 	"email registration is disabled":                                        {Code: "auth.email_registration_disabled", Message: "email registration is disabled"},
 	"email verification is disabled":                                        {Code: "auth.email_verification_disabled", Message: "email verification is disabled"},
 	"email already exists":                                                  {Code: "auth.email_already_exists", Message: "email already exists"},
-	"email already exists; bind the provider before login":                  {Code: "auth.provider_email_conflict", Message: "email already exists; bind the provider before login"},
 	"user email is invalid":                                                 {Code: "auth.invalid_email", Message: "invalid email"},
 	"admin email is invalid":                                                {Code: "auth.invalid_email", Message: "invalid email"},
 	"invalid email":                                                         {Code: "auth.invalid_email", Message: "invalid email"},

--- a/backend/internal/shared/response/error_code_test.go
+++ b/backend/internal/shared/response/error_code_test.go
@@ -25,7 +25,6 @@ func TestInferErrorCode(t *testing.T) {
 		{name: "provider", status: http.StatusBadRequest, msg: "invalid oauth state", want: "auth.oauth_state_invalid"},
 		{name: "verification", status: http.StatusBadRequest, msg: "verification code is invalid or expired", want: "auth.verification_code_invalid"},
 		{name: "email registration", status: http.StatusBadRequest, msg: "email registration is disabled", want: "auth.email_registration_disabled"},
-		{name: "provider email conflict", status: http.StatusBadRequest, msg: "email already exists; bind the provider before login", want: "auth.provider_email_conflict"},
 		{name: "two factor already enabled", status: http.StatusBadRequest, msg: "two factor authentication is already enabled", want: "auth.two_factor_already_enabled"},
 		{name: "provider redirect uri", status: http.StatusBadRequest, msg: "invalid redirect uri", want: "auth.invalid_redirect_uri"},
 		{name: "user setting value", status: http.StatusBadRequest, msg: "invalid value for chat.file_mode: must be one of 'auto', 'rag'", want: "user_settings.invalid_value"},

--- a/backend/internal/transport/http/auth/handler.go
+++ b/backend/internal/transport/http/auth/handler.go
@@ -571,6 +571,21 @@ func (h *Handler) CompleteProviderLogin(c *gin.Context) {
 		middleware.ResolveSessionAuditContext(c),
 	)
 	if err != nil {
+		var emailConflictErr *appauth.ProviderEmailConflictError
+		if errors.As(err, &emailConflictErr) {
+			response.ErrorWithDetails(
+				c,
+				http.StatusConflict,
+				"auth.provider_email_conflict",
+				err.Error(),
+				gin.H{
+					"providerSlug": emailConflictErr.ProviderSlug,
+					"email":        emailConflictErr.Email,
+					"action":       emailConflictErr.Action,
+				},
+			)
+			return
+		}
 		response.ErrorFrom(c, http.StatusBadRequest, err)
 		return
 	}

--- a/frontend/features/auth/components/auth-callback-page.tsx
+++ b/frontend/features/auth/components/auth-callback-page.tsx
@@ -3,6 +3,8 @@
 import * as React from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { Link2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { SpinnerLabel } from "@/components/ui/spinner";
 import {
   providerPKCEStorageKey,
@@ -11,16 +13,42 @@ import {
 } from "@/features/auth/model/login-page";
 import { useLocalizedErrorMessage } from "@/i18n/use-localized-error";
 import { completeProviderBind, completeProviderLogin } from "@/shared/api/auth";
+import { ApiError } from "@/shared/api/http-client";
 import { DEFAULT_AUTH_NEXT_PATH, normalizeAuthNextPath } from "@/shared/auth/local-path";
+import { AppLogo } from "@/shared/components/app-logo";
 import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
 import { writeSessionSnapshot } from "@/shared/auth/session";
+
+const PROVIDER_EMAIL_CONFLICT_ERROR_CODE = "auth.provider_email_conflict";
+const PROVIDER_EMAIL_CONFLICT_ACTION_SIGN_IN_THEN_BIND = "sign_in_then_bind";
+const ACCOUNT_SETTINGS_PATH = "/setting/account";
+
+type ProviderEmailConflictDetails = {
+  action?: string;
+  providerSlug?: string;
+  email?: string;
+};
+
+type EmailConflictState = {
+  providerSlug?: string;
+  email?: string;
+};
 
 export function AuthCallbackPage() {
   const t = useTranslations("login.oauthCallback");
   const resolveErrorMessage = useLocalizedErrorMessage();
   const router = useRouter();
   const [error, setError] = React.useState("");
+  const [emailConflict, setEmailConflict] = React.useState<EmailConflictState | null>(null);
   const handledRef = React.useRef(false);
+
+  const redirectToLogin = React.useCallback(() => {
+    router.replace("/login");
+  }, [router]);
+
+  const redirectToLoginWithAccountSettingsNext = React.useCallback(() => {
+    router.replace(`/login?next=${encodeURIComponent(ACCOUNT_SETTINGS_PATH)}`);
+  }, [router]);
 
   React.useEffect(() => {
     if (handledRef.current) {
@@ -85,15 +113,100 @@ export function AuthCallbackPage() {
         router.replace(nextPath);
       })
       .catch((caught) => {
+        if (isProviderEmailConflictError(caught)) {
+          const details = caught.details as ProviderEmailConflictDetails | undefined;
+          setEmailConflict({
+            providerSlug: details?.providerSlug?.trim() || undefined,
+            email: details?.email?.trim() || undefined,
+          });
+          return;
+        }
         setError(resolveErrorMessage(caught, t("loginFailed")));
       });
   }, [resolveErrorMessage, router, t]);
 
+  const conflictProviderLabel = React.useMemo(() => {
+    if (!emailConflict?.providerSlug) {
+      return t("emailConflict.providerUnknown");
+    }
+    return emailConflict.providerSlug;
+  }, [emailConflict?.providerSlug, t]);
+
   return (
-    <main className="flex min-h-screen items-center justify-center px-4 text-sm text-muted-foreground">
-      {error ? <span>{error}</span> : <SpinnerLabel>{t("loading")}</SpinnerLabel>}
+    <main className="flex min-h-screen items-center justify-center px-4 py-8 text-foreground">
+      <div className="w-full max-w-[360px]">
+        <div className="flex flex-col items-center text-center">
+          <AppLogo width={32} height={32} priority className="h-9 w-auto" />
+        </div>
+
+        {error ? (
+          <div className="mt-7 space-y-5 text-center">
+            <div className="space-y-2">
+              <h1 className="text-xl font-semibold leading-7">{t("errorTitle")}</h1>
+              <p className="break-words text-sm leading-6 text-muted-foreground">{error}</p>
+            </div>
+            <Button type="button" className="h-9 w-full rounded-md bg-foreground text-sm font-semibold text-background shadow-none hover:bg-foreground/90" onClick={redirectToLogin}>
+              {t("backToLogin")}
+            </Button>
+          </div>
+        ) : emailConflict ? (
+          <div className="mt-7 space-y-5">
+            <div className="space-y-2 text-center">
+              <div className="space-y-2">
+                <h1 className="text-xl font-semibold leading-7">{t("emailConflict.title")}</h1>
+                <p className="text-sm leading-6 text-muted-foreground">{t("emailConflict.description")}</p>
+              </div>
+            </div>
+
+            <div className="space-y-2 rounded-md bg-muted/60 px-3 py-3 text-sm">
+              <div className="flex min-w-0 items-center justify-between gap-3">
+                <span className="shrink-0 text-muted-foreground">{t("emailConflict.providerLabel")}</span>
+                <span className="min-w-0 truncate text-right font-medium text-foreground">{conflictProviderLabel}</span>
+              </div>
+              {emailConflict.email ? (
+                <div className="flex min-w-0 items-center justify-between gap-3">
+                  <span className="shrink-0 text-muted-foreground">{t("emailConflict.emailLabel")}</span>
+                  <span className="min-w-0 truncate text-right font-medium text-foreground">{emailConflict.email}</span>
+                </div>
+              ) : null}
+            </div>
+
+            <div className="space-y-3">
+              <Button type="button" className="h-9 w-full rounded-md bg-foreground text-sm font-semibold text-background shadow-none hover:bg-foreground/90" onClick={redirectToLoginWithAccountSettingsNext}>
+                <Link2 className="size-4" aria-hidden="true" />
+                {t("emailConflict.signInExistingAccount")}
+              </Button>
+            </div>
+
+            <p className="text-center text-xs leading-5 text-muted-foreground">
+              {t("emailConflict.notePrefix")}
+              <button
+                type="button"
+                className="font-medium text-foreground underline-offset-4 hover:underline focus-visible:underline focus-visible:outline-none"
+                onClick={redirectToLogin}
+              >
+                {t("emailConflict.noteLink")}
+              </button>
+              {t("emailConflict.noteSuffix")}
+            </p>
+          </div>
+        ) : (
+          <div className="mt-7 flex flex-col items-center gap-3 text-center text-sm text-muted-foreground">
+            <SpinnerLabel>{t("loading")}</SpinnerLabel>
+            <p>{t("loadingDescription")}</p>
+          </div>
+        )}
+      </div>
     </main>
   );
+}
+
+function isProviderEmailConflictError(error: unknown): boolean {
+  if (!(error instanceof ApiError) || error.errorCode !== PROVIDER_EMAIL_CONFLICT_ERROR_CODE) {
+    return false;
+  }
+  const details = error.details as ProviderEmailConflictDetails | undefined;
+  return details?.action === PROVIDER_EMAIL_CONFLICT_ACTION_SIGN_IN_THEN_BIND;
 }
 
 function parseProviderState(raw: string): { next: string; intent: "login" | "register" | "bind" } {

--- a/frontend/i18n/messages/en-US/login.json
+++ b/frontend/i18n/messages/en-US/login.json
@@ -16,6 +16,7 @@
   "signIn": "Sign in",
   "signingIn": "Signing in",
   "verifyAndSignIn": "Verify and sign in",
+  "backToLogin": "Back to sign-in",
   "backToPasswordLogin": "Back to password sign-in",
   "backToLoginMethods": "Back to sign-in methods",
   "rememberPassword": "Remembered your password?",
@@ -54,6 +55,20 @@
     "bindSessionExpired": "Your session expired. Please sign in again before binding this identity provider.",
     "bindFailed": "Failed to bind identity provider",
     "loginFailed": "Third-party sign-in failed",
-    "loading": "Signing in"
+    "errorTitle": "Third-party sign-in was not completed",
+    "loading": "Signing in",
+    "loadingDescription": "Verifying the third-party identity. Please wait.",
+    "backToLogin": "Back to sign-in",
+    "emailConflict": {
+      "title": "This email already has an account",
+      "description": "For account security, the third-party identity cannot be merged directly into an existing account. Sign in to the existing account first, then link the third-party identity in account settings.",
+      "providerLabel": "Provider",
+      "providerUnknown": "Unknown provider",
+      "emailLabel": "Email",
+      "notePrefix": "To use another account, ",
+      "noteLink": "return to sign-in",
+      "noteSuffix": " and choose again.",
+      "signInExistingAccount": "Sign in to existing account"
+    }
   }
 }

--- a/frontend/i18n/messages/zh-CN/login.json
+++ b/frontend/i18n/messages/zh-CN/login.json
@@ -16,6 +16,7 @@
   "signIn": "登录",
   "signingIn": "登录中",
   "verifyAndSignIn": "验证并登录",
+  "backToLogin": "返回登录",
   "backToPasswordLogin": "返回账号密码登录",
   "backToLoginMethods": "返回登录方式",
   "rememberPassword": "记得密码?",
@@ -54,6 +55,20 @@
     "bindSessionExpired": "登录状态已失效，请重新登录后再绑定",
     "bindFailed": "身份源绑定失败",
     "loginFailed": "第三方登录失败",
-    "loading": "登录中"
+    "errorTitle": "第三方登录未完成",
+    "loading": "登录中",
+    "loadingDescription": "正在校验第三方身份，请稍候。",
+    "backToLogin": "返回登录页",
+    "emailConflict": {
+      "title": "该邮箱已有账号",
+      "description": "为保护账号安全，第三方身份无法直接合并到已有账号。请先登录已有账号，前往账号设置中绑定第三方身份。",
+      "providerLabel": "身份源",
+      "providerUnknown": "未知身份源",
+      "emailLabel": "邮箱",
+      "notePrefix": "如果想继续使用其他账号，请",
+      "noteLink": "返回登录页",
+      "noteSuffix": "后重新选择。",
+      "signInExistingAccount": "登录已有账号"
+    }
   }
 }


### PR DESCRIPTION
## Summary

优化第三方登录邮箱匹配逻辑，避免 GitHub、Discord 等 OAuth 登录在邮箱已存在时错误创建新账号。后端在可确认第三方邮箱已验证时自动绑定已有账号；无法安全确认时返回结构化邮箱冲突错误，并由前端展示明确的回调提示，引导用户登录已有账号后前往账号设置绑定第三方身份。

同时优化 OAuth callback 页面错误态和邮箱冲突态 UI，清理旧字符串错误映射，保持前后端错误语义一致。

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [x] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [x] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/application/auth ./internal/application/settings ./internal/transport/http/auth ./internal/shared/response`
- [x] `git diff --check`

## Screenshots, API examples, or logs

OAuth 邮箱冲突时返回 `409 auth.provider_email_conflict`，并携带 `providerSlug`、`email`、`action` 用于前端展示和引导。

## Configuration, migration, and compatibility notes

无需配置或数据库迁移。GitHub 登录会补充读取已验证邮箱；未安全验证的第三方邮箱不会静默合并到已有账号。

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.