### PR TITLE
feat: add user avatar management functionality

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -61,6 +61,7 @@ import (
 	memoryhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/memory"
 	promptpresethttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/promptpreset"
 	settingshttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/settings"
+	userhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/user"
 	usersettingshttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/usersettings"
 	"github.com/gin-gonic/gin"
 	"github.com/go-redis/redis/v8"
@@ -77,6 +78,24 @@ type App struct {
 	redis            *redis.Client
 	geoResolver      *geoip.Client
 	backgroundCancel context.CancelFunc
+}
+
+type avatarContentOpener struct {
+	conversationService *conversation.Service
+}
+
+func (o avatarContentOpener) OpenAvatarFileContent(ctx context.Context, userID uint, fileID string) (*user.AvatarFileContent, error) {
+	content, err := o.conversationService.OpenFileContent(ctx, userID, fileID)
+	if err != nil {
+		return nil, err
+	}
+	return &user.AvatarFileContent{
+		Reader:      content.Reader,
+		ContentType: content.ContentType,
+		SizeBytes:   content.SizeBytes,
+		ModTime:     content.ModTime,
+		FileName:    content.File.FileName,
+	}, nil
 }
 
 // NewApp 创建应用。
@@ -220,9 +239,14 @@ func NewApp() (*App, error) {
 	conversationService.SetAuditWriter(auditService)
 	conversationService.SetObjectStoreProvider(objectStoreProvider)
 	conversationService.SetMCPRepository(mcpRepo)
+	userService.SetAvatarContentOpener(avatarContentOpener{conversationService: conversationService})
+	userService.SetAvatarFileValidator(conversationService)
+	authService.SetAvatarFileValidator(conversationService)
 	memoryService.SetCacheInvalidator(conversationService.InvalidateMemoryCache)
 	conversationHandler := conversationhttp.NewHandler(conversationService, runtimeCfg)
 	conversationModule := conversationhttp.NewModule(conversationHandler)
+	userHandler := userhttp.NewHandler(userService)
+	userModule := userhttp.NewModule(userHandler)
 	mcpService := appmcp.NewServiceWithRuntime(runtimeCfg, mcpRepo, mcpClient)
 	mcpService.SetSystemEventWriter(systemEventService)
 	mcpHandler := mcphttp.NewHandler(mcpService)
@@ -265,6 +289,7 @@ func NewApp() (*App, error) {
 		PromptPreset: promptPresetModule,
 		Settings:     settingsModule,
 		UserSettings: userSettingsModule,
+		User:         userModule,
 		StartupLog: func(log *zap.Logger) {
 			if log == nil || bootstrapSuperAdmin == nil {
 				return

--- a/backend/internal/application/auth/service.go
+++ b/backend/internal/application/auth/service.go
@@ -47,6 +47,7 @@ type Service struct {
 	logger               *zap.Logger
 	storeProvider        appstorage.Provider
 	auditWriter          auditWriter
+	avatarFileValidator  avatarFileValidator
 }
 
 type subscriptionResolver interface {
@@ -59,6 +60,10 @@ type subscriptionResolver interface {
 
 type auditWriter interface {
 	Write(ctx context.Context, requestID string, actorUserID uint, action string, resource string, resourceID string, ip string, userAgent string, detail interface{})
+}
+
+type avatarFileValidator interface {
+	ValidateImageFile(ctx context.Context, userID uint, fileID string) error
 }
 
 // NewService 创建服务。
@@ -106,6 +111,11 @@ func (s *Service) SetObjectStoreProvider(provider appstorage.Provider) {
 	if provider != nil {
 		s.storeProvider = provider
 	}
+}
+
+// SetAvatarFileValidator 注入头像文件校验能力。
+func (s *Service) SetAvatarFileValidator(validator avatarFileValidator) {
+	s.avatarFileValidator = validator
 }
 
 // ShouldUseSecureCookies 判断当前运行环境是否必须写入 Secure Cookie。
@@ -695,11 +705,21 @@ func sessionActivityInputFromSnapshot(snapshot sessionAuditSnapshot, lastSeenAt 
 // UpdateProfile 更新当前用户资料。
 func (s *Service) UpdateProfile(ctx context.Context, userID uint, input UpdateProfileInput) (*domainuser.User, error) {
 	updateInput := repository.UpdateUserFieldsInput{}
+	avatarFileReferenceRequested := false
 
 	if input.AvatarURL != nil {
 		nextAvatarURL := strings.TrimSpace(*input.AvatarURL)
 		if err := validateAvatarURL(nextAvatarURL); err != nil {
 			return nil, err
+		}
+		if fileID, ok := domainuser.ParseFileAvatarURL(nextAvatarURL); ok {
+			avatarFileReferenceRequested = true
+			if s.avatarFileValidator == nil {
+				return nil, ErrInvalidAvatarURL
+			}
+			if err := s.avatarFileValidator.ValidateImageFile(ctx, userID, fileID); err != nil {
+				return nil, ErrInvalidAvatarURL
+			}
 		}
 		updateInput.AvatarURL = &nextAvatarURL
 	}
@@ -740,7 +760,11 @@ func (s *Service) UpdateProfile(ctx context.Context, userID uint, input UpdatePr
 		updateInput.AppearancePreferences = &normalizedAppearancePreferences
 	}
 
-	return s.repo.UpdateProfile(ctx, userID, updateInput)
+	item, err := s.repo.UpdateProfile(ctx, userID, updateInput)
+	if avatarFileReferenceRequested && errors.Is(err, repository.ErrNotFound) {
+		return nil, ErrInvalidAvatarURL
+	}
+	return item, err
 }
 
 func normalizeAppearancePreferences(raw string) (string, error) {
@@ -1543,9 +1567,15 @@ func normalizeEditableUsername(raw string) (string, error) {
 	return username, nil
 }
 
-// validateAvatarURL 校验头像 URL 合法性；空值、相对路径和 generated: 前缀均视为合法。
+// validateAvatarURL 校验头像 URL 合法性；空值、相对路径、generated: 前缀和 file: 引用均视为合法。
 func validateAvatarURL(raw string) error {
 	if raw == "" || strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "generated:github:") {
+		return nil
+	}
+	if strings.HasPrefix(raw, "file:") {
+		if _, ok := domainuser.ParseFileAvatarURL(raw); !ok {
+			return ErrInvalidAvatarURL
+		}
 		return nil
 	}
 

--- a/backend/internal/application/conversation/errs.go
+++ b/backend/internal/application/conversation/errs.go
@@ -23,6 +23,8 @@ var (
 	ErrInvalidFileName = errors.New("invalid file name")
 	// ErrFileNotFound 文件不存在。
 	ErrFileNotFound = errors.New("file not found")
+	// ErrFileInUse 文件正在被头像等资源使用。
+	ErrFileInUse = errors.New("file in use")
 	// ErrStorageQuotaExceeded 文件配额超限。
 	ErrStorageQuotaExceeded = errors.New("storage quota exceeded")
 	// ErrFileTooLarge 文件过大。

--- a/backend/internal/application/conversation/service.go
+++ b/backend/internal/application/conversation/service.go
@@ -253,6 +253,7 @@ func NewServiceWithRuntime(
 			InvalidFileReference: ErrInvalidFileReference,
 			InvalidFileName:      ErrInvalidFileName,
 			FileNotFound:         ErrFileNotFound,
+			FileInUse:            ErrFileInUse,
 			StorageQuotaExceeded: ErrStorageQuotaExceeded,
 			FileTooLarge:         ErrFileTooLarge,
 			MIMEBlocked:          ErrMIMEBlocked,

--- a/backend/internal/application/conversation/service_file.go
+++ b/backend/internal/application/conversation/service_file.go
@@ -77,6 +77,11 @@ func (s *Service) OpenFileContent(ctx context.Context, userID uint, fileID strin
 	return s.uploadSvc.OpenFileContent(ctx, userID, fileID)
 }
 
+// ValidateImageFile 确认文件属于当前用户且可作为图片使用。
+func (s *Service) ValidateImageFile(ctx context.Context, userID uint, fileID string) error {
+	return s.uploadSvc.ValidateImageFile(ctx, userID, fileID)
+}
+
 // GetFileExtract 读取当前用户文件的提取文本产物。
 func (s *Service) GetFileExtract(ctx context.Context, userID uint, fileID string) (*FileExtractResult, error) {
 	normalizedFileID := strings.TrimSpace(fileID)

--- a/backend/internal/application/upload/service.go
+++ b/backend/internal/application/upload/service.go
@@ -45,6 +45,7 @@ type ErrorSet struct {
 	InvalidFileReference error
 	InvalidFileName      error
 	FileNotFound         error
+	FileInUse            error
 	StorageQuotaExceeded error
 	FileTooLarge         error
 	MIMEBlocked          error
@@ -453,6 +454,9 @@ func (s *Service) deleteFile(ctx context.Context, userID uint, fileID string, op
 		if options.RequireUnreferenced && errors.Is(err, repository.ErrConflict) {
 			return nil, false, nil
 		}
+		if errors.Is(err, repository.ErrConflict) {
+			return nil, false, s.errFileInUse()
+		}
 		return nil, false, err
 	}
 	if shouldRemovePhysical {
@@ -497,6 +501,27 @@ func (s *Service) UpdateFileRagOptOut(ctx context.Context, userID uint, fileID s
 		return nil, s.errInvalidFileReference()
 	}
 	return s.repo.UpdateFileObjectRagOptOut(ctx, userID, normalizedFileID, ragOptOut)
+}
+
+// ValidateImageFile 确认文件属于当前用户且可作为图片头像使用。
+func (s *Service) ValidateImageFile(ctx context.Context, userID uint, fileID string) error {
+	normalizedFileID := strings.TrimSpace(fileID)
+	if normalizedFileID == "" {
+		return s.errInvalidFileReference()
+	}
+
+	item, err := s.repo.GetActiveFileObjectByID(ctx, userID, normalizedFileID)
+	if err != nil {
+		return err
+	}
+	if item.FileCategory == fileCategoryImage {
+		return nil
+	}
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(item.DetectedMIME)), "image/") ||
+		strings.HasPrefix(strings.ToLower(strings.TrimSpace(item.MimeType)), "image/") {
+		return nil
+	}
+	return s.errMIMEBlocked()
 }
 
 // OpenFileContent 打开当前用户的文件内容。
@@ -612,6 +637,10 @@ func (s *Service) errInvalidFileName() error {
 
 func (s *Service) errFileNotFound() error {
 	return pickError(s.errors.FileNotFound, "file not found")
+}
+
+func (s *Service) errFileInUse() error {
+	return pickError(s.errors.FileInUse, "file in use")
 }
 
 func (s *Service) errStorageQuotaExceeded() error {

--- a/backend/internal/application/upload/service_test.go
+++ b/backend/internal/application/upload/service_test.go
@@ -261,6 +261,46 @@ func TestNormalizeDetectedMIMEDowngradesActiveContent(t *testing.T) {
 	}
 }
 
+func TestValidateImageFile(t *testing.T) {
+	repo := newUploadTestRepo()
+	store := newUploadTestStore()
+	service := newUploadTestService(repo, store)
+	image := domainconversation.FileObject{
+		FileID:       "file_image",
+		UserID:       1,
+		FileName:     "avatar.png",
+		MimeType:     "image/png",
+		DetectedMIME: "image/png",
+		FileCategory: "image",
+		Status:       "active",
+	}
+	repo.files = append(repo.files, image)
+
+	if err := service.ValidateImageFile(context.Background(), 1, image.FileID); err != nil {
+		t.Fatalf("ValidateImageFile() failed: %v", err)
+	}
+}
+
+func TestValidateImageFileRejectsNonImage(t *testing.T) {
+	repo := newUploadTestRepo()
+	store := newUploadTestStore()
+	service := newUploadTestService(repo, store)
+	file := domainconversation.FileObject{
+		FileID:       "file_text",
+		UserID:       1,
+		FileName:     "notes.txt",
+		MimeType:     "text/plain",
+		DetectedMIME: "text/plain",
+		FileCategory: "text",
+		Status:       "active",
+	}
+	repo.files = append(repo.files, file)
+
+	if err := service.ValidateImageFile(context.Background(), 1, file.FileID); err == nil {
+		t.Fatal("ValidateImageFile() should reject non-image files")
+	}
+}
+
 func newUploadTestService(repo *uploadTestRepo, store *uploadTestStore) *Service {
 	cfg := config.Config{
 		MaxUploadFileBytes:    1024 * 1024,

--- a/backend/internal/application/user/errs.go
+++ b/backend/internal/application/user/errs.go
@@ -15,6 +15,8 @@ var (
 	ErrUserNotFound = errors.New("user not found")
 	// ErrInvalidAvatarURL 非法头像地址。
 	ErrInvalidAvatarURL = errors.New("invalid avatar url")
+	// ErrAvatarNotFound 头像不存在。
+	ErrAvatarNotFound = errors.New("avatar not found")
 	// ErrInvalidEmail 非法邮箱。
 	ErrInvalidEmail = errors.New("invalid user email")
 	// ErrInvalidPhone 非法手机号。

--- a/backend/internal/application/user/service.go
+++ b/backend/internal/application/user/service.go
@@ -3,7 +3,10 @@ package user
 import (
 	"context"
 	"errors"
+	"io"
+	"mime"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 	"unicode"
@@ -19,7 +22,17 @@ const passwordHashCost = 12
 
 // Service 封装用户业务能力。
 type Service struct {
-	repo repository.UserRepository
+	repo                repository.UserRepository
+	avatarContentOpener avatarContentOpener
+	avatarFileValidator avatarFileValidator
+}
+
+type avatarContentOpener interface {
+	OpenAvatarFileContent(ctx context.Context, userID uint, fileID string) (*AvatarFileContent, error)
+}
+
+type avatarFileValidator interface {
+	ValidateImageFile(ctx context.Context, userID uint, fileID string) error
 }
 
 const (
@@ -32,6 +45,33 @@ func NewService(repo repository.UserRepository) *Service {
 	return &Service{repo: repo}
 }
 
+// SetAvatarContentOpener 注入头像文件内容读取能力。
+func (s *Service) SetAvatarContentOpener(opener avatarContentOpener) {
+	s.avatarContentOpener = opener
+}
+
+// SetAvatarFileValidator 注入头像文件校验能力。
+func (s *Service) SetAvatarFileValidator(validator avatarFileValidator) {
+	s.avatarFileValidator = validator
+}
+
+// AvatarFileContent 描述用户域读取到的头像源文件内容。
+type AvatarFileContent struct {
+	Reader      io.ReadCloser
+	ContentType string
+	SizeBytes   int64
+	ModTime     time.Time
+	FileName    string
+}
+
+// AvatarContentResult 描述当前头像内容读取结果。
+type AvatarContentResult struct {
+	Reader      io.ReadCloser
+	ContentType string
+	SizeBytes   int64
+	ModTime     time.Time
+}
+
 // GetByID 查询用户详情。
 func (s *Service) GetByID(ctx context.Context, userID uint) (*domainuser.User, error) {
 	item, err := s.repo.GetByID(ctx, userID)
@@ -42,6 +82,56 @@ func (s *Service) GetByID(ctx context.Context, userID uint) (*domainuser.User, e
 		return nil, err
 	}
 	return item, nil
+}
+
+// GetByPublicID 按公开 ID 查询用户详情。
+func (s *Service) GetByPublicID(ctx context.Context, publicID string) (*domainuser.User, error) {
+	normalizedPublicID := strings.TrimSpace(publicID)
+	if normalizedPublicID == "" {
+		return nil, ErrUserNotFound
+	}
+	item, err := s.repo.GetByPublicID(ctx, normalizedPublicID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrUserNotFound
+		}
+		return nil, err
+	}
+	return item, nil
+}
+
+// OpenAvatarContent 打开用户当前上传头像内容。
+func (s *Service) OpenAvatarContent(ctx context.Context, publicID string) (*AvatarContentResult, error) {
+	item, err := s.GetByPublicID(ctx, publicID)
+	if err != nil {
+		return nil, err
+	}
+	fileID, ok := domainuser.ParseFileAvatarURL(item.AvatarURL)
+	if !ok || s.avatarContentOpener == nil {
+		return nil, ErrAvatarNotFound
+	}
+
+	content, err := s.avatarContentOpener.OpenAvatarFileContent(ctx, item.ID, fileID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrAvatarNotFound
+		}
+		return nil, err
+	}
+	contentType := strings.TrimSpace(content.ContentType)
+	if contentType == "" {
+		contentType = mime.TypeByExtension(strings.ToLower(filepath.Ext(content.FileName)))
+	}
+	if !strings.HasPrefix(strings.ToLower(contentType), "image/") {
+		_ = content.Reader.Close()
+		return nil, ErrAvatarNotFound
+	}
+	return &AvatarContentResult{
+		Reader:      content.Reader,
+		ContentType: contentType,
+		SizeBytes:   content.SizeBytes,
+		ModTime:     content.ModTime,
+	}, nil
 }
 
 // ListUsers 分页查询用户列表。
@@ -127,6 +217,9 @@ func (s *Service) CreateUser(
 	normalizedAvatarURL := strings.TrimSpace(avatarURL)
 	if err = validateAvatarURL(normalizedAvatarURL); err != nil {
 		return nil, err
+	}
+	if _, ok := domainuser.ParseFileAvatarURL(normalizedAvatarURL); ok {
+		return nil, ErrInvalidAvatarURL
 	}
 
 	normalizedDisplayName := strings.TrimSpace(displayName)
@@ -251,8 +344,28 @@ func (s *Service) UpdateUserStatus(ctx context.Context, userID uint, status stri
 
 // UpdateFields 更新用户字段。
 func (s *Service) UpdateFields(ctx context.Context, userID uint, input repository.UpdateUserFieldsInput) (*domainuser.User, error) {
+	avatarFileReferenceRequested := false
+	if input.AvatarURL != nil {
+		normalizedAvatarURL := strings.TrimSpace(*input.AvatarURL)
+		if err := validateAvatarURL(normalizedAvatarURL); err != nil {
+			return nil, err
+		}
+		if fileID, ok := domainuser.ParseFileAvatarURL(normalizedAvatarURL); ok {
+			avatarFileReferenceRequested = true
+			if s.avatarFileValidator == nil {
+				return nil, ErrInvalidAvatarURL
+			}
+			if err := s.avatarFileValidator.ValidateImageFile(ctx, userID, fileID); err != nil {
+				return nil, ErrInvalidAvatarURL
+			}
+		}
+		input.AvatarURL = &normalizedAvatarURL
+	}
 	item, err := s.repo.UpdateFields(ctx, userID, input)
 	if err != nil {
+		if avatarFileReferenceRequested && errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrInvalidAvatarURL
+		}
 		if errors.Is(err, repository.ErrNotFound) {
 			return nil, ErrUserNotFound
 		}
@@ -349,6 +462,12 @@ func normalizePublicID(raw string) string {
 
 func validateAvatarURL(raw string) error {
 	if raw == "" || strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "generated:github:") {
+		return nil
+	}
+	if strings.HasPrefix(raw, "file:") {
+		if _, ok := domainuser.ParseFileAvatarURL(raw); !ok {
+			return ErrInvalidAvatarURL
+		}
 		return nil
 	}
 

--- a/backend/internal/domain/user/avatar.go
+++ b/backend/internal/domain/user/avatar.go
@@ -1,0 +1,50 @@
+package user
+
+import "strings"
+
+const fileAvatarPrefix = "file:"
+
+// BuildFileAvatarURL 生成内部文件头像引用。
+func BuildFileAvatarURL(fileID string) string {
+	return fileAvatarPrefix + strings.TrimSpace(fileID)
+}
+
+// ParseFileAvatarURL 解析内部文件头像引用。
+func ParseFileAvatarURL(raw string) (string, bool) {
+	value := strings.TrimSpace(raw)
+	if !strings.HasPrefix(value, fileAvatarPrefix) {
+		return "", false
+	}
+	fileID := strings.TrimPrefix(value, fileAvatarPrefix)
+	if fileID == "" || fileID != strings.TrimSpace(fileID) {
+		return "", false
+	}
+	if !IsValidFileAvatarID(fileID) {
+		return "", false
+	}
+	return fileID, true
+}
+
+// IsValidFileAvatarID 判断文件头像引用中的文件 ID 是否为受限安全格式。
+func IsValidFileAvatarID(fileID string) bool {
+	value := strings.TrimSpace(fileID)
+	if value == "" || value != fileID || len(value) > 128 || !strings.HasPrefix(value, "file_") {
+		return false
+	}
+	for _, item := range value {
+		if item >= 'a' && item <= 'z' {
+			continue
+		}
+		if item >= 'A' && item <= 'Z' {
+			continue
+		}
+		if item >= '0' && item <= '9' {
+			continue
+		}
+		if item == '_' || item == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/backend/internal/domain/user/avatar_test.go
+++ b/backend/internal/domain/user/avatar_test.go
@@ -1,0 +1,31 @@
+package user
+
+import "testing"
+
+func TestFileAvatarURL(t *testing.T) {
+	fileID := "file_test_123"
+	ref := BuildFileAvatarURL(fileID)
+	if ref != "file:file_test_123" {
+		t.Fatalf("BuildFileAvatarURL() = %q", ref)
+	}
+
+	parsed, ok := ParseFileAvatarURL(ref)
+	if !ok || parsed != fileID {
+		t.Fatalf("ParseFileAvatarURL() = %q, %v", parsed, ok)
+	}
+}
+
+func TestParseFileAvatarURLRejectsInvalidReference(t *testing.T) {
+	tests := []string{
+		"file:",
+		"file:avatar",
+		"file:file_../x",
+		"file: file_test",
+		"http://example.com/avatar.png",
+	}
+	for _, item := range tests {
+		if fileID, ok := ParseFileAvatarURL(item); ok {
+			t.Fatalf("ParseFileAvatarURL(%q) = %q, true; want false", item, fileID)
+		}
+	}
+}

--- a/backend/internal/infra/persistence/postgres/conversation/repository.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository.go
@@ -712,6 +712,19 @@ func ensureFileObjectUnreferencedByActiveConversations(tx *gorm.DB, userID uint,
 	return nil
 }
 
+func ensureFileObjectUnreferencedByUserAvatars(tx *gorm.DB, fileID string) error {
+	var activeReferences int64
+	if err := tx.Model(&models.User{}).
+		Where("avatar_url = ?", domainuser.BuildFileAvatarURL(fileID)).
+		Count(&activeReferences).Error; err != nil {
+		return translateError(err)
+	}
+	if activeReferences > 0 {
+		return repository.ErrConflict
+	}
+	return nil
+}
+
 // GetUserByID 按 ID 查询用户。
 func (r *Repo) GetUserByID(ctx context.Context, userID uint) (*domainuser.User, error) {
 	var item models.User
@@ -2248,6 +2261,9 @@ func (r *Repo) DeleteFileObjectAndReleaseQuota(
 			if err := ensureFileObjectUnreferencedByActiveConversations(tx, userID, fileID); err != nil {
 				return err
 			}
+		}
+		if err := ensureFileObjectUnreferencedByUserAvatars(tx, fileID); err != nil {
+			return err
 		}
 
 		quota, err := getOrInitQuotaForUpdate(tx, userID, defaultQuotaBytes)

--- a/backend/internal/infra/persistence/postgres/user/repository.go
+++ b/backend/internal/infra/persistence/postgres/user/repository.go
@@ -73,6 +73,15 @@ func (r *Repo) GetByEmail(ctx context.Context, email string) (*domainuser.User, 
 	return toDomainUser(item), nil
 }
 
+// GetByPublicID 按公开 ID 查询用户。
+func (r *Repo) GetByPublicID(ctx context.Context, publicID string) (*domainuser.User, error) {
+	var item model.User
+	if err := r.db.WithContext(ctx).Where("public_id = ?", publicID).First(&item).Error; err != nil {
+		return nil, translateError(err)
+	}
+	return toDomainUser(item), nil
+}
+
 // ListUsersByLowerEmails 按小写邮箱批量查询用户。
 func (r *Repo) ListUsersByLowerEmails(ctx context.Context, emails []string) (map[string]domainuser.User, error) {
 	results := make(map[string]domainuser.User)
@@ -182,36 +191,54 @@ func (r *Repo) updateUserFields(ctx context.Context, userID uint, input reposito
 	}
 
 	if input.Role != nil && *input.Role != model.RoleSuperAdmin {
-		return r.updateUserFieldsWithSuperAdminGuard(ctx, userID, updates)
+		return r.updateUserFieldsInTransaction(ctx, userID, updates, true)
 	}
 
-	return r.applyUserFieldUpdates(ctx, userID, updates)
+	return r.updateUserFieldsInTransaction(ctx, userID, updates, false)
 }
 
-func (r *Repo) updateUserFieldsWithSuperAdminGuard(
+func (r *Repo) updateUserFieldsInTransaction(
 	ctx context.Context,
 	userID uint,
 	updates map[string]interface{},
+	withSuperAdminGuard bool,
 ) (*domainuser.User, error) {
 	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var superAdmins []model.User
-		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-			Select("id").
-			Where("role = ?", model.RoleSuperAdmin).
-			Order("id ASC").
-			Find(&superAdmins).Error; err != nil {
-			return translateError(err)
-		}
+		if withSuperAdminGuard {
+			var superAdmins []model.User
+			if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+				Select("id").
+				Where("role = ?", model.RoleSuperAdmin).
+				Order("id ASC").
+				Find(&superAdmins).Error; err != nil {
+				return translateError(err)
+			}
 
-		targetIsSuperAdmin := false
-		for _, item := range superAdmins {
-			if item.ID == userID {
-				targetIsSuperAdmin = true
-				break
+			targetIsSuperAdmin := false
+			for _, item := range superAdmins {
+				if item.ID == userID {
+					targetIsSuperAdmin = true
+					break
+				}
+			}
+			if targetIsSuperAdmin && len(superAdmins) <= 1 {
+				return repository.ErrLastSuperAdminRoleChange
 			}
 		}
-		if targetIsSuperAdmin && len(superAdmins) <= 1 {
-			return repository.ErrLastSuperAdminRoleChange
+
+		if rawAvatarURL, ok := updates["avatar_url"].(string); ok {
+			if fileID, isFileAvatar := domainuser.ParseFileAvatarURL(rawAvatarURL); isFileAvatar {
+				var fileObject model.FileObject
+				if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+					Select("id").
+					Where("user_id = ? AND file_id = ? AND status = ?", userID, fileID, "active").
+					First(&fileObject).Error; err != nil {
+					if errors.Is(err, gorm.ErrRecordNotFound) {
+						return repository.ErrNotFound
+					}
+					return translateError(err)
+				}
+			}
 		}
 
 		result := tx.Model(&model.User{}).
@@ -228,25 +255,6 @@ func (r *Repo) updateUserFieldsWithSuperAdminGuard(
 	if err != nil {
 		return nil, err
 	}
-	return r.GetByID(ctx, userID)
-}
-
-func (r *Repo) applyUserFieldUpdates(
-	ctx context.Context,
-	userID uint,
-	updates map[string]interface{},
-) (*domainuser.User, error) {
-	result := r.db.WithContext(ctx).
-		Model(&model.User{}).
-		Where("id = ?", userID).
-		Updates(updates)
-	if result.Error != nil {
-		return nil, translateError(result.Error)
-	}
-	if result.RowsAffected == 0 {
-		return nil, repository.ErrNotFound
-	}
-
 	return r.GetByID(ctx, userID)
 }
 

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -192,6 +192,7 @@ type UserRepository interface {
 	GetByUsername(ctx context.Context, username string) (*domainuser.User, error)
 	GetByEmail(ctx context.Context, email string) (*domainuser.User, error)
 	GetByID(ctx context.Context, userID uint) (*domainuser.User, error)
+	GetByPublicID(ctx context.Context, publicID string) (*domainuser.User, error)
 	ListUsersByLowerEmails(ctx context.Context, emails []string) (map[string]domainuser.User, error)
 	ListAllUsernames(ctx context.Context) ([]string, error)
 	UpdateFields(ctx context.Context, userID uint, input UpdateUserFieldsInput) (*domainuser.User, error)

--- a/backend/internal/shared/response/error_code.go
+++ b/backend/internal/shared/response/error_code.go
@@ -29,6 +29,7 @@ const (
 	CodeBillingPricingRequired   = "billing.pricing_required"
 	CodeRateLimitExceeded        = "rate_limit.exceeded"
 	CodeQuotaExceeded            = "quota.exceeded"
+	CodeFileInUse                = "file.in_use"
 	CodeFileTooLarge             = "file.too_large"
 	CodeFileNotReady             = "file.not_ready"
 	CodeFileTypeBlocked          = "file.type_blocked"
@@ -172,6 +173,7 @@ var exactErrorSpecs = map[string]errorSpec{
 	"embedding unavailable":                                {Code: "file.embedding_unavailable", Message: "embedding is unavailable"},
 	"embedding unavailable for this file size":             {Code: "file.embedding_unavailable", Message: "embedding is unavailable for this file size"},
 	"embedding unavailable for current file capability":    {Code: "file.embedding_unavailable", Message: "embedding is unavailable for current file capability"},
+	"file is in use":                                       {Code: CodeFileInUse, Message: "file is in use"},
 	"file too large":                                       {Code: CodeFileTooLarge, Message: "file too large"},
 	"file processing not ready":                            {Code: CodeFileNotReady, Message: "file processing is not ready"},
 	"file extract not ready":                               {Code: "file.extract_not_ready", Message: "file extract is not ready"},

--- a/backend/internal/transport/http/conversation/handler_file.go
+++ b/backend/internal/transport/http/conversation/handler_file.go
@@ -325,6 +325,9 @@ func (h *Handler) DeleteFile(c *gin.Context) {
 		case errors.Is(err, appconversation.ErrFileNotFound):
 			response.Error(c, http.StatusNotFound, "file not found")
 			return
+		case errors.Is(err, appconversation.ErrFileInUse):
+			response.Error(c, http.StatusConflict, "file is in use")
+			return
 		default:
 			response.Error(c, http.StatusInternalServerError, "delete file failed")
 			return

--- a/backend/internal/transport/http/server.go
+++ b/backend/internal/transport/http/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/middleware"
 	promptpresethttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/promptpreset"
 	settingshttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/settings"
+	userhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/user"
 	usersettingshttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/usersettings"
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
@@ -59,6 +60,7 @@ type Modules struct {
 	Announcement *announcementhttp.Module
 	PromptPreset *promptpresethttp.Module
 	Settings     *settingshttp.Module
+	User         *userhttp.Module
 	UserSettings *usersettingshttp.Module
 	StartupLog   func(*zap.Logger)
 }
@@ -108,11 +110,14 @@ func NewEngine(cfg *config.Runtime, log *zap.Logger, modules Modules, hc HealthC
 		c.Header("Pragma", "no-cache")
 		c.JSON(http.StatusOK, buildinfo.Snapshot())
 	})
-	if modules.Auth != nil || modules.Settings != nil || modules.Billing != nil || modules.Conversation != nil {
+	if modules.Auth != nil || modules.Settings != nil || modules.Billing != nil || modules.Conversation != nil || modules.User != nil {
 		publicAuth := api.Group("")
 		publicAuth.Use(middleware.PublicAuthRateLimit(limiter, cfg))
 		if modules.Auth != nil {
 			modules.Auth.RegisterPublicRoutes(publicAuth)
+		}
+		if modules.User != nil {
+			modules.User.RegisterPublicRoutes(publicAuth)
 		}
 		if modules.Conversation != nil {
 			modules.Conversation.RegisterPublicRoutes(publicAuth)
@@ -158,6 +163,9 @@ func NewEngine(cfg *config.Runtime, log *zap.Logger, modules Modules, hc HealthC
 	}
 	if modules.Settings != nil {
 		modules.Settings.RegisterRoutes(authRequired)
+	}
+	if modules.User != nil {
+		modules.User.RegisterRoutes(authRequired)
 	}
 	if modules.Admin != nil || modules.Auth != nil || modules.Billing != nil || modules.Channel != nil || modules.MCP != nil || modules.Settings != nil || modules.Announcement != nil || modules.PromptPreset != nil {
 		adminGroup := authRequired.Group("/admin")

--- a/backend/internal/transport/http/user/handler.go
+++ b/backend/internal/transport/http/user/handler.go
@@ -1,6 +1,16 @@
 package user
 
-import appuser "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/user"
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	appuser "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/user"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/shared/response"
+	"github.com/gin-gonic/gin"
+)
 
 // Handler 预留用户域 HTTP 处理器（当前用户管理在 admin 模块暴露）。
 type Handler struct {
@@ -10,4 +20,46 @@ type Handler struct {
 // NewHandler 创建处理器。
 func NewHandler(service *appuser.Service) *Handler {
 	return &Handler{service: service}
+}
+
+// GetAvatar 获取用户当前上传头像内容。
+func (h *Handler) GetAvatar(c *gin.Context) {
+	publicID := strings.TrimSpace(c.Param("public_id"))
+	if publicID == "" {
+		response.Error(c, http.StatusBadRequest, "invalid user id")
+		return
+	}
+	result, err := h.service.OpenAvatarContent(c.Request.Context(), publicID)
+	if err != nil {
+		switch {
+		case errors.Is(err, appuser.ErrUserNotFound),
+			errors.Is(err, appuser.ErrAvatarNotFound):
+			response.Error(c, http.StatusNotFound, "avatar not found")
+			return
+		default:
+			response.Error(c, http.StatusInternalServerError, "open avatar failed")
+			return
+		}
+	}
+	defer result.Reader.Close() //nolint:errcheck
+
+	contentType := strings.TrimSpace(result.ContentType)
+	if !strings.HasPrefix(strings.ToLower(contentType), "image/") {
+		response.Error(c, http.StatusNotFound, "avatar not found")
+		return
+	}
+	c.Header("Content-Type", contentType)
+	c.Header("Content-Disposition", "inline")
+	c.Header("Cache-Control", "public, max-age=300")
+	c.Header("X-Content-Type-Options", "nosniff")
+	if result.SizeBytes > 0 {
+		c.Header("Content-Length", strconv.FormatInt(result.SizeBytes, 10))
+	}
+	if !result.ModTime.IsZero() {
+		c.Header("Last-Modified", result.ModTime.UTC().Format(http.TimeFormat))
+	}
+	if _, err = io.Copy(c.Writer, result.Reader); err != nil {
+		c.Abort()
+		return
+	}
 }

--- a/backend/internal/transport/http/user/router.go
+++ b/backend/internal/transport/http/user/router.go
@@ -2,5 +2,10 @@ package user
 
 import "github.com/gin-gonic/gin"
 
-// RegisterRoutes 用户域当前无独立公开路由。
+// RegisterPublicRoutes 注册用户域公开路由。
+func (m *Module) RegisterPublicRoutes(public *gin.RouterGroup) {
+	public.GET("/users/:public_id/avatar", m.Handler.GetAvatar)
+}
+
+// RegisterRoutes 用户域当前无独立登录态路由。
 func (m *Module) RegisterRoutes(_ *gin.RouterGroup) {}

--- a/frontend/features/files/hooks/use-files-page.ts
+++ b/frontend/features/files/hooks/use-files-page.ts
@@ -21,7 +21,7 @@ import {
 } from "@/shared/api/file";
 import type { FileObjectDTO, UploadFileResult, UserStorageQuotaDTO } from "@/shared/api/file.types";
 import { runBulkActionInChunks } from "@/shared/lib/bulk-action";
-import { patchByID, removeByID, replaceByID, restoreAt, upsertByID } from "@/shared/lib/optimistic-list";
+import { patchByID, replaceByID, upsertByID } from "@/shared/lib/optimistic-list";
 
 const FILES_PAGE_SIZE = 100;
 
@@ -435,38 +435,23 @@ export function useFilesPage(): UseFilesPageResult {
       }
 
       setDeletingFileID(fileID);
-      const previousFiles = filesRef.current;
-      const previousTotal = totalRef.current;
-      const deletedFile = previousFiles.find((item) => item.fileID === fileID) ?? null;
-      const deletedIndex = previousFiles.findIndex((item) => item.fileID === fileID);
-      const nextFiles = removeByID(previousFiles, fileID, (item) => item.fileID);
-      const optimisticSelectedFileID = nextFiles[deletedIndex]?.fileID ?? nextFiles[deletedIndex - 1]?.fileID ?? nextFiles[0]?.fileID ?? null;
-      filesRef.current = nextFiles;
-      setFiles(nextFiles);
-      setTotal((current) => Math.max(0, current - (deletedIndex >= 0 ? 1 : 0)));
-      if (selectedFileID === fileID) {
-        setSelectedFileID(optimisticSelectedFileID);
-      }
       try {
         const result = await deleteFile(token, fileID);
+        const currentFiles = filesRef.current;
+        const deletedIndex = currentFiles.findIndex((item) => item.fileID === fileID);
+        const nextFiles = currentFiles.filter((item) => item.fileID !== fileID);
+        const nextSelectedFileID = nextFiles[deletedIndex]?.fileID ?? nextFiles[deletedIndex - 1]?.fileID ?? nextFiles[0]?.fileID ?? null;
+
+        filesRef.current = nextFiles;
+        setFiles(nextFiles);
+        setTotal((current) => Math.max(0, current - (deletedIndex >= 0 ? 1 : 0)));
+        if (selectedFileID === fileID) {
+          setSelectedFileID(nextSelectedFileID);
+        }
         setQuota(result.quota);
-        void loadFiles({ preferredFileID: selectedFileID === fileID ? null : selectedFileID, silent: true, background: true });
+        void loadFiles({ preferredFileID: selectedFileID === fileID ? nextSelectedFileID : selectedFileID, silent: true, background: true });
         toast.success(t("toasts.deleteSucceeded"));
       } catch (error) {
-        if (deletedFile) {
-          setFiles((current) => {
-            const restored = restoreAt(current, deletedFile, deletedIndex, (item) => item.fileID);
-            filesRef.current = restored;
-            return restored;
-          });
-          setTotal((current) => Math.max(current, previousTotal));
-        }
-        setSelectedFileID((current) => {
-          if (selectedFileID === fileID && current === optimisticSelectedFileID) {
-            return fileID;
-          }
-          return current ?? selectedFileID;
-        });
         const description = resolveErrorMessage(error, t("toasts.deleteFailed"));
         toast.error(t("toasts.deleteFailed"), { description });
       } finally {

--- a/frontend/features/settings/components/sections/general/general-profile.tsx
+++ b/frontend/features/settings/components/sections/general/general-profile.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { useTranslations } from "next-intl";
+import { Sparkles, Upload } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -28,6 +29,7 @@ export function GeneralProfileSection({
   draftAvatarSrc,
   avatarDialogOpen,
   avatarDialogValue,
+  avatarUploading,
   avatarDialogPreviewSrc,
   onDraftChange,
   onUsernameDraftChange,
@@ -37,6 +39,7 @@ export function GeneralProfileSection({
   onAvatarDialogOpenChange,
   onAvatarDialogValueChange,
   onCycleGeneratedAvatar,
+  onUploadAvatarFile,
   onSaveAvatarDialog,
 }: {
   viewer: UserDTO | null;
@@ -50,6 +53,7 @@ export function GeneralProfileSection({
   draftAvatarSrc: string;
   avatarDialogOpen: boolean;
   avatarDialogValue: string;
+  avatarUploading: boolean;
   avatarDialogPreviewSrc: string;
   onDraftChange: React.Dispatch<React.SetStateAction<ProfileDraft>>;
   onUsernameDraftChange: (value: string) => void;
@@ -59,10 +63,12 @@ export function GeneralProfileSection({
   onAvatarDialogOpenChange: (open: boolean) => void;
   onAvatarDialogValueChange: (value: string) => void;
   onCycleGeneratedAvatar: () => void;
+  onUploadAvatarFile: (file: File) => void;
   onSaveAvatarDialog: () => void;
 }) {
   const t = useTranslations("settings");
   const common = useTranslations("common");
+  const avatarFileInputRef = React.useRef<HTMLInputElement | null>(null);
 
   return (
     <>
@@ -163,18 +169,59 @@ export function GeneralProfileSection({
 
           <div className="space-y-4">
             <div className="flex justify-center">
-              <button
+              <Avatar className="size-16 bg-pure">
+                <AvatarImage
+                  src={avatarDialogPreviewSrc || undefined}
+                  alt={draft.displayName || viewer?.username || t("generalPage.profile.avatarAlt")}
+                />
+                <AvatarFallback className="bg-foreground text-3xl font-medium text-background">
+                  {viewerInitial}
+                </AvatarFallback>
+              </Avatar>
+            </div>
+
+            <div className="flex justify-center gap-1.5">
+              <input
+                ref={avatarFileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(event) => {
+                  const file = event.target.files?.[0];
+                  event.currentTarget.value = "";
+                  if (file) {
+                    onUploadAvatarFile(file);
+                  }
+                }}
+              />
+              <Button
                 type="button"
-                className="rounded-2xl transition-transform hover:scale-[1.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                variant="ghost"
+                size="sm"
+                className="h-8 gap-1.5 rounded-md bg-muted/60 px-3 text-xs font-medium text-foreground shadow-none hover:bg-muted"
+                disabled={saving || avatarUploading}
+                onClick={() => avatarFileInputRef.current?.click()}
+              >
+                {avatarUploading ? (
+                  <SpinnerLabel>{t("generalPage.avatarDialog.uploading")}</SpinnerLabel>
+                ) : (
+                  <>
+                    <Upload className="size-3.5 stroke-1" />
+                    {t("generalPage.avatarDialog.upload")}
+                  </>
+                )}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-8 gap-1.5 rounded-md bg-muted/60 px-3 text-xs font-medium text-foreground shadow-none hover:bg-muted"
+                disabled={saving || avatarUploading}
                 onClick={onCycleGeneratedAvatar}
               >
-                <Avatar className="size-16 bg-pure">
-                  <AvatarImage src={avatarDialogPreviewSrc || undefined} alt={draft.displayName || viewer?.username || t("generalPage.profile.avatarAlt")} />
-                  <AvatarFallback className="bg-foreground text-3xl font-medium text-background">
-                    {viewerInitial}
-                  </AvatarFallback>
-                </Avatar>
-              </button>
+                <Sparkles className="size-3.5 stroke-1" />
+                {t("generalPage.avatarDialog.generate")}
+              </Button>
             </div>
 
             <Field>
@@ -183,16 +230,21 @@ export function GeneralProfileSection({
                 value={avatarDialogValue}
                 onChange={(event) => onAvatarDialogValueChange(event.target.value)}
                 placeholder="https://example.com/avatar.png"
-                disabled={saving}
+                disabled={saving || avatarUploading}
               />
             </Field>
           </div>
 
           <DialogFooter>
-            <Button type="button" variant="ghost" onClick={() => onAvatarDialogOpenChange(false)}>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={avatarUploading}
+              onClick={() => onAvatarDialogOpenChange(false)}
+            >
               {common("actions.cancel")}
             </Button>
-            <Button type="button" onClick={onSaveAvatarDialog}>
+            <Button type="button" disabled={avatarUploading} onClick={onSaveAvatarDialog}>
               {t("generalPage.avatarDialog.apply")}
             </Button>
           </DialogFooter>

--- a/frontend/features/settings/components/sections/general/settings-general.tsx
+++ b/frontend/features/settings/components/sections/general/settings-general.tsx
@@ -29,7 +29,13 @@ import {
   isProfileDraftEqual,
 } from "@/features/settings/utils/profile-settings";
 import { resolveLocalizedErrorMessage } from "@/i18n/resolve-error-message";
-import { createGeneratedGithubAvatarRef, generateAvatarVariant, resolveAvatarImageSrc } from "@/shared/lib/avatar";
+import {
+  createFileAvatarRef,
+  createGeneratedGithubAvatarRef,
+  generateAvatarVariant,
+  parseFileAvatarID,
+  resolveAvatarImageSrc,
+} from "@/shared/lib/avatar";
 import { useAuthSession } from "@/shared/auth/auth-session-context";
 import {
   disableResponseCompletionNotifications,
@@ -39,6 +45,7 @@ import {
   readResponseCompletionNotificationsEnabled,
 } from "@/shared/lib/browser-notifications";
 import { patchMe, patchUsername } from "@/shared/api/auth";
+import { uploadFile } from "@/shared/api/file";
 import { ApiError } from "@/shared/api/http-client";
 import {
   isDisplayNameLengthValid,
@@ -69,6 +76,11 @@ function resolveUsernameErrorMessage(
   return resolveLocalizedErrorMessage(error);
 }
 
+type AvatarUploadPreview = {
+  fileID: string;
+  url: string;
+};
+
 export function SettingsGeneral() {
   const t = useTranslations("settings");
   const { accessToken, user, userStatus } = useAuthSession();
@@ -78,6 +90,8 @@ export function SettingsGeneral() {
   const [initialDraft, setInitialDraft] = React.useState<ProfileDraft>(() => createDraftFromUser());
   const [avatarDialogOpen, setAvatarDialogOpen] = React.useState(false);
   const [avatarDialogValue, setAvatarDialogValue] = React.useState("");
+  const [avatarUploading, setAvatarUploading] = React.useState(false);
+  const [avatarUploadPreview, setAvatarUploadPreview] = React.useState<AvatarUploadPreview | null>(null);
   const [themeRuntimeReady, setThemeRuntimeReady] = React.useState(false);
   const chatFont = useChatFontPreference();
   const chatFontWeight = useChatFontWeightPreference();
@@ -129,6 +143,14 @@ export function SettingsGeneral() {
     };
   }, []);
 
+  React.useEffect(() => {
+    return () => {
+      if (avatarUploadPreview) {
+        URL.revokeObjectURL(avatarUploadPreview.url);
+      }
+    };
+  }, [avatarUploadPreview]);
+
   const viewerInitial = React.useMemo(() => {
     const source = draft.displayName || viewer?.username || "?";
     return source.trim().charAt(0).toUpperCase() || "?";
@@ -142,13 +164,23 @@ export function SettingsGeneral() {
     }),
     [draft.displayName, viewer?.displayName, viewer?.publicID, viewer?.username],
   );
+  const resolveAvatarPreviewSrc = React.useCallback(
+    (value: string) => {
+      const fileID = parseFileAvatarID(value.trim());
+      if (fileID && avatarUploadPreview?.fileID === fileID) {
+        return avatarUploadPreview.url;
+      }
+      return resolveAvatarImageSrc(value, avatarSource);
+    },
+    [avatarSource, avatarUploadPreview],
+  );
   const draftAvatarSrc = React.useMemo(
-    () => resolveAvatarImageSrc(draft.avatarUrl, avatarSource),
-    [avatarSource, draft.avatarUrl],
+    () => resolveAvatarPreviewSrc(draft.avatarUrl),
+    [draft.avatarUrl, resolveAvatarPreviewSrc],
   );
   const avatarDialogPreviewSrc = React.useMemo(
-    () => resolveAvatarImageSrc(avatarDialogValue, avatarSource),
-    [avatarDialogValue, avatarSource],
+    () => resolveAvatarPreviewSrc(avatarDialogValue),
+    [avatarDialogValue, resolveAvatarPreviewSrc],
   );
   const hasProfileEdits = !isProfileDraftEqual(draft, initialDraft);
   const canEditUsername = Boolean(viewer && !viewer.usernameChangedAt);
@@ -223,6 +255,13 @@ export function SettingsGeneral() {
       setDraft(nextDraft);
       setInitialDraft(nextDraft);
       setUsernameDraft(nextViewer.username);
+      setAvatarUploadPreview((current) => {
+        const savedFileID = parseFileAvatarID(nextDraft.avatarUrl);
+        if (current && current.fileID === savedFileID) {
+          return null;
+        }
+        return current;
+      });
       dispatchUserProfileUpdated(nextViewer);
       toast.success(
         hasUsernameEdit && !hasProfileEdits
@@ -241,6 +280,13 @@ export function SettingsGeneral() {
   const handleDiscard = React.useCallback(() => {
     setDraft(initialDraft);
     setUsernameDraft(viewer?.username ?? "");
+    setAvatarUploadPreview((current) => {
+      const initialFileID = parseFileAvatarID(initialDraft.avatarUrl);
+      if (current && current.fileID !== initialFileID) {
+        return null;
+      }
+      return current;
+    });
   }, [initialDraft, viewer?.username]);
 
   const handleOpenAvatarDialog = React.useCallback(() => {
@@ -256,6 +302,40 @@ export function SettingsGeneral() {
   const handleCycleGeneratedAvatar = React.useCallback(() => {
     setAvatarDialogValue(createGeneratedGithubAvatarRef(generateAvatarVariant()));
   }, []);
+
+  const handleUploadAvatarFile = React.useCallback(async (file: File) => {
+    if (avatarUploading) {
+      return;
+    }
+    if (!file.type.toLowerCase().startsWith("image/")) {
+      toast.error(t("generalPage.avatarDialog.uploadInvalid"));
+      return;
+    }
+
+    let previewURL: string | null = null;
+    try {
+      setAvatarUploading(true);
+      previewURL = URL.createObjectURL(file);
+      const result = await uploadFile(accessToken, file, { purpose: "avatar" });
+      const nextPreviewURL = previewURL;
+      previewURL = null;
+      setAvatarUploadPreview({
+        fileID: result.file.fileID,
+        url: nextPreviewURL,
+      });
+      setAvatarDialogValue(createFileAvatarRef(result.file.fileID));
+      toast.success(t("generalPage.avatarDialog.uploaded"));
+    } catch (error) {
+      if (previewURL) {
+        URL.revokeObjectURL(previewURL);
+      }
+      toast.error(t("generalPage.avatarDialog.uploadFailed"), {
+        description: resolveLocalizedErrorMessage(error),
+      });
+    } finally {
+      setAvatarUploading(false);
+    }
+  }, [accessToken, avatarUploading, t]);
 
   const handleResponseCompletionNotificationsChange = React.useCallback((checked: boolean) => {
     if (!notificationSupported) {
@@ -396,6 +476,7 @@ export function SettingsGeneral() {
         draftAvatarSrc={draftAvatarSrc}
         avatarDialogOpen={avatarDialogOpen}
         avatarDialogValue={avatarDialogValue}
+        avatarUploading={avatarUploading}
         avatarDialogPreviewSrc={avatarDialogPreviewSrc}
         onDraftChange={setDraft}
         onUsernameDraftChange={setUsernameDraft}
@@ -405,6 +486,7 @@ export function SettingsGeneral() {
         onAvatarDialogOpenChange={setAvatarDialogOpen}
         onAvatarDialogValueChange={setAvatarDialogValue}
         onCycleGeneratedAvatar={handleCycleGeneratedAvatar}
+        onUploadAvatarFile={(file) => void handleUploadAvatarFile(file)}
         onSaveAvatarDialog={handleSaveAvatarDialog}
       />
 

--- a/frontend/i18n/messages/en-US/errors.json
+++ b/frontend/i18n/messages/en-US/errors.json
@@ -140,6 +140,7 @@
     "invalidName": "Invalid file name.",
     "invalidReference": "Invalid file reference.",
     "invalidStream": "Invalid file stream.",
+    "inUse": "This file is in use and cannot be deleted.",
     "notFound": "File not found.",
     "notReady": "File is not ready.",
     "required": "File is required.",

--- a/frontend/i18n/messages/en-US/settings.json
+++ b/frontend/i18n/messages/en-US/settings.json
@@ -108,8 +108,14 @@
     },
     "avatarDialog": {
       "title": "Edit avatar",
-      "description": "Enter an avatar URL or click the avatar area to generate a pixel-style avatar.",
+      "description": "Upload an image, enter an avatar URL, or generate a pixel-style avatar.",
       "avatarURL": "Avatar URL",
+      "upload": "Upload image",
+      "uploading": "Uploading",
+      "uploaded": "Avatar uploaded",
+      "uploadFailed": "Failed to upload avatar",
+      "uploadInvalid": "Please choose an image file",
+      "generate": "Generate avatar",
       "apply": "Apply"
     }
   },

--- a/frontend/i18n/messages/zh-CN/errors.json
+++ b/frontend/i18n/messages/zh-CN/errors.json
@@ -140,6 +140,7 @@
     "invalidName": "文件名无效。",
     "invalidReference": "文件引用无效。",
     "invalidStream": "文件流无效。",
+    "inUse": "文件正在使用中，无法删除。",
     "notFound": "文件不存在。",
     "notReady": "文件尚未准备完成。",
     "required": "请选择文件。",

--- a/frontend/i18n/messages/zh-CN/settings.json
+++ b/frontend/i18n/messages/zh-CN/settings.json
@@ -108,8 +108,14 @@
     },
     "avatarDialog": {
       "title": "编辑头像",
-      "description": "输入头像 URL，或点击头像区域生成像素风头像。",
+      "description": "上传图片、输入头像 URL，或生成像素风头像。",
       "avatarURL": "头像 URL",
+      "upload": "上传图片",
+      "uploading": "上传中",
+      "uploaded": "头像已上传",
+      "uploadFailed": "头像上传失败",
+      "uploadInvalid": "请选择图片文件",
+      "generate": "生成头像",
       "apply": "应用"
     }
   },

--- a/frontend/shared/lib/avatar.ts
+++ b/frontend/shared/lib/avatar.ts
@@ -1,3 +1,5 @@
+import { pathParam, resolveApiBaseURL } from "@/shared/api/http-client";
+
 type AvatarSeedSource = {
   publicID?: string | null;
   username?: string | null;
@@ -5,6 +7,7 @@ type AvatarSeedSource = {
 };
 
 const GENERATED_AVATAR_PREFIX = "generated:github:";
+const FILE_AVATAR_PREFIX = "file:";
 
 function normalizeString(value: unknown, fallback = "") {
   if (typeof value !== "string") {
@@ -47,6 +50,19 @@ export function parseGeneratedGithubAvatarVariant(value: string) {
   return parsedValue;
 }
 
+export function createFileAvatarRef(fileID: string) {
+  return `${FILE_AVATAR_PREFIX}${fileID.trim()}`;
+}
+
+export function parseFileAvatarID(value: string) {
+  if (!value.startsWith(FILE_AVATAR_PREFIX)) {
+    return null;
+  }
+
+  const fileID = value.slice(FILE_AVATAR_PREFIX.length).trim();
+  return fileID.startsWith("file_") ? fileID : null;
+}
+
 export function generateAvatarVariant() {
   if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
     const values = new Uint32Array(1);
@@ -68,19 +84,15 @@ export function resolveAvatarSeed(source?: AvatarSeedSource) {
 
 export function createGithubStyleAvatar(seed: string, variant: number) {
   let state = hashString(`${seed}:${variant}`) || 1;
-  const cellSize = 11;
-  const padding = 7;
+  const canvasSize = 96;
   const gridSize = 5;
-  const canvasSize = padding * 2 + cellSize * gridSize;
+  const cellSize = 15;
+  const padding = (canvasSize - gridSize * cellSize) / 2;
   const hue = state % 360;
-  const foregroundSaturation = 42 + (state % 10);
-  const foregroundLightness = 28 + (state % 8);
-  const backgroundHue = (hue + 8 + (state % 24)) % 360;
-  const backgroundSaturation = 20 + (state % 10);
-  const backgroundLightness = 84 + (state % 5);
-  const foregroundColor = `hsl(${hue} ${foregroundSaturation}% ${foregroundLightness}%)`;
-  const backgroundColor = `hsl(${backgroundHue} ${backgroundSaturation}% ${backgroundLightness}%)`;
+  const backgroundColor = `hsl(${(hue + 8) % 360} ${18 + (state % 8)}% ${88 + (state % 5)}%)`;
+  const foregroundColor = `hsl(${hue} ${42 + (state % 10)}% ${28 + (state % 8)}%)`;
   const cells: string[] = [];
+  let grid = Array.from({ length: gridSize }, () => Array.from({ length: gridSize }, () => false));
 
   const nextValue = () => {
     state ^= state << 13;
@@ -89,28 +101,93 @@ export function createGithubStyleAvatar(seed: string, variant: number) {
     return state >>> 0;
   };
 
+  const setMirroredCell = (row: number, column: number, filled: boolean) => {
+    grid[row][column] = filled;
+    grid[row][gridSize - 1 - column] = filled;
+  };
+
+  const countNeighbors = (row: number, column: number, source: boolean[][]) => {
+    let count = 0;
+    for (let rowOffset = -1; rowOffset <= 1; rowOffset += 1) {
+      for (let columnOffset = -1; columnOffset <= 1; columnOffset += 1) {
+        if (rowOffset === 0 && columnOffset === 0) {
+          continue;
+        }
+        if (source[row + rowOffset]?.[column + columnOffset]) {
+          count += 1;
+        }
+      }
+    }
+    return count;
+  };
+
   for (let row = 0; row < gridSize; row += 1) {
     for (let column = 0; column < Math.ceil(gridSize / 2); column += 1) {
-      const filled = nextValue() % 100 < 58;
-      if (!filled) {
+      const columnBias = [42, 56, 70][column] ?? 56;
+      const rowBias = [0, 8, 12, 8, 0][row] ?? 0;
+      setMirroredCell(row, column, nextValue() % 100 < columnBias + rowBias);
+    }
+  }
+
+  grid = grid.map((rowCells, row) =>
+    rowCells.map((filled, column) => {
+      const neighbors = countNeighbors(row, column, grid);
+      if (filled) {
+        return neighbors > 0;
+      }
+
+      return neighbors >= 4;
+    }),
+  );
+
+  const countFilledCells = () => {
+    let count = 0;
+    for (const rowCells of grid) {
+      for (const filled of rowCells) {
+        if (filled) {
+          count += 1;
+        }
+      }
+    }
+    return count;
+  };
+
+  const fillOrder = [
+    [2, 2],
+    [1, 2],
+    [3, 2],
+    [2, 1],
+    [2, 3],
+    [1, 1],
+    [1, 3],
+    [3, 1],
+    [3, 3],
+    [0, 2],
+    [4, 2],
+  ];
+
+  for (const [row, column] of fillOrder) {
+    if (countFilledCells() >= 10) {
+      break;
+    }
+    setMirroredCell(row, column, true);
+  }
+
+  for (let row = 0; row < gridSize; row += 1) {
+    for (let column = 0; column < gridSize; column += 1) {
+      if (!grid[row][column]) {
         continue;
       }
 
-      const mirroredColumn = gridSize - 1 - column;
       const x = padding + column * cellSize;
       const y = padding + row * cellSize;
-      cells.push(`<rect x="${x}" y="${y}" width="${cellSize - 1}" height="${cellSize - 1}" fill="${foregroundColor}" />`);
-
-      if (mirroredColumn !== column) {
-        const mirroredX = padding + mirroredColumn * cellSize;
-        cells.push(`<rect x="${mirroredX}" y="${y}" width="${cellSize - 1}" height="${cellSize - 1}" fill="${foregroundColor}" />`);
-      }
+      cells.push(`<rect x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" fill="${foregroundColor}" />`);
     }
   }
 
   const svg = [
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${canvasSize} ${canvasSize}" fill="none">`,
-    `<rect width="${canvasSize}" height="${canvasSize}" rx="10" fill="${backgroundColor}" />`,
+    `<rect width="${canvasSize}" height="${canvasSize}" rx="12" fill="${backgroundColor}" />`,
     ...cells,
     "</svg>",
   ].join("");
@@ -123,6 +200,12 @@ export function resolveAvatarImageSrc(avatarURL: unknown, source?: AvatarSeedSou
   const generatedVariant = parseGeneratedGithubAvatarVariant(normalizedAvatarURL);
   if (generatedVariant !== null) {
     return createGithubStyleAvatar(resolveAvatarSeed(source), generatedVariant);
+  }
+
+  const fileID = parseFileAvatarID(normalizedAvatarURL);
+  const publicID = normalizeString(source?.publicID);
+  if (fileID && publicID) {
+    return `${resolveApiBaseURL()}/api/v1/users/${pathParam(publicID)}/avatar?file=${pathParam(fileID)}`;
   }
 
   return normalizedAvatarURL;


### PR DESCRIPTION
## Summary

Adds uploaded avatar support for user profiles. Uploaded avatars are stored through the existing file pipeline, preview immediately in the profile dialog, and are served through a public current-avatar endpoint.

Also prevents files currently used as avatars from being deleted, returns a clear `file.in_use` error, and avoids refreshing/jumping the file detail page when deletion fails.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [x] Authentication / authorization
- [ ] Conversations / streaming
- [x] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `frontend/node_modules/.bin/tsc -p frontend/tsconfig.json --noEmit`
- [x] `env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/app ./internal/application/user ./internal/application/auth ./internal/application/conversation ./internal/application/upload ./internal/shared/response ./internal/transport/http/user ./internal/transport/http/conversation ./internal/transport/http/admin`
- [x] `git diff --check`

## Screenshots, API examples, or logs

UI change affects the profile avatar dialog: users can upload an image, generate a GitHub-style avatar, or enter an avatar URL.

## Configuration, migration, and compatibility notes

No configuration or migration required. Existing `generated:github:*` and external avatar URLs remain supported.

Uploaded avatars are stored as internal `file:*` avatar references and served via the current avatar endpoint.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.