### PR TITLE
feat: add metadata refresh hint and enhance conversation metadata handling

### DIFF
--- a/backend/internal/application/conversation/service.go
+++ b/backend/internal/application/conversation/service.go
@@ -147,6 +147,7 @@ type SendMessageInput struct {
 type SendMessageResult struct {
 	UserMessage         model.Message
 	AssistantMessage    model.Message
+	MetadataRefreshHint string
 	Billable            bool
 	UpstreamID          uint
 	UpstreamName        string

--- a/backend/internal/application/conversation/service_media_generation.go
+++ b/backend/internal/application/conversation/service_media_generation.go
@@ -431,21 +431,22 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 	s.maybeGenerateConversationMetadataAsync(*conversation, *userMessage, model.Message{})
 
 	return &SendMessageResult{
-		UserMessage:        *userMessage,
-		AssistantMessage:   *assistantMessage,
-		UpstreamID:         route.UpstreamID,
-		UpstreamName:       route.UpstreamName,
-		PlatformModelName:  route.PlatformModelName,
-		RoutedBindingCode:  route.BindingCode,
-		UpstreamModelName:  route.UpstreamModel,
-		UpstreamProtocol:   route.Protocol,
-		EffectiveOptions:   filteredOptions,
-		UsageSpeed:         usage.Speed,
-		UsageServiceTier:   usage.ServiceTier,
-		RawUsageJSON:       usage.RawUsageJSON,
-		CacheWrite5mTokens: usage.CacheWrite5mTokens,
-		CacheWrite1hTokens: usage.CacheWrite1hTokens,
-		LatencyMS:          latencyMS,
+		UserMessage:         *userMessage,
+		AssistantMessage:    *assistantMessage,
+		MetadataRefreshHint: conversationMetadataRefreshHint(*conversation, *userMessage, model.Message{}),
+		UpstreamID:          route.UpstreamID,
+		UpstreamName:        route.UpstreamName,
+		PlatformModelName:   route.PlatformModelName,
+		RoutedBindingCode:   route.BindingCode,
+		UpstreamModelName:   route.UpstreamModel,
+		UpstreamProtocol:    route.Protocol,
+		EffectiveOptions:    filteredOptions,
+		UsageSpeed:          usage.Speed,
+		UsageServiceTier:    usage.ServiceTier,
+		RawUsageJSON:        usage.RawUsageJSON,
+		CacheWrite5mTokens:  usage.CacheWrite5mTokens,
+		CacheWrite1hTokens:  usage.CacheWrite1hTokens,
+		LatencyMS:           latencyMS,
 	}, nil
 }
 

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -1330,6 +1330,7 @@ func (s *Service) sendMessageInternal(
 	return &SendMessageResult{
 		UserMessage:         *userMessage,
 		AssistantMessage:    *assistantMessage,
+		MetadataRefreshHint: conversationMetadataRefreshHint(*conversation, *userMessage, *assistantMessage),
 		Billable:            true,
 		UpstreamID:          run.UpstreamID,
 		UpstreamName:        run.UpstreamName,

--- a/backend/internal/application/conversation/service_metadata.go
+++ b/backend/internal/application/conversation/service_metadata.go
@@ -18,8 +18,11 @@ import (
 
 const (
 	conversationMetadataMessageMaxTokens    = int64(5000)
-	conversationFirstMessageTitleMaxRunes   = 20
+	conversationFallbackTitleMaxRunes       = 16
 	conversationAutoGenerateTitleSettingKey = "chat.auto_generate_title"
+	conversationMetadataRefreshPending      = "pending"
+	conversationMetadataRefreshNotNeeded    = "not_needed"
+	conversationMetadataRefreshNoContent    = "skipped_no_titleable_content"
 	conversationMetadataTitlePrompt         = `Generate a concise title from the first conversation turn below. Return ONLY a valid JSON object.
 
 ## Constraints
@@ -68,15 +71,20 @@ func (s *Service) maybeGenerateConversationMetadataAsync(conversation model.Conv
 	if !shouldGenerateConversationMetadata(conversation) {
 		return
 	}
-	if strings.TrimSpace(userMsg.Content) == "" && strings.TrimSpace(assistantMsg.Content) == "" {
-		return
-	}
 
 	go func() {
 		asyncCtx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 		defer cancel()
 
 		if _, err := s.generateConversationMetadata(asyncCtx, conversation, userMsg, assistantMsg); err != nil && s.logger != nil {
+			if errors.Is(err, ErrInvalidConversationTitle) {
+				s.logger.Info("conversation_metadata_skipped",
+					zap.Uint("conversation_id", conversation.ID),
+					zap.String("model", conversation.Model),
+					zap.String("reason", "no_titleable_content"),
+				)
+				return
+			}
 			s.logger.Warn("conversation_metadata_generation_failed",
 				zap.Uint("conversation_id", conversation.ID),
 				zap.String("model", conversation.Model),
@@ -89,6 +97,7 @@ func (s *Service) maybeGenerateConversationMetadataAsync(conversation model.Conv
 func (s *Service) generateConversationMetadata(ctx context.Context, conversation model.Conversation, userMsg model.Message, assistantMsg model.Message) (*model.Conversation, error) {
 	cfg := s.cfg.Snapshot()
 	messages := buildConversationMetadataMessages(userMsg, assistantMsg)
+	hasTitleableMessages := strings.TrimSpace(messages) != ""
 
 	title := ""
 	labelsJSON := ""
@@ -124,7 +133,10 @@ func (s *Service) generateConversationMetadata(ctx context.Context, conversation
 		title = conversationTitleFromFirstUserMessage(userMsg.Content)
 	}
 
-	if s.routeResolver != nil && s.llmClient != nil && shouldGenerateTitle {
+	if shouldGenerateTitle && !hasTitleableMessages {
+		setTitleErr(ErrInvalidConversationTitle)
+	}
+	if s.routeResolver != nil && s.llmClient != nil && shouldGenerateTitle && hasTitleableMessages {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -141,7 +153,11 @@ func (s *Service) generateConversationMetadata(ctx context.Context, conversation
 		}()
 	}
 
-	if s.routeResolver != nil && s.llmClient != nil && conversationLabelsEmpty(conversation.LabelsJSON) {
+	shouldGenerateLabels := conversationLabelsEmpty(conversation.LabelsJSON)
+	if shouldGenerateLabels && !hasTitleableMessages {
+		setLabelsErr(ErrInvalidConversationTitle)
+	}
+	if s.routeResolver != nil && s.llmClient != nil && shouldGenerateLabels && hasTitleableMessages {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -270,6 +286,16 @@ func buildConversationMetadataMessages(userMsg model.Message, assistantMsg model
 		sb.WriteString(content)
 	}
 	return truncateByEstimatedTokens(strings.TrimSpace(sb.String()), conversationMetadataMessageMaxTokens)
+}
+
+func conversationMetadataRefreshHint(conversation model.Conversation, userMsg model.Message, assistantMsg model.Message) string {
+	if !shouldGenerateConversationMetadata(conversation) {
+		return conversationMetadataRefreshNotNeeded
+	}
+	if strings.TrimSpace(buildConversationMetadataMessages(userMsg, assistantMsg)) == "" {
+		return conversationMetadataRefreshNoContent
+	}
+	return conversationMetadataRefreshPending
 }
 
 func buildConversationTitleMessages(messages []model.Message) string {
@@ -526,8 +552,8 @@ func conversationTitleFromFirstUserMessage(content string) string {
 		return ""
 	}
 	runes := []rune(value)
-	if len(runes) > conversationFirstMessageTitleMaxRunes {
-		value = string(runes[:conversationFirstMessageTitleMaxRunes])
+	if len(runes) > conversationFallbackTitleMaxRunes {
+		value = string(runes[:conversationFallbackTitleMaxRunes])
 	}
 	return strings.TrimSpace(value)
 }

--- a/backend/internal/application/conversation/service_metadata_test.go
+++ b/backend/internal/application/conversation/service_metadata_test.go
@@ -82,8 +82,8 @@ func TestParseGeneratedConversationLabelsHandlesLooseJSON(t *testing.T) {
 
 func TestConversationTitleFromFirstUserMessage(t *testing.T) {
 	cases := map[string]string{
-		"  这是一条很长的第一条用户消息，用来测试标题截断  ":        "这是一条很长的第一条用户消息，用来测试标",
-		"\n\nhello   world   from   DEEIX\n": "hello world from DEE",
+		"  这是一条很长的第一条用户消息，用来测试标题截断  ":        "这是一条很长的第一条用户消息，用",
+		"\n\nhello   world   from   DEEIX\n": "hello world from",
 		"\"简短标题\"":                           "简短标题",
 		"   ":                                "",
 	}
@@ -91,6 +91,61 @@ func TestConversationTitleFromFirstUserMessage(t *testing.T) {
 		if got := conversationTitleFromFirstUserMessage(input); got != want {
 			t.Fatalf("unexpected first-message title for %q: got %q, want %q", input, got, want)
 		}
+	}
+}
+
+func TestConversationFallbackTitleUsesUnifiedLimit(t *testing.T) {
+	if conversationFallbackTitleMaxRunes != 16 {
+		t.Fatalf("expected fallback title limit to stay unified at 16, got %d", conversationFallbackTitleMaxRunes)
+	}
+
+	got := conversationTitleFromFirstUserMessage("0123456789abcdefXYZ")
+	if got != "0123456789abcdef" {
+		t.Fatalf("expected fallback title to truncate to 16 runes, got %q", got)
+	}
+}
+
+func TestBuildConversationMetadataMessagesEmptyWhenNoText(t *testing.T) {
+	got := buildConversationMetadataMessages(model.Message{}, model.Message{})
+	if got != "" {
+		t.Fatalf("expected no metadata prompt body for empty messages, got %q", got)
+	}
+}
+
+func TestConversationMetadataRefreshHint(t *testing.T) {
+	cases := []struct {
+		name         string
+		conversation model.Conversation
+		userMsg      model.Message
+		assistantMsg model.Message
+		want         string
+	}{
+		{
+			name:         "not needed when title and labels already exist",
+			conversation: model.Conversation{Title: "已有标题", LabelsJSON: `["技术"]`},
+			userMsg:      model.Message{Content: "新的问题"},
+			want:         conversationMetadataRefreshNotNeeded,
+		},
+		{
+			name:         "skip when no titleable text",
+			conversation: model.Conversation{Title: "新会话", LabelsJSON: "[]"},
+			want:         conversationMetadataRefreshNoContent,
+		},
+		{
+			name:         "pending when metadata needed and text exists",
+			conversation: model.Conversation{Title: "新会话", LabelsJSON: "[]"},
+			userMsg:      model.Message{Content: "帮我整理本周项目计划"},
+			want:         conversationMetadataRefreshPending,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := conversationMetadataRefreshHint(tc.conversation, tc.userMsg, tc.assistantMsg)
+			if got != tc.want {
+				t.Fatalf("unexpected metadata refresh hint: got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/backend/internal/transport/http/conversation/dto_response.go
+++ b/backend/internal/transport/http/conversation/dto_response.go
@@ -949,8 +949,9 @@ func toMessageResponseWithRunAndFallback(m model.Message, run model.Run, fallbac
 
 // SendMessageResponse 发送消息响应 DTO。
 type SendMessageResponse struct {
-	UserMessage      MessageResponse `json:"userMessage"`
-	AssistantMessage MessageResponse `json:"assistantMessage"`
+	UserMessage         MessageResponse `json:"userMessage"`
+	AssistantMessage    MessageResponse `json:"assistantMessage"`
+	MetadataRefreshHint string          `json:"metadataRefreshHint,omitempty"`
 }
 
 type CancelMessageGenerationResponse struct {
@@ -963,8 +964,9 @@ func toSendMessageResponse(r *appconversation.SendMessageResult) SendMessageResp
 		UpstreamModelName: r.UpstreamModelName,
 	}
 	return SendMessageResponse{
-		UserMessage:      toMessageResponseWithRun(r.UserMessage, run),
-		AssistantMessage: toMessageResponseWithRun(r.AssistantMessage, run),
+		UserMessage:         toMessageResponseWithRun(r.UserMessage, run),
+		AssistantMessage:    toMessageResponseWithRun(r.AssistantMessage, run),
+		MetadataRefreshHint: r.MetadataRefreshHint,
 	}
 }
 

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -173,6 +173,20 @@ function hasGeneratedConversationMetadataChanged(
   return normalizeLabelsJSON(next.labelsJSON) !== normalizeLabelsJSON(previous?.labelsJSON);
 }
 
+function shouldPollGeneratedConversationMetadata(
+  item: ConversationDTO | null,
+  result: SendMessageResult | null | undefined,
+): boolean {
+  if (!hasPendingGeneratedConversationMetadata(item)) {
+    return false;
+  }
+  const hint = result?.metadataRefreshHint?.trim();
+  if (!hint) {
+    return true;
+  }
+  return hint === "pending";
+}
+
 async function refreshGeneratedConversationMetadata(
   accessToken: string,
   conversationPublicID: string,
@@ -505,8 +519,6 @@ export function useChatMessageSubmit({
           window.history.replaceState(null, "", `/chat?conversation_id=${created.publicID}`);
           onConversationCreated?.(created.publicID);
         }
-        const shouldRefreshConversationMetadata = hasPendingGeneratedConversationMetadata(targetConversation);
-
         const commonStreamPayload = {
           model: requestPlatformModelName,
           options: Object.keys(sanitizedOptions).length > 0 ? sanitizedOptions : undefined,
@@ -737,7 +749,7 @@ export function useChatMessageSubmit({
           targetConversationID,
           toConversationPatch(targetConversation, requestPlatformModelName),
         );
-        if (assistantMessageSucceeded && shouldRefreshConversationMetadata) {
+        if (assistantMessageSucceeded && shouldPollGeneratedConversationMetadata(targetConversation, completed)) {
           void refreshGeneratedConversationMetadata(
             token,
             targetConversationID,

--- a/frontend/shared/api/conversation.types.ts
+++ b/frontend/shared/api/conversation.types.ts
@@ -420,6 +420,7 @@ export type MediaImageRequest = {
 export type SendMessageResult = {
   userMessage: MessageDTO;
   assistantMessage: MessageDTO;
+  metadataRefreshHint?: "pending" | "not_needed" | "skipped_no_titleable_content" | string;
 };
 
 export type StreamMessageEvent =


### PR DESCRIPTION
## Summary

Fixes conversation title generation refresh behavior. The backend now returns a metadata refresh hint with send-message results so the frontend only polls for generated title/label updates when metadata generation is actually pending. It also makes automatic metadata skips observable when there is no titleable content and unifies local fallback title truncation to 16 characters.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/application/conversation`
- [x] `cd frontend && pnpm lint`

## Screenshots, API examples, or logs

Send-message responses may now include:

```json
{
  "metadataRefreshHint": "pending"
}
```

Other possible values:

```json
"not_needed"
"skipped_no_titleable_content"
```

## Configuration, migration, and compatibility notes

No configuration, database schema, migration, deployment, or generated Swagger changes.

API compatibility note: `metadataRefreshHint` is an optional additive field on send-message responses. Existing clients can ignore it.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.
