### PR TITLE
feat: add support for HTTP protocol in OpenTelemetry OTLP exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,9 +374,10 @@ Static configuration environment variables:
 | GeoIP | `GEOIP_DATABASE_MAX_BYTES` | Maximum MMDB download size. |
 | GeoIP | `GEOIP_REFRESH_INTERVAL_HOURS` | MMDB refresh interval. |
 | OpenTelemetry | `OTEL_ENABLED` | Enables tracing; when omitted, a configured endpoint enables tracing automatically. |
-| OpenTelemetry | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP gRPC collector endpoint. |
+| OpenTelemetry | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint. |
 | OpenTelemetry | `OTEL_EXPORTER_OTLP_HEADERS` | OTLP headers in `key=value,key2=value2` format. |
-| OpenTelemetry | `OTEL_EXPORTER_OTLP_INSECURE` | Whether to use plaintext gRPC. |
+| OpenTelemetry | `OTEL_EXPORTER_OTLP_INSECURE` | Whether to use plaintext transport. |
+| OpenTelemetry | `OTEL_EXPORTER_OTLP_PROTOCOL` | OTLP exporter protocol: `grpc`, `http`, or `http/protobuf`; defaults to `grpc`. |
 | OpenTelemetry | `OTEL_TRACES_SAMPLER_ARG` / `OTEL_SAMPLING_RATE` | Trace sampling rate from `0` to `1`; `OTEL_TRACES_SAMPLER_ARG` takes priority. |
 
 Authentication, registration, conversation settings, model option policies, file processing, RAG, embedding, MCP, billing, payments, and announcements are runtime business settings, not static YAML configuration. Their defaults are seeded by the backend and maintained in the admin console.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -374,9 +374,10 @@ docker compose logs app
 | GeoIP | `GEOIP_DATABASE_MAX_BYTES` | MMDB 最大下载字节数。 |
 | GeoIP | `GEOIP_REFRESH_INTERVAL_HOURS` | MMDB 刷新间隔。 |
 | OpenTelemetry | `OTEL_ENABLED` | 是否启用 Trace；未显式设置时，配置 endpoint 会自动启用。 |
-| OpenTelemetry | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP gRPC Collector 地址。 |
+| OpenTelemetry | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP Collector 地址。 |
 | OpenTelemetry | `OTEL_EXPORTER_OTLP_HEADERS` | OTLP 请求头，格式为 `key=value,key2=value2`。 |
-| OpenTelemetry | `OTEL_EXPORTER_OTLP_INSECURE` | 是否使用明文 gRPC 连接。 |
+| OpenTelemetry | `OTEL_EXPORTER_OTLP_INSECURE` | 是否使用明文传输。 |
+| OpenTelemetry | `OTEL_EXPORTER_OTLP_PROTOCOL` | OTLP exporter 协议：`grpc`、`http` 或 `http/protobuf`；默认 `grpc`。 |
 | OpenTelemetry | `OTEL_TRACES_SAMPLER_ARG` / `OTEL_SAMPLING_RATE` | Trace 采样率，范围 `0~1`；`OTEL_TRACES_SAMPLER_ARG` 优先。 |
 
 认证、注册、会话配置、模型参数策略、文件处理、RAG、Embedding、MCP、计费、支付和公告等运行时业务配置不属于静态 YAML 配置，默认值由后端种子初始化，并在后台管理中维护。

--- a/backend/README.md
+++ b/backend/README.md
@@ -76,9 +76,10 @@ cp config.docker.example.yaml config.yaml
 - `GEOIP_PROVIDER`：`ipwhois`、`ipinfo`、`mmdb` 或 `none`
 - `GEOIP_DATABASE_URL` / `GEOIP_DATABASE_PATH`：MMDB 数据库下载地址与本地缓存路径
 - `OTEL_ENABLED`：是否启用 OpenTelemetry Trace；未设置时，配置了 OTLP Endpoint 会自动启用
-- `OTEL_EXPORTER_OTLP_ENDPOINT`：OTLP gRPC Collector 地址
+- `OTEL_EXPORTER_OTLP_ENDPOINT`：OTLP Collector 地址
 - `OTEL_EXPORTER_OTLP_HEADERS`：OTLP 请求头，格式为 `key=value,key2=value2`
-- `OTEL_EXPORTER_OTLP_INSECURE`：是否使用明文 gRPC 连接
+- `OTEL_EXPORTER_OTLP_INSECURE`：是否使用明文传输
+- `OTEL_EXPORTER_OTLP_PROTOCOL`：OTLP exporter 协议，支持 `grpc`、`http`、`http/protobuf`，默认 `grpc`
 - `OTEL_TRACES_SAMPLER_ARG` / `OTEL_SAMPLING_RATE`：Trace 采样率，范围 `0~1`
 
 对应 YAML：
@@ -92,6 +93,7 @@ observability:
     endpoint: "http://127.0.0.1:4317"
     headers: ""
     insecure: true
+    protocol: grpc
     sampling_rate: 1
 ```
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -28,6 +28,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
 	go.uber.org/zap v1.27.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -277,6 +277,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0 h1:QKdN8ly8zEMrByybbQg
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0/go.mod h1:bTdK1nhqF76qiPoCCdyFIV+N/sRHYXYCTQc+3VCi3MI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0 h1:DvJDOPmSWQHWywQS6lKL+pb8s3gBLOZUtw4N+mavW1I=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0/go.mod h1:EtekO9DEJb4/jRyN4v4Qjc2yA7AtfCBuz2FynRUWTXs=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0 h1:wVZXIWjQSeSmMoxF74LzAnpVQOAFDo3pPji9Y4SOFKc=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0/go.mod h1:khvBS2IggMFNwZK/6lEeHg/W57h/IX6J4URh57fuI40=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=
 go.opentelemetry.io/otel/metric v1.40.0/go.mod h1:ib/crwQH7N3r5kfiBZQbwrTge743UDc7DTFVZrrXnqc=
 go.opentelemetry.io/otel/sdk v1.4.1/go.mod h1:NBwHDgDIBYjwK2WNu1OPgsIc2IJzmBXNnvIJxJc8BpE=

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -112,6 +112,7 @@ func NewApp() (*App, error) {
 		Endpoint:     cfg.OTelExporterOTLPEndpoint,
 		Headers:      cfg.OTelExporterOTLPHeaders,
 		Insecure:     cfg.OTelExporterOTLPInsecure,
+		Protocol:     cfg.OTelExporterOTLPProtocol,
 		SamplingRate: cfg.OTelSamplingRate,
 	}); err != nil {
 		return nil, fmt.Errorf("init tracing: %w", err)

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -234,6 +234,7 @@ type yamlConfig struct {
 			Endpoint     string  `yaml:"endpoint"`
 			Headers      string  `yaml:"headers"`
 			Insecure     *bool   `yaml:"insecure"`
+			Protocol     string  `yaml:"protocol"`
 			SamplingRate float64 `yaml:"sampling_rate"`
 		} `yaml:"tracing"`
 	} `yaml:"observability"`
@@ -306,6 +307,7 @@ type Config struct {
 	OTelExporterOTLPEndpoint     string
 	OTelExporterOTLPHeaders      string
 	OTelExporterOTLPInsecure     bool
+	OTelExporterOTLPProtocol     string
 	OTelSamplingRate             float64
 
 	// ── 动态配置（由 DB 种子初始化默认值，settings.RuntimeSettings.ApplyTo 覆盖） ──
@@ -523,6 +525,7 @@ func Load() Config {
 		OTelExporterOTLPEndpoint:     envOr("OTEL_EXPORTER_OTLP_ENDPOINT", yc.Observability.Tracing.Endpoint, ""),
 		OTelExporterOTLPHeaders:      envOr("OTEL_EXPORTER_OTLP_HEADERS", yc.Observability.Tracing.Headers, ""),
 		OTelExporterOTLPInsecure:     envOrBoolPtr("OTEL_EXPORTER_OTLP_INSECURE", yc.Observability.Tracing.Insecure, false),
+		OTelExporterOTLPProtocol:     normalizeOTelExporterOTLPProtocol(envOr("OTEL_EXPORTER_OTLP_PROTOCOL", yc.Observability.Tracing.Protocol, "grpc")),
 		OTelSamplingRate:             envOrFloat("OTEL_TRACES_SAMPLER_ARG", envOrFloat("OTEL_SAMPLING_RATE", yc.Observability.Tracing.SamplingRate, 1), 1),
 
 		// 动态配置默认值（会被 DB 覆盖）
@@ -840,6 +843,15 @@ func normalizeCacheDriver(value string) string {
 		return "memory"
 	default:
 		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func normalizeOTelExporterOTLPProtocol(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "http", "http/protobuf":
+		return "http"
+	default:
+		return "grpc"
 	}
 }
 

--- a/backend/internal/infra/observability/tracing/tracing.go
+++ b/backend/internal/infra/observability/tracing/tracing.go
@@ -3,12 +3,15 @@ package tracing
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -27,6 +30,7 @@ type Config struct {
 	Endpoint     string
 	Headers      string
 	Insecure     bool
+	Protocol     string
 	SamplingRate float64
 }
 
@@ -47,7 +51,7 @@ func Init(ctx context.Context, cfg Config) error {
 		serviceName = "deeix-chat"
 	}
 
-	exporter, err := otlptracegrpc.New(ctx, exporterOptions(cfg)...)
+	exporter, err := newExporter(ctx, cfg)
 	if err != nil {
 		return err
 	}
@@ -103,7 +107,18 @@ func enabled(cfg Config) bool {
 	return strings.TrimSpace(cfg.Endpoint) != ""
 }
 
-func exporterOptions(cfg Config) []otlptracegrpc.Option {
+func newExporter(ctx context.Context, cfg Config) (*otlptrace.Exporter, error) {
+	switch cfg.Protocol {
+	case "grpc":
+		return otlptracegrpc.New(ctx, grpcExporterOptions(cfg)...)
+	case "http":
+		return otlptracehttp.New(ctx, httpExporterOptions(cfg)...)
+	default:
+		return nil, fmt.Errorf("unsupported otel exporter protocol %q", cfg.Protocol)
+	}
+}
+
+func grpcExporterOptions(cfg Config) []otlptracegrpc.Option {
 	options := make([]otlptracegrpc.Option, 0, 3)
 	if endpoint := strings.TrimSpace(cfg.Endpoint); endpoint != "" {
 		if strings.Contains(endpoint, "://") {
@@ -117,6 +132,24 @@ func exporterOptions(cfg Config) []otlptracegrpc.Option {
 	}
 	if cfg.Insecure {
 		options = append(options, otlptracegrpc.WithInsecure())
+	}
+	return options
+}
+
+func httpExporterOptions(cfg Config) []otlptracehttp.Option {
+	options := make([]otlptracehttp.Option, 0, 3)
+	if endpoint := strings.TrimSpace(cfg.Endpoint); endpoint != "" {
+		if strings.Contains(endpoint, "://") {
+			options = append(options, otlptracehttp.WithEndpointURL(endpoint))
+		} else {
+			options = append(options, otlptracehttp.WithEndpoint(endpoint))
+		}
+	}
+	if headers := parseHeaders(cfg.Headers); len(headers) > 0 {
+		options = append(options, otlptracehttp.WithHeaders(headers))
+	}
+	if cfg.Insecure {
+		options = append(options, otlptracehttp.WithInsecure())
 	}
 	return options
 }

--- a/backend/internal/infra/observability/tracing/tracing.go
+++ b/backend/internal/infra/observability/tracing/tracing.go
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -80,4 +80,5 @@ observability:
     endpoint: ""
     headers: ""
     insecure: false
+    protocol: grpc
     sampling_rate: 1


### PR DESCRIPTION
## Summary

HTTP Exporter

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [x] Deployment / Docker / configuration
- [ ] Documentation

## Verification

<!-- List the commands or checks you ran. For example: cd backend && go test ./..., cd frontend && pnpm lint, cd frontend && pnpm build. -->

HTTP & GRPC Report 

## Documentation

- [ ] Documentation is not needed for this change.
- [x] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.
