### PR TITLE
feat: add content width setting to chat configuration

### DIFF
--- a/backend/internal/application/usersettings/service.go
+++ b/backend/internal/application/usersettings/service.go
@@ -35,6 +35,7 @@ var allowedKeys = map[string]string{
 	"chat.restore_draft_on_failure":             "true",
 	"chat.preserve_conversation_drafts":         "true",
 	"chat.input_height":                         "standard",
+	"chat.content_width":                        "compact",
 	"chat.default_mcp_tool_ids":                 "[]",
 }
 
@@ -57,6 +58,7 @@ var enumKeys = map[string]map[string]bool{
 	"chat.file_mode":     {"auto": true, "full_context": true, "rag": true},
 	"chat.send_on_enter": {"enter": true, "ctrl_enter": true, "meta_enter": true},
 	"chat.input_height":  {"compact": true, "standard": true, "loose": true},
+	"chat.content_width": {"compact": true, "standard": true, "wide": true},
 }
 
 // validateValue 校验 key 对应 value 的合法性。

--- a/backend/internal/application/usersettings/service_test.go
+++ b/backend/internal/application/usersettings/service_test.go
@@ -42,3 +42,19 @@ func TestDefaultMCPToolIDsSettingIsAllowed(t *testing.T) {
 		t.Fatalf("expected chat.default_mcp_tool_ids to be accepted, got %v", err)
 	}
 }
+
+func TestContentWidthSettingIsAllowed(t *testing.T) {
+	t.Parallel()
+
+	if got := allowedKeys["chat.content_width"]; got != "compact" {
+		t.Fatalf("expected chat.content_width default to be compact, got %q", got)
+	}
+	for _, value := range []string{"compact", "standard", "wide"} {
+		if err := validateValue("chat.content_width", value); err != nil {
+			t.Fatalf("expected chat.content_width=%s to be accepted, got %v", value, err)
+		}
+	}
+	if err := validateValue("chat.content_width", "loose"); err == nil {
+		t.Fatal("expected invalid chat.content_width to be rejected")
+	}
+}

--- a/frontend/features/chat/components/app-chat-area.tsx
+++ b/frontend/features/chat/components/app-chat-area.tsx
@@ -20,6 +20,7 @@ import { useChatViewerProfile } from "@/features/chat/hooks/use-chat-viewer-prof
 import { useChatConversationExport } from "@/features/chat/hooks/use-chat-conversation-export";
 import { useChatVisualPrompt } from "@/features/chat/hooks/use-chat-visual-prompt";
 import { ChatInput } from "@/features/chat/components/sections/chat-input";
+import { resolveChatContentWidthClassName } from "@/shared/model/chat-content-width";
 import {
   ConversationShareDialog,
   sharePatchFromDTO,
@@ -57,7 +58,6 @@ import { cn } from "@/lib/utils";
 const MODEL_OPTIONS_STORAGE_PREFIX = "deeix-chat:chat-model-options:";
 const DEFAULT_MCP_TOOLS_SETTING_KEY = "chat.default_mcp_tool_ids";
 const EMPTY_CONVERSATION_OPTIONS: ConversationOptions = {};
-
 function dragEventContainsFiles(event: React.DragEvent<HTMLElement>): boolean {
   return Array.from(event.dataTransfer.types ?? []).includes("Files");
 }
@@ -296,6 +296,7 @@ export function AppChatArea() {
     restoreDraftOnFailure,
     preserveConversationDrafts,
     inputHeight,
+    contentWidth,
     markdownRender,
     showModelInfo,
     showLatency,
@@ -1009,6 +1010,7 @@ export function AppChatArea() {
     onSendMessage,
     onStopMessage: onStopActiveMessage,
   };
+  const chatContentWidthClassName = resolveChatContentWidthClassName(contentWidth);
   const isConversationLoading = Boolean(conversationID) && loading && visibleMessageCount === 0 && messagesWithInlineError.length === 0;
   const isConversationLoadFailed = Boolean(conversationID) && !loading && errorMsg.trim().length > 0 && visibleMessageCount === 0;
   const shouldUseCenteredComposer =
@@ -1028,6 +1030,7 @@ export function AppChatArea() {
             greetingTitle={activeRouteProject?.name || greetingTitle}
             badgeLabel={activeRouteProject ? t("projectMode") : undefined}
             badgeTooltip={activeRouteProject ? t("projectModeTooltip") : undefined}
+            contentWidthClassName={chatContentWidthClassName}
           >
             <ChatInput {...chatInputProps} />
           </ChatEmptyState>
@@ -1095,13 +1098,14 @@ export function AppChatArea() {
                   showTokenUsage={showTokenUsage}
                   showBillingCost={showBillingCost}
                   splitRightInset={hasInlineArtifact}
+                  contentWidthClassName={chatContentWidthClassName}
                 />
               )}
             </div>
 
             {!isConversationLoadFailed ? (
               <div className="relative z-10 shrink-0 px-3 pb-3 md:px-6">
-                <div className="mx-auto w-full max-w-[800px]">
+                <div className={cn("mx-auto w-full", chatContentWidthClassName)}>
                   <ChatInput {...chatInputProps} />
                 </div>
               </div>

--- a/frontend/features/chat/components/message/message-bot.tsx
+++ b/frontend/features/chat/components/message/message-bot.tsx
@@ -103,6 +103,7 @@ type ChatMessageBotProps = {
   onEditImageAttachment?: (attachment: MessageAttachment, sourceModelName?: string) => void;
   artifactActions?: MarkdownArtifactActions;
   showBranchNavigator?: boolean;
+  contentWidthClassName?: string;
 };
 
 export function ChatMessageBot({
@@ -126,6 +127,7 @@ export function ChatMessageBot({
   onEditImageAttachment,
   artifactActions,
   showBranchNavigator = true,
+  contentWidthClassName = "max-w-[1080px]",
 }: ChatMessageBotProps) {
   const tCommon = useTranslations("common.actions");
   const submitT = useTranslations("chat.submit");
@@ -223,7 +225,7 @@ export function ChatMessageBot({
 
     return (
       <div className="flex justify-start">
-        <div className="w-full max-w-[760px] rounded-lg bg-muted/40 p-3 text-foreground">
+        <div className={cn("w-full rounded-lg bg-muted/40 p-3 text-foreground", contentWidthClassName)}>
           <Textarea
             autoFocus
             value={editingValue}

--- a/frontend/features/chat/components/sections/chat-area.tsx
+++ b/frontend/features/chat/components/sections/chat-area.tsx
@@ -99,6 +99,7 @@ type ChatAreaProps = {
   showTokenUsage?: boolean;
   showBillingCost?: boolean;
   splitRightInset?: boolean;
+  contentWidthClassName?: string;
 };
 
 function useStableEvent<Args extends unknown[], Return>(callback: (...args: Args) => Return) {
@@ -132,6 +133,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
   showLatency,
   showTokenUsage,
   showBillingCost,
+  contentWidthClassName,
 }: {
   item: ChatAreaMessage;
   busy: boolean;
@@ -154,6 +156,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
   showLatency: boolean;
   showTokenUsage: boolean;
   showBillingCost: boolean;
+  contentWidthClassName: string;
 }) {
   const t = useTranslations("chat.messages");
   const { copy, isCopied } = useCopyAction({
@@ -218,6 +221,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
         showLatency={showLatency}
         showTokenUsage={showTokenUsage}
         showBillingCost={showBillingCost}
+        contentWidthClassName={contentWidthClassName}
       />
     );
   }
@@ -242,6 +246,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
   previous.showLatency === next.showLatency &&
   previous.showTokenUsage === next.showTokenUsage &&
   previous.showBillingCost === next.showBillingCost &&
+  previous.contentWidthClassName === next.contentWidthClassName &&
   previous.modelOptions === next.modelOptions &&
   previous.selectedPlatformModelName === next.selectedPlatformModelName &&
   previous.onModelChange === next.onModelChange &&
@@ -289,6 +294,7 @@ export function ChatArea({
   showTokenUsage = true,
   showBillingCost = false,
   splitRightInset = false,
+  contentWidthClassName = "max-w-[1080px]",
 }: ChatAreaProps) {
   const t = useTranslations("chat");
   const { getReaction, onReactAssistantMessage } = useChatMessageFeedback(messages);
@@ -345,7 +351,7 @@ export function ChatArea({
         >
           <div
             ref={messageContentRef}
-            className="mx-auto w-full max-w-[760px]"
+            className={cn("mx-auto w-full", contentWidthClassName)}
             style={{ fontFamily: "var(--font-chat)", fontWeight: "var(--font-chat-weight)" }}
           >
             {messages.map((item, index) => {
@@ -381,6 +387,7 @@ export function ChatArea({
                   showLatency={showLatency}
                   showTokenUsage={showTokenUsage}
                   showBillingCost={showBillingCost}
+                  contentWidthClassName={contentWidthClassName}
                 />
               );
 
@@ -444,7 +451,7 @@ export function ChatAreaSkeleton() {
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden px-3 pb-8 pt-2 md:px-6">
-        <div className="mx-auto w-full max-w-[760px] space-y-6">
+        <div className="mx-auto w-full max-w-[1080px] space-y-6">
           <ChatUserMessageSkeleton widthClassName="w-[min(26rem,70%)] max-sm:w-[88%]" />
 
           <ChatAssistantMessageSkeleton />

--- a/frontend/features/chat/components/sections/chat-empty.tsx
+++ b/frontend/features/chat/components/sections/chat-empty.tsx
@@ -5,11 +5,13 @@ import { AnimatePresence, motion } from "motion/react";
 
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 
 type ChatEmptyStateProps = {
   greetingTitle: string;
   badgeLabel?: string;
   badgeTooltip?: string;
+  contentWidthClassName?: string;
   children?: React.ReactNode;
 };
 
@@ -18,7 +20,7 @@ const CHAT_EMPTY_TEXT_TRANSITION = {
   ease: [0.16, 1, 0.3, 1] as const,
 };
 
-export function ChatEmptyState({ greetingTitle, badgeLabel, badgeTooltip, children }: ChatEmptyStateProps) {
+export function ChatEmptyState({ greetingTitle, badgeLabel, badgeTooltip, contentWidthClassName = "max-w-[1080px]", children }: ChatEmptyStateProps) {
   const badge = badgeLabel ? (
     <span className="absolute left-full top-0 ml-1.5">
       <Badge
@@ -57,7 +59,7 @@ export function ChatEmptyState({ greetingTitle, badgeLabel, badgeTooltip, childr
           </motion.div>
         </AnimatePresence>
       </motion.div>
-      {children ? <div className="mt-7 w-full max-w-[800px] md:mt-8">{children}</div> : null}
+      {children ? <div className={cn("mt-7 w-full md:mt-8", contentWidthClassName)}>{children}</div> : null}
     </div>
   );
 }

--- a/frontend/features/chat/hooks/use-chat-model-options.ts
+++ b/frontend/features/chat/hooks/use-chat-model-options.ts
@@ -11,6 +11,11 @@ import type {
 import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
 import { parseProtocolsJSON } from "@/shared/lib/model-protocols";
 import { sanitizeConversationOptions } from "@/features/chat/model/conversation-options";
+import {
+  DEFAULT_CHAT_CONTENT_WIDTH,
+  parseChatContentWidth,
+  type ChatContentWidth,
+} from "@/shared/model/chat-content-width";
 import { listConversationRuns } from "@/shared/api/conversation";
 import { listPublicModels } from "@/shared/api/model";
 import { getBillingConfig } from "@/shared/api/billing";
@@ -22,6 +27,7 @@ import { parseKindsJSON } from "@/shared/model/llm-schema";
 import type { ConversationOptions } from "@/shared/api/conversation.types";
 import type { SendShortcut } from "@/features/settings/types/settings";
 import { parseSendShortcut } from "@/features/settings/utils/chat-settings";
+import { USER_SETTINGS_UPDATED_EVENT } from "@/features/settings/events/user-settings-events";
 
 type ModelCatalogRefreshResult = {
   models: PublicModelDTO[];
@@ -42,6 +48,10 @@ function parseJSONObject(raw: string): Record<string, unknown> | null {
   } catch {
     return null;
   }
+}
+
+function resolveChatContentWidth(settings: Record<string, string>): ChatContentWidth {
+  return parseChatContentWidth(settings["chat.content_width"]);
 }
 
 function normalizeNativeToolPayload(value: unknown): Record<string, unknown> {
@@ -302,6 +312,7 @@ export function useChatModelOptions({
   const [restoreDraftOnFailure, setRestoreDraftOnFailure] = React.useState(true);
   const [preserveConversationDrafts, setPreserveConversationDrafts] = React.useState(true);
   const [inputHeight, setInputHeight] = React.useState<"compact" | "standard" | "loose">("standard");
+  const [contentWidth, setContentWidth] = React.useState<ChatContentWidth>(DEFAULT_CHAT_CONTENT_WIDTH);
   const [markdownRender, setMarkdownRender] = React.useState(true);
   const [showModelInfo, setShowModelInfo] = React.useState(true);
   const [showLatency, setShowLatency] = React.useState(true);
@@ -406,6 +417,7 @@ export function useChatModelOptions({
             ? settings["chat.input_height"]
             : "standard",
         );
+        setContentWidth(resolveChatContentWidth(settings));
       } catch {
         if (!cancelled) {
           setModelsErrorMsg(t("loadFailed"));
@@ -422,6 +434,21 @@ export function useChatModelOptions({
       cancelled = true;
     };
   }, [applyModelCatalog, loadModelCatalog, t]);
+
+  React.useEffect(() => {
+    const handleUserSettingsUpdated = (event: Event) => {
+      const settings = (event as CustomEvent<Record<string, string>>).detail;
+      if (!settings || typeof settings !== "object") {
+        return;
+      }
+      setContentWidth(resolveChatContentWidth(settings));
+    };
+
+    window.addEventListener(USER_SETTINGS_UPDATED_EVENT, handleUserSettingsUpdated);
+    return () => {
+      window.removeEventListener(USER_SETTINGS_UPDATED_EVENT, handleUserSettingsUpdated);
+    };
+  }, []);
 
   React.useEffect(() => {
     const normalizedConversationID = conversationPublicID?.trim() || null;
@@ -506,6 +533,7 @@ export function useChatModelOptions({
     restoreDraftOnFailure,
     preserveConversationDrafts,
     inputHeight,
+    contentWidth,
     markdownRender,
     showModelInfo,
     showLatency,

--- a/frontend/features/settings/components/sections/chat/chat-display-appearance.tsx
+++ b/frontend/features/settings/components/sections/chat/chat-display-appearance.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
+import {
+  type ChatFontOption,
+  type ChatFontWeightOption,
+} from "@/features/settings/utils/chat-font";
+import type {
+  ChatFontPreview,
+  ChatFontWeightPreview,
+} from "@/features/settings/types/settings";
+import { cn } from "@/lib/utils";
+import {
+  CHAT_CONTENT_WIDTH_OPTIONS,
+  type ChatContentWidth,
+  type ChatContentWidthOption,
+} from "@/shared/model/chat-content-width";
+
+const CHAT_FONT_OPTIONS: ChatFontPreview[] = [
+  { label: "Default", value: "default", fontFamily: "var(--font-sans)", sampleText: "Aa" },
+  { label: "Serif", value: "songti", fontFamily: "var(--font-songti)", sampleText: "Aa" },
+  { label: "Sans", value: "heiti", fontFamily: "var(--font-heiti)", sampleText: "Aa" },
+  { label: "Mono", value: "mono", fontFamily: "var(--font-mono)", sampleText: "Aa" },
+];
+
+const CHAT_FONT_WEIGHT_OPTIONS: ChatFontWeightPreview[] = [
+  { label: "Regular", value: "regular", fontWeight: 400, sampleText: "Aa" },
+  { label: "Medium", value: "medium", fontWeight: 500, sampleText: "Aa" },
+  { label: "Semibold", value: "semibold", fontWeight: 600, sampleText: "Aa" },
+  { label: "Bold", value: "bold", fontWeight: 700, sampleText: "Aa" },
+];
+
+function ChatContentWidthPreviewCard({
+  item,
+  active,
+  disabled,
+  onSelect,
+}: {
+  item: ChatContentWidthOption & { label: string };
+  active: boolean;
+  disabled?: boolean;
+  onSelect: (value: ChatContentWidth) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item.value)}
+      className="group text-left disabled:pointer-events-none disabled:opacity-60"
+      aria-pressed={active}
+      disabled={disabled}
+    >
+      <div
+        className={cn(
+          "flex h-24 w-full flex-col items-center justify-center gap-2 rounded-xl border bg-background px-2 transition-all duration-200 hover:scale-102 hover:border-primary/60",
+          active ? "border-primary/60" : "border-border/50",
+        )}
+      >
+        <span className={cn("h-2 rounded-full bg-foreground/75", item.previewScaleClassName)} aria-hidden="true" />
+        <span className="truncate text-center text-sm font-medium leading-none text-foreground/90">
+          {item.label} - {item.width}px
+        </span>
+      </div>
+    </button>
+  );
+}
+
+function ChatFontPreviewCard({
+  item,
+  active,
+  onSelect,
+}: {
+  item: ChatFontPreview;
+  active: boolean;
+  onSelect: (value: ChatFontOption) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item.value)}
+      className="group text-left"
+      aria-pressed={active}
+    >
+      <div
+        className={cn(
+          "flex h-24 w-full items-center justify-center rounded-xl border bg-background px-1 transition-all duration-200 hover:scale-102 hover:border-primary/60",
+          active ? "border-primary/60" : "border-border/50",
+        )}
+      >
+        <span
+          className="truncate text-center text-base leading-none text-foreground/90"
+          style={{ fontFamily: item.fontFamily }}
+        >
+          {item.label} {item.sampleText}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+function ChatFontWeightPreviewCard({
+  item,
+  active,
+  onSelect,
+}: {
+  item: ChatFontWeightPreview;
+  active: boolean;
+  onSelect: (value: ChatFontWeightOption) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item.value)}
+      className="group text-left"
+      aria-pressed={active}
+    >
+      <div
+        className={cn(
+          "flex h-24 w-full items-center justify-center rounded-xl border bg-background px-1 transition-all duration-200 hover:scale-102 hover:border-primary/60",
+          active ? "border-primary/60" : "border-border/50",
+        )}
+      >
+        <span
+          className="truncate text-center text-base leading-none text-foreground/90"
+          style={{ fontFamily: "var(--font-chat)", fontWeight: item.fontWeight }}
+        >
+          {item.label} {item.sampleText}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+export function ChatDisplayAppearance({
+  contentWidth,
+  chatFont,
+  chatFontWeight,
+  onContentWidthChange,
+  onChatFontChange,
+  onChatFontWeightChange,
+  disabled,
+}: {
+  contentWidth: ChatContentWidth;
+  chatFont: ChatFontOption;
+  chatFontWeight: ChatFontWeightOption;
+  onContentWidthChange: (value: ChatContentWidth) => void;
+  onChatFontChange: (value: ChatFontOption) => void;
+  onChatFontWeightChange: (value: ChatFontWeightOption) => void;
+  disabled?: boolean;
+}) {
+  const t = useTranslations("settings.chatPage.display");
+
+  return (
+    <FieldGroup className="gap-3 md:gap-4">
+      <Field>
+        <FieldLabel>{t("widthTitle")}</FieldLabel>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:gap-3 xl:gap-4">
+          {CHAT_CONTENT_WIDTH_OPTIONS.map((item) => (
+            <ChatContentWidthPreviewCard
+              key={item.value}
+              item={{ ...item, label: t(`width.${item.value}`) }}
+              active={contentWidth === item.value}
+              onSelect={onContentWidthChange}
+              disabled={disabled}
+            />
+          ))}
+        </div>
+      </Field>
+
+      <Field>
+        <FieldLabel>{t("chatFont")}</FieldLabel>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:gap-3 xl:gap-4">
+          {CHAT_FONT_OPTIONS.map((item) => (
+            <ChatFontPreviewCard
+              key={item.value}
+              item={{ ...item, label: t(`font.${item.value}`) }}
+              active={chatFont === item.value}
+              onSelect={onChatFontChange}
+            />
+          ))}
+        </div>
+      </Field>
+
+      <Field>
+        <FieldLabel>{t("chatFontWeight")}</FieldLabel>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:gap-3 xl:gap-4">
+          {CHAT_FONT_WEIGHT_OPTIONS.map((item) => (
+            <ChatFontWeightPreviewCard
+              key={item.value}
+              item={{ ...item, label: t(`fontWeight.${item.value}`) }}
+              active={chatFontWeight === item.value}
+              onSelect={onChatFontWeightChange}
+            />
+          ))}
+        </div>
+      </Field>
+    </FieldGroup>
+  );
+}

--- a/frontend/features/settings/components/sections/chat/settings-chat.tsx
+++ b/frontend/features/settings/components/sections/chat/settings-chat.tsx
@@ -26,7 +26,17 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import type { ChatContentWidth } from "@/shared/model/chat-content-width";
+import { useAppearancePreferencesPersistence } from "@/features/settings/hooks/use-appearance-preferences-persistence";
 import { useSettingsChat } from "@/features/settings/hooks/use-settings-chat";
+import {
+  type ChatFontOption,
+  type ChatFontWeightOption,
+  useChatFontPreference,
+  useChatFontWeightPreference,
+  writeChatFontPreference,
+  writeChatFontWeightPreference,
+} from "@/features/settings/utils/chat-font";
 import { useLocalizedErrorMessage } from "@/i18n/use-localized-error";
 import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
 import { listUserMemories, upsertUserMemory, deleteUserMemory } from "@/shared/api/memory";
@@ -43,6 +53,7 @@ import { resolveModelOptionIconUrl, resolveModelOptionLabel } from "@/shared/lib
 import { parseKindsJSON } from "@/shared/model/llm-schema";
 import { platformModifierLabel, platformSendShortcut } from "@/shared/lib/platform-shortcuts";
 import type { SendShortcut } from "@/features/settings/types/settings";
+import { ChatDisplayAppearance } from "./chat-display-appearance";
 
 type ModelOption = ModelSelectOption;
 
@@ -417,6 +428,9 @@ export function SettingsChat() {
     handleDefaultModel,
   } = useSettingsChat();
   const billingEnabled = billingMode !== "self";
+  const chatFont = useChatFontPreference();
+  const chatFontWeight = useChatFontWeightPreference();
+  const persistAppearancePreferences = useAppearancePreferencesPersistence();
   const [modifierLabel, setModifierLabel] = React.useState<"Command" | "Ctrl">("Ctrl");
   const [modifierShortcut, setModifierShortcut] = React.useState<Exclude<SendShortcut, "enter">>("ctrl_enter");
   const modelOptions = React.useMemo<ModelOption[]>(
@@ -445,6 +459,20 @@ export function SettingsChat() {
   }, []);
 
   const sendShortcutLabel = settings.sendShortcut === "enter" ? "Enter" : `${modifierLabel}+Enter`;
+
+  const handleChatFontChange = React.useCallback((value: ChatFontOption) => {
+    writeChatFontPreference(value);
+    persistAppearancePreferences({ chatFont: value });
+  }, [persistAppearancePreferences]);
+
+  const handleChatFontWeightChange = React.useCallback((value: ChatFontWeightOption) => {
+    writeChatFontWeightPreference(value);
+    persistAppearancePreferences({ chatFontWeight: value });
+  }, [persistAppearancePreferences]);
+
+  const handleContentWidthChange = React.useCallback((value: ChatContentWidth) => {
+    handleEnum("chat.content_width", "contentWidth")(value);
+  }, [handleEnum]);
 
   return (
     <SettingsPage>
@@ -640,6 +668,18 @@ export function SettingsChat() {
                 aria-label={t("display.costTitle")}
               />
             </SettingsFieldRow>
+          </div>
+
+          <div className="pt-4">
+            <ChatDisplayAppearance
+              contentWidth={settings.contentWidth}
+              chatFont={chatFont}
+              chatFontWeight={chatFontWeight}
+              onContentWidthChange={handleContentWidthChange}
+              onChatFontChange={handleChatFontChange}
+              onChatFontWeightChange={handleChatFontWeightChange}
+              disabled={loading}
+            />
           </div>
         </SettingsFieldList>
       </SettingsSection>

--- a/frontend/features/settings/components/sections/general/general-appearance.tsx
+++ b/frontend/features/settings/components/sections/general/general-appearance.tsx
@@ -5,14 +5,8 @@ import { Monitor, Moon, Sun } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
-import {
-  type ChatFontOption,
-  type ChatFontWeightOption,
-} from "@/features/settings/utils/chat-font";
 import type { FontSizeOption } from "@/features/settings/utils/font-size";
 import type {
-  ChatFontPreview,
-  ChatFontWeightPreview,
   FontSizePreview,
   ThemeMode,
   ThemePresetPreview,
@@ -230,20 +224,6 @@ const THEME_PRESET_PREVIEWS: ThemePresetPreview[] = [
   },
 ];
 
-const CHAT_FONT_OPTIONS: ChatFontPreview[] = [
-  { label: "Default", value: "default", fontFamily: "var(--font-sans)", sampleText: "Aa" },
-  { label: "Serif", value: "songti", fontFamily: "var(--font-songti)", sampleText: "Aa" },
-  { label: "Sans", value: "heiti", fontFamily: "var(--font-heiti)", sampleText: "Aa" },
-  { label: "Mono", value: "mono", fontFamily: "var(--font-mono)", sampleText: "Aa" },
-];
-
-const CHAT_FONT_WEIGHT_OPTIONS: ChatFontWeightPreview[] = [
-  { label: "Regular", value: "regular", fontWeight: 400, sampleText: "Aa" },
-  { label: "Medium", value: "medium", fontWeight: 500, sampleText: "Aa" },
-  { label: "Semibold", value: "semibold", fontWeight: 600, sampleText: "Aa" },
-  { label: "Bold", value: "bold", fontWeight: 700, sampleText: "Aa" },
-];
-
 const FONT_SIZE_OPTIONS: FontSizePreview[] = [
   { label: "Small", value: "small", scale: 0.88 },
   { label: "Standard", value: "standard", scale: 1 },
@@ -406,72 +386,6 @@ function ThemePreviewCard({
   );
 }
 
-function ChatFontPreviewCard({
-  item,
-  active,
-  onSelect,
-}: {
-  item: ChatFontPreview;
-  active: boolean;
-  onSelect: (value: ChatFontOption) => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={() => onSelect(item.value)}
-      className="group text-left"
-      aria-pressed={active}
-    >
-      <div
-        className={cn(
-          "flex h-24 w-full items-center justify-center rounded-xl border bg-background px-1 transition-all duration-200 hover:scale-102 hover:border-primary/60",
-          active ? "border-primary/60" : "border-border/50",
-        )}
-      >
-        <span
-          className="truncate text-center text-[clamp(0.9rem,2.8vw,1.125rem)] leading-none text-foreground/90"
-          style={{ fontFamily: item.fontFamily }}
-        >
-          {item.label} {item.sampleText}
-        </span>
-      </div>
-    </button>
-  );
-}
-
-function ChatFontWeightPreviewCard({
-  item,
-  active,
-  onSelect,
-}: {
-  item: ChatFontWeightPreview;
-  active: boolean;
-  onSelect: (value: ChatFontWeightOption) => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={() => onSelect(item.value)}
-      className="group text-left"
-      aria-pressed={active}
-    >
-      <div
-        className={cn(
-          "flex h-24 w-full items-center justify-center rounded-xl border bg-background px-1 transition-all duration-200 hover:scale-102 hover:border-primary/60",
-          active ? "border-primary/60" : "border-border/50",
-        )}
-      >
-        <span
-          className="truncate text-center text-[clamp(0.9rem,2.8vw,1.125rem)] leading-none text-foreground/90"
-          style={{ fontFamily: "var(--font-chat)", fontWeight: item.fontWeight }}
-        >
-          {item.label} {item.sampleText}
-        </span>
-      </div>
-    </button>
-  );
-}
-
 function FontSizePreviewCard({
   item,
   active,
@@ -509,25 +423,17 @@ export function GeneralAppearanceSection({
   resolvedTheme,
   activeThemeMode,
   activeThemePreset,
-  chatFont,
-  chatFontWeight,
   fontSize,
   onThemeModeChange,
   onThemePresetChange,
-  onChatFontChange,
-  onChatFontWeightChange,
   onFontSizeChange,
 }: {
   resolvedTheme: "light" | "dark";
   activeThemeMode: ThemeMode;
   activeThemePreset: ThemePreset;
-  chatFont: ChatFontOption;
-  chatFontWeight: ChatFontWeightOption;
   fontSize: FontSizeOption;
   onThemeModeChange: (mode: ThemeMode) => void;
   onThemePresetChange: (preset: ThemePreset) => void;
-  onChatFontChange: (value: ChatFontOption) => void;
-  onChatFontWeightChange: (value: ChatFontWeightOption) => void;
   onFontSizeChange: (value: FontSizeOption) => void;
 }) {
   const t = useTranslations("settings");
@@ -598,33 +504,6 @@ export function GeneralAppearanceSection({
           </div>
         </Field>
 
-        <Field>
-          <FieldLabel>{t("generalPage.appearance.chatFont")}</FieldLabel>
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:gap-3 xl:gap-4">
-            {CHAT_FONT_OPTIONS.map((item) => (
-              <ChatFontPreviewCard
-                key={item.value}
-                item={{ ...item, label: t(`generalPage.appearance.font.${item.value}`) }}
-                active={chatFont === item.value}
-                onSelect={onChatFontChange}
-              />
-            ))}
-          </div>
-        </Field>
-
-        <Field>
-          <FieldLabel>{t("generalPage.appearance.chatFontWeight")}</FieldLabel>
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:gap-3 xl:gap-4">
-            {CHAT_FONT_WEIGHT_OPTIONS.map((item) => (
-              <ChatFontWeightPreviewCard
-                key={item.value}
-                item={{ ...item, label: t(`generalPage.appearance.fontWeight.${item.value}`) }}
-                active={chatFontWeight === item.value}
-                onSelect={onChatFontWeightChange}
-              />
-            ))}
-          </div>
-        </Field>
       </FieldGroup>
     </SettingsSection>
   );

--- a/frontend/features/settings/components/sections/general/settings-general.tsx
+++ b/frontend/features/settings/components/sections/general/settings-general.tsx
@@ -5,19 +5,7 @@ import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
 import { dispatchUserProfileUpdated } from "@/features/settings/events/user-profile-events";
-import {
-  readLocalAppearancePreferences,
-  serializeAppearancePreferences,
-  type AppearancePreferencePatch,
-} from "@/features/settings/utils/appearance-preferences";
-import {
-  type ChatFontOption,
-  type ChatFontWeightOption,
-  useChatFontPreference,
-  useChatFontWeightPreference,
-  writeChatFontPreference,
-  writeChatFontWeightPreference,
-} from "@/features/settings/utils/chat-font";
+import { useAppearancePreferencesPersistence } from "@/features/settings/hooks/use-appearance-preferences-persistence";
 import {
   type FontSizeOption,
   useFontSizePreference,
@@ -93,8 +81,6 @@ export function SettingsGeneral() {
   const [avatarUploading, setAvatarUploading] = React.useState(false);
   const [avatarUploadPreview, setAvatarUploadPreview] = React.useState<AvatarUploadPreview | null>(null);
   const [themeRuntimeReady, setThemeRuntimeReady] = React.useState(false);
-  const chatFont = useChatFontPreference();
-  const chatFontWeight = useChatFontWeightPreference();
   const fontSize = useFontSizePreference();
   const [notificationRuntimeReady, setNotificationRuntimeReady] = React.useState(false);
   const [notificationSupported, setNotificationSupported] = React.useState(false);
@@ -104,8 +90,7 @@ export function SettingsGeneral() {
   const [saving, setSaving] = React.useState(false);
   const [usernameDraft, setUsernameDraft] = React.useState("");
   const initialUsernameToastShownRef = React.useRef(false);
-  const appearanceSaveTimerRef = React.useRef<number | null>(null);
-  const pendingAppearancePatchRef = React.useRef<AppearancePreferencePatch>({});
+  const persistAppearancePreferences = useAppearancePreferencesPersistence();
 
   React.useEffect(() => {
     if (userStatus === "loading") {
@@ -133,14 +118,6 @@ export function SettingsGeneral() {
     setNotificationSupported(isBrowserNotificationSupported());
     setResponseCompletionNotificationsEnabled(readResponseCompletionNotificationsEnabled());
     setNotificationPermission(getBrowserNotificationPermission());
-  }, []);
-
-  React.useEffect(() => {
-    return () => {
-      if (appearanceSaveTimerRef.current !== null) {
-        window.clearTimeout(appearanceSaveTimerRef.current);
-      }
-    };
   }, []);
 
   React.useEffect(() => {
@@ -376,45 +353,6 @@ export function SettingsGeneral() {
     })();
   }, [notificationSupported, t]);
 
-  const persistAppearancePreferences = React.useCallback(
-    (patch: AppearancePreferencePatch) => {
-      if (!accessToken) {
-        return;
-      }
-
-      pendingAppearancePatchRef.current = {
-        ...pendingAppearancePatchRef.current,
-        ...patch,
-      };
-      if (appearanceSaveTimerRef.current !== null) {
-        window.clearTimeout(appearanceSaveTimerRef.current);
-      }
-
-      appearanceSaveTimerRef.current = window.setTimeout(() => {
-        void (async () => {
-          const pendingPatch = pendingAppearancePatchRef.current;
-          pendingAppearancePatchRef.current = {};
-          appearanceSaveTimerRef.current = null;
-          const appearancePreferences = serializeAppearancePreferences({
-            ...readLocalAppearancePreferences(),
-            ...pendingPatch,
-          });
-          try {
-            const nextViewer = await patchMe(accessToken, { appearancePreferences });
-            setViewer((current) =>
-              current ? { ...current, appearancePreferences: nextViewer.appearancePreferences } : nextViewer,
-            );
-          } catch (error) {
-            toast.error(t("generalPage.toast.saveProfileFailed"), {
-              description: resolveLocalizedErrorMessage(error),
-            });
-          }
-        })();
-      }, 300);
-    },
-    [accessToken, t],
-  );
-
   const notificationHelpText = React.useMemo(() => {
     if (!notificationRuntimeReady) {
       return t("generalPage.notifications.defaultHelp");
@@ -446,16 +384,6 @@ export function SettingsGeneral() {
     },
     [persistAppearancePreferences, setPreset],
   );
-
-  const handleChatFontChange = React.useCallback((value: ChatFontOption) => {
-    writeChatFontPreference(value);
-    persistAppearancePreferences({ chatFont: value });
-  }, [persistAppearancePreferences]);
-
-  const handleChatFontWeightChange = React.useCallback((value: ChatFontWeightOption) => {
-    writeChatFontWeightPreference(value);
-    persistAppearancePreferences({ chatFontWeight: value });
-  }, [persistAppearancePreferences]);
 
   const handleFontSizeChange = React.useCallback((value: FontSizeOption) => {
     writeFontSizePreference(value);
@@ -506,13 +434,9 @@ export function SettingsGeneral() {
         resolvedTheme={resolvedTheme}
         activeThemeMode={activeThemeMode}
         activeThemePreset={activeThemePreset}
-        chatFont={chatFont}
-        chatFontWeight={chatFontWeight}
         fontSize={fontSize}
         onThemeModeChange={handleThemeModeChange}
         onThemePresetChange={handleThemePresetChange}
-        onChatFontChange={handleChatFontChange}
-        onChatFontWeightChange={handleChatFontWeightChange}
         onFontSizeChange={handleFontSizeChange}
       />
     </SettingsPage>

--- a/frontend/features/settings/hooks/use-appearance-preferences-persistence.ts
+++ b/frontend/features/settings/hooks/use-appearance-preferences-persistence.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import * as React from "react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+import {
+  readLocalAppearancePreferences,
+  serializeAppearancePreferences,
+  type AppearancePreferencePatch,
+} from "@/features/settings/utils/appearance-preferences";
+import { resolveLocalizedErrorMessage } from "@/i18n/resolve-error-message";
+import { patchMe } from "@/shared/api/auth";
+import { useAuthSession } from "@/shared/auth/auth-session-context";
+
+export function useAppearancePreferencesPersistence() {
+  const t = useTranslations("settings");
+  const { accessToken } = useAuthSession();
+  const appearanceSaveTimerRef = React.useRef<number | null>(null);
+  const pendingAppearancePatchRef = React.useRef<AppearancePreferencePatch>({});
+
+  React.useEffect(() => {
+    return () => {
+      if (appearanceSaveTimerRef.current !== null) {
+        window.clearTimeout(appearanceSaveTimerRef.current);
+      }
+    };
+  }, []);
+
+  return React.useCallback(
+    (patch: AppearancePreferencePatch) => {
+      if (!accessToken) {
+        return;
+      }
+
+      pendingAppearancePatchRef.current = {
+        ...pendingAppearancePatchRef.current,
+        ...patch,
+      };
+      if (appearanceSaveTimerRef.current !== null) {
+        window.clearTimeout(appearanceSaveTimerRef.current);
+      }
+
+      appearanceSaveTimerRef.current = window.setTimeout(() => {
+        void (async () => {
+          const pendingPatch = pendingAppearancePatchRef.current;
+          pendingAppearancePatchRef.current = {};
+          appearanceSaveTimerRef.current = null;
+          const appearancePreferences = serializeAppearancePreferences({
+            ...readLocalAppearancePreferences(),
+            ...pendingPatch,
+          });
+          try {
+            await patchMe(accessToken, { appearancePreferences });
+          } catch (error) {
+            toast.error(t("generalPage.toast.saveProfileFailed"), {
+              description: resolveLocalizedErrorMessage(error),
+            });
+          }
+        })();
+      }, 300);
+    },
+    [accessToken, t],
+  );
+}

--- a/frontend/features/settings/types/settings.ts
+++ b/frontend/features/settings/types/settings.ts
@@ -1,3 +1,4 @@
+import type { ChatContentWidth } from "@/shared/model/chat-content-width";
 import type { ChatFontOption, ChatFontWeightOption } from "@/features/settings/utils/chat-font";
 import type { FontSizeOption } from "@/features/settings/utils/font-size";
 import type { ThemePreset } from "@/shared/components/theme-provider";
@@ -6,7 +7,6 @@ import type { PublicModelDTO } from "@/shared/api/model.types";
 export type SendShortcut = "enter" | "ctrl_enter" | "meta_enter";
 export type FileMode = "auto" | "full_context" | "rag";
 export type ChatInputHeight = "compact" | "standard" | "loose";
-
 export type ChatSettings = {
   defaultModel: string;
   sendShortcut: SendShortcut;
@@ -21,6 +21,7 @@ export type ChatSettings = {
   restoreDraftOnFailure: boolean;
   preserveConversationDrafts: boolean;
   inputHeight: ChatInputHeight;
+  contentWidth: ChatContentWidth;
   fileMode: FileMode;
 };
 

--- a/frontend/features/settings/utils/chat-settings.ts
+++ b/frontend/features/settings/utils/chat-settings.ts
@@ -1,3 +1,4 @@
+import { parseChatContentWidth } from "@/shared/model/chat-content-width";
 import type { ChatInputHeight, ChatSettings, FileMode, ModelVendorGroup, SendShortcut } from "@/features/settings/types/settings";
 import type { UserSettingsMap } from "@/shared/api/user-settings";
 import type { PublicModelDTO } from "@/shared/api/model.types";
@@ -21,12 +22,14 @@ export const DEFAULT_CHAT_SETTINGS: ChatSettings = {
   restoreDraftOnFailure: true,
   preserveConversationDrafts: true,
   inputHeight: "standard",
+  contentWidth: "compact",
   fileMode: "auto",
 };
 
 export function parseChatSettings(map: UserSettingsMap): ChatSettings {
   const fileMode = map["chat.file_mode"];
   const inputHeight = map["chat.input_height"];
+  const contentWidth = map["chat.content_width"];
   const sendShortcut = map["chat.send_on_enter"];
 
   return {
@@ -43,6 +46,7 @@ export function parseChatSettings(map: UserSettingsMap): ChatSettings {
     restoreDraftOnFailure: map["chat.restore_draft_on_failure"] !== "false",
     preserveConversationDrafts: map["chat.preserve_conversation_drafts"] !== "false",
     inputHeight: INPUT_HEIGHTS.includes(inputHeight as ChatInputHeight) ? (inputHeight as ChatInputHeight) : "standard",
+    contentWidth: parseChatContentWidth(contentWidth),
     fileMode: FILE_MODES.includes(fileMode as FileMode) ? (fileMode as FileMode) : "auto",
   };
 }

--- a/frontend/i18n/messages/en-US/settings.json
+++ b/frontend/i18n/messages/en-US/settings.json
@@ -70,8 +70,6 @@
       "colorMode": "Color mode",
       "themePreset": "Theme",
       "fontSize": "Font size",
-      "chatFont": "Chat font",
-      "chatFontWeight": "Chat font weight",
       "preset": {
         "default": "Default",
         "azure": "Azure",
@@ -87,23 +85,11 @@
         "system": "System",
         "dark": "Dark"
       },
-      "font": {
-        "default": "Default",
-        "songti": "Serif",
-        "heiti": "Sans",
-        "mono": "Mono"
-      },
       "fontSizeOption": {
         "small": "Small",
         "standard": "Standard",
         "medium": "Medium",
         "large": "Large"
-      },
-      "fontWeight": {
-        "regular": "Regular",
-        "medium": "Medium",
-        "semibold": "Semibold",
-        "bold": "Bold"
       }
     },
     "avatarDialog": {
@@ -359,7 +345,7 @@
       "description": "The model preselected for new chats. Leave empty to use the first available system-recommended model.",
       "systemRecommended": "System default",
       "autoTitle": "Auto-generate titles",
-      "autoTitleDescription": "When disabled, new chats use the first 20 characters of the first message as the title."
+      "autoTitleDescription": "When disabled, new chats use the first 16 characters of the first message as the title."
     },
     "input": {
       "sectionTitle": "Input and sending",
@@ -391,7 +377,27 @@
       "latencyDescription": "Controls whether total call latency appears below AI replies.",
       "costTitle": "Show total cost",
       "costDescription": "Controls whether total call cost appears below AI replies.",
-      "costDescriptionSelfMode": "Controls whether total call cost appears below AI replies. Hidden in self-use mode."
+      "costDescriptionSelfMode": "Controls whether total call cost appears below AI replies. Hidden in self-use mode.",
+      "widthTitle": "Chat area width",
+      "width": {
+        "compact": "Compact",
+        "standard": "Standard",
+        "wide": "Wide"
+      },
+      "chatFont": "Chat font",
+      "chatFontWeight": "Chat font weight",
+      "font": {
+        "default": "Default",
+        "songti": "Serif",
+        "heiti": "Sans",
+        "mono": "Mono"
+      },
+      "fontWeight": {
+        "regular": "Regular",
+        "medium": "Medium",
+        "semibold": "Semibold",
+        "bold": "Bold"
+      }
     },
     "context": {
       "sectionTitle": "Context management",

--- a/frontend/i18n/messages/zh-CN/settings.json
+++ b/frontend/i18n/messages/zh-CN/settings.json
@@ -70,8 +70,6 @@
       "colorMode": "颜色模式",
       "themePreset": "主题",
       "fontSize": "字体大小",
-      "chatFont": "对话字体",
-      "chatFontWeight": "对话字重",
       "preset": {
         "default": "默认",
         "azure": "Azure",
@@ -87,23 +85,11 @@
         "system": "跟随系统",
         "dark": "深色"
       },
-      "font": {
-        "default": "默认",
-        "songti": "衬线",
-        "heiti": "无衬线",
-        "mono": "等宽"
-      },
       "fontSizeOption": {
         "small": "小号",
         "standard": "标准",
         "medium": "中号",
         "large": "大号"
-      },
-      "fontWeight": {
-        "regular": "常规",
-        "medium": "中等",
-        "semibold": "半粗",
-        "bold": "粗体"
       }
     },
     "avatarDialog": {
@@ -359,7 +345,7 @@
       "description": "开启新对话时预选的模型。留空则使用系统推荐的第一个可用模型。",
       "systemRecommended": "系统默认",
       "autoTitle": "自动生成标题",
-      "autoTitleDescription": "关闭后，新对话使用第一条消息的前 20 个字符作为标题。"
+      "autoTitleDescription": "关闭后，新对话使用第一条消息的前 16 个字符作为标题。"
     },
     "input": {
       "sectionTitle": "输入与发送",
@@ -391,7 +377,27 @@
       "latencyDescription": "控制 AI 回复下方是否展示本次调用的总耗时。",
       "costTitle": "显示调用总费用",
       "costDescription": "控制 AI 回复下方是否展示本次调用的总费用。",
-      "costDescriptionSelfMode": "控制 AI 回复下方是否展示本次调用的总费用。自用模式不展示。"
+      "costDescriptionSelfMode": "控制 AI 回复下方是否展示本次调用的总费用。自用模式不展示。",
+      "widthTitle": "对话区域宽度",
+      "width": {
+        "compact": "紧凑",
+        "standard": "标准",
+        "wide": "宽屏"
+      },
+      "chatFont": "对话字体",
+      "chatFontWeight": "对话字重",
+      "font": {
+        "default": "默认",
+        "songti": "衬线",
+        "heiti": "无衬线",
+        "mono": "等宽"
+      },
+      "fontWeight": {
+        "regular": "常规",
+        "medium": "中等",
+        "semibold": "半粗",
+        "bold": "粗体"
+      }
     },
     "context": {
       "sectionTitle": "上下文管理",

--- a/frontend/shared/model/chat-content-width.ts
+++ b/frontend/shared/model/chat-content-width.ts
@@ -1,0 +1,46 @@
+export type ChatContentWidth = "compact" | "standard" | "wide";
+
+export type ChatContentWidthOption = {
+  value: ChatContentWidth;
+  width: number;
+  className: string;
+  previewScaleClassName: string;
+};
+
+export const DEFAULT_CHAT_CONTENT_WIDTH: ChatContentWidth = "compact";
+
+export const CHAT_CONTENT_WIDTH_OPTIONS: ChatContentWidthOption[] = [
+  {
+    value: "compact",
+    width: 760,
+    className: "max-w-[760px]",
+    previewScaleClassName: "w-7/12",
+  },
+  {
+    value: "standard",
+    width: 900,
+    className: "max-w-[900px]",
+    previewScaleClassName: "w-9/12",
+  },
+  {
+    value: "wide",
+    width: 1080,
+    className: "max-w-[1080px]",
+    previewScaleClassName: "w-11/12",
+  },
+];
+
+export function isChatContentWidth(value: unknown): value is ChatContentWidth {
+  return value === "compact" || value === "standard" || value === "wide";
+}
+
+export function parseChatContentWidth(value: string | null | undefined): ChatContentWidth {
+  return isChatContentWidth(value) ? value : DEFAULT_CHAT_CONTENT_WIDTH;
+}
+
+export function resolveChatContentWidthClassName(value: ChatContentWidth): string {
+  return (
+    CHAT_CONTENT_WIDTH_OPTIONS.find((item) => item.value === value)?.className ??
+    CHAT_CONTENT_WIDTH_OPTIONS[0].className
+  );
+}


### PR DESCRIPTION
## Summary

Improves conversation title generation and chat display settings.

This change makes title refresh state explicit so the frontend only polls when title generation is pending, fixes title fallback length to 16 characters, and adds user-configurable chat display controls for conversation width, chat font, and chat font weight. Chat display settings are now grouped under Chat settings → Display and rendering, with width shown as cards and persisted through user settings / appearance preferences.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm build`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/application/usersettings ./internal/application/conversation`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Not included. UI changes are limited to settings layout and chat width behavior.

## Configuration, migration, and compatibility notes

No database migration required.

Adds/uses `chat.content_width` user setting with allowed values `compact`, `standard`, and `wide`. Default is `compact`. Existing users without the setting will receive the default; existing saved values remain valid.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.