### PR TITLE
feat: implement period billing mode with overage handling

### DIFF
--- a/backend/internal/application/billing/service.go
+++ b/backend/internal/application/billing/service.go
@@ -779,7 +779,7 @@ func (s *Service) CreateTopUpPaymentOrder(ctx context.Context, input TopUpPaymen
 	if err != nil {
 		return nil, err
 	}
-	if mode != "usage" {
+	if mode != "usage" && mode != "period" {
 		return nil, ErrPaymentRequired
 	}
 	provider := strings.TrimSpace(input.Provider)
@@ -941,14 +941,34 @@ func (s *Service) RecordUsage(ctx context.Context, usage *domainbilling.UsageLed
 	return s.RecordUsageWithReservation(ctx, usage, nil)
 }
 
-// RecordUsageWithReservation 记录用量，并在按量模式下结算预扣差额。
+// RecordUsageWithReservation 记录用量，并结算需要走余额的部分。
 func (s *Service) RecordUsageWithReservation(ctx context.Context, usage *domainbilling.UsageLedger, reservation *domainbilling.UsageBalanceReservation) error {
+	if usage == nil {
+		return nil
+	}
 	mode, err := s.repo.GetBillingMode(ctx)
 	if err != nil {
 		return err
 	}
-	if mode == "usage" || reservation != nil {
+	if mode == "usage" || (mode != "period" && reservation != nil) {
 		if err := s.repo.AddUsageAndSettleBalance(ctx, usage, reservation); err != nil {
+			if errors.Is(err, repository.ErrInsufficientBalance) {
+				return ErrUsageBalanceInsufficient
+			}
+			return err
+		}
+		return nil
+	}
+	if mode == "period" {
+		now := usage.UsageDate
+		if now.IsZero() {
+			now = time.Now()
+		}
+		plan, startAt, endAt, planErr := s.currentPeriodPlan(ctx, usage.UserID, now)
+		if planErr != nil {
+			return planErr
+		}
+		if err := s.repo.AddPeriodUsageAndSettleOverage(ctx, usage, startAt, endAt, plan.PeriodCreditNanousd, reservation); err != nil {
 			if errors.Is(err, repository.ErrInsufficientBalance) {
 				return ErrUsageBalanceInsufficient
 			}
@@ -959,13 +979,13 @@ func (s *Service) RecordUsageWithReservation(ctx context.Context, usage *domainb
 	return s.repo.AddUsage(ctx, usage)
 }
 
-// ReserveUsageBalance 在按量模式下按配置金额预扣余额；非按量或免费模型不预扣。
+// ReserveUsageBalance 在按量模式下预扣余额；周期模式仅对可能超出套餐额度的部分预扣。
 func (s *Service) ReserveUsageBalance(ctx context.Context, userID uint, platformModelName string, refNo string) (*domainbilling.UsageBalanceReservation, error) {
 	mode, err := s.repo.GetBillingMode(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if mode != "usage" {
+	if mode != "usage" && mode != "period" {
 		return nil, nil
 	}
 	pricing, err := s.getResolvedModelPricing(ctx, platformModelName)
@@ -985,7 +1005,26 @@ func (s *Service) ReserveUsageBalance(ctx context.Context, userID uint, platform
 	if prepaidNanousd <= 0 {
 		return nil, nil
 	}
-	reservation, err := s.repo.ReserveUsageBalance(ctx, userID, prepaidNanousd, refNo)
+	reserveNanousd := prepaidNanousd
+	if mode == "period" {
+		plan, startAt, endAt, planErr := s.currentPeriodPlan(ctx, userID, time.Now())
+		if planErr != nil {
+			return nil, planErr
+		}
+		usedNanousd, usedErr := s.repo.SumBillableNanousd(ctx, userID, startAt, endAt)
+		if usedErr != nil {
+			return nil, usedErr
+		}
+		remainingNanousd := plan.PeriodCreditNanousd - usedNanousd
+		if remainingNanousd < 0 {
+			remainingNanousd = 0
+		}
+		reserveNanousd = prepaidNanousd - remainingNanousd
+		if reserveNanousd <= 0 {
+			return nil, nil
+		}
+	}
+	reservation, err := s.repo.ReserveUsageBalance(ctx, userID, reserveNanousd, refNo)
 	if err != nil {
 		if errors.Is(err, repository.ErrInsufficientBalance) {
 			return nil, ErrUsageBalanceInsufficient
@@ -1024,22 +1063,7 @@ func (s *Service) EnsureModelUsable(ctx context.Context, userID uint, platformMo
 		return ErrModelPricingRequired
 	}
 	if mode == "usage" {
-		account, accountErr := s.repo.GetOrCreateBillingAccount(ctx, userID)
-		if accountErr != nil {
-			return accountErr
-		}
-		prepaidNanousd, prepaidErr := s.repo.GetBillingPrepaidAmountNanousd(ctx)
-		if prepaidErr != nil {
-			return prepaidErr
-		}
-		requiredBalance := int64(1)
-		if prepaidNanousd > requiredBalance {
-			requiredBalance = prepaidNanousd
-		}
-		if account.BalanceNanousd < requiredBalance {
-			return ErrUsageBalanceInsufficient
-		}
-		return nil
+		return s.ensureUsageBalance(ctx, userID)
 	}
 	if mode != "period" {
 		return nil
@@ -1049,15 +1073,31 @@ func (s *Service) EnsureModelUsable(ctx context.Context, userID uint, platformMo
 	if err != nil {
 		return err
 	}
-	if plan.PeriodCreditNanousd <= 0 {
-		return ErrPeriodCreditExceeded
-	}
 	usedNanousd, err := s.repo.SumBillableNanousd(ctx, userID, startAt, endAt)
 	if err != nil {
 		return err
 	}
-	if usedNanousd >= plan.PeriodCreditNanousd {
-		return ErrPeriodCreditExceeded
+	if plan.PeriodCreditNanousd > 0 && usedNanousd < plan.PeriodCreditNanousd {
+		return nil
+	}
+	return s.ensureUsageBalance(ctx, userID)
+}
+
+func (s *Service) ensureUsageBalance(ctx context.Context, userID uint) error {
+	account, accountErr := s.repo.GetOrCreateBillingAccount(ctx, userID)
+	if accountErr != nil {
+		return accountErr
+	}
+	prepaidNanousd, prepaidErr := s.repo.GetBillingPrepaidAmountNanousd(ctx)
+	if prepaidErr != nil {
+		return prepaidErr
+	}
+	requiredBalance := int64(1)
+	if prepaidNanousd > requiredBalance {
+		requiredBalance = prepaidNanousd
+	}
+	if account.BalanceNanousd < requiredBalance {
+		return ErrUsageBalanceInsufficient
 	}
 	return nil
 }
@@ -2268,6 +2308,10 @@ func (s *Service) GetBillingOverview(ctx context.Context, userID uint, now time.
 	if mode != "period" {
 		return overview, nil
 	}
+	account, accountErr := s.repo.GetOrCreateBillingAccount(ctx, userID)
+	if accountErr != nil {
+		return nil, accountErr
+	}
 
 	plan, startAt, endAt, err := s.currentPeriodPlan(ctx, userID, now)
 	if err != nil {
@@ -2313,6 +2357,7 @@ func (s *Service) GetBillingOverview(ctx context.Context, userID uint, now time.
 	}
 
 	overview.Plan = &planView
+	overview.Account = toBillingAccountView(account)
 	overview.PeriodStartAt = &startAt
 	overview.PeriodEndAt = &endAt
 	overview.PeriodCreditNanousd = plan.PeriodCreditNanousd
@@ -2336,7 +2381,7 @@ func (s *Service) SetBillingAccountBalance(ctx context.Context, input BillingAcc
 	if err != nil {
 		return nil, err
 	}
-	if mode != "usage" {
+	if mode != "usage" && mode != "period" {
 		return nil, ErrPaymentRequired
 	}
 	return s.repo.SetBillingAccountBalance(ctx, input.UserID, usdToNanousd(input.BalanceUSD), input.RefNo, input.Description)

--- a/backend/internal/application/billing/service_model_identity_test.go
+++ b/backend/internal/application/billing/service_model_identity_test.go
@@ -35,10 +35,15 @@ type billingRepositoryStub struct {
 	plans                      []domainbilling.Plan
 	prices                     []domainbilling.Price
 	subscriptions              []domainbilling.Subscription
+	account                    *domainbilling.BillingAccount
+	prepaidNanousd             int64
+	billableNanousd            int64
 	nativeToolBillingEnabled   bool
 	nativeToolPricingJSON      string
 	requestedPlatformModelName string
 	replacedSubscription       *domainbilling.Subscription
+	reservedNanousd            int64
+	periodUsageSettled         bool
 }
 
 func (r *billingRepositoryStub) GetBillingMode(context.Context) (string, error) {
@@ -46,7 +51,7 @@ func (r *billingRepositoryStub) GetBillingMode(context.Context) (string, error) 
 }
 
 func (r *billingRepositoryStub) GetBillingPrepaidAmountNanousd(context.Context) (int64, error) {
-	return 0, nil
+	return r.prepaidNanousd, nil
 }
 
 func (r *billingRepositoryStub) GetNativeToolBillingEnabled(context.Context) (bool, error) {
@@ -157,14 +162,22 @@ func (r *billingRepositoryStub) AddUsageAndDebitBalance(context.Context, *domain
 func (r *billingRepositoryStub) AddUsageAndSettleBalance(context.Context, *domainbilling.UsageLedger, *domainbilling.UsageBalanceReservation) error {
 	panic("not used")
 }
-func (r *billingRepositoryStub) ReserveUsageBalance(context.Context, uint, int64, string) (*domainbilling.UsageBalanceReservation, error) {
-	panic("not used")
+func (r *billingRepositoryStub) AddPeriodUsageAndSettleOverage(context.Context, *domainbilling.UsageLedger, time.Time, time.Time, int64, *domainbilling.UsageBalanceReservation) error {
+	r.periodUsageSettled = true
+	return nil
+}
+func (r *billingRepositoryStub) ReserveUsageBalance(_ context.Context, userID uint, amountNanousd int64, refNo string) (*domainbilling.UsageBalanceReservation, error) {
+	r.reservedNanousd = amountNanousd
+	return &domainbilling.UsageBalanceReservation{UserID: userID, AmountNanousd: amountNanousd, RefNo: refNo}, nil
 }
 func (r *billingRepositoryStub) ReleaseUsageBalanceReservation(context.Context, uint, string, string) error {
 	panic("not used")
 }
-func (r *billingRepositoryStub) GetOrCreateBillingAccount(context.Context, uint) (*domainbilling.BillingAccount, error) {
-	panic("not used")
+func (r *billingRepositoryStub) GetOrCreateBillingAccount(_ context.Context, userID uint) (*domainbilling.BillingAccount, error) {
+	if r.account != nil {
+		return r.account, nil
+	}
+	return &domainbilling.BillingAccount{UserID: userID, Currency: "USD", Status: "active"}, nil
 }
 func (r *billingRepositoryStub) ListBillingAccountsByUserIDs(context.Context, []uint) ([]domainbilling.BillingAccount, error) {
 	panic("not used")
@@ -218,7 +231,7 @@ func (r *billingRepositoryStub) ListDailyUsageByUser(context.Context, uint, time
 	panic("not used")
 }
 func (r *billingRepositoryStub) SumBillableNanousd(context.Context, uint, time.Time, time.Time) (int64, error) {
-	panic("not used")
+	return r.billableNanousd, nil
 }
 
 func TestBuildUsageLedgerSnapshotsModelIdentity(t *testing.T) {

--- a/backend/internal/application/billing/service_redemption.go
+++ b/backend/internal/application/billing/service_redemption.go
@@ -113,22 +113,34 @@ func (s *Service) ListRedemptionCodes(ctx context.Context, input RedemptionCodeL
 	status := strings.TrimSpace(input.Status)
 	availability := strings.TrimSpace(input.Availability)
 	query := strings.TrimSpace(input.Query)
+	currentMode := ""
 	if availability == "available" {
-		currentMode, err := s.repo.GetBillingMode(ctx)
+		modeValue, err := s.repo.GetBillingMode(ctx)
 		if err != nil {
 			return nil, 0, err
 		}
-		currentMode = strings.TrimSpace(currentMode)
+		currentMode = strings.TrimSpace(modeValue)
 		if currentMode != domainbilling.RedemptionCodeModeUsage && currentMode != domainbilling.RedemptionCodeModePeriod {
 			return []RedemptionCodeView{}, 0, nil
 		}
-		if mode != "" && mode != currentMode {
+		if mode != "" && !redemptionCodeModeAvailableInBillingMode(mode, currentMode) {
 			return []RedemptionCodeView{}, 0, nil
 		}
-		mode = currentMode
+		if mode == "" {
+			if currentMode == domainbilling.RedemptionCodeModePeriod {
+				mode = ""
+			} else {
+				mode = currentMode
+			}
+		}
+	}
+	modes := []string(nil)
+	if availability == "available" && mode == "" {
+		modes = redemptionCodeModesAvailableInBillingMode(currentMode)
 	}
 	items, total, err := s.repo.ListRedemptionCodes(ctx, repository.RedemptionCodeListFilter{
 		Mode:         mode,
+		Modes:        modes,
 		Status:       status,
 		Availability: availability,
 		Query:        query,
@@ -510,6 +522,33 @@ func normalizeRedemptionMode(value string) string {
 		return domainbilling.RedemptionCodeModePeriod
 	default:
 		return ""
+	}
+}
+
+func redemptionCodeModeAvailableInBillingMode(codeMode string, billingMode string) bool {
+	switch strings.TrimSpace(billingMode) {
+	case domainbilling.RedemptionCodeModeUsage:
+		return strings.TrimSpace(codeMode) == domainbilling.RedemptionCodeModeUsage
+	case domainbilling.RedemptionCodeModePeriod:
+		switch strings.TrimSpace(codeMode) {
+		case domainbilling.RedemptionCodeModeUsage, domainbilling.RedemptionCodeModePeriod:
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}
+
+func redemptionCodeModesAvailableInBillingMode(billingMode string) []string {
+	switch strings.TrimSpace(billingMode) {
+	case domainbilling.RedemptionCodeModeUsage:
+		return []string{domainbilling.RedemptionCodeModeUsage}
+	case domainbilling.RedemptionCodeModePeriod:
+		return []string{domainbilling.RedemptionCodeModeUsage, domainbilling.RedemptionCodeModePeriod}
+	default:
+		return nil
 	}
 }
 

--- a/backend/internal/application/billing/service_redemption_test.go
+++ b/backend/internal/application/billing/service_redemption_test.go
@@ -218,6 +218,45 @@ func TestListRedemptionCodesAvailableUsesCurrentBillingMode(t *testing.T) {
 	}
 }
 
+func TestListRedemptionCodesAvailablePeriodIncludesUsageBalanceCodes(t *testing.T) {
+	repo := newRedemptionRepositoryStub(domainbilling.RedemptionCodeModePeriod)
+	service := NewService(repo)
+
+	_, _, err := service.ListRedemptionCodes(context.Background(), RedemptionCodeListInput{
+		Availability: "available",
+		Page:         1,
+		PageSize:     20,
+	})
+	if err != nil {
+		t.Fatalf("ListRedemptionCodes() error = %v", err)
+	}
+	if !repo.listCalled {
+		t.Fatalf("ListRedemptionCodes() did not query repository")
+	}
+	wantModes := []string{domainbilling.RedemptionCodeModeUsage, domainbilling.RedemptionCodeModePeriod}
+	if repo.listFilter.Mode != "" || !equalStringSlices(repo.listFilter.Modes, wantModes) || repo.listFilter.Availability != "available" {
+		t.Fatalf("List filter = %+v, want modes %v", repo.listFilter, wantModes)
+	}
+}
+
+func TestListRedemptionCodesAvailablePeriodAllowsExplicitUsageMode(t *testing.T) {
+	repo := newRedemptionRepositoryStub(domainbilling.RedemptionCodeModePeriod)
+	service := NewService(repo)
+
+	_, _, err := service.ListRedemptionCodes(context.Background(), RedemptionCodeListInput{
+		Mode:         domainbilling.RedemptionCodeModeUsage,
+		Availability: "available",
+		Page:         1,
+		PageSize:     20,
+	})
+	if err != nil {
+		t.Fatalf("ListRedemptionCodes() error = %v", err)
+	}
+	if !repo.listCalled || repo.listFilter.Mode != domainbilling.RedemptionCodeModeUsage {
+		t.Fatalf("List filter = %+v, want explicit usage mode", repo.listFilter)
+	}
+}
+
 func TestListRedemptionCodesAvailableSkipsModeMismatch(t *testing.T) {
 	repo := newRedemptionRepositoryStub(domainbilling.RedemptionCodeModeUsage)
 	service := NewService(repo)
@@ -481,6 +520,18 @@ func isUppercaseUUID(value string) bool {
 	}
 	for _, item := range value {
 		if item >= 'a' && item <= 'z' {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStringSlices(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
 			return false
 		}
 	}

--- a/backend/internal/application/billing/service_subscription_timeline_test.go
+++ b/backend/internal/application/billing/service_subscription_timeline_test.go
@@ -207,6 +207,111 @@ func TestCreateTopUpPaymentOrderResolvesProviderPaymentCurrency(t *testing.T) {
 	}
 }
 
+func TestCreateTopUpPaymentOrderAllowsPeriodModeOverageBalance(t *testing.T) {
+	repo := &billingRepositoryStub{mode: "period"}
+	service := NewService(repo)
+
+	order, err := service.CreateTopUpPaymentOrder(context.Background(), TopUpPaymentOrderInput{
+		UserID:      1,
+		AmountCents: 5000,
+		Provider:    domainbilling.PaymentProviderStripe,
+	})
+	if err != nil {
+		t.Fatalf("CreateTopUpPaymentOrder() error = %v", err)
+	}
+	if order.OrderType != domainbilling.PaymentOrderTypeTopUp || order.CreditNanousd <= 0 {
+		t.Fatalf("unexpected top up order: %+v", order)
+	}
+}
+
+func TestEnsureModelUsableAllowsPeriodOverageWhenBalanceIsAvailable(t *testing.T) {
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	endAt := now.Add(30 * 24 * time.Hour)
+	repo := &billingRepositoryStub{
+		mode:            "period",
+		prepaidNanousd:  300,
+		billableNanousd: 1000,
+		account:         &domainbilling.BillingAccount{UserID: 1, BalanceNanousd: 500, Currency: "USD", Status: "active"},
+		pricing: &domainbilling.ModelPricing{
+			PlatformModelName:       "gpt-test",
+			Currency:                "USD",
+			InputNanousdPerMTokens:  1,
+			OutputNanousdPerMTokens: 1,
+		},
+		plans: []domainbilling.Plan{
+			{ID: 2, Code: "pro", Name: "Pro", PeriodCreditNanousd: 1000, IsActive: true},
+		},
+		subscriptions: []domainbilling.Subscription{
+			{ID: 20, UserID: 1, PlanID: 2, Status: "active", CurrentPeriodStartAt: now, CurrentPeriodEndAt: &endAt},
+		},
+	}
+	service := NewService(repo)
+
+	if err := service.EnsureModelUsable(context.Background(), 1, "gpt-test", now); err != nil {
+		t.Fatalf("EnsureModelUsable() error = %v", err)
+	}
+}
+
+func TestEnsureModelUsableRejectsPeriodOverageWhenBalanceIsInsufficient(t *testing.T) {
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	endAt := now.Add(30 * 24 * time.Hour)
+	repo := &billingRepositoryStub{
+		mode:            "period",
+		prepaidNanousd:  300,
+		billableNanousd: 1000,
+		account:         &domainbilling.BillingAccount{UserID: 1, BalanceNanousd: 100, Currency: "USD", Status: "active"},
+		pricing: &domainbilling.ModelPricing{
+			PlatformModelName:       "gpt-test",
+			Currency:                "USD",
+			InputNanousdPerMTokens:  1,
+			OutputNanousdPerMTokens: 1,
+		},
+		plans: []domainbilling.Plan{
+			{ID: 2, Code: "pro", Name: "Pro", PeriodCreditNanousd: 1000, IsActive: true},
+		},
+		subscriptions: []domainbilling.Subscription{
+			{ID: 20, UserID: 1, PlanID: 2, Status: "active", CurrentPeriodStartAt: now, CurrentPeriodEndAt: &endAt},
+		},
+	}
+	service := NewService(repo)
+
+	err := service.EnsureModelUsable(context.Background(), 1, "gpt-test", now)
+	if !errors.Is(err, ErrUsageBalanceInsufficient) {
+		t.Fatalf("EnsureModelUsable() error = %v, want ErrUsageBalanceInsufficient", err)
+	}
+}
+
+func TestReserveUsageBalancePeriodModeReservesOnlyPotentialOverage(t *testing.T) {
+	now := time.Now()
+	endAt := now.Add(30 * 24 * time.Hour)
+	repo := &billingRepositoryStub{
+		mode:            "period",
+		prepaidNanousd:  300,
+		billableNanousd: 900,
+		pricing: &domainbilling.ModelPricing{
+			PlatformModelName:       "gpt-test",
+			Currency:                "USD",
+			InputNanousdPerMTokens:  1,
+			OutputNanousdPerMTokens: 1,
+		},
+		plans: []domainbilling.Plan{
+			{ID: 2, Code: "pro", Name: "Pro", PeriodCreditNanousd: 1000, IsActive: true},
+		},
+		subscriptions: []domainbilling.Subscription{
+			{ID: 20, UserID: 1, PlanID: 2, Status: "active", CurrentPeriodStartAt: now.Add(-time.Hour), CurrentPeriodEndAt: &endAt},
+		},
+	}
+	service := NewService(repo)
+
+	reservation, err := service.ReserveUsageBalance(context.Background(), 1, "gpt-test", "run_1")
+	if err != nil {
+		t.Fatalf("ReserveUsageBalance() error = %v", err)
+	}
+	if reservation == nil || reservation.AmountNanousd != 200 || repo.reservedNanousd != 200 {
+		t.Fatalf("reservation = %+v, reserved = %d, want 200", reservation, repo.reservedNanousd)
+	}
+}
+
 func TestBuildSubscriptionEntitlementViewsShowsCurrentAndQueuedPlans(t *testing.T) {
 	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 	day := 24 * time.Hour

--- a/backend/internal/infra/persistence/postgres/billing/repository.go
+++ b/backend/internal/infra/persistence/postgres/billing/repository.go
@@ -621,6 +621,118 @@ func (r *Repo) AddUsageAndSettleBalance(ctx context.Context, usage *domainbillin
 	})
 }
 
+// AddPeriodUsageAndSettleOverage 写入周期用量，并将超出套餐额度的部分按量结算。
+func (r *Repo) AddPeriodUsageAndSettleOverage(
+	ctx context.Context,
+	usage *domainbilling.UsageLedger,
+	periodStart time.Time,
+	periodEnd time.Time,
+	periodCreditNanousd int64,
+	reservation *domainbilling.UsageBalanceReservation,
+) error {
+	if usage == nil {
+		return nil
+	}
+	if usage.UserID == 0 || periodStart.IsZero() || !periodEnd.After(periodStart) || periodCreditNanousd < 0 {
+		return repository.ErrInvalidInput
+	}
+	settledSnapshotJSON := ""
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		account, err := getOrCreateBillingAccountForUpdate(tx, usage.UserID)
+		if err != nil {
+			return err
+		}
+
+		var usedBeforeNanousd int64
+		if err = tx.Model(&model.UsageLedger{}).
+			Select("COALESCE(SUM(billed_nanousd), 0)").
+			Where("user_id = ? AND is_free_model = ? AND created_at >= ? AND created_at < ?", usage.UserID, false, periodStart, periodEnd).
+			Scan(&usedBeforeNanousd).Error; err != nil {
+			return translateError(err)
+		}
+
+		chargeNanousd := usage.BilledNanousd
+		if usage.IsFreeModel || chargeNanousd <= 0 {
+			chargeNanousd = 0
+		}
+		remainingNanousd := periodCreditNanousd - usedBeforeNanousd
+		if remainingNanousd < 0 {
+			remainingNanousd = 0
+		}
+		coveredNanousd := minInt64(chargeNanousd, remainingNanousd)
+		overageNanousd := chargeNanousd - coveredNanousd
+		reservedNanousd := int64(0)
+		if reservation != nil {
+			reservedNanousd = reservation.AmountNanousd
+			if reservedNanousd < 0 {
+				return repository.ErrInvalidInput
+			}
+		}
+		deltaNanousd := overageNanousd - reservedNanousd
+		if deltaNanousd > 0 && account.BalanceNanousd < deltaNanousd {
+			return repository.ErrInsufficientBalance
+		}
+
+		ledger := *usage
+		ledger.PricingSnapshotJSON = withPeriodSettlementSnapshot(ledger.PricingSnapshotJSON, map[string]interface{}{
+			"period_credit_nanousd":                   periodCreditNanousd,
+			"period_used_before_nanousd":              usedBeforeNanousd,
+			"period_used_after_nanousd":               usedBeforeNanousd + chargeNanousd,
+			"period_credit_covered_nanousd":           coveredNanousd,
+			"period_overage_billed_nanousd":           overageNanousd,
+			"period_balance_debited_nanousd":          overageNanousd,
+			"period_balance_reserved_nanousd":         reservedNanousd,
+			"period_balance_settlement_delta_nanousd": deltaNanousd,
+		})
+		record := toModelUsageLedger(&ledger)
+		if err := tx.Create(&record).Error; err != nil {
+			return translateError(err)
+		}
+		if deltaNanousd == 0 {
+			settledSnapshotJSON = ledger.PricingSnapshotJSON
+			return nil
+		}
+
+		nextBalance := account.BalanceNanousd - deltaNanousd
+		if err := tx.Model(account).Updates(map[string]interface{}{
+			"balance_nanousd": nextBalance,
+			"currency":        "USD",
+			"status":          "active",
+		}).Error; err != nil {
+			return translateError(err)
+		}
+		transactionType := domainbilling.BalanceTransactionTypeUsage
+		description := "周期套餐超额按量扣费"
+		if deltaNanousd < 0 {
+			transactionType = domainbilling.BalanceTransactionTypeUsageRefund
+			description = "周期套餐超额预扣差额退回"
+		}
+		transaction := model.BalanceTransaction{
+			AccountID:           account.ID,
+			UserID:              usage.UserID,
+			Type:                transactionType,
+			AmountNanousd:       -deltaNanousd,
+			BalanceAfterNanousd: nextBalance,
+			RefType:             "usage_ledger",
+			RefID:               record.ID,
+			RefNo:               reservationRefNo(reservation),
+			Description:         description,
+		}
+		if err := tx.Create(&transaction).Error; err != nil {
+			return translateError(err)
+		}
+		settledSnapshotJSON = ledger.PricingSnapshotJSON
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if settledSnapshotJSON != "" {
+		usage.PricingSnapshotJSON = settledSnapshotJSON
+	}
+	return nil
+}
+
 // ReserveUsageBalance 在真实调用前预扣固定金额，避免并发请求透支余额。
 func (r *Repo) ReserveUsageBalance(ctx context.Context, userID uint, amountNanousd int64, refNo string) (*domainbilling.UsageBalanceReservation, error) {
 	refNo = strings.TrimSpace(refNo)
@@ -747,6 +859,21 @@ func reservationRefNo(reservation *domainbilling.UsageBalanceReservation) string
 		return ""
 	}
 	return strings.TrimSpace(reservation.RefNo)
+}
+
+func withPeriodSettlementSnapshot(raw string, values map[string]interface{}) string {
+	snapshot := map[string]interface{}{}
+	if trimmed := strings.TrimSpace(raw); trimmed != "" {
+		_ = json.Unmarshal([]byte(trimmed), &snapshot)
+	}
+	for key, value := range values {
+		snapshot[key] = value
+	}
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		return raw
+	}
+	return string(encoded)
 }
 
 // GetOrCreateBillingAccount 查询或创建用户按量余额账户。
@@ -926,7 +1053,18 @@ func (r *Repo) ListRedemptionCodes(ctx context.Context, filter repository.Redemp
 	items := make([]model.RedemptionCode, 0, limit)
 	var total int64
 	query := r.db.WithContext(ctx).Model(&model.RedemptionCode{})
-	if mode := strings.TrimSpace(filter.Mode); mode != "" {
+	if len(filter.Modes) > 0 {
+		modes := make([]string, 0, len(filter.Modes))
+		for _, mode := range filter.Modes {
+			if normalized := normalizeRedemptionMode(mode); normalized != "" {
+				modes = append(modes, normalized)
+			}
+		}
+		if len(modes) == 0 {
+			return []domainbilling.RedemptionCode{}, 0, nil
+		}
+		query = query.Where("mode IN ?", modes)
+	} else if mode := strings.TrimSpace(filter.Mode); mode != "" {
 		query = query.Where("mode = ?", mode)
 	}
 	if status := strings.TrimSpace(filter.Status); status != "" {
@@ -1840,10 +1978,13 @@ func getOrCreateBillingAccountForUpdate(tx *gorm.DB, userID uint) (*model.Billin
 		BalanceNanousd: 0,
 		Status:         "active",
 	}
-	if err := tx.Create(&account).Error; err != nil {
+	if err := tx.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "user_id"}},
+		DoNothing: true,
+	}).Create(&account).Error; err != nil {
 		return nil, translateError(err)
 	}
-	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", account.ID).First(&account).Error; err != nil {
+	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("user_id = ?", userID).First(&account).Error; err != nil {
 		return nil, translateError(err)
 	}
 	return &account, nil
@@ -1922,7 +2063,7 @@ func toDomainRedemption(item model.Redemption) domainbilling.Redemption {
 
 func validateRedeemableCode(tx *gorm.DB, code model.RedemptionCode, userID uint, currentMode string, now time.Time) error {
 	if code.Status != domainbilling.RedemptionCodeStatusActive ||
-		code.Mode != currentMode ||
+		!redemptionCodeModeAvailableInBillingMode(code.Mode, currentMode) ||
 		(code.ExpiresAt != nil && !code.ExpiresAt.After(now)) {
 		return repository.ErrRedemptionUnavailable
 	}
@@ -2536,6 +2677,22 @@ func normalizeRedemptionMode(value string) string {
 	}
 }
 
+func redemptionCodeModeAvailableInBillingMode(codeMode string, billingMode string) bool {
+	switch strings.TrimSpace(billingMode) {
+	case domainbilling.RedemptionCodeModeUsage:
+		return strings.TrimSpace(codeMode) == domainbilling.RedemptionCodeModeUsage
+	case domainbilling.RedemptionCodeModePeriod:
+		switch strings.TrimSpace(codeMode) {
+		case domainbilling.RedemptionCodeModeUsage, domainbilling.RedemptionCodeModePeriod:
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}
+
 func normalizeRedemptionRewardType(value string) string {
 	switch strings.TrimSpace(value) {
 	case domainbilling.RedemptionRewardTypeSubscription:
@@ -2590,6 +2747,13 @@ func clampNonNegative(value int64) int64 {
 		return 0
 	}
 	return value
+}
+
+func minInt64(a int64, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func clampPercent(value int) int {

--- a/backend/internal/infra/persistence/postgres/billing/repository_sqlite_test.go
+++ b/backend/internal/infra/persistence/postgres/billing/repository_sqlite_test.go
@@ -2,9 +2,11 @@ package billing
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
+	domainbilling "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/billing"
 	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/models"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
 	"gorm.io/driver/sqlite"
@@ -88,6 +90,125 @@ func TestUsageQueriesUseSQLitePortableExpressions(t *testing.T) {
 	}
 }
 
+func TestAddPeriodUsageAndSettleOverageSplitsCreditAndBalance(t *testing.T) {
+	db := openBillingSQLiteTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	periodStart := now.Add(-2 * time.Hour)
+	periodEnd := now.Add(2 * time.Hour)
+
+	account := model.BillingAccount{
+		UserID:         1,
+		Currency:       "USD",
+		BalanceNanousd: 500,
+		Status:         "active",
+	}
+	if err := db.Create(&account).Error; err != nil {
+		t.Fatalf("create billing account: %v", err)
+	}
+	if err := db.Create(&model.UsageLedger{
+		BaseModel:           model.BaseModel{CreatedAt: now.Add(-time.Hour)},
+		UserID:              1,
+		PlatformModelName:   "gpt-before",
+		UsageDate:           now.Add(-time.Hour),
+		BilledCurrency:      "USD",
+		BilledNanousd:       800,
+		PricingSnapshotJSON: `{}`,
+	}).Error; err != nil {
+		t.Fatalf("create previous usage: %v", err)
+	}
+
+	usage := &domainbilling.UsageLedger{
+		UserID:              1,
+		PlatformModelName:   "gpt-current",
+		UsageDate:           now,
+		BilledCurrency:      "USD",
+		BilledNanousd:       500,
+		PricingSnapshotJSON: `{"pricing_mode":"token"}`,
+	}
+	err := repo.AddPeriodUsageAndSettleOverage(ctx, usage, periodStart, periodEnd, 1000, nil)
+	if err != nil {
+		t.Fatalf("AddPeriodUsageAndSettleOverage() error = %v", err)
+	}
+
+	var refreshed model.BillingAccount
+	if err := db.Where("user_id = ?", 1).First(&refreshed).Error; err != nil {
+		t.Fatalf("load billing account: %v", err)
+	}
+	if refreshed.BalanceNanousd != 200 {
+		t.Fatalf("balance = %d, want 200", refreshed.BalanceNanousd)
+	}
+	var tx model.BalanceTransaction
+	if err := db.Where("user_id = ? AND type = ?", 1, domainbilling.BalanceTransactionTypeUsage).First(&tx).Error; err != nil {
+		t.Fatalf("load balance transaction: %v", err)
+	}
+	if tx.AmountNanousd != -300 || tx.BalanceAfterNanousd != 200 {
+		t.Fatalf("transaction amount/balance = %d/%d, want -300/200", tx.AmountNanousd, tx.BalanceAfterNanousd)
+	}
+
+	var ledger model.UsageLedger
+	if err := db.Where("platform_model_name = ?", "gpt-current").First(&ledger).Error; err != nil {
+		t.Fatalf("load current usage: %v", err)
+	}
+	if ledger.BilledNanousd != 500 {
+		t.Fatalf("billed nanousd = %d, want 500", ledger.BilledNanousd)
+	}
+	var snapshot map[string]interface{}
+	if err := json.Unmarshal([]byte(ledger.PricingSnapshotJSON), &snapshot); err != nil {
+		t.Fatalf("decode pricing snapshot: %v", err)
+	}
+	if usage.PricingSnapshotJSON != ledger.PricingSnapshotJSON {
+		t.Fatalf("usage snapshot was not updated after settlement")
+	}
+	covered := int64(snapshot["period_credit_covered_nanousd"].(float64))
+	overage := int64(snapshot["period_overage_billed_nanousd"].(float64))
+	if covered != 200 || overage != 300 {
+		t.Fatalf("snapshot split = covered %d overage %d, want 200/300", covered, overage)
+	}
+	debited := int64(snapshot["period_balance_debited_nanousd"].(float64))
+	delta := int64(snapshot["period_balance_settlement_delta_nanousd"].(float64))
+	if debited != 300 || delta != 300 {
+		t.Fatalf("snapshot balance = debit %d delta %d, want 300/300", debited, delta)
+	}
+}
+
+func TestValidateRedeemableCodeAllowsUsageCodeInPeriodModeOnly(t *testing.T) {
+	db := openBillingSQLiteTestDB(t)
+	now := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+
+	usageCode := model.RedemptionCode{
+		Status:         domainbilling.RedemptionCodeStatusActive,
+		Mode:           domainbilling.RedemptionCodeModeUsage,
+		RewardType:     domainbilling.RedemptionRewardTypeBalance,
+		CreditNanousd:  100,
+		PerUserLimit:   1,
+		RedeemedCount:  0,
+		MaxRedemptions: nil,
+	}
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return validateRedeemableCode(tx, usageCode, 1, domainbilling.RedemptionCodeModePeriod, now)
+	})
+	if err != nil {
+		t.Fatalf("validateRedeemableCode(usage code in period mode) error = %v", err)
+	}
+
+	periodCode := model.RedemptionCode{
+		Status:        domainbilling.RedemptionCodeStatusActive,
+		Mode:          domainbilling.RedemptionCodeModePeriod,
+		RewardType:    domainbilling.RedemptionRewardTypeSubscription,
+		PlanID:        2,
+		PerUserLimit:  1,
+		RedeemedCount: 0,
+	}
+	err = db.Transaction(func(tx *gorm.DB) error {
+		return validateRedeemableCode(tx, periodCode, 1, domainbilling.RedemptionCodeModeUsage, now)
+	})
+	if err != repository.ErrRedemptionUnavailable {
+		t.Fatalf("validateRedeemableCode(period code in usage mode) error = %v, want ErrRedemptionUnavailable", err)
+	}
+}
+
 func openBillingSQLiteTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 
@@ -104,8 +225,8 @@ func openBillingSQLiteTestDB(t *testing.T) *gorm.DB {
 		_ = sqlDB.Close()
 	})
 
-	if err := db.AutoMigrate(&model.UsageLedger{}); err != nil {
-		t.Fatalf("migrate usage ledgers: %v", err)
+	if err := db.AutoMigrate(&model.UsageLedger{}, &model.BillingAccount{}, &model.BalanceTransaction{}, &model.Redemption{}); err != nil {
+		t.Fatalf("migrate billing tables: %v", err)
 	}
 	return db
 }

--- a/backend/internal/repository/billing.go
+++ b/backend/internal/repository/billing.go
@@ -26,6 +26,7 @@ type BillingRepository interface {
 	AddUsage(ctx context.Context, usage *domainbilling.UsageLedger) error
 	AddUsageAndDebitBalance(ctx context.Context, usage *domainbilling.UsageLedger) error
 	AddUsageAndSettleBalance(ctx context.Context, usage *domainbilling.UsageLedger, reservation *domainbilling.UsageBalanceReservation) error
+	AddPeriodUsageAndSettleOverage(ctx context.Context, usage *domainbilling.UsageLedger, periodStart time.Time, periodEnd time.Time, periodCreditNanousd int64, reservation *domainbilling.UsageBalanceReservation) error
 	ReserveUsageBalance(ctx context.Context, userID uint, amountNanousd int64, refNo string) (*domainbilling.UsageBalanceReservation, error)
 	ReleaseUsageBalanceReservation(ctx context.Context, userID uint, refNo string, description string) error
 	GetOrCreateBillingAccount(ctx context.Context, userID uint) (*domainbilling.BillingAccount, error)
@@ -57,6 +58,7 @@ type BillingRepository interface {
 // RedemptionCodeListFilter 描述管理员兑换码列表筛选条件。
 type RedemptionCodeListFilter struct {
 	Mode         string
+	Modes        []string
 	Status       string
 	Availability string
 	Query        string

--- a/frontend/features/admin/components/sections/accounts/accounts-user-editor.tsx
+++ b/frontend/features/admin/components/sections/accounts/accounts-user-editor.tsx
@@ -630,22 +630,20 @@ export function EditUserSheet({
                   </DialogCollapsible>
                 </div>
               ) : null}
-              {billingMode !== "self" ? (
-                <div className="grid gap-3 md:grid-cols-2">
-                  <div className="space-y-1">
-                    <Label className="text-xs font-normal text-muted-foreground">{t("editor.accountBalance")}</Label>
-                    <Input
-                      type="number"
-                      min="0"
-                      step="0.000001"
-                      value={editPayload.billingBalanceUSD}
-                      onChange={(event) => setEditPayload((current) => ({ ...current, billingBalanceUSD: event.target.value }))}
-                      disabled={pending}
-                    />
-                  </div>
-                  <ReadOnlyField label={t("editor.billingStatus")} value={resolveBillingAccountStatusLabel(editDialogTarget?.billingAccountStatus || "active")} />
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="space-y-1">
+                  <Label className="text-xs font-normal text-muted-foreground">{t("editor.accountBalance")}</Label>
+                  <Input
+                    type="number"
+                    min="0"
+                    step="0.000001"
+                    value={editPayload.billingBalanceUSD}
+                    onChange={(event) => setEditPayload((current) => ({ ...current, billingBalanceUSD: event.target.value }))}
+                    disabled={pending}
+                  />
                 </div>
-              ) : null}
+                <ReadOnlyField label={t("editor.billingStatus")} value={resolveBillingAccountStatusLabel(editDialogTarget?.billingAccountStatus || "active")} />
+              </div>
             </SheetSection>
           ) : null}
 

--- a/frontend/features/admin/components/sections/accounts/accounts-user-editor.tsx
+++ b/frontend/features/admin/components/sections/accounts/accounts-user-editor.tsx
@@ -447,7 +447,7 @@ export function EditUserSheet({
                 {billingMode === "period" ? (
                   <Badge variant="outline" className="text-muted-foreground">{resolveDetailValue(editDialogTarget?.subscriptionTier)}</Badge>
                 ) : null}
-                {billingMode === "usage" ? (
+                {billingMode !== "self" ? (
                   <Badge variant="outline" className="text-muted-foreground">
                     {formatBillingBalance(editDialogTarget?.billingBalanceUSD)}
                   </Badge>
@@ -630,7 +630,7 @@ export function EditUserSheet({
                   </DialogCollapsible>
                 </div>
               ) : null}
-              {billingMode === "usage" ? (
+              {billingMode !== "self" ? (
                 <div className="grid gap-3 md:grid-cols-2">
                   <div className="space-y-1">
                     <Label className="text-xs font-normal text-muted-foreground">{t("editor.accountBalance")}</Label>

--- a/frontend/features/admin/components/sections/accounts/accounts-users.tsx
+++ b/frontend/features/admin/components/sections/accounts/accounts-users.tsx
@@ -360,7 +360,7 @@ const UserTableRow = React.memo(function UserTableRow({
           </div>
         </TableCell>
       ) : null}
-      {billingMode === "usage" ? (
+      {billingMode !== "self" ? (
         <TableCell className="whitespace-nowrap text-foreground">
           <span title={resolveBillingAccountStatusLabel(item.billingAccountStatus || "active")}>
             {formatBillingBalance(item.billingBalanceUSD)}
@@ -564,6 +564,9 @@ export function AccountsUsers({
     }
   }
 
+  const showBalanceColumn = billingMode !== "self";
+  const tableColSpan = 9 + (billingMode === "period" ? 2 : showBalanceColumn ? 1 : 0);
+
   return (
     <>
       <div className="space-y-3">
@@ -687,7 +690,7 @@ export function AccountsUsers({
                 />
               </BulkActionControlRow>
 
-              {billingMode === "usage" ? (
+              {showBalanceColumn ? (
                 <BulkActionControlRow
                   icon={<DollarSign className="size-3 stroke-1" />}
                   label={t("actions.apply")}
@@ -779,7 +782,7 @@ export function AccountsUsers({
                 <TableHead>{t("fields.role")}</TableHead>
                 <TableHead>{t("fields.status")}</TableHead>
                 {billingMode === "period" ? <TableHead>{t("fields.subscription")}</TableHead> : null}
-                {billingMode === "usage" ? <TableHead>{t("fields.balance")}</TableHead> : null}
+                {showBalanceColumn ? <TableHead>{t("fields.balance")}</TableHead> : null}
                 <TableHead className="text-center">2FA</TableHead>
                 <TableHead>{t("fields.timezone")}</TableHead>
                 <TableHead>{t("fields.lastLogin")}</TableHead>
@@ -788,9 +791,9 @@ export function AccountsUsers({
             </TableHeader>
             <TableBody>
               {initialLoading ? (
-                <TableLoadingRow colSpan={billingMode === "self" ? 9 : 10} />
+                <TableLoadingRow colSpan={tableColSpan} />
               ) : null}
-              {showRows ? <VirtualTablePaddingRow colSpan={billingMode === "self" ? 9 : 10} height={virtualRows.paddingTop} /> : null}
+              {showRows ? <VirtualTablePaddingRow colSpan={tableColSpan} height={virtualRows.paddingTop} /> : null}
               {showRows
                 ? virtualRows.rows.map(({ item }) => (
                     <UserTableRow
@@ -811,9 +814,9 @@ export function AccountsUsers({
                     />
                   ))
                 : null}
-              {showRows ? <VirtualTablePaddingRow colSpan={billingMode === "self" ? 9 : 10} height={virtualRows.paddingBottom} /> : null}
+              {showRows ? <VirtualTablePaddingRow colSpan={tableColSpan} height={virtualRows.paddingBottom} /> : null}
               {!loading && filteredItems.length === 0 ? (
-                <TableEmptyRow colSpan={billingMode === "self" ? 9 : 10}>{t("table.empty")}</TableEmptyRow>
+                <TableEmptyRow colSpan={tableColSpan}>{t("table.empty")}</TableEmptyRow>
               ) : null}
             </TableBody>
         </Table>

--- a/frontend/features/admin/components/sections/billing/admin-billing.tsx
+++ b/frontend/features/admin/components/sections/billing/admin-billing.tsx
@@ -1400,7 +1400,10 @@ export function AdminBillingPage() {
       return t("redemption.unavailableSelf");
     }
     const codeMode = item.mode === "period" ? "period" : "usage";
-    if (billingMode !== codeMode) {
+    const modeAllowed = billingMode === "period"
+      ? codeMode === "usage" || codeMode === "period"
+      : billingMode === codeMode;
+    if (!modeAllowed) {
       return t("redemption.unavailableModeMismatch", {
         currentMode: redemptionModeLabel(billingMode),
         codeMode: redemptionModeLabel(codeMode),

--- a/frontend/features/admin/hooks/use-admin-users-page.ts
+++ b/frontend/features/admin/hooks/use-admin-users-page.ts
@@ -598,11 +598,11 @@ export function useAdminUsersPage({
     }
 
     const billingBalanceChanged =
-      billingMode === "usage" &&
+      billingMode !== "self" &&
       Number.isFinite(nextBillingBalance) &&
       roundBillingBalance(nextBillingBalance) !== roundBillingBalance(editDialogTarget.billingBalanceUSD ?? 0);
 
-    if (billingMode === "usage" && (!Number.isFinite(nextBillingBalance) || nextBillingBalance < 0)) {
+    if (billingMode !== "self" && (!Number.isFinite(nextBillingBalance) || nextBillingBalance < 0)) {
       toast.error(t("toast.editFailed"), { description: t("validation.invalidUsageBalance") });
       return;
     }
@@ -1018,7 +1018,7 @@ export function useAdminUsersPage({
     if (!selectedUsers.length || !batchBalance.trim() || pendingAction) {
       return;
     }
-    if (billingMode !== "usage") {
+    if (billingMode === "self") {
       return;
     }
     if (!Number.isFinite(nextBalance) || nextBalance < 0) {

--- a/frontend/features/settings/components/sections/subscription/subscription-summary.tsx
+++ b/frontend/features/settings/components/sections/subscription/subscription-summary.tsx
@@ -334,6 +334,17 @@ export function SubscriptionSummary({
               </div>
             </div>
           </div>
+
+          <ActionRow
+            title={t("periodOverage.title")}
+            value={t("periodOverage.balance", { value: formatAccountBalance(billingAccount?.balanceUSD ?? 0) })}
+            action={
+              <Button type="button" variant="outline" disabled={billingLoading || topUpLoading || paymentDisabled} onClick={onOpenTopUpDialog}>
+                <Banknote className="size-3.5" />
+                {t("usageBilling.topUp")}
+              </Button>
+            }
+          />
         </section>
       ) : null}
 

--- a/frontend/i18n/messages/en-US/admin-billing.json
+++ b/frontend/i18n/messages/en-US/admin-billing.json
@@ -15,7 +15,7 @@
     "mode": "Billing mode",
     "modeDescription": "Self-use records usage only. Subscription billing limits usage by plan credits. Usage billing calculates cost from model pricing.",
     "prepaidAmount": "Prepaid amount",
-    "prepaidAmountDescription": "In usage billing, calls can start only when the account balance meets this amount. The final deduction still uses the actual bill.",
+    "prepaidAmountDescription": "In usage billing and subscription overage billing, calls can start only when the account balance meets this amount. The final deduction still uses the actual bill.",
     "modes": {
       "self": "Self-use",
       "period": "Subscription billing",

--- a/frontend/i18n/messages/en-US/settings.json
+++ b/frontend/i18n/messages/en-US/settings.json
@@ -472,6 +472,10 @@
       "used": "Used {value}",
       "total": "Total {value}"
     },
+    "periodOverage": {
+      "title": "Overage billing",
+      "balance": "Available balance {value}"
+    },
     "entitlements": {
       "title": "Subscription entitlements",
       "count": "{count} segments",

--- a/frontend/i18n/messages/zh-CN/admin-billing.json
+++ b/frontend/i18n/messages/zh-CN/admin-billing.json
@@ -15,7 +15,7 @@
     "mode": "计费模式",
     "modeDescription": "自用模式只记录用量；周期计费按订阅额度限制；按量计费按模型定价计算费用。",
     "prepaidAmount": "预付费金额",
-    "prepaidAmountDescription": "按量模式发起调用前要求账户余额达到该金额；最终仍按真实账单扣费。",
+    "prepaidAmountDescription": "按量模式及周期超额按量扣费时，发起调用前要求账户余额达到该金额；最终仍按真实账单扣费。",
     "modes": {
       "self": "自用模式",
       "period": "周期计费",

--- a/frontend/i18n/messages/zh-CN/settings.json
+++ b/frontend/i18n/messages/zh-CN/settings.json
@@ -472,6 +472,10 @@
       "used": "已使用 {value}",
       "total": "总额度 {value}"
     },
+    "periodOverage": {
+      "title": "超额按量",
+      "balance": "可用余额 {value}"
+    },
     "entitlements": {
       "title": "订阅权益",
       "count": "{count} 段",


### PR DESCRIPTION
## Summary

Support subscription overage billing while keeping the existing billing modes unchanged.

Period billing now uses subscription credit first and settles any overage against the usage balance. The frontend also exposes overage balance and top-up flows in period mode, and redemption code availability now matches the new boundary.

## Change type

- [x] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [x] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/application/billing ./internal/application/conversation ./internal/infra/persistence/postgres/billing`
- [x] `cd frontend && pnpm lint`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Not included. This change updates billing logic and existing settings/admin UI states.

## Configuration, migration, and compatibility notes

No database migration or new billing mode is introduced.

Backend billing modes remain:
- `self`
- `usage`
- `period`

In `period` mode:
- subscription credit is consumed first;
- overage is charged from usage balance;
- usage ledgers still record the full billed amount;
- settlement split details are stored in `PricingSnapshotJSON`.

Usage balance top-up and admin balance adjustment are now available in both `usage` and `period` modes.

Redemption code availability:
- `usage` mode accepts usage balance codes only;
- `period` mode accepts both usage balance codes and period subscription codes;
- `self` mode accepts neither.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including provider routing, billing settlement, balance transactions, and redemption code application.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.