### PR TITLE
refactor: update file processing timeouts and enhance batch response handling

### DIFF
--- a/backend/internal/application/processing/service.go
+++ b/backend/internal/application/processing/service.go
@@ -20,7 +20,7 @@ const (
 	DefaultExtractorVersion  = "file-pipeline-v1"
 	fileProcessingMaxRetries = 3
 	defaultProcessingPreview = 280
-	fixedExtractTimeout      = 60 * time.Second
+	defaultExtractTimeout    = 60 * time.Second
 	fixedEmbeddingTimeout    = 5 * time.Minute
 	failurePersistTimeout    = 5 * time.Second
 )
@@ -200,7 +200,9 @@ func (s *Service) ProcessFile(ctx context.Context, userID uint, fileID string) e
 		return nil
 	}
 
-	runCtx, cancel := context.WithTimeout(ctx, fixedExtractTimeout+fixedEmbeddingTimeout)
+	cfg := s.snapshot()
+	extractTimeout := resolveProcessingExtractTimeout(cfg, fileObj.FileCategory)
+	runCtx, cancel := context.WithTimeout(ctx, extractTimeout+fixedEmbeddingTimeout)
 	defer cancel()
 
 	startedAt := time.Now()
@@ -221,7 +223,7 @@ func (s *Service) ProcessFile(ctx context.Context, userID uint, fileID string) e
 		return err
 	}
 
-	extractCtx, extractCancel := context.WithTimeout(runCtx, fixedExtractTimeout)
+	extractCtx, extractCancel := context.WithTimeout(runCtx, extractTimeout)
 	extractResult, extractErr := s.extractTextForProcessing(extractCtx, *fileObj)
 	extractCancel()
 	if extractErr != nil {
@@ -640,6 +642,65 @@ func (s *Service) snapshot() config.Config {
 		return config.Config{}
 	}
 	return s.cfg.Snapshot()
+}
+
+func resolveProcessingExtractTimeout(cfg config.Config, fileCategory string) time.Duration {
+	primaryTimeout := resolvePrimaryExtractTimeout(cfg)
+	ocrTimeout := resolveOCRExtractTimeout(cfg)
+
+	switch strings.ToLower(strings.TrimSpace(fileCategory)) {
+	case "image":
+		if cfg.ExtractImageOCREnabled {
+			return ocrTimeout
+		}
+	case "pdf":
+		if cfg.ExtractPDFOCRFallbackEnabled {
+			return primaryTimeout + ocrTimeout
+		}
+	}
+	return primaryTimeout
+}
+
+func resolvePrimaryExtractTimeout(cfg config.Config) time.Duration {
+	timeoutSeconds := 0
+	switch strings.ToLower(strings.TrimSpace(cfg.ExtractEngine)) {
+	case extraction.EngineTika:
+		timeoutSeconds = cfg.ExtractTikaTimeoutSeconds
+	case extraction.EngineDocling:
+		timeoutSeconds = cfg.ExtractDoclingTimeoutSeconds
+	case extraction.EngineMinerU:
+		timeoutSeconds = cfg.ExtractMinerUTimeoutSeconds
+	default:
+		timeoutSeconds = int(defaultExtractTimeout / time.Second)
+	}
+	if timeoutSeconds <= 0 {
+		return defaultExtractTimeout
+	}
+	return time.Duration(timeoutSeconds) * time.Second
+}
+
+func resolveOCRExtractTimeout(cfg config.Config) time.Duration {
+	timeoutSeconds := 0
+	switch strings.ToLower(strings.TrimSpace(cfg.ExtractOCREngine)) {
+	case extraction.OCREngineTesseract:
+		timeoutSeconds = cfg.ExtractTesseractOCRTimeoutSeconds
+	case extraction.OCREngineRapidOCR:
+		timeoutSeconds = cfg.ExtractRapidOCRTimeoutSeconds
+	case extraction.OCREnginePaddle:
+		timeoutSeconds = cfg.ExtractPaddleOCRTimeoutSeconds
+	case extraction.OCREngineTencent:
+		timeoutSeconds = cfg.ExtractTencentOCRTimeoutSeconds
+	case extraction.OCREngineAliyun:
+		timeoutSeconds = cfg.ExtractAliyunOCRTimeoutSeconds
+	case extraction.OCREngineLLM:
+		timeoutSeconds = cfg.ExtractLLMOCRTimeoutSeconds
+	default:
+		timeoutSeconds = int(defaultExtractTimeout / time.Second)
+	}
+	if timeoutSeconds <= 0 {
+		return defaultExtractTimeout
+	}
+	return time.Duration(timeoutSeconds) * time.Second
 }
 
 func (s *Service) version() string {

--- a/backend/internal/application/processing/service_timeout_test.go
+++ b/backend/internal/application/processing/service_timeout_test.go
@@ -1,0 +1,77 @@
+package processing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/extraction"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
+)
+
+func TestResolveProcessingExtractTimeoutUsesMinerUConfig(t *testing.T) {
+	cfg := config.Config{
+		ExtractEngine:               extraction.EngineMinerU,
+		ExtractMinerUTimeoutSeconds: 180,
+	}
+
+	got := resolveProcessingExtractTimeout(cfg, "pdf")
+	if got != 180*time.Second {
+		t.Fatalf("expected MinerU timeout to be 180s, got %s", got)
+	}
+}
+
+func TestResolveProcessingExtractTimeoutFallsBackToDefault(t *testing.T) {
+	cfg := config.Config{
+		ExtractEngine:               extraction.EngineMinerU,
+		ExtractMinerUTimeoutSeconds: 0,
+	}
+
+	got := resolveProcessingExtractTimeout(cfg, "word")
+	if got != defaultExtractTimeout {
+		t.Fatalf("expected default timeout %s, got %s", defaultExtractTimeout, got)
+	}
+}
+
+func TestResolveProcessingExtractTimeoutUsesImageOCRConfig(t *testing.T) {
+	cfg := config.Config{
+		ExtractEngine:                     extraction.EngineBuiltin,
+		ExtractImageOCREnabled:            true,
+		ExtractOCREngine:                  extraction.OCREngineRapidOCR,
+		ExtractRapidOCRTimeoutSeconds:     90,
+		ExtractTesseractOCRTimeoutSeconds: 120,
+	}
+
+	got := resolveProcessingExtractTimeout(cfg, "image")
+	if got != 90*time.Second {
+		t.Fatalf("expected image OCR timeout to be 90s, got %s", got)
+	}
+}
+
+func TestResolveProcessingExtractTimeoutAddsPDFOCRFallbackWindow(t *testing.T) {
+	cfg := config.Config{
+		ExtractEngine:                     extraction.EngineTika,
+		ExtractTikaTimeoutSeconds:         80,
+		ExtractPDFOCRFallbackEnabled:      true,
+		ExtractOCREngine:                  extraction.OCREngineTesseract,
+		ExtractTesseractOCRTimeoutSeconds: 90,
+	}
+
+	got := resolveProcessingExtractTimeout(cfg, "pdf")
+	if got != 170*time.Second {
+		t.Fatalf("expected PDF extraction plus OCR fallback timeout to be 170s, got %s", got)
+	}
+}
+
+func TestResolveProcessingExtractTimeoutIgnoresOCRForPDFWhenFallbackDisabled(t *testing.T) {
+	cfg := config.Config{
+		ExtractEngine:                extraction.EngineDocling,
+		ExtractDoclingTimeoutSeconds: 75,
+		ExtractOCREngine:             extraction.OCREngineLLM,
+		ExtractLLMOCRTimeoutSeconds:  180,
+	}
+
+	got := resolveProcessingExtractTimeout(cfg, "pdf")
+	if got != 75*time.Second {
+		t.Fatalf("expected PDF timeout to use primary engine only, got %s", got)
+	}
+}

--- a/backend/internal/infra/extract/mineru/client.go
+++ b/backend/internal/infra/extract/mineru/client.go
@@ -369,10 +369,10 @@ func (c *Client) createBatch(ctx context.Context, req Request) (string, string, 
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 2*1024*1024)).Decode(&parsed); err != nil {
 		return "", "", fmt.Errorf("mineru_invalid_response")
 	}
-	if strings.TrimSpace(parsed.Data.BatchID) == "" || len(parsed.Data.FileURLs) == 0 || strings.TrimSpace(parsed.Data.FileURLs[0].UploadURL) == "" {
+	if strings.TrimSpace(parsed.Data.BatchID) == "" || len(parsed.Data.FileURLs) == 0 || strings.TrimSpace(parsed.Data.FileURLs[0]) == "" {
 		return "", "", fmt.Errorf("mineru_invalid_response")
 	}
-	return strings.TrimSpace(parsed.Data.BatchID), strings.TrimSpace(parsed.Data.FileURLs[0].UploadURL), nil
+	return strings.TrimSpace(parsed.Data.BatchID), strings.TrimSpace(parsed.Data.FileURLs[0]), nil
 }
 
 func (c *Client) uploadFile(ctx context.Context, uploadURL string, absolutePath string) error {
@@ -446,20 +446,27 @@ func (c *Client) pollBatch(ctx context.Context, batchID string) (string, error) 
 		}
 
 		state := strings.ToLower(strings.TrimSpace(parsed.Data.State))
+		var item batchResultItem
+		if len(parsed.Data.ExtractResult) > 0 {
+			item = parsed.Data.ExtractResult[0]
+			if itemState := strings.ToLower(strings.TrimSpace(item.State)); itemState != "" {
+				state = itemState
+			}
+		}
 		switch state {
 		case "done", "success", "completed":
 			if len(parsed.Data.ExtractResult) == 0 {
 				return "", fmt.Errorf("mineru_invalid_response")
 			}
-			zipURL := strings.TrimSpace(parsed.Data.ExtractResult[0].FullZipURL)
+			zipURL := strings.TrimSpace(item.FullZipURL)
 			if zipURL == "" {
 				return "", fmt.Errorf("mineru_invalid_response")
 			}
 			return zipURL, nil
 		case "failed", "error":
 			detail := strings.TrimSpace(parsed.Data.ErrMsg)
-			if detail == "" && len(parsed.Data.ExtractResult) > 0 {
-				detail = strings.TrimSpace(parsed.Data.ExtractResult[0].ErrMsg)
+			if detail == "" {
+				detail = strings.TrimSpace(item.ErrMsg)
 			}
 			if detail == "" {
 				return "", fmt.Errorf("mineru_failed")
@@ -663,10 +670,8 @@ func awaitMultipartWriteError(errCh <-chan error) error {
 
 type batchCreateResponse struct {
 	Data struct {
-		BatchID  string `json:"batch_id"`
-		FileURLs []struct {
-			UploadURL string `json:"upload_url"`
-		} `json:"file_urls"`
+		BatchID  string   `json:"batch_id"`
+		FileURLs []string `json:"file_urls"`
 	} `json:"data"`
 }
 
@@ -689,11 +694,14 @@ func (r selfHostedResponse) firstMarkdown() string {
 
 type batchResultResponse struct {
 	Data struct {
-		State         string `json:"state"`
-		ErrMsg        string `json:"err_msg"`
-		ExtractResult []struct {
-			ErrMsg     string `json:"err_msg"`
-			FullZipURL string `json:"full_zip_url"`
-		} `json:"extract_result"`
+		State         string            `json:"state"`
+		ErrMsg        string            `json:"err_msg"`
+		ExtractResult []batchResultItem `json:"extract_result"`
 	} `json:"data"`
+}
+
+type batchResultItem struct {
+	State      string `json:"state"`
+	ErrMsg     string `json:"err_msg"`
+	FullZipURL string `json:"full_zip_url"`
 }

--- a/backend/internal/infra/extract/mineru/client_test.go
+++ b/backend/internal/infra/extract/mineru/client_test.go
@@ -1,0 +1,109 @@
+package mineru
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestBatchCreateResponseParsesFileURLsAsStrings(t *testing.T) {
+	raw := []byte(`{
+		"code": 0,
+		"msg": "ok",
+		"data": {
+			"batch_id": "batch-1",
+			"file_urls": ["https://example.com/upload"]
+		}
+	}`)
+
+	var parsed batchCreateResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal batch create response: %v", err)
+	}
+	if parsed.Data.BatchID != "batch-1" {
+		t.Fatalf("unexpected batch id %q", parsed.Data.BatchID)
+	}
+	if len(parsed.Data.FileURLs) != 1 || parsed.Data.FileURLs[0] != "https://example.com/upload" {
+		t.Fatalf("unexpected file urls %#v", parsed.Data.FileURLs)
+	}
+}
+
+func TestBatchResultResponseParsesExtractResultStateAndZipURL(t *testing.T) {
+	raw := []byte(`{
+		"code": 0,
+		"msg": "ok",
+		"data": {
+			"state": "running",
+			"extract_result": [
+				{
+					"state": "done",
+					"full_zip_url": "https://example.com/result.zip"
+				}
+			]
+		}
+	}`)
+
+	var parsed batchResultResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal batch result response: %v", err)
+	}
+	if len(parsed.Data.ExtractResult) != 1 {
+		t.Fatalf("unexpected extract result %#v", parsed.Data.ExtractResult)
+	}
+	if parsed.Data.ExtractResult[0].State != "done" {
+		t.Fatalf("unexpected item state %q", parsed.Data.ExtractResult[0].State)
+	}
+	if parsed.Data.ExtractResult[0].FullZipURL != "https://example.com/result.zip" {
+		t.Fatalf("unexpected full zip url %q", parsed.Data.ExtractResult[0].FullZipURL)
+	}
+}
+
+func TestPollBatchUsesExtractResultState(t *testing.T) {
+	var calls int
+	client := &Client{
+		baseURL: "https://mineru.example/api/v4",
+		httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			calls++
+			if r.URL.Path != "/api/v4/extract-results/batch/batch-1" {
+				t.Fatalf("unexpected path %q", r.URL.Path)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(`{
+			"code": 0,
+			"msg": "ok",
+			"data": {
+				"state": "running",
+				"extract_result": [
+					{
+						"state": "done",
+						"full_zip_url": "https://example.com/result.zip"
+					}
+				]
+			}
+		}`)),
+			}, nil
+		})},
+	}
+
+	zipURL, err := client.pollBatch(context.Background(), "batch-1")
+	if err != nil {
+		t.Fatalf("poll batch: %v", err)
+	}
+	if zipURL != "https://example.com/result.zip" {
+		t.Fatalf("unexpected zip url %q", zipURL)
+	}
+	if calls != 1 {
+		t.Fatalf("expected one poll call, got %d", calls)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}


### PR DESCRIPTION
## Summary

Fix MinerU cloud document extraction so uploaded files no longer stay in processing until timeout. The MinerU v4 integration now matches the official batch API response shape, reads per-file result status and `full_zip_url`, and uses configured extraction/OCR timeouts instead of a fixed 60s processing window.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [x] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/infra/extract/mineru ./internal/application/processing`

## Screenshots, API examples, or logs

MinerU v4 batch response handling was aligned with the official API shape:
- `file_urls` is parsed as `[]string`
- batch completion is read from `data.extract_result[].state`
- result archive URL is read from `data.extract_result[].full_zip_url`

## Configuration, migration, and compatibility notes

No database migration or configuration change required.

The existing MinerU timeout setting now applies to the file processing extraction context. OCR-related processing windows also respect the selected OCR timeout configuration.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.