### PR TITLE
fix: update load more sentinel conditions to include loadingMore state

### DIFF
--- a/frontend/features/layouts/components/navigation/nav-recents.tsx
+++ b/frontend/features/layouts/components/navigation/nav-recents.tsx
@@ -93,7 +93,7 @@ export function NavRecents() {
   })
 
   useLoadMoreSentinel({
-    enabled: recentsOpen && hasMore && !loadingInitial && !loadMoreFailed,
+    enabled: recentsOpen && hasMore && !loadingInitial && !loadingMore && !loadMoreFailed,
     targetRef: loadMoreRef,
     onLoadMore: loadMore,
   })

--- a/frontend/features/prompts/hooks/use-skills-prompt-page.ts
+++ b/frontend/features/prompts/hooks/use-skills-prompt-page.ts
@@ -270,7 +270,7 @@ export function useSkillsPromptPage() {
   }, [fetchPage, hasMore, loading, pagination, resolveErrorMessage, t]);
 
   useLoadMoreSentinel({
-    enabled: hasMore && !loading && !loadMoreFailed,
+    enabled: hasMore && !loading && !loadingMore && !loadMoreFailed,
     targetRef: loadMoreRef,
     rootMargin: "160px",
     onLoadMore: loadMore,

--- a/frontend/features/recent/hooks/use-recent-page.ts
+++ b/frontend/features/recent/hooks/use-recent-page.ts
@@ -297,7 +297,7 @@ export function useRecentPage() {
   }, [hasMore, loadPage, loadingInitial, resolveErrorMessage, t]);
 
   useLoadMoreSentinel({
-    enabled: hasMore && !loadingInitial && !loadMoreFailed,
+    enabled: hasMore && !loadingInitial && !loadingMore && !loadMoreFailed,
     targetRef: loadMoreRef,
     rootMargin: "160px",
     onLoadMore: loadMore,


### PR DESCRIPTION
## Summary

Fixes an infinite-scroll edge case where sidebar chat history could stop loading more conversations on desktop even when additional records existed. The load-more sentinel is now disabled while a page is loading and re-enabled afterward, so if the sentinel remains visible after new rows render, the observer is recreated and can trigger the next page.

The same fix is applied to other shared sentinel-based lists to avoid the same stuck pagination behavior.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm build`
- [x] `git diff --check`

- [ ] Not run; reason:

## Screenshots, API examples, or logs

No screenshots, API examples, or logs included.

## Configuration, migration, and compatibility notes

No configuration, migration, deployment, or API contract changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.