### PR TITLE
feat: implement OpenAI responses instructions handling and previous response ID routes

### DIFF
--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -699,6 +699,7 @@ func (s *Service) sendMessageInternal(
 		Options:        filteredOptions,
 	}
 	fullLLMMessages := llmMessages
+	applyOpenAIResponsesInstructions(route, routeConfig.Endpoint, &generateInput)
 	statefulContextConfig := buildPromptContextConfigSignature(cfg)
 	statefulContextState := buildPromptContextStateSignature(stableFullContextAttachments, prefixMemories)
 	statefulPrefixFingerprint := buildPromptStateFingerprint(promptStateFingerprintInput{
@@ -994,6 +995,7 @@ func (s *Service) sendMessageInternal(
 		_ = s.repo.UpdateConversationLastResponseID(ctx, input.ConversationID, "")
 		generateInput.PreviousResponseID = ""
 		generateInput.Messages = fullLLMMessages
+		applyOpenAIResponsesInstructions(route, routeConfig.Endpoint, &generateInput)
 		estimatedPromptTokens = estimatePromptTokens(fullLLMMessages)
 		initialPromptShape = summarizePromptShape("full_retry", generateInput.Messages, fullLLMMessages, "")
 		if traceRecorder != nil {
@@ -1102,12 +1104,14 @@ func (s *Service) sendMessageInternal(
 			followUpInput.Tools = nil
 			followUpInput.DisableTools = true
 			followUpInput.PreviousResponseID = ""
-		} else if routeConfig.Endpoint == llm.EndpointResponses && strings.TrimSpace(upstreamOutput.ResponseID) != "" {
+			applyOpenAIResponsesInstructions(route, routeConfig.Endpoint, &followUpInput)
+		} else if routeConfig.Endpoint == llm.EndpointResponses && supportsPreviousResponseIDRoute(route) && strings.TrimSpace(upstreamOutput.ResponseID) != "" {
 			followUpInput.PreviousResponseID = strings.TrimSpace(upstreamOutput.ResponseID)
 			followUpInput.Messages = []llm.Message{{Role: "tool", ToolResults: toolResult.ToolResults}}
 		} else {
 			followUpInput.Messages = llmMessages
 			followUpInput.PreviousResponseID = ""
+			applyOpenAIResponsesInstructions(route, routeConfig.Endpoint, &followUpInput)
 		}
 
 		nextOutput, nextErr := runGenerate(followUpInput)
@@ -1139,6 +1143,7 @@ func (s *Service) sendMessageInternal(
 		finalInput.Tools = nil
 		finalInput.DisableTools = true
 		finalInput.PreviousResponseID = ""
+		applyOpenAIResponsesInstructions(route, routeConfig.Endpoint, &finalInput)
 		nextOutput, nextErr := runGenerate(finalInput)
 		if handleCanceledGeneration(nextErr) {
 			return nil, retErr

--- a/backend/internal/application/conversation/service_stateful_responses.go
+++ b/backend/internal/application/conversation/service_stateful_responses.go
@@ -44,13 +44,16 @@ func resolvePreviousResponseID(route *channel.ResolvedRoute, branchReason string
 	if responseID == "" || !strings.EqualFold(strings.TrimSpace(branchReason), "default") {
 		return ""
 	}
-	if route == nil || !llm.SupportsPreviousResponseID(route.Protocol) {
-		return ""
-	}
-	if !isOfficialOpenAIBaseURL(route.BaseURL) {
+	if !supportsPreviousResponseIDRoute(route) {
 		return ""
 	}
 	return responseID
+}
+
+func supportsPreviousResponseIDRoute(route *channel.ResolvedRoute) bool {
+	return route != nil &&
+		llm.SupportsPreviousResponseID(route.Protocol) &&
+		isOfficialOpenAIBaseURL(route.BaseURL)
 }
 
 func isOfficialOpenAIBaseURL(raw string) bool {
@@ -76,6 +79,57 @@ func buildStatefulResponseMessages(messages []llm.Message) []llm.Message {
 		}
 	}
 	return nil
+}
+
+func applyOpenAIResponsesInstructions(route *channel.ResolvedRoute, endpoint string, input *llm.GenerateInput) {
+	if input == nil || endpoint != llm.EndpointResponses || !supportsPreviousResponseIDRoute(route) {
+		return
+	}
+	instructions, messages := extractOpenAIResponsesInstructions(input.Messages)
+	if strings.TrimSpace(instructions) == "" {
+		return
+	}
+	input.Instructions = instructions
+	input.Messages = messages
+}
+
+func extractOpenAIResponsesInstructions(messages []llm.Message) (string, []llm.Message) {
+	if len(messages) == 0 {
+		return "", nil
+	}
+	var builder strings.Builder
+	result := make([]llm.Message, 0, len(messages))
+	for _, message := range messages {
+		if message.Role != "system" {
+			result = append(result, message)
+			continue
+		}
+		text := strings.TrimSpace(systemInstructionText(message))
+		if text == "" {
+			continue
+		}
+		if builder.Len() > 0 {
+			builder.WriteString("\n\n")
+		}
+		builder.WriteString(text)
+	}
+	if builder.Len() == 0 {
+		return "", cloneLLMMessages(messages)
+	}
+	return builder.String(), result
+}
+
+func systemInstructionText(message llm.Message) string {
+	if strings.TrimSpace(message.Content) != "" || len(message.Parts) == 0 {
+		return message.Content
+	}
+	parts := make([]string, 0, len(message.Parts))
+	for _, part := range message.Parts {
+		if strings.TrimSpace(part.Text) != "" {
+			parts = append(parts, strings.TrimSpace(part.Text))
+		}
+	}
+	return strings.Join(parts, "\n\n")
 }
 
 func shouldRetryWithoutPreviousResponseID(err error) bool {

--- a/backend/internal/application/conversation/service_stateful_responses_test.go
+++ b/backend/internal/application/conversation/service_stateful_responses_test.go
@@ -50,6 +50,27 @@ func TestResolvePreviousResponseIDOnlyEnablesKnownSafeRoutes(t *testing.T) {
 	})
 }
 
+func TestSupportsPreviousResponseIDRouteOnlyAllowsOfficialOpenAIResponses(t *testing.T) {
+	if !supportsPreviousResponseIDRoute(&channel.ResolvedRoute{
+		Protocol: llm.AdapterOpenAIResponses,
+		BaseURL:  "https://api.openai.com/v1",
+	}) {
+		t.Fatalf("expected official OpenAI Responses route to support previous_response_id")
+	}
+	if supportsPreviousResponseIDRoute(&channel.ResolvedRoute{
+		Protocol: llm.AdapterOpenAIResponses,
+		BaseURL:  "http://host.docker.internal:42113/v1",
+	}) {
+		t.Fatalf("expected custom Responses-compatible route to disable previous_response_id")
+	}
+	if supportsPreviousResponseIDRoute(&channel.ResolvedRoute{
+		Protocol: llm.AdapterOpenAIChatCompletions,
+		BaseURL:  "https://api.openai.com/v1",
+	}) {
+		t.Fatalf("expected non-Responses route to disable previous_response_id")
+	}
+}
+
 func TestBuildStatefulResponseMessagesKeepsLatestUserOnly(t *testing.T) {
 	messages := []llm.Message{
 		{Role: "system", Content: "behavior"},
@@ -65,6 +86,40 @@ func TestBuildStatefulResponseMessagesKeepsLatestUserOnly(t *testing.T) {
 	}
 	if got[0].Role != "user" || got[0].Content != "<ctx>files</ctx><q>Q2</q>" {
 		t.Fatalf("expected latest user message, got %#v", got[0])
+	}
+}
+
+func TestApplyOpenAIResponsesInstructionsOnlyForOfficialRoute(t *testing.T) {
+	official := &channel.ResolvedRoute{
+		Protocol: llm.AdapterOpenAIResponses,
+		BaseURL:  "https://api.openai.com/v1",
+	}
+	input := llm.GenerateInput{
+		Messages: []llm.Message{
+			{Role: "system", Content: "platform policy"},
+			{Role: "user", Content: "hello"},
+			{Role: "system", Content: "final synthesis only"},
+			{Role: "tool", ToolResults: []llm.ToolResult{{ToolCallID: "call_1", OutputJSON: `{"ok":true}`}}},
+		},
+	}
+
+	applyOpenAIResponsesInstructions(official, llm.EndpointResponses, &input)
+
+	if input.Instructions != "platform policy\n\nfinal synthesis only" {
+		t.Fatalf("expected extracted instructions, got %q", input.Instructions)
+	}
+	if len(input.Messages) != 2 || input.Messages[0].Role != "user" || input.Messages[1].Role != "tool" {
+		t.Fatalf("expected system messages removed from input, got %#v", input.Messages)
+	}
+
+	custom := &channel.ResolvedRoute{
+		Protocol: llm.AdapterOpenAIResponses,
+		BaseURL:  "https://reverse.example.com/v1",
+	}
+	compatInput := llm.GenerateInput{Messages: []llm.Message{{Role: "system", Content: "policy"}, {Role: "user", Content: "hello"}}}
+	applyOpenAIResponsesInstructions(custom, llm.EndpointResponses, &compatInput)
+	if compatInput.Instructions != "" || len(compatInput.Messages) != 2 {
+		t.Fatalf("expected custom route to keep system messages, got %#v", compatInput)
 	}
 }
 

--- a/backend/internal/infra/llm/client.go
+++ b/backend/internal/infra/llm/client.go
@@ -126,13 +126,16 @@ type GenerateInput struct {
 	RequestID      string
 	ConversationID uint
 	Messages       []Message
-	Tools          []ToolDefinition
+	// Instructions 映射 OpenAI Responses API 顶层 instructions 字段。
+	// 仅由确认支持该字段的 adapter 使用；普通兼容路由继续通过 messages 承载系统提示。
+	Instructions string
+	Tools        []ToolDefinition
 	// DisableTools 表示本轮调用必须只生成文本，adapter 不再声明 MCP 或厂商原生工具。
 	DisableTools bool
 	// Options 承载本次调用的自由 JSON 参数。系统字段（model/messages/input/stream）
 	// 由 adapter 固定构造；Options 只表达采样、推理、工具、缓存和厂商原生扩展。
 	Options map[string]interface{}
-	// PreviousResponseID 供 OpenAI/xAI Responses API 实现有状态会话。
+	// PreviousResponseID 供 OpenAI Responses API 实现有状态会话。
 	// 非空时：仅在 input 中发送本轮新消息，服务端从存储状态续接历史。
 	// 空串时：退回全量发送模式，适用于所有 adapter。
 	PreviousResponseID string

--- a/backend/internal/infra/llm/client.go
+++ b/backend/internal/infra/llm/client.go
@@ -126,8 +126,8 @@ type GenerateInput struct {
 	RequestID      string
 	ConversationID uint
 	Messages       []Message
-	// Instructions 映射 OpenAI Responses API 顶层 instructions 字段。
-	// 仅由确认支持该字段的 adapter 使用；普通兼容路由继续通过 messages 承载系统提示。
+	// Instructions 承载可映射到上游原生指令字段的系统/开发者指令。
+	// 不支持原生指令字段的 adapter 应继续通过 messages 承载系统提示。
 	Instructions string
 	Tools        []ToolDefinition
 	// DisableTools 表示本轮调用必须只生成文本，adapter 不再声明 MCP 或厂商原生工具。

--- a/backend/internal/infra/llm/openai_responses.go
+++ b/backend/internal/infra/llm/openai_responses.go
@@ -47,6 +47,9 @@ func buildResponsesRequestBody(
 		"input":  items,
 		"stream": stream,
 	}
+	if instructions := strings.TrimSpace(input.Instructions); adapter == AdapterOpenAIResponses && instructions != "" {
+		payload["instructions"] = instructions
+	}
 	if maxTokens := modelParamInt(input.Options, "max_output_tokens"); maxTokens > 0 {
 		payload["max_output_tokens"] = maxTokens
 	}
@@ -71,7 +74,7 @@ func buildResponsesRequestBody(
 	if streamOptions := responsesStreamOptions(providerStreamOptions); stream && len(streamOptions) > 0 {
 		payload["stream_options"] = streamOptions
 	}
-	applyProviderOptions(payload, input.Options, responsesProtectedProviderOptionKeys(adapter)...)
+	applyProviderOptions(payload, input.Options, responsesProtectedProviderOptionKeys(adapter, strings.TrimSpace(input.Instructions) != "")...)
 	if supportsResponsesIncludeDefaults(adapter) {
 		defaultIncludes := responsesDefaultIncludeValues(adapter, stream, nativeTools)
 		appendResponseInclude(payload, responseIncludeValues(input.Options, defaultIncludes...)...)
@@ -81,7 +84,7 @@ func buildResponsesRequestBody(
 	return payload
 }
 
-func responsesProtectedProviderOptionKeys(adapter string) []string {
+func responsesProtectedProviderOptionKeys(adapter string, hasManagedInstructions bool) []string {
 	keys := []string{
 		"contents",
 		"include",
@@ -100,6 +103,8 @@ func responsesProtectedProviderOptionKeys(adapter string) []string {
 	}
 	if adapter != AdapterOpenAIResponses {
 		keys = append(keys, "instructions", "metadata", "prompt")
+	} else if hasManagedInstructions {
+		keys = append(keys, "instructions")
 	}
 	return keys
 }

--- a/backend/internal/infra/llm/openrouter_responses.go
+++ b/backend/internal/infra/llm/openrouter_responses.go
@@ -66,7 +66,7 @@ func buildOpenRouterResponsesRequestBody(
 	if streamOptions := responsesStreamOptions(providerStreamOptions); stream && len(streamOptions) > 0 {
 		payload["stream_options"] = streamOptions
 	}
-	applyProviderOptions(payload, input.Options, responsesProtectedProviderOptionKeys(AdapterOpenRouterResponses)...)
+	applyProviderOptions(payload, input.Options, responsesProtectedProviderOptionKeys(AdapterOpenRouterResponses, false)...)
 	if include := responseIncludeValues(input.Options); len(include) > 0 {
 		appendResponseInclude(payload, include...)
 	}

--- a/backend/internal/infra/llm/request_params_test.go
+++ b/backend/internal/infra/llm/request_params_test.go
@@ -495,6 +495,30 @@ func TestBuildOpenAIResponsesNestedProviderOptionsMergeAndOfficialFields(t *test
 	}
 }
 
+func TestBuildOpenAIResponsesUsesManagedInstructions(t *testing.T) {
+	payload := mustBuildRequestBody(t, AdapterOpenAIResponses, "gpt-5", EndpointResponses, GenerateInput{
+		Messages:     []Message{{Role: "user", Content: "hello"}},
+		Instructions: "managed developer instructions",
+		Options: map[string]interface{}{
+			"instructions": "provider override",
+			"metadata":     map[string]interface{}{"trace": "ok"},
+			"prompt":       map[string]interface{}{"id": "pmpt_123"},
+		},
+	}, true)
+
+	if payload["instructions"] != "managed developer instructions" {
+		t.Fatalf("expected managed instructions, got %#v", payload["instructions"])
+	}
+	metadata, ok := payload["metadata"].(map[string]interface{})
+	if !ok || metadata["trace"] != "ok" {
+		t.Fatalf("expected metadata to remain available, got %#v", payload["metadata"])
+	}
+	prompt, ok := payload["prompt"].(map[string]interface{})
+	if !ok || prompt["id"] != "pmpt_123" {
+		t.Fatalf("expected prompt to remain available, got %#v", payload["prompt"])
+	}
+}
+
 func TestBuildXAIResponsesOmitsUnsupportedSystemMetadata(t *testing.T) {
 	payload := mustBuildRequestBody(t, AdapterXAIResponses, "grok-4.3", EndpointResponses, GenerateInput{
 		RequestID:      "req-123",


### PR DESCRIPTION
## Summary

Fix Responses API state handling for official OpenAI routes and compatible upstreams.

Official OpenAI Responses requests now move platform/system instructions into the top-level `instructions` field, while compatible or reverse-proxy Responses routes continue using `system` messages for safer compatibility. `previous_response_id` remains limited to official OpenAI Responses routes, and tool follow-up calls only use it when the route is known to support it.

This avoids sending unsupported stateful fields to compatible upstreams while keeping official OpenAI payloads aligned with the Responses API contract.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [x] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test -count=1 ./internal/infra/llm ./internal/application/conversation`
- [x] `git diff --check`

## Screenshots, API examples, or logs

No UI screenshots needed.

Behavioral payload shape:

- Official OpenAI Responses routes send managed system instructions through top-level `instructions`.
- Compatible Responses routes keep system instructions in `input` as `system` messages.
- `previous_response_id` is only sent for official OpenAI Responses routes.

## Configuration, migration, and compatibility notes

No configuration, database migration, or deployment changes.

Compatibility note: reverse proxies and OpenAI-compatible Responses providers no longer receive `previous_response_id` unless they are the official OpenAI API route, reducing failures from partially compatible upstream implementations.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.