### PR TITLE
feat: enhance model option filtering and input generation for text tasks

### DIFF
--- a/backend/internal/application/conversation/model_option_policy.go
+++ b/backend/internal/application/conversation/model_option_policy.go
@@ -39,10 +39,6 @@ type modelOptionPolicyConfig struct {
 }
 
 func filterModelOptions(options map[string]interface{}, protocol string, cfg modelOptionPolicyConfig) map[string]interface{} {
-	if len(options) == 0 {
-		return nil
-	}
-
 	mode := strings.TrimSpace(cfg.Mode)
 	if mode == "" {
 		mode = modelOptionPolicyAllowlist
@@ -52,8 +48,11 @@ func filterModelOptions(options map[string]interface{}, protocol string, cfg mod
 	}
 
 	protocolKey := modelOptionPolicyProtocolKey(protocol)
-	nativeTools := nativeProviderToolsFromOption(protocolKey, options["tools"], cfg.ModelCapabilitiesJSON)
-	policyOptions := cloneModelOptionMap(options)
+	policyOptions := mergeModelOptionDefaults(modelCapabilityDefaultOptions(cfg.ModelCapabilitiesJSON), options)
+	if len(policyOptions) == 0 {
+		return nil
+	}
+	nativeTools := nativeProviderToolsFromOption(protocolKey, policyOptions["tools"], cfg.ModelCapabilitiesJSON)
 	delete(policyOptions, "tools")
 	denied := append([][]string{}, hardDeniedModelOptionPaths...)
 
@@ -83,6 +82,34 @@ func filterModelOptions(options map[string]interface{}, protocol string, cfg mod
 		return nil
 	}
 	return filtered
+}
+
+// modelCapabilityDefaultOptions 提取管理员在模型能力 JSON 中声明的默认请求参数。
+func modelCapabilityDefaultOptions(raw string) map[string]interface{} {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return nil
+	}
+	var config struct {
+		DefaultOptions map[string]interface{} `json:"defaultOptions"`
+	}
+	if err := json.Unmarshal([]byte(value), &config); err != nil {
+		return nil
+	}
+	return cloneModelOptionMap(config.DefaultOptions)
+}
+
+// mergeModelOptionDefaults 以能力默认值为基础合并本次显式参数，显式参数优先。
+func mergeModelOptionDefaults(defaults map[string]interface{}, options map[string]interface{}) map[string]interface{} {
+	merged := cloneModelOptionMap(defaults)
+	if merged == nil {
+		merged = make(map[string]interface{}, len(options))
+	}
+	mergeModelOptionMap(merged, options)
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
 }
 
 // nativeProviderToolsFromOption 将用户 options.tools 收敛为当前协议允许的官方原生工具。

--- a/backend/internal/application/conversation/model_option_policy_test.go
+++ b/backend/internal/application/conversation/model_option_policy_test.go
@@ -68,6 +68,67 @@ func TestFilterModelOptionsAllowlistUsesDefaultAndProtocolPaths(t *testing.T) {
 	}
 }
 
+func TestFilterModelOptionsAppliesCapabilityDefaultOptions(t *testing.T) {
+	filtered := filterModelOptions(map[string]interface{}{
+		"reasoning": map[string]interface{}{
+			"effort": "high",
+		},
+	}, llm.AdapterOpenAIResponses, modelOptionPolicyConfig{
+		Mode:             modelOptionPolicyAllowlist,
+		AllowedPathsJSON: config.DefaultModelOptionAllowedPathsJSON(),
+		DeniedPathsJSON:  config.DefaultModelOptionDeniedPathsJSON(),
+		ModelCapabilitiesJSON: `{
+			"defaultOptions": {
+				"reasoning": {"effort": "medium", "summary": "auto"},
+				"text": {"verbosity": "low"},
+				"model": "blocked"
+			}
+		}`,
+	})
+
+	reasoning := filtered["reasoning"].(map[string]interface{})
+	if reasoning["effort"] != "high" || reasoning["summary"] != "auto" {
+		t.Fatalf("expected explicit option to override default and default summary to remain, got %#v", reasoning)
+	}
+	text := filtered["text"].(map[string]interface{})
+	if text["verbosity"] != "low" {
+		t.Fatalf("expected default text verbosity to pass, got %#v", filtered)
+	}
+	if _, ok := filtered["model"]; ok {
+		t.Fatalf("expected hard-denied default option to be removed, got %#v", filtered)
+	}
+}
+
+func TestFilterModelOptionsOnlyInjectsDefaultToolsFromDefaultOptions(t *testing.T) {
+	allowedOnly := filterModelOptions(nil, llm.AdapterOpenAIResponses, modelOptionPolicyConfig{
+		Mode:                  modelOptionPolicyAllowlist,
+		AllowedPathsJSON:      config.DefaultModelOptionAllowedPathsJSON(),
+		DeniedPathsJSON:       config.DefaultModelOptionDeniedPathsJSON(),
+		ModelCapabilitiesJSON: `{"nativeToolKeys":["openai.web_search_preview"]}`,
+	})
+	if _, ok := allowedOnly["tools"]; ok {
+		t.Fatalf("expected nativeToolKeys to allow but not inject tools, got %#v", allowedOnly)
+	}
+
+	withDefault := filterModelOptions(nil, llm.AdapterOpenAIResponses, modelOptionPolicyConfig{
+		Mode:             modelOptionPolicyAllowlist,
+		AllowedPathsJSON: config.DefaultModelOptionAllowedPathsJSON(),
+		DeniedPathsJSON:  config.DefaultModelOptionDeniedPathsJSON(),
+		ModelCapabilitiesJSON: `{
+			"defaultOptions": {
+				"tools": [{"type": "web_search_preview", "search_context_size": "low"}]
+			}
+		}`,
+	})
+	tools, ok := withDefault["tools"].([]map[string]interface{})
+	if !ok || len(tools) != 1 {
+		t.Fatalf("expected default tool to be injected through capability defaults, got %#v", withDefault)
+	}
+	if tools[0]["type"] != "web_search_preview" || tools[0]["search_context_size"] != "low" {
+		t.Fatalf("expected default tool parameters to pass, got %#v", tools[0])
+	}
+}
+
 func TestFilterModelOptionsRejectsUnsupportedOpenAIServiceTier(t *testing.T) {
 	for _, serviceTier := range []string{"auto", "scale", "unknown"} {
 		t.Run(serviceTier, func(t *testing.T) {

--- a/backend/internal/application/conversation/service_generation_support.go
+++ b/backend/internal/application/conversation/service_generation_support.go
@@ -151,15 +151,14 @@ func (s *Service) callCompactLLM(ctx context.Context, platformModelName string, 
 		AttributionTitle:    attributionTitle,
 	}
 	startedAt := time.Now()
-	out, err := s.llmClient.Generate(ctx, routeConfig, llm.GenerateInput{
-		Messages: llmMsgs,
-	})
+	generateInput := buildTextTaskGenerateInput(route, s.cfg.Snapshot(), llmMsgs)
+	out, err := s.llmClient.Generate(ctx, routeConfig, generateInput)
 	if err != nil {
 		return "", fmt.Errorf("compact llm generate: %w", err)
 	}
 	text := strings.TrimSpace(out.Text)
 	if billingCtx, ok := ctx.Value(basicServiceBillingContextKey{}).(basicServiceBillingContext); ok {
-		s.recordBasicServiceUsage(ctx, billingCtx.UserID, billingCtx.ConversationID, "compact", "上下文压缩", code, route.BindingCode, route.Protocol, route.UpstreamName, route.UpstreamModel, "5m", out.Usage, llmMsgs, text, time.Since(startedAt).Milliseconds())
+		s.recordBasicServiceUsage(ctx, billingCtx.UserID, billingCtx.ConversationID, "compact", "上下文压缩", code, route.BindingCode, route.Protocol, route.UpstreamName, route.UpstreamModel, "5m", out.Usage, generateInput.Messages, text, time.Since(startedAt).Milliseconds())
 	}
 	return text, nil
 }

--- a/backend/internal/application/conversation/service_metadata.go
+++ b/backend/internal/application/conversation/service_metadata.go
@@ -401,7 +401,8 @@ func (s *Service) callConversationMetadataLLM(ctx context.Context, configuredMod
 			AttributionTitle:    attributionTitle,
 		}
 		startedAt := time.Now()
-		out, generateErr := s.llmClient.Generate(ctx, routeConfig, llm.GenerateInput{Messages: messages})
+		generateInput := buildTextTaskGenerateInput(route, s.cfg.Snapshot(), messages)
+		out, generateErr := s.llmClient.Generate(ctx, routeConfig, generateInput)
 		if generateErr != nil {
 			lastErr = fmt.Errorf("metadata llm generate: %w", generateErr)
 			continue
@@ -409,7 +410,7 @@ func (s *Service) callConversationMetadataLLM(ctx context.Context, configuredMod
 		return &conversationMetadataLLMResult{
 			Text:              strings.TrimSpace(out.Text),
 			Usage:             out.Usage,
-			Messages:          messages,
+			Messages:          generateInput.Messages,
 			PlatformModelName: route.PlatformModelName,
 			RoutedBindingCode: route.BindingCode,
 			ProviderProtocol:  route.Protocol,

--- a/backend/internal/application/conversation/service_text_task_route.go
+++ b/backend/internal/application/conversation/service_text_task_route.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/channel"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/llm"
 )
 
 const textTaskFollowModel = "follow"
@@ -120,4 +122,49 @@ func (s *Service) resolveTextTaskModel(ctx context.Context, configured string, c
 		return ""
 	}
 	return strings.TrimSpace(route.PlatformModelName)
+}
+
+// buildTextTaskGenerateInput 为标题、标签、压缩等内部文本任务统一应用模型能力策略。
+func buildTextTaskGenerateInput(route *channel.ResolvedRoute, cfg config.Config, messages []llm.Message) llm.GenerateInput {
+	if route == nil {
+		return llm.GenerateInput{Messages: cloneLLMMessages(messages)}
+	}
+	input := llm.GenerateInput{
+		Messages: normalizeTextTaskSystemMessages(route, messages),
+		Options: filterModelOptions(nil, route.Protocol, modelOptionPolicyConfig{
+			Mode:                  cfg.ModelOptionPolicyMode,
+			AllowedPathsJSON:      cfg.ModelOptionAllowedPaths,
+			DeniedPathsJSON:       cfg.ModelOptionDeniedPaths,
+			ModelCapabilitiesJSON: route.ModelCapabilitiesJSON,
+		}),
+	}
+	applyOpenAIResponsesInstructions(route, llm.DefaultEndpointForAdapter(route.Protocol), &input)
+	return input
+}
+
+// normalizeTextTaskSystemMessages 按模型能力决定内部文本任务是否需要把 system 指令降级进 user 消息。
+func normalizeTextTaskSystemMessages(route *channel.ResolvedRoute, messages []llm.Message) []llm.Message {
+	if route == nil || !shouldInlineSystemPromptToUser(*route) {
+		return cloneLLMMessages(messages)
+	}
+	var systemText strings.Builder
+	remaining := make([]llm.Message, 0, len(messages))
+	for _, message := range messages {
+		if message.Role != "system" {
+			remaining = append(remaining, message)
+			continue
+		}
+		text := strings.TrimSpace(systemInstructionText(message))
+		if text == "" {
+			continue
+		}
+		if systemText.Len() > 0 {
+			systemText.WriteString("\n\n")
+		}
+		systemText.WriteString(text)
+	}
+	if systemText.Len() == 0 {
+		return remaining
+	}
+	return inlineSystemPromptIntoLatestUserMessage(remaining, systemText.String())
 }

--- a/backend/internal/application/conversation/service_text_task_route_test.go
+++ b/backend/internal/application/conversation/service_text_task_route_test.go
@@ -3,9 +3,12 @@ package conversation
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/channel"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/llm"
 )
 
 type textTaskRouteResolverStub struct {
@@ -89,5 +92,57 @@ func TestResolveTextTaskRouteCandidatesFollowFallsBackWhenCurrentRouteFails(t *t
 	}
 	if len(routes) != 1 || routes[0].BindingCode != "default" {
 		t.Fatalf("expected default route after current route failure, got %#v", routes)
+	}
+}
+
+func TestBuildTextTaskGenerateInputAppliesDefaultsAndInstructions(t *testing.T) {
+	route := &channel.ResolvedRoute{
+		Protocol:              llm.AdapterOpenAIResponses,
+		BaseURL:               "https://api.openai.com/v1",
+		ModelCapabilitiesJSON: `{"defaultOptions":{"reasoning":{"effort":"medium"}}}`,
+	}
+	input := buildTextTaskGenerateInput(route, config.Config{
+		ModelOptionPolicyMode: modelOptionPolicyAllowlist,
+		ModelOptionAllowedPaths: `{
+			"openai_responses": ["reasoning.effort"]
+		}`,
+		ModelOptionDeniedPaths: config.DefaultModelOptionDeniedPathsJSON(),
+	}, []llm.Message{
+		{Role: "system", Content: "summarize carefully"},
+		{Role: "user", Content: "hello"},
+	})
+
+	if input.Instructions != "summarize carefully" {
+		t.Fatalf("expected official Responses instructions, got %q", input.Instructions)
+	}
+	if len(input.Messages) != 1 || input.Messages[0].Role != "user" {
+		t.Fatalf("expected system message to be removed from input, got %#v", input.Messages)
+	}
+	reasoning := input.Options["reasoning"].(map[string]interface{})
+	if reasoning["effort"] != "medium" {
+		t.Fatalf("expected default reasoning effort, got %#v", input.Options)
+	}
+}
+
+func TestBuildTextTaskGenerateInputInlinesSystemWhenCapabilitiesDisableSystemPrompt(t *testing.T) {
+	route := &channel.ResolvedRoute{
+		Protocol:              llm.AdapterOpenAIResponses,
+		BaseURL:               "https://api.openai.com/v1",
+		ModelCapabilitiesJSON: `{"supportsSystemPrompt":false}`,
+	}
+	input := buildTextTaskGenerateInput(route, config.Config{}, []llm.Message{
+		{Role: "system", Content: "title only"},
+		{Role: "user", Content: "hello"},
+	})
+
+	if input.Instructions != "" {
+		t.Fatalf("expected no native instructions for inline-user capability, got %q", input.Instructions)
+	}
+	if len(input.Messages) != 1 || input.Messages[0].Role != "user" {
+		t.Fatalf("expected one inlined user message, got %#v", input.Messages)
+	}
+	content := input.Messages[0].Content
+	if !strings.Contains(content, "<system_instructions>") || !strings.Contains(content, "title only") || !strings.Contains(content, "hello") {
+		t.Fatalf("expected system prompt to be inlined into user message, got %q", content)
 	}
 }


### PR DESCRIPTION
## Summary

Apply model capability JSON consistently across conversation and internal text-task model calls.

Model `defaultOptions` are now merged into request options before allowlist / denylist / hard-deny filtering, with explicit request options taking precedence. Native tool capability flags continue to mean “allowed” only; tools are injected by default only when configured under `defaultOptions.tools`.

Internal text tasks such as title generation, label generation, and context compaction now use the same capability-aware input normalization as regular conversation calls, including system prompt fallback behavior and official OpenAI Responses `instructions` handling.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test -count=1 ./internal/application/conversation ./internal/infra/llm`
- [x] `git diff --check`

## Screenshots, API examples, or logs

No UI screenshots needed.

Capability behavior example:

```json
{
  "nativeToolKeys": ["openai.web_search_preview"]
}
```

Allows the native tool but does not inject it by default.

```json
{
  "defaultOptions": {
    "tools": [
      { "type": "web_search_preview", "search_context_size": "low" }
    ],
    "reasoning": { "effort": "medium" }
  }
}
```

Injects defaults after policy filtering and native tool validation.

## Configuration, migration, and compatibility notes

No database migration or deployment change.

Compatibility note: existing capability flags remain non-invasive. Default request parameters are applied only when configured under `defaultOptions`, and still pass through existing model option policy controls.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.