### PR TITLE
feat: update sidebar auto collapse behavior

### DIFF
--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -33,7 +33,8 @@ const SIDEBAR_WIDTH = "17.96875rem"
 const SIDEBAR_WIDTH_MOBILE = "17.96875rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
-const SIDEBAR_AUTO_COLLAPSE_BREAKPOINT = 1280
+const SIDEBAR_AUTO_COLLAPSE_AT = 1180
+const SIDEBAR_AUTO_RESTORE_AT = 1360
 
 type SidebarContextProps = {
   state: "expanded" | "collapsed"
@@ -56,8 +57,12 @@ function useSidebar() {
   return context
 }
 
-function isCompactSidebarViewport() {
-  return typeof window !== "undefined" && window.innerWidth < SIDEBAR_AUTO_COLLAPSE_BREAKPOINT
+function shouldAutoCollapseSidebar() {
+  return typeof window !== "undefined" && window.innerWidth < SIDEBAR_AUTO_COLLAPSE_AT
+}
+
+function shouldAutoRestoreSidebar() {
+  return typeof window !== "undefined" && window.innerWidth >= SIDEBAR_AUTO_RESTORE_AT
 }
 
 function readSidebarInitialOpen(defaultOpen: boolean) {
@@ -83,19 +88,32 @@ function readSidebarInitialOpen(defaultOpen: boolean) {
   return defaultOpen
 }
 
-function useCompactSidebarViewport() {
-  const [isCompact, setIsCompact] = React.useState(isCompactSidebarViewport)
+function useSidebarAutoViewport() {
+  const [autoViewport, setAutoViewport] = React.useState(() => ({
+    shouldCollapse: shouldAutoCollapseSidebar(),
+    shouldRestore: shouldAutoRestoreSidebar(),
+  }))
 
   React.useEffect(() => {
-    const mediaQuery = window.matchMedia(`(max-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT - 1}px)`)
-    const sync = () => setIsCompact(mediaQuery.matches)
+    const collapseQuery = window.matchMedia(`(max-width: ${SIDEBAR_AUTO_COLLAPSE_AT - 1}px)`)
+    const restoreQuery = window.matchMedia(`(min-width: ${SIDEBAR_AUTO_RESTORE_AT}px)`)
+    const sync = () => {
+      setAutoViewport({
+        shouldCollapse: collapseQuery.matches,
+        shouldRestore: restoreQuery.matches,
+      })
+    }
 
     sync()
-    mediaQuery.addEventListener("change", sync)
-    return () => mediaQuery.removeEventListener("change", sync)
+    collapseQuery.addEventListener("change", sync)
+    restoreQuery.addEventListener("change", sync)
+    return () => {
+      collapseQuery.removeEventListener("change", sync)
+      restoreQuery.removeEventListener("change", sync)
+    }
   }, [])
 
-  return isCompact
+  return autoViewport
 }
 
 function SidebarProvider({
@@ -112,14 +130,15 @@ function SidebarProvider({
   onOpenChange?: (open: boolean) => void
 }) {
   const isMobile = useIsMobile()
-  const isCompactViewport = useCompactSidebarViewport()
+  const { shouldCollapse, shouldRestore } = useSidebarAutoViewport()
   const [openMobile, setOpenMobile] = React.useState(false)
-  const wasCompactViewportRef = React.useRef(isCompactSidebarViewport())
-  const autoCollapsedRef = React.useRef(readSidebarInitialOpen(defaultOpen) && isCompactSidebarViewport())
+  const autoCollapsedRef = React.useRef(readSidebarInitialOpen(defaultOpen) && shouldAutoCollapseSidebar())
+  const wasAutoCollapseViewportRef = React.useRef(shouldAutoCollapseSidebar())
+  const wasAutoRestoreViewportRef = React.useRef(shouldAutoRestoreSidebar())
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
-  const [_open, _setOpen] = React.useState(() => readSidebarInitialOpen(defaultOpen) && !isCompactSidebarViewport())
+  const [_open, _setOpen] = React.useState(() => readSidebarInitialOpen(defaultOpen) && !shouldAutoCollapseSidebar())
   const open = openProp ?? _open
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
@@ -143,11 +162,12 @@ function SidebarProvider({
   )
 
   React.useEffect(() => {
-    const leftCompactViewport = !isCompactViewport && wasCompactViewportRef.current
-    const enteredCompactViewport = isCompactViewport && !wasCompactViewportRef.current
-    wasCompactViewportRef.current = isCompactViewport
+    const enteredAutoCollapseViewport = shouldCollapse && !wasAutoCollapseViewportRef.current
+    const enteredAutoRestoreViewport = shouldRestore && !wasAutoRestoreViewportRef.current
+    wasAutoCollapseViewportRef.current = shouldCollapse
+    wasAutoRestoreViewportRef.current = shouldRestore
 
-    if (enteredCompactViewport) {
+    if (enteredAutoCollapseViewport) {
       autoCollapsedRef.current = open
       if (!open) {
         return
@@ -162,7 +182,7 @@ function SidebarProvider({
       return
     }
 
-    if (!leftCompactViewport || !autoCollapsedRef.current) {
+    if (!enteredAutoRestoreViewport || !autoCollapsedRef.current) {
       return
     }
 
@@ -173,7 +193,7 @@ function SidebarProvider({
     }
 
     _setOpen(true)
-  }, [isCompactViewport, open, setOpenProp])
+  }, [open, setOpenProp, shouldCollapse, shouldRestore])
 
   // Helper to toggle the sidebar.
   const toggleSidebar = React.useCallback(() => {

--- a/frontend/features/layouts/components/navigation/nav-projects.tsx
+++ b/frontend/features/layouts/components/navigation/nav-projects.tsx
@@ -115,10 +115,47 @@ const PROJECT_TREE_ACCORDION_MASK_STYLE = {
 const PROJECT_CREATE_ACTION_CLASS =
   "static size-7 shrink-0 opacity-0 transition-[background-color,color,opacity,transform] duration-150 group-hover/project-create:opacity-100 group-focus-within/project-create:opacity-100"
 const PROJECTS_OPEN_STORAGE_KEY = "deeix.sidebar.projects.open"
+const PROJECT_EXPANDED_IDS_STORAGE_KEY = "deeix.sidebar.projects.expanded"
 
 type ProjectFolderIconHandle = {
   startAnimation: () => void
   stopAnimation: () => void
+}
+
+function readStoredProjectIDSet(storageKey: string): Set<string> {
+  if (typeof window === "undefined") {
+    return new Set()
+  }
+
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(storageKey) ?? "[]") as unknown
+    if (!Array.isArray(parsed)) {
+      return new Set()
+    }
+    return new Set(parsed.map((item) => (typeof item === "string" ? item.trim() : "")).filter(Boolean))
+  } catch {
+    return new Set()
+  }
+}
+
+function hasStoredProjectIDSet(storageKey: string): boolean {
+  if (typeof window === "undefined") {
+    return false
+  }
+
+  try {
+    return window.localStorage.getItem(storageKey) !== null
+  } catch {
+    return false
+  }
+}
+
+function writeStoredProjectIDSet(storageKey: string, value: Set<string>) {
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(Array.from(value)))
+  } catch {
+    // localStorage can be unavailable in private browsing or strict environments.
+  }
 }
 
 function ProjectGroupHeader({
@@ -330,7 +367,7 @@ export function NavProjects() {
   const [shareTarget, setShareTarget] = React.useState<{ publicID: string; title: string } | null>(null)
   const [renameValue, setRenameValue] = React.useState("")
   const [autoRenamingConversationID, setAutoRenamingConversationID] = React.useState<string | null>(null)
-  const [expandedProjectIDs, setExpandedProjectIDs] = React.useState<Set<string>>(() => new Set())
+  const [expandedProjectIDs, setExpandedProjectIDs] = React.useState<Set<string>>(() => readStoredProjectIDSet(PROJECT_EXPANDED_IDS_STORAGE_KEY))
   const [projectConversationState, setProjectConversationState] = React.useState<ProjectConversationStateMap>({})
   const [openProjectMenuID, setOpenProjectMenuID] = React.useState<string | null>(null)
   const [hoveredProjectMenuID, setHoveredProjectMenuID] = React.useState<string | null>(null)
@@ -340,6 +377,8 @@ export function NavProjects() {
   const [projectsOpen, setProjectsOpen] = useStoredBoolean(PROJECTS_OPEN_STORAGE_KEY, true)
   const projectConversationStateRef = React.useRef(projectConversationState)
   const expandedProjectIDsRef = React.useRef(expandedProjectIDs)
+  const activeRevealedProjectIDsRef = React.useRef(new Set<string>())
+  const hasStoredExpandedProjectIDsRef = React.useRef(hasStoredProjectIDSet(PROJECT_EXPANDED_IDS_STORAGE_KEY))
   const activeConversationProjectID = React.useMemo(
     () => items.find((item) => item.publicID === activeConversationID)?.projectID ?? "",
     [activeConversationID, items],
@@ -359,10 +398,17 @@ export function NavProjects() {
     setProjectConversationState(next)
   }, [])
 
-  const updateExpandedProjectIDs = React.useCallback((updater: (prev: Set<string>) => Set<string>) => {
+  const updateExpandedProjectIDs = React.useCallback((updater: (prev: Set<string>) => Set<string>, persist = false) => {
     const next = updater(expandedProjectIDsRef.current)
     expandedProjectIDsRef.current = next
     setExpandedProjectIDs(next)
+    if (persist) {
+      hasStoredExpandedProjectIDsRef.current = true
+      writeStoredProjectIDSet(
+        PROJECT_EXPANDED_IDS_STORAGE_KEY,
+        new Set(Array.from(next).filter((projectID) => !activeRevealedProjectIDsRef.current.has(projectID))),
+      )
+    }
   }, [])
 
   const closeDraft = React.useCallback(() => {
@@ -499,9 +545,22 @@ export function NavProjects() {
     }
   }, [updateProjectConversationState])
 
+  React.useEffect(() => {
+    const visibleProjectIDs = new Set(projects.map((project) => project.publicID))
+    expandedProjectIDs.forEach((projectID) => {
+      if (!visibleProjectIDs.has(projectID)) {
+        return
+      }
+      void loadProjectConversations(projectID)
+    })
+  }, [expandedProjectIDs, loadProjectConversations, projects])
+
   const ensureProjectExpanded = React.useCallback(
-    (projectID: string) => {
+    (projectID: string, persist = false) => {
       const shouldLoad = !projectConversationStateRef.current[projectID]?.loaded
+      if (persist) {
+        activeRevealedProjectIDsRef.current.delete(projectID)
+      }
       updateExpandedProjectIDs((prev) => {
         if (prev.has(projectID)) {
           return prev
@@ -509,7 +568,7 @@ export function NavProjects() {
         const next = new Set(prev)
         next.add(projectID)
         return next
-      })
+      }, persist)
       if (shouldLoad) {
         void loadProjectConversations(projectID)
       }
@@ -521,6 +580,7 @@ export function NavProjects() {
     (projectID: string) => {
       const shouldLoad = !projectConversationStateRef.current[projectID]?.loaded
       const expandedNext = !expandedProjectIDsRef.current.has(projectID)
+      activeRevealedProjectIDsRef.current.delete(projectID)
       updateExpandedProjectIDs((prev) => {
         const next = new Set(prev)
         if (next.has(projectID)) {
@@ -529,7 +589,7 @@ export function NavProjects() {
           next.add(projectID)
         }
         return next
-      })
+      }, true)
       if (expandedNext && shouldLoad) {
         void loadProjectConversations(projectID)
       }
@@ -539,7 +599,7 @@ export function NavProjects() {
 
   const startProjectConversation = React.useCallback(
     (projectID: string) => {
-      ensureProjectExpanded(projectID)
+      ensureProjectExpanded(projectID, true)
       requestNewConversation({ projectID })
       router.push(`/chat?project_id=${encodeURIComponent(projectID)}`)
       if (isMobile) {
@@ -550,9 +610,11 @@ export function NavProjects() {
   )
 
   React.useEffect(() => {
-    if (activeProjectID) {
-      ensureProjectExpanded(activeProjectID)
+    if (!activeProjectID || hasStoredExpandedProjectIDsRef.current || activeRevealedProjectIDsRef.current.has(activeProjectID)) {
+      return
     }
+    activeRevealedProjectIDsRef.current.add(activeProjectID)
+    ensureProjectExpanded(activeProjectID, false)
   }, [activeProjectID, ensureProjectExpanded])
 
   React.useEffect(() => {
@@ -649,7 +711,7 @@ export function NavProjects() {
         const next = new Set(prev)
         next.delete(deletingProjectID)
         return next
-      })
+      }, true)
       updateProjectConversationState((prev) => {
         const { [deletingProjectID]: _deleted, ...next } = prev
         return next


### PR DESCRIPTION
## Summary

Improve sidebar state handling so user layout preferences are remembered consistently while automatic responsive behavior remains temporary.

The main sidebar now uses separate auto-collapse and auto-restore trigger points to avoid width-threshold flicker. Automatic collapse does not overwrite the saved user preference. Project sections keep their existing persisted open state, and individual project expansion is now persisted separately. Active project reveal remains temporary and does not pollute the saved project expansion state.

## Change type

- [x] Bug fix
- [x] Frontend / UI

## Affected areas

- [x] Frontend / UI

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm build`
- [x] `git diff --check`

## Screenshots, API examples, or logs

N/A

## Configuration, migration, and compatibility notes

No deployment or database migration required.

This change adds/uses local browser storage keys for layout preferences:

- `deeix.sidebar.open`
- `deeix.sidebar.projects.open`
- `deeix.sidebar.projects.expanded`
- Existing `deeix.sidebar.recents.open` and `deeix.sidebar.starred.open` behavior remains unchanged.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed; this change only affects local UI state persistence.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.