### PR TITLE
feat: add user session activity tracking and enhance user view with last active time

### DIFF
--- a/backend/internal/application/admin/service.go
+++ b/backend/internal/application/admin/service.go
@@ -26,6 +26,7 @@ import (
 
 type userService interface {
 	ListUsers(ctx context.Context, page int, pageSize int) ([]domainuser.User, int64, error)
+	ListLatestSessionActivityByUserIDs(ctx context.Context, userIDs []uint) (map[uint]time.Time, error)
 	CountSuperAdmins(ctx context.Context) (int64, error)
 	CreateUser(
 		ctx context.Context,
@@ -201,7 +202,11 @@ func (s *Service) ListUsers(ctx context.Context, page int, pageSize int) ([]user
 // BuildUserView 构建单个用户的前端展示视图。
 func (s *Service) BuildUserView(ctx context.Context, item domainuser.User) (userview.UserView, error) {
 	if s.subscriptionResolver == nil {
-		return s.applyTwoFactorView(ctx, userview.FromUser(item, nil))
+		view, err := s.applyTwoFactorView(ctx, userview.FromUser(item, nil))
+		if err != nil {
+			return userview.UserView{}, err
+		}
+		return s.applyLastActiveView(ctx, view)
 	}
 
 	mode, err := s.subscriptionResolver.GetBillingMode(ctx)
@@ -222,7 +227,11 @@ func (s *Service) BuildUserView(ctx context.Context, item domainuser.User) (user
 				Status:         account.Status,
 			})
 		}
-		return s.applyTwoFactorView(ctx, view)
+		view, err = s.applyTwoFactorView(ctx, view)
+		if err != nil {
+			return userview.UserView{}, err
+		}
+		return s.applyLastActiveView(ctx, view)
 	}
 
 	subscription, err := s.subscriptionResolver.GetCurrentSubscriptionSnapshot(ctx, item.ID, time.Now())
@@ -230,16 +239,24 @@ func (s *Service) BuildUserView(ctx context.Context, item domainuser.User) (user
 		return userview.UserView{}, err
 	}
 	if subscription == nil {
-		return s.applyTwoFactorView(ctx, userview.FromUser(item, nil))
+		view, err := s.applyTwoFactorView(ctx, userview.FromUser(item, nil))
+		if err != nil {
+			return userview.UserView{}, err
+		}
+		return s.applyLastActiveView(ctx, view)
 	}
 
-	return s.applyTwoFactorView(ctx, userview.FromUser(item, &userview.SubscriptionState{
+	view, err := s.applyTwoFactorView(ctx, userview.FromUser(item, &userview.SubscriptionState{
 		PlanID:    subscription.PlanID,
 		PlanName:  subscription.PlanName,
 		Tier:      subscription.Tier,
 		Status:    subscription.Status,
 		ExpiresAt: subscription.ExpiresAt,
 	}))
+	if err != nil {
+		return userview.UserView{}, err
+	}
+	return s.applyLastActiveView(ctx, view)
 }
 
 // BuildUserViews 批量构建用户展示视图。
@@ -257,7 +274,7 @@ func (s *Service) BuildUserViews(ctx context.Context, items []domainuser.User) (
 			}
 			results = append(results, view)
 		}
-		return results, nil
+		return s.applyLastActiveViews(ctx, results)
 	}
 
 	userIDs := make([]uint, 0, len(items))
@@ -286,7 +303,7 @@ func (s *Service) BuildUserViews(ctx context.Context, items []domainuser.User) (
 			}
 			results = append(results, view)
 		}
-		return results, nil
+		return s.applyLastActiveViews(ctx, results)
 	}
 
 	subscriptions, err := s.subscriptionResolver.ListCurrentSubscriptionSnapshots(ctx, userIDs, time.Now())
@@ -318,7 +335,38 @@ func (s *Service) BuildUserViews(ctx context.Context, items []domainuser.User) (
 		results = append(results, view)
 	}
 
-	return results, nil
+	return s.applyLastActiveViews(ctx, results)
+}
+
+func (s *Service) applyLastActiveView(ctx context.Context, view userview.UserView) (userview.UserView, error) {
+	activities, err := s.userService.ListLatestSessionActivityByUserIDs(ctx, []uint{view.ID})
+	if err != nil {
+		return userview.UserView{}, err
+	}
+	if value, ok := activities[view.ID]; ok {
+		return userview.WithLastActiveAt(view, &value), nil
+	}
+	return view, nil
+}
+
+func (s *Service) applyLastActiveViews(ctx context.Context, views []userview.UserView) ([]userview.UserView, error) {
+	if len(views) == 0 {
+		return views, nil
+	}
+	userIDs := make([]uint, 0, len(views))
+	for _, view := range views {
+		userIDs = append(userIDs, view.ID)
+	}
+	activities, err := s.userService.ListLatestSessionActivityByUserIDs(ctx, userIDs)
+	if err != nil {
+		return nil, err
+	}
+	for index, view := range views {
+		if value, ok := activities[view.ID]; ok {
+			views[index] = userview.WithLastActiveAt(view, &value)
+		}
+	}
+	return views, nil
 }
 
 func (s *Service) applyTwoFactorView(ctx context.Context, view userview.UserView) (userview.UserView, error) {

--- a/backend/internal/application/admin/service_test.go
+++ b/backend/internal/application/admin/service_test.go
@@ -193,6 +193,10 @@ func (s *adminUserServiceFake) ListUsers(context.Context, int, int) ([]domainuse
 	return nil, 0, nil
 }
 
+func (s *adminUserServiceFake) ListLatestSessionActivityByUserIDs(context.Context, []uint) (map[uint]time.Time, error) {
+	return map[uint]time.Time{}, nil
+}
+
 func (s *adminUserServiceFake) CountSuperAdmins(context.Context) (int64, error) {
 	if s.superAdminCount != nil {
 		return *s.superAdminCount, nil

--- a/backend/internal/application/user/service.go
+++ b/backend/internal/application/user/service.go
@@ -140,6 +140,14 @@ func (s *Service) ListUsers(ctx context.Context, page int, pageSize int) ([]doma
 	return s.repo.ListUsers(ctx, offset, limit)
 }
 
+// ListLatestSessionActivityByUserIDs 批量查询用户最近会话活跃时间。
+func (s *Service) ListLatestSessionActivityByUserIDs(ctx context.Context, userIDs []uint) (map[uint]time.Time, error) {
+	if len(userIDs) == 0 {
+		return map[uint]time.Time{}, nil
+	}
+	return s.repo.ListLatestSessionActivityByUserIDs(ctx, userIDs)
+}
+
 func normalizePage(page int, pageSize int) (int, int) {
 	if page <= 0 {
 		page = 1

--- a/backend/internal/application/userview/view.go
+++ b/backend/internal/application/userview/view.go
@@ -56,6 +56,7 @@ type UserView struct {
 	TwoFactorRequired       bool
 	TwoFactorRecoveryCount  int
 	LastLoginAt             *time.Time
+	LastActiveAt            *time.Time
 	CreatedAt               time.Time
 	UpdatedAt               time.Time
 	SubscriptionTier        string
@@ -91,6 +92,7 @@ func FromUser(item domainuser.User, subscription *SubscriptionState) UserView {
 		PhoneVerifiedAt:        item.PhoneVerifiedAt,
 		UsernameChangedAt:      item.UsernameChangedAt,
 		LastLoginAt:            item.LastLoginAt,
+		LastActiveAt:           item.LastLoginAt,
 		CreatedAt:              item.CreatedAt,
 		UpdatedAt:              item.UpdatedAt,
 		SubscriptionTier:       "free",
@@ -119,6 +121,14 @@ func FromUser(item domainuser.User, subscription *SubscriptionState) UserView {
 	view.SubscriptionPlanID = subscription.PlanID
 	view.SubscriptionExpiresAt = subscription.ExpiresAt
 
+	return view
+}
+
+// WithLastActiveAt 设置用户视图中的最近活跃时间。
+func WithLastActiveAt(view UserView, value *time.Time) UserView {
+	if value != nil {
+		view.LastActiveAt = value
+	}
 	return view
 }
 

--- a/backend/internal/infra/persistence/postgres/user/repository.go
+++ b/backend/internal/infra/persistence/postgres/user/repository.go
@@ -786,6 +786,36 @@ func (r *Repo) UpdateLastLogin(ctx context.Context, userID uint) error {
 		Error)
 }
 
+// ListLatestSessionActivityByUserIDs 批量查询用户最近会话活跃时间。
+func (r *Repo) ListLatestSessionActivityByUserIDs(ctx context.Context, userIDs []uint) (map[uint]time.Time, error) {
+	results := make(map[uint]time.Time, len(userIDs))
+	if len(userIDs) == 0 {
+		return results, nil
+	}
+
+	sessions := make([]model.UserSession, 0, len(userIDs))
+	latestSessionQuery := r.db.WithContext(ctx).
+		Model(&model.UserSession{}).
+		Select("identity_sessions.*, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY COALESCE(last_seen_at, issued_at) DESC, id DESC) AS row_number").
+		Where("user_id IN ?", userIDs)
+
+	if err := r.db.WithContext(ctx).
+		Table("(?) AS latest_sessions", latestSessionQuery).
+		Where("row_number = ?", 1).
+		Find(&sessions).Error; err != nil {
+		return nil, translateError(err)
+	}
+
+	for _, session := range sessions {
+		if session.LastSeenAt != nil {
+			results[session.UserID] = *session.LastSeenAt
+			continue
+		}
+		results[session.UserID] = session.IssuedAt
+	}
+	return results, nil
+}
+
 // DeleteAccountHard 删除用户主记录及主要用户域数据。
 func (r *Repo) DeleteAccountHard(ctx context.Context, userID uint) error {
 	return translateError(r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -232,6 +232,7 @@ type UserRepository interface {
 	ResetPasswordByAdmin(ctx context.Context, userID uint, passwordHash string, mustResetPassword bool) error
 	MarkBootstrapSuperAdminPasswordResetRequired(ctx context.Context, username string) error
 	UpdateLastLogin(ctx context.Context, userID uint) error
+	ListLatestSessionActivityByUserIDs(ctx context.Context, userIDs []uint) (map[uint]time.Time, error)
 	DeleteAccountHard(ctx context.Context, userID uint) error
 	ListDistinctFileStoragePathsByUserID(ctx context.Context, userID uint) ([]string, error)
 	RecordAuthEvent(

--- a/backend/internal/transport/http/admin/dto.go
+++ b/backend/internal/transport/http/admin/dto.go
@@ -87,6 +87,7 @@ type UserResponse struct {
 	TwoFactorRequired      bool       `json:"twoFactorRequired"`
 	TwoFactorRecoveryCount int        `json:"twoFactorRecoveryCount"`
 	LastLoginAt            *time.Time `json:"lastLoginAt"`
+	LastActiveAt           *time.Time `json:"lastActiveAt"`
 	CreatedAt              time.Time  `json:"createdAt"`
 	UpdatedAt              time.Time  `json:"updatedAt"`
 	SubscriptionTier       string     `json:"subscriptionTier"`
@@ -426,6 +427,7 @@ func toUserResponse(v userview.UserView) UserResponse {
 		TwoFactorRequired:      v.TwoFactorRequired,
 		TwoFactorRecoveryCount: v.TwoFactorRecoveryCount,
 		LastLoginAt:            v.LastLoginAt,
+		LastActiveAt:           v.LastActiveAt,
 		CreatedAt:              v.CreatedAt,
 		UpdatedAt:              v.UpdatedAt,
 		SubscriptionTier:       v.SubscriptionTier,

--- a/backend/internal/transport/http/admin/handler_security_test.go
+++ b/backend/internal/transport/http/admin/handler_security_test.go
@@ -55,6 +55,10 @@ func (s *handlerUserServiceFake) ListUsers(context.Context, int, int) ([]domainu
 	return nil, 0, nil
 }
 
+func (s *handlerUserServiceFake) ListLatestSessionActivityByUserIDs(context.Context, []uint) (map[uint]time.Time, error) {
+	return map[uint]time.Time{}, nil
+}
+
 func (s *handlerUserServiceFake) CountSuperAdmins(context.Context) (int64, error) {
 	var count int64
 	for _, item := range s.users {

--- a/backend/internal/transport/http/auth/dto.go
+++ b/backend/internal/transport/http/auth/dto.go
@@ -321,6 +321,7 @@ type UserResponse struct {
 	TwoFactorRequired       bool       `json:"twoFactorRequired"`
 	TwoFactorRecoveryCount  int        `json:"twoFactorRecoveryCount"`
 	LastLoginAt             *time.Time `json:"lastLoginAt"`
+	LastActiveAt            *time.Time `json:"lastActiveAt"`
 	CreatedAt               time.Time  `json:"createdAt"`
 	UpdatedAt               time.Time  `json:"updatedAt"`
 	SubscriptionTier        string     `json:"subscriptionTier"`
@@ -521,6 +522,7 @@ func toUserResponse(v userview.UserView) UserResponse {
 		TwoFactorRequired:       v.TwoFactorRequired,
 		TwoFactorRecoveryCount:  v.TwoFactorRecoveryCount,
 		LastLoginAt:             v.LastLoginAt,
+		LastActiveAt:            v.LastActiveAt,
 		CreatedAt:               v.CreatedAt,
 		UpdatedAt:               v.UpdatedAt,
 		SubscriptionTier:        v.SubscriptionTier,

--- a/frontend/features/admin/components/sections/accounts/accounts-user-editor.tsx
+++ b/frontend/features/admin/components/sections/accounts/accounts-user-editor.tsx
@@ -653,6 +653,7 @@ export function EditUserSheet({
                 label={t("editor.twoFactor")}
                 value={editDialogTarget?.twoFactorEnabled ? t("editor.twoFactorEnabled", { count: editDialogTarget.twoFactorRecoveryCount }) : t("editor.twoFactorDisabled")}
               />
+              <ReadOnlyField label={t("fields.lastActive")} value={formatSheetDateTime(editDialogTarget?.lastActiveAt || editDialogTarget?.lastLoginAt, locale)} />
               <ReadOnlyField label={t("fields.lastLogin")} value={formatSheetDateTime(editDialogTarget?.lastLoginAt, locale)} />
             </div>
           </SheetSection>

--- a/frontend/features/admin/components/sections/accounts/accounts-users.tsx
+++ b/frontend/features/admin/components/sections/accounts/accounts-users.tsx
@@ -377,7 +377,7 @@ const UserTableRow = React.memo(function UserTableRow({
           {resolveValue(item.timezone)}
         </div>
       </TableCell>
-      <TableCell className="whitespace-nowrap text-muted-foreground">{formatDateTime(item.lastLoginAt, locale)}</TableCell>
+      <TableCell className="whitespace-nowrap text-muted-foreground">{formatDateTime(item.lastActiveAt || item.lastLoginAt, locale)}</TableCell>
       <TableCell className="w-[56px] py-1.5 whitespace-nowrap" stickyEnd>
         <div className="flex h-7 items-center justify-end">
           <Button
@@ -787,7 +787,7 @@ export function AccountsUsers({
                 {showBalanceColumn ? <TableHead>{t("fields.balance")}</TableHead> : null}
                 <TableHead className="text-center">2FA</TableHead>
                 <TableHead>{t("fields.timezone")}</TableHead>
-                <TableHead>{t("fields.lastLogin")}</TableHead>
+                <TableHead>{t("fields.lastActive")}</TableHead>
                 <TableHead className="w-[56px]" stickyEnd />
               </TableRow>
             </TableHeader>

--- a/frontend/features/admin/hooks/use-admin-user-filters.ts
+++ b/frontend/features/admin/hooks/use-admin-user-filters.ts
@@ -44,7 +44,7 @@ export function useAdminUserFilters(items: UserDTO[]): UseAdminUserFiltersState 
       return matchesQuery && matchesRole && matchesStatus && matchesTier;
     });
 
-    const lastLoginTimestamps = new Map(next.map((item) => [item.id, new Date(item.lastLoginAt || 0).getTime()]));
+    const lastActiveTimestamps = new Map(next.map((item) => [item.id, new Date(item.lastActiveAt || item.lastLoginAt || 0).getTime()]));
     const updatedTimestamps = new Map(next.map((item) => [item.id, new Date(item.updatedAt || 0).getTime()]));
 
     next.sort((left, right) => {
@@ -52,7 +52,7 @@ export function useAdminUserFilters(items: UserDTO[]): UseAdminUserFiltersState 
         case "id_asc":
           return left.id - right.id;
         case "last_login_desc":
-          return (lastLoginTimestamps.get(right.id) ?? 0) - (lastLoginTimestamps.get(left.id) ?? 0);
+          return (lastActiveTimestamps.get(right.id) ?? 0) - (lastActiveTimestamps.get(left.id) ?? 0);
         case "updated_desc":
           return (updatedTimestamps.get(right.id) ?? 0) - (updatedTimestamps.get(left.id) ?? 0);
         case "display_name_asc":

--- a/frontend/features/admin/types/accounts.ts
+++ b/frontend/features/admin/types/accounts.ts
@@ -15,7 +15,7 @@ export const USER_TIER_OPTIONS = ["free", "pro", "max", "ultra"] as const;
 export const USER_SORT_OPTIONS = [
   { labelKey: "sort.idDesc", value: "id_desc" },
   { labelKey: "sort.idAsc", value: "id_asc" },
-  { labelKey: "sort.lastLoginDesc", value: "last_login_desc" },
+  { labelKey: "sort.lastActiveDesc", value: "last_login_desc" },
   { labelKey: "sort.updatedDesc", value: "updated_desc" },
   { labelKey: "sort.displayNameAsc", value: "display_name_asc" },
 ] as const;

--- a/frontend/i18n/messages/en-US/admin-users.json
+++ b/frontend/i18n/messages/en-US/admin-users.json
@@ -94,7 +94,8 @@
     "subscription": "Subscription",
     "balance": "Balance",
     "timezone": "Timezone",
-    "lastLogin": "Last login"
+    "lastLogin": "Last login",
+    "lastActive": "Last active"
   },
   "actions": {
     "apply": "Apply",
@@ -109,6 +110,7 @@
     "idDesc": "ID newest first",
     "idAsc": "ID oldest first",
     "lastLoginDesc": "Last login",
+    "lastActiveDesc": "Last active",
     "updatedDesc": "Recently updated",
     "displayNameAsc": "Display name A-Z"
   },

--- a/frontend/i18n/messages/zh-CN/admin-users.json
+++ b/frontend/i18n/messages/zh-CN/admin-users.json
@@ -94,7 +94,8 @@
     "subscription": "订阅",
     "balance": "余额",
     "timezone": "时区",
-    "lastLogin": "最近登录"
+    "lastLogin": "最近登录",
+    "lastActive": "最近活跃"
   },
   "actions": {
     "apply": "应用",
@@ -109,6 +110,7 @@
     "idDesc": "ID 从新到旧",
     "idAsc": "ID 从旧到新",
     "lastLoginDesc": "最近登录",
+    "lastActiveDesc": "最近活跃",
     "updatedDesc": "最近更新",
     "displayNameAsc": "昵称 A-Z"
   },

--- a/frontend/shared/api/auth.types.ts
+++ b/frontend/shared/api/auth.types.ts
@@ -29,6 +29,7 @@ export type UserDTO = {
   twoFactorRequired: boolean;
   twoFactorRecoveryCount: number;
   lastLoginAt: string | null;
+  lastActiveAt: string | null;
   createdAt: string;
   updatedAt: string;
   subscriptionTier: string;


### PR DESCRIPTION
## Summary

Fix admin user activity time display. The user list previously showed `lastLoginAt`, which only changes after a successful login and does not reflect current active usage. This change adds `lastActiveAt` based on latest session activity, keeps `lastLoginAt` as the real login timestamp, and updates the admin user list/detail UI to display recent activity correctly.

The backend now derives recent activity from `identity_sessions.last_seen_at` with `issued_at` as fallback, without changing login semantics.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [x] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/infra/persistence/postgres/user ./internal/application/admin ./internal/application/user ./internal/transport/http/admin`
- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm build`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Admin users API now returns both timestamps:

```json
{
  "lastLoginAt": "2026-06-16T17:37:00+08:00",
  "lastActiveAt": "2026-06-18T13:41:00+08:00"
}
```

The admin users table displays `lastActiveAt` with `lastLoginAt` as fallback.

## Configuration, migration, and compatibility notes

No configuration or deployment changes are required.

API response adds a backward-compatible `lastActiveAt` field. Existing `lastLoginAt` behavior is unchanged and continues to represent successful login time.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.