### PR TITLE
feat: update public share message mapping to rewrite shared file content URLs

### DIFF
--- a/frontend/features/share/components/public-share-page.tsx
+++ b/frontend/features/share/components/public-share-page.tsx
@@ -107,11 +107,25 @@ function toReadOnlyMessageDTO(item: PublicSharedMessageDTO): MessageDTO {
   };
 }
 
-function mapPublicSharedMessage(item: PublicSharedMessageDTO, fallbackModel: string): ChatAreaMessage {
+function rewriteSharedFileContentURLs(content: string, shareID: string): string {
+  const normalizedShareID = shareID.trim();
+  if (!normalizedShareID || !content.includes("/api/v1/files/")) {
+    return content;
+  }
+  const encodedShareID = encodeURIComponent(normalizedShareID);
+  return content.replace(
+    /(^|[\s("'=])\/api\/v1\/files\/([^/?#)\s"'<>]+)\/content([?#][^)\s"'<>]*)?/g,
+    (_match, prefix: string, fileID: string, suffix: string = "") =>
+      `${prefix}/api/v1/shared-conversations/${encodedShareID}/files/${encodeURIComponent(fileID)}/content${suffix}`,
+  );
+}
+
+function mapPublicSharedMessage(item: PublicSharedMessageDTO, fallbackModel: string, shareID: string): ChatAreaMessage {
   const message = mapServerMessage(toReadOnlyMessageDTO(item));
   const platformModelName = item.platformModelName?.trim() || fallbackModel.trim();
   return {
     ...message,
+    content: rewriteSharedFileContentURLs(message.content, shareID),
     platformModelName,
     billingCost: undefined,
     branchNavigator: undefined,
@@ -263,7 +277,7 @@ export function PublicSharePage() {
   }, [authSession?.accessToken]);
 
   const messages = React.useMemo(
-    () => data?.messages.map((message) => mapPublicSharedMessage(message, data.model)) ?? [],
+    () => data?.messages.map((message) => mapPublicSharedMessage(message, data.model, data.shareID)) ?? [],
     [data],
   );
   const defaultSelectionKey = React.useMemo(


### PR DESCRIPTION
## Summary

Fix public share rendering for generated images and prepare the `0.2.7` release.

Public share pages now rewrite in-message generated image URLs from private file endpoints to the public share file endpoint, so unauthenticated viewers can see images included in the shared snapshot. The backend public file access boundary remains scoped by active share, snapshot attachments, and share owner file ownership.

Also updates release metadata to `0.2.7` and fixes PostgreSQL example DSNs to use `TimeZone=Asia/Shanghai`, with backend config compatibility for legacy `Asia%2FShanghai` deployments.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [x] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [x] Deployment / Docker / configuration
- [x] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm build`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/infra/config`
- [x] `node scripts/sync-version.mjs --check`
- [x] `git diff --check`

`cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./...` was also attempted, but existing unrelated failures remain in backend layering/import checks and HTTP nil-logger test setup.

## Screenshots, API examples, or logs

Public share generated image markdown now resolves from:

```text
/api/v1/files/{file_id}/content
```

to:

```text
/api/v1/shared-conversations/{share_id}/files/{file_id}/content
```

Only relative first-party file URLs are rewritten.

## Configuration, migration, and compatibility notes

- Version metadata updated to `0.2.7`.
- PostgreSQL example DSNs now use `TimeZone=Asia/Shanghai`.
- Existing deployments using `TimeZone=Asia%2FShanghai` remain compatible through backend config normalization.
- No database migration required.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.