### PR TITLE
fix: restore mobile sidebar conversation switching after refresh

### DIFF
--- a/frontend/features/layouts/components/navigation/nav-projects.tsx
+++ b/frontend/features/layouts/components/navigation/nav-projects.tsx
@@ -64,6 +64,7 @@ import { useChatSession } from "@/features/chat/context/chat-session-context"
 import { DeleteFilesOption } from "@/shared/components/delete-files-option"
 import { useSettingsChatPreferences } from "@/features/settings/hooks/use-settings-chat-preferences"
 import { useLayoutActiveConversation } from "@/features/layouts/hooks/use-layout-active-conversation"
+import { useMobileSidebarNavigation } from "@/features/layouts/hooks/use-mobile-sidebar-navigation"
 import { SidebarConversationItem } from "@/features/layouts/components/navigation/sidebar-conversation-item"
 import type {
   SidebarConversationDeleteTarget,
@@ -334,6 +335,7 @@ export function NavProjects() {
   const tRecent = useTranslations("recent")
   const { isMobile, setOpenMobile } = useSidebar()
   const router = useRouter()
+  const onNavigate = useMobileSidebarNavigation()
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const activeRecentProjectID = searchParams.get("project") ?? ""
@@ -961,7 +963,7 @@ export function NavProjects() {
                                 onShare={(publicID, shareTitle) => setShareTarget({ publicID, title: shareTitle })}
                                 onExport={onExportConversation}
                                 onDelete={onDeleteConversation}
-                                onNavigate={isMobile ? () => setOpenMobile(false) : undefined}
+                                onNavigate={onNavigate}
                                 menuTriggerID={`project-conversation-menu-trigger-${conversation.publicID}`}
                               />
                             )

--- a/frontend/features/layouts/components/navigation/nav-recents.tsx
+++ b/frontend/features/layouts/components/navigation/nav-recents.tsx
@@ -38,6 +38,7 @@ import { CollapsibleMotionContent } from "@/shared/components/collapsible-motion
 import { useSettingsChatPreferences } from "@/features/settings/hooks/use-settings-chat-preferences"
 import { useLayoutActiveConversation } from "@/features/layouts/hooks/use-layout-active-conversation"
 import { useLayoutSidebarListFlip } from "@/features/layouts/hooks/use-layout-sidebar-list-flip"
+import { useMobileSidebarNavigation } from "@/features/layouts/hooks/use-mobile-sidebar-navigation"
 import type {
   SidebarConversationDeleteTarget,
   SidebarConversationRenameTarget,
@@ -52,7 +53,7 @@ const RECENTS_OPEN_STORAGE_KEY = "deeix.sidebar.recents.open"
 
 export function NavRecents() {
   const t = useTranslations("recent")
-  const { isMobile, setOpenMobile } = useSidebar()
+  const onNavigate = useMobileSidebarNavigation()
   const router = useRouter()
   const activeConversationID = useLayoutActiveConversation()
   const { deleteFilesByDefault } = useSettingsChatPreferences()
@@ -276,7 +277,7 @@ export function NavRecents() {
                           onShare={onShare}
                           onExport={onExport}
                           onDelete={onDelete}
-                          onNavigate={isMobile ? () => setOpenMobile(false) : undefined}
+                          onNavigate={onNavigate}
                           menuTriggerID={`recent-item-menu-trigger-${publicID}`}
                         />
                       )

--- a/frontend/features/layouts/components/navigation/nav-starred.tsx
+++ b/frontend/features/layouts/components/navigation/nav-starred.tsx
@@ -41,6 +41,7 @@ import { DeleteFilesOption } from "@/shared/components/delete-files-option"
 import { useSettingsChatPreferences } from "@/features/settings/hooks/use-settings-chat-preferences"
 import { useLayoutActiveConversation } from "@/features/layouts/hooks/use-layout-active-conversation"
 import { useLayoutSidebarListFlip } from "@/features/layouts/hooks/use-layout-sidebar-list-flip"
+import { useMobileSidebarNavigation } from "@/features/layouts/hooks/use-mobile-sidebar-navigation"
 import { SIDEBAR_OVERFLOW_ROW_TRANSITION } from "@/features/layouts/model/sidebar-motion"
 import type {
   SidebarConversationDeleteTarget,
@@ -70,6 +71,7 @@ export function NavStarred() {
   const t = useTranslations("recent")
   const { isMobile, setOpenMobile } = useSidebar()
   const router = useRouter()
+  const onNavigate = useMobileSidebarNavigation()
   const activeConversationID = useLayoutActiveConversation()
   const { deleteFilesByDefault } = useSettingsChatPreferences()
 
@@ -339,7 +341,7 @@ export function NavStarred() {
                         onShare={onShare}
                         onExport={onExport}
                         onDelete={onDelete}
-                        onNavigate={isMobile ? () => setOpenMobile(false) : undefined}
+                        onNavigate={onNavigate}
                         menuTriggerID={`starred-item-menu-trigger-${item.publicID}`}
                       />
                     ))}

--- a/frontend/features/layouts/components/navigation/sidebar-conversation-item.tsx
+++ b/frontend/features/layouts/components/navigation/sidebar-conversation-item.tsx
@@ -49,7 +49,7 @@ type SidebarConversationItemProps = {
   onShare?: (publicID: string, title: string) => void
   onExport?: (publicID: string) => void | Promise<void>
   onDelete: (publicID: string, title: string) => void
-  onNavigate?: () => void
+  onNavigate?: (url: string, event: React.MouseEvent<HTMLAnchorElement>) => void
 }
 
 export function SidebarConversationItem({
@@ -147,7 +147,7 @@ export function SidebarConversationItem({
             href={item.url}
             prefetch={false}
             className={cn("flex h-full min-w-0 flex-1 items-center pl-2 pr-9", linkClassName)}
-            onClick={onNavigate}
+            onClick={(event) => onNavigate?.(item.url, event)}
           >
             <AnimatedText
               text={item.title}

--- a/frontend/features/layouts/hooks/use-mobile-sidebar-navigation.ts
+++ b/frontend/features/layouts/hooks/use-mobile-sidebar-navigation.ts
@@ -1,0 +1,20 @@
+"use client"
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+
+import { useSidebar } from "@/components/ui/sidebar"
+
+export function useMobileSidebarNavigation() {
+  const router = useRouter()
+  const { isMobile } = useSidebar()
+
+  return React.useCallback((href: string, event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!isMobile) {
+      return
+    }
+
+    event.preventDefault()
+    router.push(href)
+  }, [isMobile, router])
+}


### PR DESCRIPTION
- Fixes mobile conversation switching from the sidebar after page refresh.
- Prevents the mobile sidebar from closing before client-side navigation completes.
- Applies the same routing fix to both recents and starred conversation lists.
- Related issue https://github.com/DEEIX-AI/DEEIX-Chat/issues/328
