### PR TITLE
fix: preserve admin billing balance display after refresh

### DIFF
--- a/backend/internal/application/admin/service.go
+++ b/backend/internal/application/admin/service.go
@@ -213,7 +213,7 @@ func (s *Service) BuildUserView(ctx context.Context, item domainuser.User) (user
 	if err != nil {
 		return userview.UserView{}, err
 	}
-	if mode == "usage" {
+	if mode != "self" {
 		accounts, accountErr := s.subscriptionResolver.ListBillingAccountSnapshots(ctx, []uint{item.ID})
 		if accountErr != nil {
 			return userview.UserView{}, accountErr
@@ -286,7 +286,7 @@ func (s *Service) BuildUserViews(ctx context.Context, items []domainuser.User) (
 	if err != nil {
 		return nil, err
 	}
-	if mode == "usage" {
+	if mode != "self" {
 		accounts, accountErr := s.subscriptionResolver.ListBillingAccountSnapshots(ctx, userIDs)
 		if accountErr != nil {
 			return nil, accountErr

--- a/backend/internal/application/admin/service.go
+++ b/backend/internal/application/admin/service.go
@@ -213,20 +213,12 @@ func (s *Service) BuildUserView(ctx context.Context, item domainuser.User) (user
 	if err != nil {
 		return userview.UserView{}, err
 	}
-	if mode != "self" {
+	if mode == "usage" {
 		accounts, accountErr := s.subscriptionResolver.ListBillingAccountSnapshots(ctx, []uint{item.ID})
 		if accountErr != nil {
 			return userview.UserView{}, accountErr
 		}
-		account, ok := accounts[item.ID]
-		view := userview.FromUser(item, nil)
-		if ok {
-			view = userview.WithBillingAccount(view, &userview.BillingAccountState{
-				Currency:       account.Currency,
-				BalanceNanousd: account.BalanceNanousd,
-				Status:         account.Status,
-			})
-		}
+		view := userViewFromMode(item, nil, accounts[item.ID], true)
 		view, err = s.applyTwoFactorView(ctx, view)
 		if err != nil {
 			return userview.UserView{}, err
@@ -238,21 +230,26 @@ func (s *Service) BuildUserView(ctx context.Context, item domainuser.User) (user
 	if err != nil {
 		return userview.UserView{}, err
 	}
+	account := billing.UserBillingAccountSnapshot{}
+	includeAccount := false
+	if mode == "period" {
+		accounts, accountErr := s.subscriptionResolver.ListBillingAccountSnapshots(ctx, []uint{item.ID})
+		if accountErr != nil {
+			return userview.UserView{}, accountErr
+		}
+		account = accounts[item.ID]
+		includeAccount = true
+	}
 	if subscription == nil {
-		view, err := s.applyTwoFactorView(ctx, userview.FromUser(item, nil))
+		view, err := s.applyTwoFactorView(ctx, userViewFromMode(item, nil, account, includeAccount))
 		if err != nil {
 			return userview.UserView{}, err
 		}
 		return s.applyLastActiveView(ctx, view)
 	}
 
-	view, err := s.applyTwoFactorView(ctx, userview.FromUser(item, &userview.SubscriptionState{
-		PlanID:    subscription.PlanID,
-		PlanName:  subscription.PlanName,
-		Tier:      subscription.Tier,
-		Status:    subscription.Status,
-		ExpiresAt: subscription.ExpiresAt,
-	}))
+	view := userViewFromMode(item, subscription, account, includeAccount)
+	view, err = s.applyTwoFactorView(ctx, view)
 	if err != nil {
 		return userview.UserView{}, err
 	}
@@ -286,18 +283,13 @@ func (s *Service) BuildUserViews(ctx context.Context, items []domainuser.User) (
 	if err != nil {
 		return nil, err
 	}
-	if mode != "self" {
+	if mode == "usage" {
 		accounts, accountErr := s.subscriptionResolver.ListBillingAccountSnapshots(ctx, userIDs)
 		if accountErr != nil {
 			return nil, accountErr
 		}
 		for _, item := range items {
-			account := accounts[item.ID]
-			view, viewErr := s.applyTwoFactorView(ctx, userview.WithBillingAccount(userview.FromUser(item, nil), &userview.BillingAccountState{
-				Currency:       account.Currency,
-				BalanceNanousd: account.BalanceNanousd,
-				Status:         account.Status,
-			}))
+			view, viewErr := s.applyTwoFactorView(ctx, userViewFromMode(item, nil, accounts[item.ID], true))
 			if viewErr != nil {
 				return nil, viewErr
 			}
@@ -310,25 +302,21 @@ func (s *Service) BuildUserViews(ctx context.Context, items []domainuser.User) (
 	if err != nil {
 		return nil, err
 	}
+	accounts := map[uint]billing.UserBillingAccountSnapshot{}
+	if mode == "period" {
+		accounts, err = s.subscriptionResolver.ListBillingAccountSnapshots(ctx, userIDs)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	for _, item := range items {
-		subscription, ok := subscriptions[item.ID]
-		if !ok {
-			view, viewErr := s.applyTwoFactorView(ctx, userview.FromUser(item, nil))
-			if viewErr != nil {
-				return nil, viewErr
-			}
-			results = append(results, view)
-			continue
+		subscription, _ := subscriptions[item.ID]
+		var snapshot *billing.UserSubscriptionSnapshot
+		if subscription.PlanID != nil || strings.TrimSpace(subscription.PlanName) != "" || strings.TrimSpace(subscription.Tier) != "" || strings.TrimSpace(subscription.Status) != "" || subscription.ExpiresAt != nil {
+			snapshot = &subscription
 		}
-
-		view, viewErr := s.applyTwoFactorView(ctx, userview.FromUser(item, &userview.SubscriptionState{
-			PlanID:    subscription.PlanID,
-			PlanName:  subscription.PlanName,
-			Tier:      subscription.Tier,
-			Status:    subscription.Status,
-			ExpiresAt: subscription.ExpiresAt,
-		}))
+		view, viewErr := s.applyTwoFactorView(ctx, userViewFromMode(item, snapshot, accounts[item.ID], mode == "period"))
 		if viewErr != nil {
 			return nil, viewErr
 		}
@@ -347,6 +335,33 @@ func (s *Service) applyLastActiveView(ctx context.Context, view userview.UserVie
 		return userview.WithLastActiveAt(view, &value), nil
 	}
 	return view, nil
+}
+
+func userViewFromMode(
+	item domainuser.User,
+	subscription *billing.UserSubscriptionSnapshot,
+	account billing.UserBillingAccountSnapshot,
+	includeAccount bool,
+) userview.UserView {
+	var subscriptionState *userview.SubscriptionState
+	if subscription != nil {
+		subscriptionState = &userview.SubscriptionState{
+			PlanID:    subscription.PlanID,
+			PlanName:  subscription.PlanName,
+			Tier:      subscription.Tier,
+			Status:    subscription.Status,
+			ExpiresAt: subscription.ExpiresAt,
+		}
+	}
+	view := userview.FromUser(item, subscriptionState)
+	if !includeAccount {
+		return view
+	}
+	return userview.WithBillingAccount(view, &userview.BillingAccountState{
+		Currency:       account.Currency,
+		BalanceNanousd: account.BalanceNanousd,
+		Status:         account.Status,
+	})
 }
 
 func (s *Service) applyLastActiveViews(ctx context.Context, views []userview.UserView) ([]userview.UserView, error) {

--- a/backend/internal/application/admin/service_test.go
+++ b/backend/internal/application/admin/service_test.go
@@ -7,10 +7,48 @@ import (
 	"time"
 
 	auditapp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/audit"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/billing"
 	domainaudit "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/audit"
 	domainuser "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/user"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
 )
+
+func TestBuildUserViewsIncludesBillingBalanceOutsideSelfMode(t *testing.T) {
+       users := newAdminUserServiceFake(map[uint]domainuser.User{
+               7: {ID: 7, Username: "alice", Role: domainuser.RoleUser},
+       })
+       service := NewService(users, auditServiceFake{})
+       service.SetSubscriptionResolver(subscriptionResolverFake{
+               billingMode: "period",
+               accounts: map[uint]billing.UserBillingAccountSnapshot{
+                       7: {
+                               UserID:         7,
+                               Currency:       "USD",
+                               BalanceNanousd: 2_500_000_000,
+                               Status:         "active",
+                       },
+               },
+       })
+
+       views, err := service.BuildUserViews(context.Background(), []domainuser.User{
+               {ID: 7, Username: "alice", Role: domainuser.RoleUser},
+       })
+       if err != nil {
+               t.Fatalf("expected build user views to succeed, got %v", err)
+       }
+       if len(views) != 1 {
+               t.Fatalf("expected 1 view, got %d", len(views))
+       }
+       if views[0].BillingBalanceNanousd != 2_500_000_000 {
+               t.Fatalf("expected billing balance nanousd to be preserved, got %d", views[0].BillingBalanceNanousd)
+       }
+       if views[0].BillingAccountCurrency != "USD" {
+               t.Fatalf("expected billing currency to be preserved, got %q", views[0].BillingAccountCurrency)
+       }
+       if views[0].BillingAccountStatus != "active" {
+               t.Fatalf("expected billing status to be preserved, got %q", views[0].BillingAccountStatus)
+       }
+}
 
 func TestPatchUserByAdminAllowsAdditionalSuperAdmin(t *testing.T) {
 	users := newAdminUserServiceFake(map[uint]domainuser.User{
@@ -309,5 +347,34 @@ func (auditServiceFake) List(context.Context, int, int, auditapp.ListFilter) ([]
 	return nil, 0, nil
 }
 
+type subscriptionResolverFake struct {
+       billingMode string
+       accounts    map[uint]billing.UserBillingAccountSnapshot
+}
+
+func (s subscriptionResolverFake) ListCurrentSubscriptionSnapshots(context.Context, []uint, time.Time) (map[uint]billing.UserSubscriptionSnapshot, error) {
+       return map[uint]billing.UserSubscriptionSnapshot{}, nil
+}
+
+func (s subscriptionResolverFake) GetCurrentSubscriptionSnapshot(context.Context, uint, time.Time) (*billing.UserSubscriptionSnapshot, error) {
+       return nil, nil
+}
+
+func (s subscriptionResolverFake) GetBillingMode(context.Context) (string, error) {
+       return s.billingMode, nil
+}
+
+func (s subscriptionResolverFake) ListBillingAccountSnapshots(context.Context, []uint) (map[uint]billing.UserBillingAccountSnapshot, error) {
+       if s.accounts == nil {
+               return map[uint]billing.UserBillingAccountSnapshot{}, nil
+       }
+       return s.accounts, nil
+}
+
+func (s subscriptionResolverFake) SetUserSubscriptionByPlanCode(context.Context, uint, string, *time.Time) (*billing.UserSubscriptionSnapshot, error) {
+       return nil, nil
+}
+
 var _ userService = (*adminUserServiceFake)(nil)
 var _ auditService = auditServiceFake{}
+var _ subscriptionResolver = subscriptionResolverFake{}

--- a/backend/internal/application/admin/service_test.go
+++ b/backend/internal/application/admin/service_test.go
@@ -14,40 +14,112 @@ import (
 )
 
 func TestBuildUserViewsIncludesBillingBalanceOutsideSelfMode(t *testing.T) {
-       users := newAdminUserServiceFake(map[uint]domainuser.User{
-               7: {ID: 7, Username: "alice", Role: domainuser.RoleUser},
-       })
-       service := NewService(users, auditServiceFake{})
-       service.SetSubscriptionResolver(subscriptionResolverFake{
-               billingMode: "period",
-               accounts: map[uint]billing.UserBillingAccountSnapshot{
-                       7: {
-                               UserID:         7,
-                               Currency:       "USD",
-                               BalanceNanousd: 2_500_000_000,
-                               Status:         "active",
-                       },
-               },
-       })
+	users := newAdminUserServiceFake(map[uint]domainuser.User{
+		7: {ID: 7, Username: "alice", Role: domainuser.RoleUser},
+	})
+	planID := uint(42)
+	expiresAt := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	service := NewService(users, auditServiceFake{})
+	service.SetSubscriptionResolver(subscriptionResolverFake{
+		billingMode: "period",
+		subscriptions: map[uint]billing.UserSubscriptionSnapshot{
+			7: {
+				UserID:    7,
+				PlanID:    &planID,
+				PlanName:  "Pro Monthly",
+				Tier:      "pro",
+				Status:    "active",
+				ExpiresAt: &expiresAt,
+			},
+		},
+		accounts: map[uint]billing.UserBillingAccountSnapshot{
+			7: {
+				UserID:         7,
+				Currency:       "USD",
+				BalanceNanousd: 2_500_000_000,
+				Status:         "active",
+			},
+		},
+	})
 
-       views, err := service.BuildUserViews(context.Background(), []domainuser.User{
-               {ID: 7, Username: "alice", Role: domainuser.RoleUser},
-       })
-       if err != nil {
-               t.Fatalf("expected build user views to succeed, got %v", err)
-       }
-       if len(views) != 1 {
-               t.Fatalf("expected 1 view, got %d", len(views))
-       }
-       if views[0].BillingBalanceNanousd != 2_500_000_000 {
-               t.Fatalf("expected billing balance nanousd to be preserved, got %d", views[0].BillingBalanceNanousd)
-       }
-       if views[0].BillingAccountCurrency != "USD" {
-               t.Fatalf("expected billing currency to be preserved, got %q", views[0].BillingAccountCurrency)
-       }
-       if views[0].BillingAccountStatus != "active" {
-               t.Fatalf("expected billing status to be preserved, got %q", views[0].BillingAccountStatus)
-       }
+	views, err := service.BuildUserViews(context.Background(), []domainuser.User{
+		{ID: 7, Username: "alice", Role: domainuser.RoleUser},
+	})
+	if err != nil {
+		t.Fatalf("expected build user views to succeed, got %v", err)
+	}
+	if len(views) != 1 {
+		t.Fatalf("expected 1 view, got %d", len(views))
+	}
+	if views[0].SubscriptionTier != "pro" {
+		t.Fatalf("expected subscription tier to be preserved, got %q", views[0].SubscriptionTier)
+	}
+	if views[0].SubscriptionPlanName != "Pro Monthly" {
+		t.Fatalf("expected subscription plan name to be preserved, got %q", views[0].SubscriptionPlanName)
+	}
+	if views[0].SubscriptionStatus != "active" {
+		t.Fatalf("expected subscription status to be preserved, got %q", views[0].SubscriptionStatus)
+	}
+	if views[0].SubscriptionPlanID == nil || *views[0].SubscriptionPlanID != planID {
+		t.Fatalf("expected subscription plan id %d, got %+v", planID, views[0].SubscriptionPlanID)
+	}
+	if views[0].SubscriptionExpiresAt == nil || !views[0].SubscriptionExpiresAt.Equal(expiresAt) {
+		t.Fatalf("expected subscription expiration %v, got %+v", expiresAt, views[0].SubscriptionExpiresAt)
+	}
+	if views[0].BillingBalanceNanousd != 2_500_000_000 {
+		t.Fatalf("expected billing balance nanousd to be preserved, got %d", views[0].BillingBalanceNanousd)
+	}
+	if views[0].BillingAccountCurrency != "USD" {
+		t.Fatalf("expected billing currency to be preserved, got %q", views[0].BillingAccountCurrency)
+	}
+	if views[0].BillingAccountStatus != "active" {
+		t.Fatalf("expected billing status to be preserved, got %q", views[0].BillingAccountStatus)
+	}
+}
+
+func TestBuildUserViewsUsageModeKeepsAccountOnlyView(t *testing.T) {
+	users := newAdminUserServiceFake(map[uint]domainuser.User{
+		7: {ID: 7, Username: "alice", Role: domainuser.RoleUser},
+	})
+	service := NewService(users, auditServiceFake{})
+	service.SetSubscriptionResolver(subscriptionResolverFake{
+		billingMode: "usage",
+		subscriptions: map[uint]billing.UserSubscriptionSnapshot{
+			7: {
+				UserID:   7,
+				PlanName: "Should Not Be Used",
+				Tier:     "pro",
+				Status:   "active",
+			},
+		},
+		accounts: map[uint]billing.UserBillingAccountSnapshot{
+			7: {
+				UserID:         7,
+				Currency:       "USD",
+				BalanceNanousd: 900_000_000,
+				Status:         "active",
+			},
+		},
+	})
+
+	views, err := service.BuildUserViews(context.Background(), []domainuser.User{
+		{ID: 7, Username: "alice", Role: domainuser.RoleUser},
+	})
+	if err != nil {
+		t.Fatalf("expected build user views to succeed, got %v", err)
+	}
+	if len(views) != 1 {
+		t.Fatalf("expected 1 view, got %d", len(views))
+	}
+	if views[0].SubscriptionTier != "free" {
+		t.Fatalf("expected usage mode to keep account-only subscription tier, got %q", views[0].SubscriptionTier)
+	}
+	if views[0].SubscriptionPlanName != "free" {
+		t.Fatalf("expected usage mode to keep account-only plan name, got %q", views[0].SubscriptionPlanName)
+	}
+	if views[0].BillingBalanceNanousd != 900_000_000 {
+		t.Fatalf("expected billing balance nanousd to be preserved, got %d", views[0].BillingBalanceNanousd)
+	}
 }
 
 func TestPatchUserByAdminAllowsAdditionalSuperAdmin(t *testing.T) {
@@ -348,31 +420,42 @@ func (auditServiceFake) List(context.Context, int, int, auditapp.ListFilter) ([]
 }
 
 type subscriptionResolverFake struct {
-       billingMode string
-       accounts    map[uint]billing.UserBillingAccountSnapshot
+	billingMode   string
+	subscriptions map[uint]billing.UserSubscriptionSnapshot
+	accounts      map[uint]billing.UserBillingAccountSnapshot
 }
 
 func (s subscriptionResolverFake) ListCurrentSubscriptionSnapshots(context.Context, []uint, time.Time) (map[uint]billing.UserSubscriptionSnapshot, error) {
-       return map[uint]billing.UserSubscriptionSnapshot{}, nil
+	if s.subscriptions == nil {
+		return map[uint]billing.UserSubscriptionSnapshot{}, nil
+	}
+	return s.subscriptions, nil
 }
 
-func (s subscriptionResolverFake) GetCurrentSubscriptionSnapshot(context.Context, uint, time.Time) (*billing.UserSubscriptionSnapshot, error) {
-       return nil, nil
+func (s subscriptionResolverFake) GetCurrentSubscriptionSnapshot(_ context.Context, userID uint, _ time.Time) (*billing.UserSubscriptionSnapshot, error) {
+	if s.subscriptions == nil {
+		return nil, nil
+	}
+	subscription, ok := s.subscriptions[userID]
+	if !ok {
+		return nil, nil
+	}
+	return &subscription, nil
 }
 
 func (s subscriptionResolverFake) GetBillingMode(context.Context) (string, error) {
-       return s.billingMode, nil
+	return s.billingMode, nil
 }
 
 func (s subscriptionResolverFake) ListBillingAccountSnapshots(context.Context, []uint) (map[uint]billing.UserBillingAccountSnapshot, error) {
-       if s.accounts == nil {
-               return map[uint]billing.UserBillingAccountSnapshot{}, nil
-       }
-       return s.accounts, nil
+	if s.accounts == nil {
+		return map[uint]billing.UserBillingAccountSnapshot{}, nil
+	}
+	return s.accounts, nil
 }
 
 func (s subscriptionResolverFake) SetUserSubscriptionByPlanCode(context.Context, uint, string, *time.Time) (*billing.UserSubscriptionSnapshot, error) {
-       return nil, nil
+	return nil, nil
 }
 
 var _ userService = (*adminUserServiceFake)(nil)


### PR DESCRIPTION
- Fixes admin user balance display after refresh in non-self billing modes.
- Ensures admin user views hydrate billing account snapshots for both `usage` and `period`.
- Adds a regression test covering the `period` mode path.
- Related issue https://github.com/DEEIX-AI/DEEIX-Chat/issues/330