### PR TITLE
feat: enhance conversation default model resolution logic

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -3928,6 +3928,240 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/skills": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-skills"
+                ],
+                "summary": "管理员查询内置技能",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "搜索关键词",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "是否启用",
+                        "name": "enabled",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "页码",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "每页数量",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillPageResponseDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-skills"
+                ],
+                "summary": "管理员创建内置技能",
+                "parameters": [
+                    {
+                        "description": "技能配置",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.WriteSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/skills/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-skills"
+                ],
+                "summary": "管理员删除内置技能",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "技能ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillDeleteResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-skills"
+                ],
+                "summary": "管理员更新内置技能",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "技能ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新字段",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.PatchSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/system-events": {
             "get": {
                 "security": [
@@ -6236,6 +6470,40 @@ const docTemplate = `{
                         "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/internal_transport_http_conversation.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_conversation.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations/default-model-candidate": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "返回当前用户最近一次真实运行使用的模型，用于系统默认的新会话模型选择",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "chat"
+                ],
+                "summary": "查询新会话默认模型候选",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_conversation.ConversationDefaultModelCandidateResponseDoc"
                         }
                     },
                     "500": {
@@ -8787,6 +9055,349 @@ const docTemplate = `{
                 }
             }
         },
+        "/skills": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "返回管理员内置和当前用户自定义的已启用技能摘要，用于会话按需选择 Skill 上下文",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "查询当前用户可用技能",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "搜索关键词",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "页码",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "每页数量",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillSummaryPageResponseDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/skills/mine": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "查询我的自定义技能",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "搜索关键词",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "是否启用",
+                        "name": "enabled",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "页码",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "每页数量",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillPageResponseDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "创建我的自定义技能",
+                "parameters": [
+                    {
+                        "description": "技能配置",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.WriteSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/skills/mine/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "删除我的自定义技能",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "技能ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillDeleteResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "更新我的自定义技能",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "技能ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新字段",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.PatchSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/skills/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "按需返回单个可用 Skill 的完整 SKILL.md 内容，用于用户查看详情",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "查询当前用户可用技能详情",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "技能ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/user/settings": {
             "get": {
                 "security": [
@@ -9641,6 +10252,9 @@ const docTemplate = `{
                 "billedUSD": {
                     "type": "number"
                 },
+                "billingAt": {
+                    "type": "string"
+                },
                 "cacheReadTokens": {
                     "type": "integer"
                 },
@@ -9814,6 +10428,9 @@ const docTemplate = `{
                 },
                 "id": {
                     "type": "integer"
+                },
+                "lastActiveAt": {
+                    "type": "string"
                 },
                 "lastLoginAt": {
                     "type": "string"
@@ -10848,6 +11465,9 @@ const docTemplate = `{
                 },
                 "initialUsernameRequired": {
                     "type": "boolean"
+                },
+                "lastActiveAt": {
+                    "type": "string"
                 },
                 "lastLoginAt": {
                     "type": "string"
@@ -12245,6 +12865,9 @@ const docTemplate = `{
                 },
                 "billedUSD": {
                     "type": "number"
+                },
+                "billingAt": {
+                    "type": "string"
                 },
                 "cacheReadTokens": {
                     "type": "integer"
@@ -14000,6 +14623,31 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_transport_http_conversation.ConversationDefaultModelCandidateResponse": {
+            "type": "object",
+            "properties": {
+                "platformModelName": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "usedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_conversation.ConversationDefaultModelCandidateResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_conversation.ConversationDefaultModelCandidateResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_transport_http_conversation.ConversationDeleteResponse": {
             "type": "object",
             "properties": {
@@ -15290,6 +15938,13 @@ const docTemplate = `{
                         "type": "integer"
                     }
                 },
+                "skillIDs": {
+                    "type": "array",
+                    "maxItems": 128,
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "sourceMessagePublicID": {
                     "type": "string",
                     "maxLength": 32
@@ -15566,11 +16221,11 @@ const docTemplate = `{
             "properties": {
                 "content": {
                     "type": "string",
-                    "maxLength": 16384
+                    "maxLength": 10000
                 },
                 "description": {
                     "type": "string",
-                    "maxLength": 64
+                    "maxLength": 256
                 },
                 "enabled": {
                     "type": "boolean"
@@ -15580,11 +16235,11 @@ const docTemplate = `{
                 },
                 "title": {
                     "type": "string",
-                    "maxLength": 16
+                    "maxLength": 64
                 },
                 "trigger": {
                     "type": "string",
-                    "maxLength": 16
+                    "maxLength": 64
                 }
             }
         },
@@ -15699,11 +16354,11 @@ const docTemplate = `{
             "properties": {
                 "content": {
                     "type": "string",
-                    "maxLength": 16384
+                    "maxLength": 10000
                 },
                 "description": {
                     "type": "string",
-                    "maxLength": 64
+                    "maxLength": 256
                 },
                 "enabled": {
                     "type": "boolean"
@@ -15713,11 +16368,11 @@ const docTemplate = `{
                 },
                 "title": {
                     "type": "string",
-                    "maxLength": 16
+                    "maxLength": 64
                 },
                 "trigger": {
                     "type": "string",
-                    "maxLength": 16
+                    "maxLength": 64
                 }
             }
         },
@@ -15754,6 +16409,228 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/internal_transport_http_settings.PatchItem"
                     }
+                }
+            }
+        },
+        "internal_transport_http_skill.ErrorDoc": {
+            "type": "object",
+            "properties": {
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_skill.PatchSkillRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "maxLength": 256
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "markdown": {
+                    "type": "string",
+                    "maxLength": 10000
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 64
+                },
+                "trigger": {
+                    "type": "string",
+                    "maxLength": 64
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillDataResponse": {
+            "type": "object",
+            "properties": {
+                "skill": {
+                    "$ref": "#/definitions/internal_transport_http_skill.SkillResponse"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillDeleteDataResponse": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillDeleteResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_skill.SkillDeleteDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillPageResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_transport_http_skill.SkillResponse"
+                            }
+                        },
+                        "total": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillResponse": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserID": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "markdown": {
+                    "type": "string"
+                },
+                "scope": {
+                    "type": "string"
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "trigger": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "updatedByUserID": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_skill.SkillDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillSummaryPageResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_transport_http_skill.SkillSummaryResponse"
+                            }
+                        },
+                        "total": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillSummaryResponse": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "scope": {
+                    "type": "string"
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "trigger": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_skill.WriteSkillRequest": {
+            "type": "object",
+            "required": [
+                "markdown",
+                "title",
+                "trigger"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "maxLength": 256
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "markdown": {
+                    "type": "string",
+                    "maxLength": 10000
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 64
+                },
+                "trigger": {
+                    "type": "string",
+                    "maxLength": 64
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3921,6 +3921,240 @@
                 }
             }
         },
+        "/admin/skills": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-skills"
+                ],
+                "summary": "管理员查询内置技能",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "搜索关键词",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "是否启用",
+                        "name": "enabled",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "页码",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "每页数量",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillPageResponseDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-skills"
+                ],
+                "summary": "管理员创建内置技能",
+                "parameters": [
+                    {
+                        "description": "技能配置",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.WriteSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/skills/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-skills"
+                ],
+                "summary": "管理员删除内置技能",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "技能ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillDeleteResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-skills"
+                ],
+                "summary": "管理员更新内置技能",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "技能ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新字段",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.PatchSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/system-events": {
             "get": {
                 "security": [
@@ -6229,6 +6463,40 @@
                         "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/internal_transport_http_conversation.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_conversation.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations/default-model-candidate": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "返回当前用户最近一次真实运行使用的模型，用于系统默认的新会话模型选择",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "chat"
+                ],
+                "summary": "查询新会话默认模型候选",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_conversation.ConversationDefaultModelCandidateResponseDoc"
                         }
                     },
                     "500": {
@@ -8780,6 +9048,349 @@
                 }
             }
         },
+        "/skills": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "返回管理员内置和当前用户自定义的已启用技能摘要，用于会话按需选择 Skill 上下文",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "查询当前用户可用技能",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "搜索关键词",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "页码",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "每页数量",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillSummaryPageResponseDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/skills/mine": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "查询我的自定义技能",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "搜索关键词",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "是否启用",
+                        "name": "enabled",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "页码",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "每页数量",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillPageResponseDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "创建我的自定义技能",
+                "parameters": [
+                    {
+                        "description": "技能配置",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.WriteSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/skills/mine/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "删除我的自定义技能",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "技能ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillDeleteResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "更新我的自定义技能",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "技能ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新字段",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.PatchSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/skills/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "按需返回单个可用 Skill 的完整 SKILL.md 内容，用于用户查看详情",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "查询当前用户可用技能详情",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "技能ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.SkillResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_transport_http_skill.ErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/user/settings": {
             "get": {
                 "security": [
@@ -9634,6 +10245,9 @@
                 "billedUSD": {
                     "type": "number"
                 },
+                "billingAt": {
+                    "type": "string"
+                },
                 "cacheReadTokens": {
                     "type": "integer"
                 },
@@ -9807,6 +10421,9 @@
                 },
                 "id": {
                     "type": "integer"
+                },
+                "lastActiveAt": {
+                    "type": "string"
                 },
                 "lastLoginAt": {
                     "type": "string"
@@ -10841,6 +11458,9 @@
                 },
                 "initialUsernameRequired": {
                     "type": "boolean"
+                },
+                "lastActiveAt": {
+                    "type": "string"
                 },
                 "lastLoginAt": {
                     "type": "string"
@@ -12238,6 +12858,9 @@
                 },
                 "billedUSD": {
                     "type": "number"
+                },
+                "billingAt": {
+                    "type": "string"
                 },
                 "cacheReadTokens": {
                     "type": "integer"
@@ -13993,6 +14616,31 @@
                 }
             }
         },
+        "internal_transport_http_conversation.ConversationDefaultModelCandidateResponse": {
+            "type": "object",
+            "properties": {
+                "platformModelName": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "usedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_conversation.ConversationDefaultModelCandidateResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_conversation.ConversationDefaultModelCandidateResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_transport_http_conversation.ConversationDeleteResponse": {
             "type": "object",
             "properties": {
@@ -15283,6 +15931,13 @@
                         "type": "integer"
                     }
                 },
+                "skillIDs": {
+                    "type": "array",
+                    "maxItems": 128,
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "sourceMessagePublicID": {
                     "type": "string",
                     "maxLength": 32
@@ -15559,11 +16214,11 @@
             "properties": {
                 "content": {
                     "type": "string",
-                    "maxLength": 16384
+                    "maxLength": 10000
                 },
                 "description": {
                     "type": "string",
-                    "maxLength": 64
+                    "maxLength": 256
                 },
                 "enabled": {
                     "type": "boolean"
@@ -15573,11 +16228,11 @@
                 },
                 "title": {
                     "type": "string",
-                    "maxLength": 16
+                    "maxLength": 64
                 },
                 "trigger": {
                     "type": "string",
-                    "maxLength": 16
+                    "maxLength": 64
                 }
             }
         },
@@ -15692,11 +16347,11 @@
             "properties": {
                 "content": {
                     "type": "string",
-                    "maxLength": 16384
+                    "maxLength": 10000
                 },
                 "description": {
                     "type": "string",
-                    "maxLength": 64
+                    "maxLength": 256
                 },
                 "enabled": {
                     "type": "boolean"
@@ -15706,11 +16361,11 @@
                 },
                 "title": {
                     "type": "string",
-                    "maxLength": 16
+                    "maxLength": 64
                 },
                 "trigger": {
                     "type": "string",
-                    "maxLength": 16
+                    "maxLength": 64
                 }
             }
         },
@@ -15747,6 +16402,228 @@
                     "items": {
                         "$ref": "#/definitions/internal_transport_http_settings.PatchItem"
                     }
+                }
+            }
+        },
+        "internal_transport_http_skill.ErrorDoc": {
+            "type": "object",
+            "properties": {
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_skill.PatchSkillRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "maxLength": 256
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "markdown": {
+                    "type": "string",
+                    "maxLength": 10000
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 64
+                },
+                "trigger": {
+                    "type": "string",
+                    "maxLength": 64
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillDataResponse": {
+            "type": "object",
+            "properties": {
+                "skill": {
+                    "$ref": "#/definitions/internal_transport_http_skill.SkillResponse"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillDeleteDataResponse": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillDeleteResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_skill.SkillDeleteDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillPageResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_transport_http_skill.SkillResponse"
+                            }
+                        },
+                        "total": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillResponse": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserID": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "markdown": {
+                    "type": "string"
+                },
+                "scope": {
+                    "type": "string"
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "trigger": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "updatedByUserID": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_transport_http_skill.SkillDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillSummaryPageResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_transport_http_skill.SkillSummaryResponse"
+                            }
+                        },
+                        "total": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_skill.SkillSummaryResponse": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "scope": {
+                    "type": "string"
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "trigger": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_transport_http_skill.WriteSkillRequest": {
+            "type": "object",
+            "required": [
+                "markdown",
+                "title",
+                "trigger"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "maxLength": 256
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "markdown": {
+                    "type": "string",
+                    "maxLength": 10000
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 64
+                },
+                "trigger": {
+                    "type": "string",
+                    "maxLength": 64
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -517,6 +517,8 @@ definitions:
         type: integer
       billedUSD:
         type: number
+      billingAt:
+        type: string
       cacheReadTokens:
         type: integer
       cacheWrite1hTokens:
@@ -631,6 +633,8 @@ definitions:
         type: string
       id:
         type: integer
+      lastActiveAt:
+        type: string
       lastLoginAt:
         type: string
       locale:
@@ -1323,6 +1327,8 @@ definitions:
         type: boolean
       initialUsernameRequired:
         type: boolean
+      lastActiveAt:
+        type: string
       lastLoginAt:
         type: string
       locale:
@@ -2255,6 +2261,8 @@ definitions:
         type: integer
       billedUSD:
         type: number
+      billingAt:
+        type: string
       cacheReadTokens:
         type: integer
       cacheWrite1hTokens:
@@ -3429,6 +3437,22 @@ definitions:
       errorMsg:
         type: string
     type: object
+  internal_transport_http_conversation.ConversationDefaultModelCandidateResponse:
+    properties:
+      platformModelName:
+        type: string
+      source:
+        type: string
+      usedAt:
+        type: string
+    type: object
+  internal_transport_http_conversation.ConversationDefaultModelCandidateResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/internal_transport_http_conversation.ConversationDefaultModelCandidateResponse'
+      errorMsg:
+        type: string
+    type: object
   internal_transport_http_conversation.ConversationDeleteResponse:
     properties:
       deleted:
@@ -4279,6 +4303,11 @@ definitions:
           type: integer
         maxItems: 128
         type: array
+      skillIDs:
+        items:
+          type: integer
+        maxItems: 128
+        type: array
       sourceMessagePublicID:
         maxLength: 32
         type: string
@@ -4465,20 +4494,20 @@ definitions:
   internal_transport_http_promptpreset.PatchPromptPresetRequest:
     properties:
       content:
-        maxLength: 16384
+        maxLength: 10000
         type: string
       description:
-        maxLength: 64
+        maxLength: 256
         type: string
       enabled:
         type: boolean
       sortOrder:
         type: integer
       title:
-        maxLength: 16
+        maxLength: 64
         type: string
       trigger:
-        maxLength: 16
+        maxLength: 64
         type: string
     type: object
   internal_transport_http_promptpreset.PromptPresetDataResponse:
@@ -4549,20 +4578,20 @@ definitions:
   internal_transport_http_promptpreset.WritePromptPresetRequest:
     properties:
       content:
-        maxLength: 16384
+        maxLength: 10000
         type: string
       description:
-        maxLength: 64
+        maxLength: 256
         type: string
       enabled:
         type: boolean
       sortOrder:
         type: integer
       title:
-        maxLength: 16
+        maxLength: 64
         type: string
       trigger:
-        maxLength: 16
+        maxLength: 64
         type: string
     required:
     - content
@@ -4592,6 +4621,153 @@ definitions:
         type: array
     required:
     - items
+    type: object
+  internal_transport_http_skill.ErrorDoc:
+    properties:
+      errorMsg:
+        type: string
+    type: object
+  internal_transport_http_skill.PatchSkillRequest:
+    properties:
+      description:
+        maxLength: 256
+        type: string
+      enabled:
+        type: boolean
+      markdown:
+        maxLength: 10000
+        type: string
+      sortOrder:
+        type: integer
+      title:
+        maxLength: 64
+        type: string
+      trigger:
+        maxLength: 64
+        type: string
+    type: object
+  internal_transport_http_skill.SkillDataResponse:
+    properties:
+      skill:
+        $ref: '#/definitions/internal_transport_http_skill.SkillResponse'
+    type: object
+  internal_transport_http_skill.SkillDeleteDataResponse:
+    properties:
+      deleted:
+        type: boolean
+    type: object
+  internal_transport_http_skill.SkillDeleteResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/internal_transport_http_skill.SkillDeleteDataResponse'
+      errorMsg:
+        type: string
+    type: object
+  internal_transport_http_skill.SkillPageResponseDoc:
+    properties:
+      data:
+        properties:
+          results:
+            items:
+              $ref: '#/definitions/internal_transport_http_skill.SkillResponse'
+            type: array
+          total:
+            type: integer
+        type: object
+      errorMsg:
+        type: string
+    type: object
+  internal_transport_http_skill.SkillResponse:
+    properties:
+      createdAt:
+        type: string
+      createdByUserID:
+        type: integer
+      description:
+        type: string
+      enabled:
+        type: boolean
+      id:
+        type: integer
+      markdown:
+        type: string
+      scope:
+        type: string
+      sortOrder:
+        type: integer
+      title:
+        type: string
+      trigger:
+        type: string
+      updatedAt:
+        type: string
+      updatedByUserID:
+        type: integer
+    type: object
+  internal_transport_http_skill.SkillResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/internal_transport_http_skill.SkillDataResponse'
+      errorMsg:
+        type: string
+    type: object
+  internal_transport_http_skill.SkillSummaryPageResponseDoc:
+    properties:
+      data:
+        properties:
+          results:
+            items:
+              $ref: '#/definitions/internal_transport_http_skill.SkillSummaryResponse'
+            type: array
+          total:
+            type: integer
+        type: object
+      errorMsg:
+        type: string
+    type: object
+  internal_transport_http_skill.SkillSummaryResponse:
+    properties:
+      createdAt:
+        type: string
+      description:
+        type: string
+      enabled:
+        type: boolean
+      id:
+        type: integer
+      scope:
+        type: string
+      sortOrder:
+        type: integer
+      title:
+        type: string
+      trigger:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  internal_transport_http_skill.WriteSkillRequest:
+    properties:
+      description:
+        maxLength: 256
+        type: string
+      enabled:
+        type: boolean
+      markdown:
+        maxLength: 10000
+        type: string
+      sortOrder:
+        type: integer
+      title:
+        maxLength: 64
+        type: string
+      trigger:
+        maxLength: 64
+        type: string
+    required:
+    - markdown
+    - title
+    - trigger
     type: object
   internal_transport_http_usersettings.PatchSettingsRequest:
     properties:
@@ -7102,6 +7278,154 @@ paths:
       summary: 停止托管 Tika
       tags:
       - admin/settings
+  /admin/skills:
+    get:
+      consumes:
+      - application/json
+      parameters:
+      - description: 搜索关键词
+        in: query
+        name: q
+        type: string
+      - description: 是否启用
+        in: query
+        name: enabled
+        type: boolean
+      - description: 页码
+        in: query
+        name: page
+        type: integer
+      - description: 每页数量
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.SkillPageResponseDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 管理员查询内置技能
+      tags:
+      - admin-skills
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: 技能配置
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_transport_http_skill.WriteSkillRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.SkillResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 管理员创建内置技能
+      tags:
+      - admin-skills
+  /admin/skills/{id}:
+    delete:
+      consumes:
+      - application/json
+      parameters:
+      - description: 技能ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.SkillDeleteResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 管理员删除内置技能
+      tags:
+      - admin-skills
+    patch:
+      consumes:
+      - application/json
+      parameters:
+      - description: 技能ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: 更新字段
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_transport_http_skill.PatchSkillRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.SkillResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 管理员更新内置技能
+      tags:
+      - admin-skills
   /admin/system-events:
     get:
       consumes:
@@ -9200,6 +9524,27 @@ paths:
       summary: 自动重新命名会话
       tags:
       - chat
+  /conversations/default-model-candidate:
+    get:
+      consumes:
+      - application/json
+      description: 返回当前用户最近一次真实运行使用的模型，用于系统默认的新会话模型选择
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_conversation.ConversationDefaultModelCandidateResponseDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_conversation.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 查询新会话默认模型候选
+      tags:
+      - chat
   /conversations/project:
     post:
       consumes:
@@ -10194,6 +10539,223 @@ paths:
       summary: 获取公开分享附件内容
       tags:
       - chat
+  /skills:
+    get:
+      consumes:
+      - application/json
+      description: 返回管理员内置和当前用户自定义的已启用技能摘要，用于会话按需选择 Skill 上下文
+      parameters:
+      - description: 搜索关键词
+        in: query
+        name: q
+        type: string
+      - description: 页码
+        in: query
+        name: page
+        type: integer
+      - description: 每页数量
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.SkillSummaryPageResponseDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 查询当前用户可用技能
+      tags:
+      - skills
+  /skills/{id}:
+    get:
+      consumes:
+      - application/json
+      description: 按需返回单个可用 Skill 的完整 SKILL.md 内容，用于用户查看详情
+      parameters:
+      - description: 技能ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.SkillResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 查询当前用户可用技能详情
+      tags:
+      - skills
+  /skills/mine:
+    get:
+      consumes:
+      - application/json
+      parameters:
+      - description: 搜索关键词
+        in: query
+        name: q
+        type: string
+      - description: 是否启用
+        in: query
+        name: enabled
+        type: boolean
+      - description: 页码
+        in: query
+        name: page
+        type: integer
+      - description: 每页数量
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.SkillPageResponseDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 查询我的自定义技能
+      tags:
+      - skills
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: 技能配置
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_transport_http_skill.WriteSkillRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.SkillResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 创建我的自定义技能
+      tags:
+      - skills
+  /skills/mine/{id}:
+    delete:
+      consumes:
+      - application/json
+      parameters:
+      - description: 技能ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.SkillDeleteResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 删除我的自定义技能
+      tags:
+      - skills
+    patch:
+      consumes:
+      - application/json
+      parameters:
+      - description: 技能ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: 更新字段
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_transport_http_skill.PatchSkillRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.SkillResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_transport_http_skill.ErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 更新我的自定义技能
+      tags:
+      - skills
   /user/settings:
     get:
       description: 返回当前用户全部个人偏好配置，缺失项以默认值填充

--- a/backend/internal/application/conversation/service_conversation.go
+++ b/backend/internal/application/conversation/service_conversation.go
@@ -409,6 +409,18 @@ func (s *Service) ListConversationRuns(
 	return s.repo.ListConversationRuns(ctx, userID, conversationID, offset, limit)
 }
 
+// GetLatestConversationRunModel 查询当前用户最近一次真实使用的模型。
+func (s *Service) GetLatestConversationRunModel(ctx context.Context, userID uint) (*model.Run, error) {
+	run, err := s.repo.GetLatestConversationRunModel(ctx, userID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return run, nil
+}
+
 // EventLogListFilter 描述管理员对话事件筛选和排序条件。
 type EventLogListFilter struct {
 	Query          string

--- a/backend/internal/infra/persistence/postgres/conversation/repository.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository.go
@@ -1575,6 +1575,20 @@ func (r *Repo) ListConversationRuns(
 	return toConversationRunDomains(items), total, nil
 }
 
+// GetLatestConversationRunModel 查询用户最近一次成功运行的模型记录。
+func (r *Repo) GetLatestConversationRunModel(ctx context.Context, userID uint) (*domainconversation.Run, error) {
+	var item models.ConversationRun
+	if err := r.db.WithContext(ctx).
+		Model(&models.ConversationRun{}).
+		Where("user_id = ? AND status = ? AND platform_model_name <> ?", userID, "success", "").
+		Order("id DESC").
+		First(&item).Error; err != nil {
+		return nil, translateError(err)
+	}
+	result := toConversationRunDomain(item)
+	return &result, nil
+}
+
 // ListConversationEventLogs 分页查询管理员对话事件日志。
 func (r *Repo) ListConversationEventLogs(
 	ctx context.Context,

--- a/backend/internal/infra/persistence/postgres/conversation/repository_test.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/models"
 	"gorm.io/driver/sqlite"
@@ -310,6 +311,68 @@ func TestListConversationsByUserSearchesMetadataProjectsAndMessages(t *testing.T
 	}
 }
 
+func TestGetLatestConversationRunModelUsesLatestSuccessfulUserRun(t *testing.T) {
+	db := openConversationRepositoryTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+	now := time.Now()
+
+	runs := []model.ConversationRun{
+		{
+			UserID:            1,
+			ConversationID:    11,
+			RunID:             "run_old_success",
+			PlatformModelName: "gpt-old",
+			Status:            "success",
+			StartedAt:         now.Add(-5 * time.Minute),
+		},
+		{
+			UserID:            2,
+			ConversationID:    21,
+			RunID:             "run_other_user",
+			PlatformModelName: "gpt-other",
+			Status:            "success",
+			StartedAt:         now.Add(-4 * time.Minute),
+		},
+		{
+			UserID:            1,
+			ConversationID:    12,
+			RunID:             "run_latest_success",
+			PlatformModelName: "gpt-latest",
+			Status:            "success",
+			StartedAt:         now.Add(-3 * time.Minute),
+		},
+		{
+			UserID:            1,
+			ConversationID:    13,
+			RunID:             "run_error",
+			PlatformModelName: "gpt-error",
+			Status:            "error",
+			StartedAt:         now.Add(-2 * time.Minute),
+		},
+		{
+			UserID:         1,
+			ConversationID: 14,
+			RunID:          "run_empty_model",
+			Status:         "success",
+			StartedAt:      now.Add(-1 * time.Minute),
+		},
+	}
+	for _, run := range runs {
+		if err := db.Create(&run).Error; err != nil {
+			t.Fatalf("create run %q: %v", run.RunID, err)
+		}
+	}
+
+	got, err := repo.GetLatestConversationRunModel(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetLatestConversationRunModel() error = %v", err)
+	}
+	if got == nil || got.PlatformModelName != "gpt-latest" {
+		t.Fatalf("latest model = %#v, want gpt-latest", got)
+	}
+}
+
 func openConversationRepositoryTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	name := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
@@ -323,7 +386,7 @@ func openConversationRepositoryTestDB(t *testing.T) *gorm.DB {
 			_ = sqlDB.Close()
 		}
 	})
-	if err := db.AutoMigrate(&model.Conversation{}, &model.ConversationProject{}, &model.ConversationShare{}, &model.Message{}, &model.Attachment{}, &model.FileObject{}); err != nil {
+	if err := db.AutoMigrate(&model.Conversation{}, &model.ConversationProject{}, &model.ConversationShare{}, &model.Message{}, &model.Attachment{}, &model.FileObject{}, &model.ConversationRun{}); err != nil {
 		t.Fatalf("migrate models: %v", err)
 	}
 	return db

--- a/backend/internal/repository/conversation_core.go
+++ b/backend/internal/repository/conversation_core.go
@@ -106,6 +106,7 @@ type ConversationTraceRepository interface {
 	ListConversationMessageTraceEventsByMessageIDs(ctx context.Context, messageIDs []uint) ([]domainconversation.MessageTraceEventRow, error)
 	CreateConversationToolCalls(ctx context.Context, items []domainconversation.ToolCall) error
 	ListConversationRuns(ctx context.Context, userID uint, conversationID uint, offset int, limit int) ([]domainconversation.Run, int64, error)
+	GetLatestConversationRunModel(ctx context.Context, userID uint) (*domainconversation.Run, error)
 	ListConversationRunsByRunIDs(ctx context.Context, userID uint, conversationID uint, runIDs []string) ([]domainconversation.Run, error)
 	ListConversationEventLogs(ctx context.Context, filter ConversationEventLogListFilter, offset int, limit int) ([]domainconversation.EventLog, int64, error)
 }

--- a/backend/internal/transport/http/conversation/dto_response.go
+++ b/backend/internal/transport/http/conversation/dto_response.go
@@ -57,6 +57,13 @@ type ConversationExportCompatibilityResponse struct {
 	Notes  string `json:"notes"`
 }
 
+// ConversationDefaultModelCandidateResponse 返回新会话自动选模候选。
+type ConversationDefaultModelCandidateResponse struct {
+	PlatformModelName string     `json:"platformModelName"`
+	Source            string     `json:"source"`
+	UsedAt            *time.Time `json:"usedAt"`
+}
+
 func toConversationResponse(item *model.Conversation) ConversationResponse {
 	labelsJSON := strings.TrimSpace(item.LabelsJSON)
 	if labelsJSON == "" || labelsJSON == "null" {
@@ -1201,6 +1208,12 @@ type FileUpdateResponseDoc struct {
 type ConversationCreateResponseDoc struct {
 	ErrorMsg string               `json:"errorMsg"`
 	Data     ConversationResponse `json:"data"`
+}
+
+// ConversationDefaultModelCandidateResponseDoc 新会话默认模型候选响应文档。
+type ConversationDefaultModelCandidateResponseDoc struct {
+	ErrorMsg string                                    `json:"errorMsg"`
+	Data     ConversationDefaultModelCandidateResponse `json:"data"`
 }
 
 // ConversationExportResponseDoc 会话导出响应文档。

--- a/backend/internal/transport/http/conversation/handler_conversation.go
+++ b/backend/internal/transport/http/conversation/handler_conversation.go
@@ -91,6 +91,40 @@ func (h *Handler) ListConversations(c *gin.Context) {
 	response.SuccessPage(c, total, results)
 }
 
+// GetConversationDefaultModelCandidate godoc
+// @Summary 查询新会话默认模型候选
+// @Description 返回当前用户最近一次真实运行使用的模型，用于系统默认的新会话模型选择
+// @Tags chat
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Success 200 {object} ConversationDefaultModelCandidateResponseDoc
+// @Failure 500 {object} ErrorDoc
+// @Router /conversations/default-model-candidate [get]
+func (h *Handler) GetConversationDefaultModelCandidate(c *gin.Context) {
+	userID := middleware.MustUserID(c)
+
+	run, err := h.service.GetLatestConversationRunModel(c.Request.Context(), userID)
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, "load default model candidate failed")
+		return
+	}
+	if run == nil {
+		response.Success(c, ConversationDefaultModelCandidateResponse{})
+		return
+	}
+
+	usedAt := run.EndedAt
+	if usedAt == nil {
+		usedAt = &run.StartedAt
+	}
+	response.Success(c, ConversationDefaultModelCandidateResponse{
+		PlatformModelName: run.PlatformModelName,
+		Source:            "latest_run",
+		UsedAt:            usedAt,
+	})
+}
+
 // GetConversation godoc
 // @Summary 查询会话
 // @Description 查询当前用户的单个会话元信息

--- a/backend/internal/transport/http/conversation/router.go
+++ b/backend/internal/transport/http/conversation/router.go
@@ -7,6 +7,7 @@ func (m *Module) RegisterRoutes(authRequired *gin.RouterGroup) {
 	authRequired.POST("/conversations", m.Handler.CreateConversation)
 	authRequired.GET("/conversations", m.Handler.ListConversations)
 	authRequired.POST("/conversations/shares/revoke", m.Handler.RevokeConversationShares)
+	authRequired.GET("/conversations/default-model-candidate", m.Handler.GetConversationDefaultModelCandidate)
 	authRequired.GET("/conversation-projects", m.Handler.ListConversationProjects)
 	authRequired.POST("/conversation-projects", m.Handler.CreateConversationProject)
 	authRequired.POST("/conversation-projects/reorder", m.Handler.ReorderConversationProjects)

--- a/frontend/features/chat/components/app-chat-area.tsx
+++ b/frontend/features/chat/components/app-chat-area.tsx
@@ -310,6 +310,7 @@ export function AppChatArea() {
   } = useChatModelOptions({
     conversationPublicID: conversationID,
     conversationModel: currentConversation?.model ?? null,
+    resetToken: newConversationRevision,
   });
   const {
     conversationKey,

--- a/frontend/features/chat/hooks/use-chat-model-options.ts
+++ b/frontend/features/chat/hooks/use-chat-model-options.ts
@@ -24,6 +24,7 @@ import { getUserSettings } from "@/shared/api/user-settings";
 import type { PublicModelDTO } from "@/shared/api/model.types";
 import type { ModelNativeToolConfig, ModelOptionPolicy } from "@/shared/lib/model-option-policy";
 import { parseKindsJSON } from "@/shared/model/llm-schema";
+import { resolveConversationDefaultModel } from "@/shared/model/conversation-default-model";
 import type { ConversationOptions } from "@/shared/api/conversation.types";
 import type { SendShortcut } from "@/features/settings/types/settings";
 import { parseSendShortcut } from "@/features/settings/utils/chat-settings";
@@ -318,9 +319,11 @@ function toChatModelOption(item: PublicModelDTO): ChatModelOption {
 export function useChatModelOptions({
   conversationPublicID,
   conversationModel,
+  resetToken,
 }: {
   conversationPublicID: string | null;
   conversationModel?: string | null;
+  resetToken?: number;
 }) {
   const t = useTranslations("chat.models");
   const [availableModels, setAvailableModels] = React.useState<PublicModelDTO[]>([]);
@@ -474,6 +477,7 @@ export function useChatModelOptions({
     const normalizedConversationID = conversationPublicID?.trim() || null;
     if (!normalizedConversationID) {
       activeConversationRef.current = null;
+      userSelectedModelRef.current = false;
       return;
     }
 
@@ -512,7 +516,7 @@ export function useChatModelOptions({
     return () => {
       cancelled = true;
     };
-  }, [conversationModel, conversationPublicID]);
+  }, [conversationModel, conversationPublicID, resetToken]);
 
   React.useEffect(() => {
     if (availableModels.length === 0) {
@@ -522,20 +526,31 @@ export function useChatModelOptions({
       return;
     }
 
-    setSelectedPlatformModelName((current) => {
-      const normalizedCurrent = current.trim();
-      if (normalizedCurrent && availableModels.some((item) => item.platformModelName === normalizedCurrent)) {
-        return normalizedCurrent;
+    let cancelled = false;
+    async function applyDefaultModel() {
+      const token = await resolveAccessToken();
+      if (!token || cancelled || userSelectedModelRef.current) {
+        return;
       }
-
-      // User default model for new conversations.
-      if (userDefaultModel && availableModels.some((item) => item.platformModelName === userDefaultModel)) {
-        return userDefaultModel;
+      const result = await resolveConversationDefaultModel({
+        accessToken: token,
+        availableModels,
+        userDefaultModel,
+      });
+      if (!cancelled && !userSelectedModelRef.current) {
+        setSelectedPlatformModelName(result.platformModelName);
       }
+    }
 
-      return availableModels[0].platformModelName;
+    void applyDefaultModel().catch(() => {
+      if (!cancelled && !userSelectedModelRef.current) {
+        setSelectedPlatformModelName(availableModels[0]?.platformModelName ?? "");
+      }
     });
-  }, [availableModels, conversationPublicID, userDefaultModel]);
+    return () => {
+      cancelled = true;
+    };
+  }, [availableModels, conversationPublicID, resetToken, userDefaultModel]);
 
   const modelOptions = React.useMemo<ChatModelOption[]>(
     () =>

--- a/frontend/features/recent/hooks/use-recent-sidebar-recents.ts
+++ b/frontend/features/recent/hooks/use-recent-sidebar-recents.ts
@@ -7,6 +7,7 @@ import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
 import { readAccessToken } from "@/shared/auth/session";
 import { dispatchFileLibraryInvalidated } from "@/shared/events/file-library-events";
 import { runBulkActionInChunks } from "@/shared/lib/bulk-action";
+import { resolveConversationDefaultModel } from "@/shared/model/conversation-default-model";
 import {
   batchSetConversationProject,
   createConversation,
@@ -421,10 +422,12 @@ export function useRecentSidebarRecentsController(): SidebarRecentsControllerVal
     if (!token) {
       return null;
     }
+    const explicitModel = platformModelName?.trim() || "";
+    const modelName = explicitModel || (await resolveConversationDefaultModel({ accessToken: token })).platformModelName;
 
     const item = await createConversation(token, {
       title: t("newChat"),
-      model: platformModelName?.trim() || "",
+      model: modelName,
       projectID: projectID?.trim() || "",
     });
     setRecentItems((prev) => mergeUniqueByPublicID([item], prev, sortByUpdatedAtDesc));

--- a/frontend/shared/api/conversation.ts
+++ b/frontend/shared/api/conversation.ts
@@ -3,6 +3,7 @@ import { apiRequest, ApiError, pathParam } from "@/shared/api/http-client";
 import type { PagePayload } from "@/shared/api/common.types";
 import type {
   ConversationDTO,
+  ConversationDefaultModelCandidateDTO,
   ConversationExportDTO,
   ConversationProjectDTO,
   ConversationProjectFilter,
@@ -365,6 +366,18 @@ export async function listConversations(
     total: data.total ?? 0,
     results: data.results ?? [],
   };
+}
+
+export async function getConversationDefaultModelCandidate(
+  accessToken: string,
+): Promise<ConversationDefaultModelCandidateDTO> {
+  return authedRequest<ConversationDefaultModelCandidateDTO>(
+    "/api/v1/conversations/default-model-candidate",
+    {
+      accessToken,
+    },
+    true,
+  );
 }
 
 export async function listConversationProjects(

--- a/frontend/shared/api/conversation.types.ts
+++ b/frontend/shared/api/conversation.types.ts
@@ -25,6 +25,12 @@ export type ConversationDTO = {
   updatedAt: string;
 };
 
+export type ConversationDefaultModelCandidateDTO = {
+  platformModelName: string;
+  source: string;
+  usedAt: string | null;
+};
+
 export type ConversationStatusFilter = "active" | "archived" | "all";
 export type ConversationStarredFilter = "all" | "starred" | "unstarred";
 export type ConversationShareFilter = "all" | "shared" | "unshared";

--- a/frontend/shared/model/conversation-default-model.ts
+++ b/frontend/shared/model/conversation-default-model.ts
@@ -1,0 +1,56 @@
+import { getConversationDefaultModelCandidate } from "@/shared/api/conversation";
+import { listPublicModels } from "@/shared/api/model";
+import type { PublicModelDTO } from "@/shared/api/model.types";
+import { getUserSettings } from "@/shared/api/user-settings";
+
+export type ConversationDefaultModelSource = "explicit" | "user_default" | "latest_run" | "recommended" | "none";
+
+export type ConversationDefaultModelResult = {
+  platformModelName: string;
+  source: ConversationDefaultModelSource;
+};
+
+type ResolveConversationDefaultModelInput = {
+  accessToken: string;
+  explicitModel?: string;
+  availableModels?: PublicModelDTO[];
+  userDefaultModel?: string;
+};
+
+function findAvailableModel(models: PublicModelDTO[], platformModelName: string): string {
+  const normalizedName = platformModelName.trim();
+  if (!normalizedName) {
+    return "";
+  }
+  return models.some((item) => item.platformModelName === normalizedName) ? normalizedName : "";
+}
+
+export async function resolveConversationDefaultModel({
+  accessToken,
+  explicitModel,
+  availableModels,
+  userDefaultModel,
+}: ResolveConversationDefaultModelInput): Promise<ConversationDefaultModelResult> {
+  const models = availableModels ?? await listPublicModels(accessToken);
+  const explicit = findAvailableModel(models, explicitModel ?? "");
+  if (explicit) {
+    return { platformModelName: explicit, source: "explicit" };
+  }
+
+  const defaultModel = userDefaultModel ?? (await getUserSettings(accessToken).catch(() => ({})))["chat.default_model"];
+  const userDefault = findAvailableModel(models, defaultModel ?? "");
+  if (userDefault) {
+    return { platformModelName: userDefault, source: "user_default" };
+  }
+
+  const latestRunCandidate = await getConversationDefaultModelCandidate(accessToken).catch(() => null);
+  const latestRunModel = findAvailableModel(models, latestRunCandidate?.platformModelName ?? "");
+  if (latestRunModel) {
+    return { platformModelName: latestRunModel, source: "latest_run" };
+  }
+
+  const recommended = models[0]?.platformModelName?.trim() ?? "";
+  return recommended
+    ? { platformModelName: recommended, source: "recommended" }
+    : { platformModelName: "", source: "none" };
+}


### PR DESCRIPTION
## Summary

Fix new conversation model selection so it no longer depends on transient frontend state. New conversations now resolve the default model through a clear priority chain: user default model, latest successful run model for the current user, then the first available administrator-sorted model. Explicit model selections are still respected for the active send flow, while clicking “New conversation” resets back to the system default resolution path.

The backend adds a narrow default-model candidate API that returns only the current user’s latest successful run model metadata, and Swagger artifacts were regenerated.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [x] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm build`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/application/conversation ./internal/infra/persistence/postgres/conversation ./internal/transport/http/conversation`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache make swagger`
- [x] `node scripts/sync-version.mjs --check backend`
- [x] `git diff --check`

## Screenshots, API examples, or logs

New API:

```http
GET /api/v1/conversations/default-model-candidate
```

Response data:

```json
{
  "platformModelName": "gpt-example",
  "source": "latest_run",
  "usedAt": "2026-06-22T10:00:00Z"
}
```

## Configuration, migration, and compatibility notes

No database migration or deployment configuration change is required.

API contract changed by adding `GET /api/v1/conversations/default-model-candidate`. Swagger generated artifacts were updated.

## Documentation

- [ ] Documentation is not needed for this change.
- [x] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

The new backend query is scoped by current `user_id`, only considers successful runs, skips empty model names, and returns only model candidate metadata.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.