### PR TITLE
fix: handle large single-line SSE payloads in MCP client

### DIFF
--- a/backend/internal/infra/mcp/client.go
+++ b/backend/internal/infra/mcp/client.go
@@ -259,10 +259,14 @@ func parseRPCResponse(contentType string, body []byte) (json.RawMessage, error) 
 }
 
 func extractSSEDataPayload(payload string) string {
-	scanner := bufio.NewScanner(strings.NewReader(payload))
+	reader := bufio.NewReader(strings.NewReader(payload))
 	dataLines := make([]string, 0, 4)
-	for scanner.Scan() {
-		line := strings.TrimRight(scanner.Text(), "\r")
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil && len(line) == 0 {
+			break
+		}
+		line = strings.TrimRight(line, "\r\n")
 		if line == "" {
 			if len(dataLines) > 0 {
 				break

--- a/backend/internal/infra/mcp/client_test.go
+++ b/backend/internal/infra/mcp/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -203,5 +204,34 @@ func TestClientListToolsParsesSSEJSONRPC(t *testing.T) {
 	}
 	if len(tools) != 1 || tools[0].Name != "memory.list" || tools[0].Description != "List memories" {
 		t.Fatalf("unexpected tools: %#v", tools)
+	}
+}
+
+func TestParseRPCResponseParsesLargeSingleLineSSEData(t *testing.T) {
+	toolDescription := strings.Repeat("x", 70*1024)
+	payload := `event: message
+data: {"jsonrpc":"2.0","id":3,"result":{"tools":[{"name":"memory.list","description":"` + toolDescription + `"}]}}
+
+`
+
+	result, err := parseRPCResponse("text/event-stream", []byte(payload))
+	if err != nil {
+		t.Fatalf("parse rpc response: %v", err)
+	}
+
+	var parsed struct {
+		Tools []struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(parsed.Tools) != 1 || parsed.Tools[0].Name != "memory.list" {
+		t.Fatalf("unexpected tools: %#v", parsed.Tools)
+	}
+	if parsed.Tools[0].Description != toolDescription {
+		t.Fatalf("unexpected tool description length: got %d want %d", len(parsed.Tools[0].Description), len(toolDescription))
 	}
 }


### PR DESCRIPTION
## Related issue

- https://github.com/DEEIX-AI/DEEIX-Chat/issues/334

## Summary

- replace Scanner-based SSE line parsing in the MCP client
- handle single-line `data:` payloads larger than 64 KiB
- add a regression test for large SSE JSON-RPC responses

## Problem

The MCP client parsed `text/event-stream` responses with `bufio.Scanner`, which has a default token limit of about 64 KiB. When an MCP server returned a large single-line `data:` payload, the parser produced an empty event-stream payload and surfaced `mcp event stream response is empty`.

## Solution

Switch SSE line reading from `bufio.Scanner` to `bufio.Reader.ReadString('\n')` so large single-line payloads can be read without hitting the Scanner token limit, while keeping the existing SSE event extraction behavior unchanged.

Reference implementation:

- <https://github.com/modelcontextprotocol/go-sdk/blob/cd7d80c591c8867696d4fdcb923a58efd96cc6a1/mcp/event.go#L69>

## Testing

- `cd backend && go test ./internal/infra/mcp`

