### PR TITLE
feat: add upstreamStatus to model upstream source and update related components

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -13916,6 +13916,9 @@ const docTemplate = `{
                 "upstreamName": {
                     "type": "string"
                 },
+                "upstreamStatus": {
+                    "type": "string"
+                },
                 "weight": {
                     "type": "integer"
                 }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -13909,6 +13909,9 @@
                 "upstreamName": {
                     "type": "string"
                 },
+                "upstreamStatus": {
+                    "type": "string"
+                },
                 "weight": {
                     "type": "integer"
                 }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -2928,6 +2928,8 @@ definitions:
         type: string
       upstreamName:
         type: string
+      upstreamStatus:
+        type: string
       weight:
         type: integer
     type: object

--- a/backend/internal/application/channel/dto.go
+++ b/backend/internal/application/channel/dto.go
@@ -191,6 +191,7 @@ type ModelUpstreamSourceView struct {
 	ID                     uint
 	UpstreamID             uint
 	UpstreamName           string
+	UpstreamStatus         string
 	BaseURL                string
 	BindingCode            string
 	UpstreamModelName      string

--- a/backend/internal/application/channel/service_view_normalization.go
+++ b/backend/internal/application/channel/service_view_normalization.go
@@ -129,6 +129,7 @@ func toModelUpstreamSourceView(item repository.ChannelModelSourceRow) ModelUpstr
 		ID:                     item.ID,
 		UpstreamID:             item.UpstreamID,
 		UpstreamName:           item.UpstreamName,
+		UpstreamStatus:         item.UpstreamStatus,
 		BaseURL:                item.BaseURL,
 		BindingCode:            item.BindingCode,
 		UpstreamModelName:      item.UpstreamModelName,

--- a/backend/internal/infra/persistence/postgres/channel/repository.go
+++ b/backend/internal/infra/persistence/postgres/channel/repository.go
@@ -1098,7 +1098,7 @@ func (r *Repo) ListModelUpstreamSources(ctx context.Context, platformModelName s
 	if err := r.db.WithContext(ctx).
 		Table("llm_model_routes AS r").
 		Select(
-			"r.*, um.upstream_id, u.name AS upstream_name, u.base_url AS base_url, "+
+			"r.*, um.upstream_id, u.name AS upstream_name, u.status AS upstream_status, u.base_url AS base_url, "+
 				"um.binding_code, um.upstream_model_name, um.vendor AS upstream_model_vendor, um.icon AS upstream_model_icon, "+
 				"um.kinds_json AS upstream_model_kinds_json, um.suggested_protocol, um.status AS upstream_model_status",
 		).
@@ -1121,7 +1121,7 @@ func (r *Repo) GetModelUpstreamSourceByRouteID(ctx context.Context, platformMode
 	if err := r.db.WithContext(ctx).
 		Table("llm_model_routes AS r").
 		Select(
-			"r.*, um.upstream_id, u.name AS upstream_name, u.base_url AS base_url, "+
+			"r.*, um.upstream_id, u.name AS upstream_name, u.status AS upstream_status, u.base_url AS base_url, "+
 				"um.binding_code, um.upstream_model_name, um.vendor AS upstream_model_vendor, um.icon AS upstream_model_icon, "+
 				"um.kinds_json AS upstream_model_kinds_json, um.suggested_protocol, um.status AS upstream_model_status",
 		).

--- a/backend/internal/repository/channel.go
+++ b/backend/internal/repository/channel.go
@@ -167,6 +167,7 @@ type ChannelModelSourceRow struct {
 	domainchannel.PlatformModelRoute
 	UpstreamID             uint
 	UpstreamName           string
+	UpstreamStatus         string
 	BaseURL                string
 	BindingCode            string
 	UpstreamModelName      string

--- a/backend/internal/transport/http/channel/dto_response.go
+++ b/backend/internal/transport/http/channel/dto_response.go
@@ -206,6 +206,7 @@ type ModelUpstreamSourceResponse struct {
 	ID                     uint   `json:"id"`
 	UpstreamID             uint   `json:"upstreamID"`
 	UpstreamName           string `json:"upstreamName"`
+	UpstreamStatus         string `json:"upstreamStatus"`
 	BaseURL                string `json:"baseURL"`
 	BindingCode            string `json:"bindingCode"`
 	UpstreamModelName      string `json:"upstreamModelName"`
@@ -235,6 +236,7 @@ func toModelUpstreamSourceResponse(v appchannel.ModelUpstreamSourceView) ModelUp
 		ID:                     v.ID,
 		UpstreamID:             v.UpstreamID,
 		UpstreamName:           v.UpstreamName,
+		UpstreamStatus:         v.UpstreamStatus,
 		BaseURL:                v.BaseURL,
 		BindingCode:            v.BindingCode,
 		UpstreamModelName:      v.UpstreamModelName,

--- a/frontend/features/admin/api/llm.types.ts
+++ b/frontend/features/admin/api/llm.types.ts
@@ -122,6 +122,7 @@ export type AdminLLMModelUpstreamSourceDTO = {
   id: number;
   upstreamID: number;
   upstreamName: string;
+  upstreamStatus: AdminLLMStatus;
   baseURL: string;
   bindingCode: string;
   upstreamModelName: string;

--- a/frontend/features/admin/components/sections/models/models-sheet.tsx
+++ b/frontend/features/admin/components/sections/models/models-sheet.tsx
@@ -1281,7 +1281,7 @@ export function ModelSheet({ open, mode, target, models, onClose, onSuccess }: M
                                     </div>
                                   </TooltipContent>
                                 </Tooltip>
-                              ) : src.status === "inactive" ? (
+                              ) : src.status === "inactive" || src.upstreamStatus === "inactive" || src.upstreamModelStatus === "inactive" ? (
                                 <Badge variant="ghost" className="h-5 rounded-md px-1.5 text-[10px] font-normal text-muted-foreground">
                                   {t("status.inactive")}
                                 </Badge>

--- a/frontend/features/admin/components/sections/models/models-sources-sheet.tsx
+++ b/frontend/features/admin/components/sections/models/models-sources-sheet.tsx
@@ -148,6 +148,26 @@ function SourceCircuitStatus({
   );
 }
 
+function SourceInactiveStatus({
+  reason,
+}: {
+  reason: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <X
+          className="size-4 text-muted-foreground"
+          aria-label={reason}
+        />
+      </TooltipTrigger>
+      <TooltipContent side="top" className="text-xs">
+        {reason}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 export function UpstreamSourcesSheet({
   model,
   onClose,
@@ -873,6 +893,14 @@ export function UpstreamSourcesSheet({
                                 <SourceCircuitStatus
                                   circuitUntil={source.circuitUntil}
                                   circuitScope={source.circuitScope}
+                                />
+                              ) : source.upstreamStatus === "inactive" || source.upstreamModelStatus === "inactive" ? (
+                                <SourceInactiveStatus
+                                  reason={
+                                    source.upstreamStatus === "inactive"
+                                      ? t("upstreamInactive")
+                                      : t("upstreamModelInactive")
+                                  }
                                 />
                               ) : (
                                 <Switch

--- a/frontend/features/admin/components/sections/models/models-table.tsx
+++ b/frontend/features/admin/components/sections/models/models-table.tsx
@@ -217,17 +217,27 @@ function ModelAvailabilityBadge({ availability }: { availability: ModelAvailabil
 
 function SourceStatusText({
   status,
+  upstreamStatus,
+  upstreamModelStatus,
   circuitOpen,
   circuitUntil,
   circuitScope,
 }: {
   status: AdminLLMStatus;
+  upstreamStatus: AdminLLMStatus;
+  upstreamModelStatus: AdminLLMStatus;
   circuitOpen: boolean;
   circuitUntil: string;
   circuitScope: "upstream" | "source" | "";
 }) {
   const t = useTranslations("adminModels");
   const locale = useLocale();
+  const inactiveReason =
+    upstreamStatus === "inactive"
+      ? t("sources.upstreamInactive")
+      : upstreamModelStatus === "inactive"
+        ? t("sources.upstreamModelInactive")
+        : t("status.inactive");
   if (circuitOpen) {
     return (
       <Tooltip>
@@ -246,12 +256,19 @@ function SourceStatusText({
       </Tooltip>
     );
   }
-  if (status === "inactive") {
+  if (status === "inactive" || upstreamStatus === "inactive" || upstreamModelStatus === "inactive") {
     return (
-      <CircleX
-        className="size-4 text-muted-foreground"
-        aria-label={t("status.inactive")}
-      />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <CircleX
+            className="size-4 text-muted-foreground"
+            aria-label={inactiveReason}
+          />
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          {inactiveReason}
+        </TooltipContent>
+      </Tooltip>
     );
   }
   return (
@@ -593,6 +610,8 @@ const ModelTableRow = React.memo(function ModelTableRow({
                     <div className="flex h-7 items-center justify-center">
                       <SourceStatusText
                         status={source.status}
+                        upstreamStatus={source.upstreamStatus}
+                        upstreamModelStatus={source.upstreamModelStatus}
                         circuitOpen={source.circuitOpen}
                         circuitUntil={source.circuitUntil}
                         circuitScope={source.circuitScope}

--- a/frontend/features/admin/components/sections/upstreams/upstreams-models-dialog.tsx
+++ b/frontend/features/admin/components/sections/upstreams/upstreams-models-dialog.tsx
@@ -325,17 +325,18 @@ async function runOperationsInOrder(operations: Array<() => Promise<unknown>>): 
 type ModelRowProps = {
   row: RowDraft;
   isSelected: boolean;
+  upstreamInactive: boolean;
   onSelect: (draftKey: string, checked: boolean) => void;
   onUpdate: (draftKey: string, patch: Partial<Omit<RowDraft, "draftKey" | "isDirty">>) => void;
   onTest: (row: RowDraft, routeID: number) => void;
 };
 
-const ModelRow = React.memo(function ModelRow({ row, isSelected, onSelect, onUpdate, onTest }: ModelRowProps) {
+const ModelRow = React.memo(function ModelRow({ row, isSelected, upstreamInactive, onSelect, onUpdate, onTest }: ModelRowProps) {
   const t = useTranslations("adminUpstreams");
   const modelT = useTranslations("adminModels");
   const platformModelName = row.platformModelNameDraft.trim();
   const hasBindingDraft = platformModelName.length > 0;
-  const routeChecked = row.routeStatus === "active";
+  const routeChecked = !upstreamInactive && row.routeStatus === "active";
   const routeIDs = routeIDsForRow(row);
   const persistedRouteCount = routeIDs.length;
   const testRouteID = row.routeID || routeIDs[0] || 0;
@@ -363,12 +364,24 @@ const ModelRow = React.memo(function ModelRow({ row, isSelected, onSelect, onUpd
       </TableCell>
       <TableCell className="w-[56px] py-1.5 whitespace-nowrap">
         <div className="flex h-7 items-center">
-          <Switch
-            size="sm"
-            checked={routeChecked}
-            onCheckedChange={(checked) => onUpdate(row.draftKey, { routeStatus: checked ? "active" : "inactive" })}
-            aria-label={t("modelsDialog.routeStatusFor", { name: row.upstreamModelName })}
-          />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <Switch
+                  size="sm"
+                  checked={routeChecked}
+                  disabled={upstreamInactive}
+                  onCheckedChange={(checked) => onUpdate(row.draftKey, { routeStatus: checked ? "active" : "inactive" })}
+                  aria-label={t("modelsDialog.routeStatusFor", { name: row.upstreamModelName })}
+                />
+              </span>
+            </TooltipTrigger>
+            {upstreamInactive ? (
+              <TooltipContent side="top" className="text-xs">
+                {t("modelsDialog.upstreamInactive")}
+              </TooltipContent>
+            ) : null}
+          </Tooltip>
         </div>
       </TableCell>
       <TableCell className="max-w-[220px] py-1.5 font-mono text-xs text-muted-foreground">
@@ -1349,6 +1362,7 @@ export function UpstreamModelsDialog({
         .reduce((count, row) => count + routeIDsForRow(row).length, 0),
     [rows, selected],
   );
+  const upstreamInactive = upstream?.status === "inactive";
 
   return (
     <>
@@ -1542,6 +1556,7 @@ export function UpstreamModelsDialog({
                           key={row.draftKey}
                           row={row}
                           isSelected={selected.has(row.draftKey)}
+                          upstreamInactive={upstreamInactive}
                           onSelect={handleSelectOne}
                           onUpdate={updateRow}
                           onTest={handleTestRoute}

--- a/frontend/features/admin/hooks/use-admin-upstreams.ts
+++ b/frontend/features/admin/hooks/use-admin-upstreams.ts
@@ -88,6 +88,15 @@ type UseAdminUpstreamsState = {
   handleUpstreamUpdated: (updated: AdminLLMUpstreamView) => void;
 };
 
+function mergeUpstreamListView(current: AdminLLMUpstreamView, updated: AdminLLMUpstreamView): AdminLLMUpstreamView {
+  return {
+    ...current,
+    ...updated,
+    modelsCount: current.modelsCount,
+    activeModelsCount: current.activeModelsCount,
+  };
+}
+
 export function useAdminUpstreams(): UseAdminUpstreamsState {
   const t = useTranslations("adminUpstreams.toast");
   const resolveErrorMessage = useLocalizedErrorMessage();
@@ -245,7 +254,7 @@ export function useAdminUpstreams(): UseAdminUpstreamsState {
       const data = await updateAdminLLMUpstream(token, item.id, {
         status: newStatus,
       });
-      setItems((prev) => replaceByID(prev, item.id, (current) => current.id, data.upstream));
+      setItems((prev) => prev.map((current) => (current.id === item.id ? mergeUpstreamListView(current, data.upstream) : current)));
       toast.success(newStatus === "active" ? t("upstreamEnabled") : t("upstreamDisabled"));
     } catch (error) {
       setItems((prev) => replaceByID(prev, item.id, (current) => current.id, previousItem));
@@ -291,7 +300,10 @@ export function useAdminUpstreams(): UseAdminUpstreamsState {
         .map((result) => result.value.upstream);
 
       setItems((prev) =>
-        successResponses.reduce((next, upstream) => replaceByID(next, upstream.id, (item) => item.id, upstream), prev),
+        successResponses.reduce(
+          (next, upstream) => next.map((item) => (item.id === upstream.id ? mergeUpstreamListView(item, upstream) : item)),
+          prev,
+        ),
       );
       if (failedUpstreams.length > 0) {
         const failedIDs = new Set(failedUpstreams.map((item) => item.id));
@@ -345,7 +357,7 @@ export function useAdminUpstreams(): UseAdminUpstreamsState {
       const index = prev.findIndex((current) => current.id === item.id);
       if (index >= 0) {
         const next = [...prev];
-        next[index] = item;
+        next[index] = mergeUpstreamListView(next[index], item);
         return next;
       }
       setTotal((current) => current + 1);
@@ -381,13 +393,13 @@ export function useAdminUpstreams(): UseAdminUpstreamsState {
 
   function handleCircuitDone(updated: AdminLLMUpstreamView) {
     setItems((prev) =>
-      prev.map((item) => (item.id === updated.id ? updated : item)),
+      prev.map((item) => (item.id === updated.id ? mergeUpstreamListView(item, updated) : item)),
     );
   }
 
   function handleUpstreamUpdated(updated: AdminLLMUpstreamView) {
     setItems((prev) =>
-      prev.map((item) => (item.id === updated.id ? updated : item)),
+      prev.map((item) => (item.id === updated.id ? mergeUpstreamListView(item, updated) : item)),
     );
     if (modelsTarget?.id === updated.id) {
       setModelsTarget(updated);

--- a/frontend/i18n/messages/en-US/admin-models.json
+++ b/frontend/i18n/messages/en-US/admin-models.json
@@ -154,6 +154,8 @@
     "circuitWindow": "Rolling window (minutes)",
     "circuitScopeUpstream": "Upstream circuit",
     "circuitScopeSource": "Source circuit",
+    "upstreamInactive": "Upstream is disabled",
+    "upstreamModelInactive": "Upstream model is disabled",
     "circuitInheritHint": "Use 0 to inherit the parent model fallback. If that fallback is also 0, the system default is used.",
     "circuitPolicyOverriddenHint": "The parent model uses global override. These values are saved but do not take effect at runtime.",
     "saveCircuitSettings": "Save",

--- a/frontend/i18n/messages/zh-CN/admin-models.json
+++ b/frontend/i18n/messages/zh-CN/admin-models.json
@@ -154,6 +154,8 @@
     "circuitWindow": "滑动窗口（分钟）",
     "circuitScopeUpstream": "上游熔断",
     "circuitScopeSource": "来源熔断",
+    "upstreamInactive": "上游已停用",
+    "upstreamModelInactive": "上游模型已停用",
     "circuitInheritHint": "填 0 表示继承主模型的兜底配置；主模型也为 0 时使用系统默认。",
     "circuitPolicyOverriddenHint": "当前主模型启用了全局覆盖，此处配置会保存，但运行时不会生效。",
     "saveCircuitSettings": "保存",


### PR DESCRIPTION
## Summary

Fix upstream disable state propagation in admin model management. The change makes model source availability account for upstream status, keeps route/model configuration separate from effective availability, and prevents upstream list counters from being overwritten by partial update responses.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [x] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/application/channel ./internal/infra/persistence/postgres/channel ./internal/transport/http/channel`
- [x] `cd frontend && pnpm lint`
- [x] `git diff --check`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache make swagger`

## Screenshots, API examples, or logs

N/A

## Configuration, migration, and compatibility notes

No database migration or deployment configuration change is required.

`ModelUpstreamSourceResponse` now includes `upstreamStatus` so the admin UI can distinguish a disabled upstream from a disabled route or upstream model. Existing route and upstream model status values are not modified when an upstream is disabled.

Generated Swagger docs were updated.

## Documentation

- [ ] Documentation is not needed for this change.
- [x] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.