### PR TITLE
refactor: simplify conversation metadata generation and updating related functions

### DIFF
--- a/backend/internal/application/conversation/service_media_generation.go
+++ b/backend/internal/application/conversation/service_media_generation.go
@@ -254,6 +254,7 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 	userMessage.ParentPublicID = branchState.ParentPublicID
 	userMessage.SourcePublicID = branchState.SourcePublicID
 	assistantMessage.ParentPublicID = userMessage.PublicID
+	s.maybeGenerateConversationMetadataAsync(*conversation, *userMessage)
 	traceRecorder := newMessageTraceRecorder(s, ctx, assistantMessage, input.OnEvent)
 	defer func() {
 		if retErr != nil && traceRecorder != nil {
@@ -427,13 +428,11 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 	run.CacheReadTokens = usage.CacheReadTokens
 	run.CacheWriteTokens = usage.CacheWriteTokens
 	run.ReasoningTokens = usage.ReasoningTokens
-	// 图片会话首轮没有文本 assistant 回复，标题/标签只使用用户第一条气泡内容生成。
-	s.maybeGenerateConversationMetadataAsync(*conversation, *userMessage, model.Message{})
 
 	return &SendMessageResult{
 		UserMessage:         *userMessage,
 		AssistantMessage:    *assistantMessage,
-		MetadataRefreshHint: conversationMetadataRefreshHint(*conversation, *userMessage, model.Message{}),
+		MetadataRefreshHint: conversationMetadataRefreshHint(*conversation, *userMessage),
 		UpstreamID:          route.UpstreamID,
 		UpstreamName:        route.UpstreamName,
 		PlatformModelName:   route.PlatformModelName,

--- a/backend/internal/application/conversation/service_message_completion.go
+++ b/backend/internal/application/conversation/service_message_completion.go
@@ -176,7 +176,6 @@ func (s *Service) finishSuccessfulMessageGeneration(ctx context.Context, input p
 	}
 
 	s.updateStatefulResponseAsync(input.SendInput.ConversationID, input.ResponseID, input.StatefulPromptFingerprint)
-	s.maybeGenerateConversationMetadataAsync(*input.Conversation, *input.UserMessage, *input.AssistantMessage)
 	s.embedMessagePairAsync(input.SendInput, input.UserMessage, input.AssistantMessage)
 
 	return nil

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -368,6 +368,7 @@ func (s *Service) sendMessageInternal(
 			return nil, err
 		}
 	}
+	s.maybeGenerateConversationMetadataAsync(*conversation, *userMessage)
 	run.Endpoint = llm.DefaultEndpointForAdapter(route.Protocol)
 	run.ProviderProtocol = route.Protocol
 	run.UpstreamID = route.UpstreamID
@@ -1344,7 +1345,7 @@ func (s *Service) sendMessageInternal(
 	return &SendMessageResult{
 		UserMessage:         *userMessage,
 		AssistantMessage:    *assistantMessage,
-		MetadataRefreshHint: conversationMetadataRefreshHint(*conversation, *userMessage, *assistantMessage),
+		MetadataRefreshHint: conversationMetadataRefreshHint(*conversation, *userMessage),
 		Billable:            true,
 		UpstreamID:          run.UpstreamID,
 		UpstreamName:        run.UpstreamName,

--- a/backend/internal/application/conversation/service_metadata.go
+++ b/backend/internal/application/conversation/service_metadata.go
@@ -67,16 +67,30 @@ type conversationMetadataLLMResult struct {
 	LatencyMS         int64
 }
 
-func (s *Service) maybeGenerateConversationMetadataAsync(conversation model.Conversation, userMsg model.Message, assistantMsg model.Message) {
+func (s *Service) maybeGenerateConversationMetadataAsync(conversation model.Conversation, userMsg model.Message) {
 	if !shouldGenerateConversationMetadata(conversation) {
 		return
+	}
+	fallbackTitle := ""
+	if shouldAutoReplaceConversationTitle(conversation.Title) {
+		fallbackTitle = conversationTitleFromFirstUserMessage(userMsg.Content)
 	}
 
 	go func() {
 		asyncCtx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 		defer cancel()
 
-		if _, err := s.generateConversationMetadata(asyncCtx, conversation, userMsg, assistantMsg); err != nil && s.logger != nil {
+		if fallbackTitle != "" {
+			if _, err := s.repo.UpdateConversationMetadata(asyncCtx, conversation.ID, repository.ConversationMetadataPatch{Title: fallbackTitle}); err != nil && s.logger != nil {
+				s.logger.Warn("conversation_fallback_title_update_failed",
+					zap.Uint("conversation_id", conversation.ID),
+					zap.String("model", conversation.Model),
+					zap.Error(err),
+				)
+			}
+		}
+
+		if _, err := s.generateConversationMetadata(asyncCtx, conversation, userMsg); err != nil && s.logger != nil {
 			if errors.Is(err, ErrInvalidConversationTitle) {
 				s.logger.Info("conversation_metadata_skipped",
 					zap.Uint("conversation_id", conversation.ID),
@@ -94,15 +108,14 @@ func (s *Service) maybeGenerateConversationMetadataAsync(conversation model.Conv
 	}()
 }
 
-func (s *Service) generateConversationMetadata(ctx context.Context, conversation model.Conversation, userMsg model.Message, assistantMsg model.Message) (*model.Conversation, error) {
+func (s *Service) generateConversationMetadata(ctx context.Context, conversation model.Conversation, userMsg model.Message) (*model.Conversation, error) {
 	cfg := s.cfg.Snapshot()
-	messages := buildConversationMetadataMessages(userMsg, assistantMsg)
+	messages := buildConversationMetadataMessages(userMsg)
 	hasTitleableMessages := strings.TrimSpace(messages) != ""
 
-	title := ""
-	labelsJSON := ""
 	var titleErr error
 	var labelsErr error
+	var updated *model.Conversation
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
@@ -126,12 +139,18 @@ func (s *Service) generateConversationMetadata(ctx context.Context, conversation
 			labelsErr = err
 		}
 	}
+	setUpdated := func(item *model.Conversation) {
+		if item == nil {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		updated = item
+	}
 
 	shouldReplaceTitle := shouldAutoReplaceConversationTitle(conversation.Title)
 	shouldGenerateTitle := shouldReplaceTitle && s.autoGenerateConversationTitleEnabled(ctx, conversation.UserID)
-	if shouldReplaceTitle && !shouldGenerateTitle {
-		title = conversationTitleFromFirstUserMessage(userMsg.Content)
-	}
+	fallbackTitle := conversationTitleFromFirstUserMessage(userMsg.Content)
 
 	if shouldGenerateTitle && !hasTitleableMessages {
 		setTitleErr(ErrInvalidConversationTitle)
@@ -147,9 +166,26 @@ func (s *Service) generateConversationMetadata(ctx context.Context, conversation
 				return
 			}
 			s.recordBasicServiceUsage(ctx, conversation.UserID, conversation.ID, "title", "标题", out.PlatformModelName, out.RoutedBindingCode, out.ProviderProtocol, out.UpstreamName, out.UpstreamModel, "5m", out.Usage, out.Messages, out.Text, out.LatencyMS)
-			mu.Lock()
-			title = sanitizeGeneratedConversationTitle(parseGeneratedConversationTitle(out.Text))
-			mu.Unlock()
+			title := resolveConversationMetadataTitle(shouldReplaceTitle, sanitizeGeneratedConversationTitle(parseGeneratedConversationTitle(out.Text)), userMsg.Content)
+			if title == "" {
+				return
+			}
+			updated, err := s.repo.UpdateConversationMetadata(ctx, conversation.ID, repository.ConversationMetadataPatch{
+				Title:             title,
+				ReplaceableTitles: []string{fallbackTitle},
+			})
+			if err != nil {
+				setTitleErr(fmt.Errorf("update conversation title metadata: %w", err))
+				return
+			}
+			setUpdated(updated)
+			if s.logger != nil {
+				s.logger.Info("conversation_metadata_updated",
+					zap.Uint("conversation_id", conversation.ID),
+					zap.String("conversation_model", conversation.Model),
+					zap.Bool("title_updated", true),
+				)
+			}
 		}()
 	}
 
@@ -177,44 +213,40 @@ func (s *Service) generateConversationMetadata(ctx context.Context, conversation
 				setLabelsErr(marshalErr)
 				return
 			}
-			mu.Lock()
-			labelsJSON = string(raw)
-			mu.Unlock()
+			updated, err := s.repo.UpdateConversationMetadata(ctx, conversation.ID, repository.ConversationMetadataPatch{LabelsJSON: string(raw)})
+			if err != nil {
+				setLabelsErr(fmt.Errorf("update conversation labels metadata: %w", err))
+				return
+			}
+			setUpdated(updated)
+			if s.logger != nil {
+				s.logger.Info("conversation_metadata_updated",
+					zap.Uint("conversation_id", conversation.ID),
+					zap.String("conversation_model", conversation.Model),
+					zap.Bool("labels_updated", true),
+				)
+			}
 		}()
 	}
 
 	wg.Wait()
 	mu.Lock()
-	resolvedTitle := strings.TrimSpace(title)
-	resolvedLabelsJSON := strings.TrimSpace(labelsJSON)
 	resolvedTitleErr := titleErr
 	resolvedLabelsErr := labelsErr
+	resolvedUpdated := updated
 	mu.Unlock()
 
-	resolvedTitle = resolveConversationMetadataTitle(shouldReplaceTitle, resolvedTitle, userMsg.Content)
-	resolvedErr := resolveConversationMetadataError(resolvedTitle, resolvedLabelsJSON, resolvedTitleErr, resolvedLabelsErr)
-
-	if resolvedTitle == "" && resolvedLabelsJSON == "" {
-		return nil, resolvedErr
+	if resolvedUpdated != nil {
+		return resolvedUpdated, nil
 	}
-	updated, err := s.repo.UpdateConversationMetadata(ctx, conversation.ID, resolvedTitle, resolvedLabelsJSON)
-	if err != nil {
-		return nil, fmt.Errorf("update conversation metadata: %w", err)
+	if shouldReplaceTitle && !shouldGenerateTitle && fallbackTitle != "" {
+		updated, err := s.repo.UpdateConversationMetadata(ctx, conversation.ID, repository.ConversationMetadataPatch{Title: fallbackTitle})
+		if err != nil {
+			return nil, fmt.Errorf("update conversation fallback title metadata: %w", err)
+		}
+		return updated, nil
 	}
-	if s.logger != nil {
-		fields := []zap.Field{
-			zap.Uint("conversation_id", conversation.ID),
-			zap.String("conversation_model", conversation.Model),
-		}
-		if resolvedTitle != "" {
-			fields = append(fields, zap.Bool("title_updated", true))
-		}
-		if resolvedLabelsJSON != "" {
-			fields = append(fields, zap.Bool("labels_updated", true))
-		}
-		s.logger.Info("conversation_metadata_updated", fields...)
-	}
-	return updated, resolvedErr
+	return nil, resolveConversationMetadataError("", "", resolvedTitleErr, resolvedLabelsErr)
 }
 
 // RegenerateConversationTitle 根据已有会话正文强制重新生成标题。
@@ -274,25 +306,20 @@ func (s *Service) RegenerateConversationTitle(ctx context.Context, userID uint, 
 	return updated, nil
 }
 
-func buildConversationMetadataMessages(userMsg model.Message, assistantMsg model.Message) string {
+func buildConversationMetadataMessages(userMsg model.Message) string {
 	var sb strings.Builder
 	if content := strings.TrimSpace(userMsg.Content); content != "" {
 		sb.WriteString("user:\n")
-		sb.WriteString(content)
-		sb.WriteString("\n\n")
-	}
-	if content := strings.TrimSpace(assistantMsg.Content); content != "" {
-		sb.WriteString("assistant:\n")
 		sb.WriteString(content)
 	}
 	return truncateByEstimatedTokens(strings.TrimSpace(sb.String()), conversationMetadataMessageMaxTokens)
 }
 
-func conversationMetadataRefreshHint(conversation model.Conversation, userMsg model.Message, assistantMsg model.Message) string {
+func conversationMetadataRefreshHint(conversation model.Conversation, userMsg model.Message) string {
 	if !shouldGenerateConversationMetadata(conversation) {
 		return conversationMetadataRefreshNotNeeded
 	}
-	if strings.TrimSpace(buildConversationMetadataMessages(userMsg, assistantMsg)) == "" {
+	if strings.TrimSpace(buildConversationMetadataMessages(userMsg)) == "" {
 		return conversationMetadataRefreshNoContent
 	}
 	return conversationMetadataRefreshPending
@@ -607,7 +634,7 @@ func (s *Service) autoGenerateConversationTitleEnabled(ctx context.Context, user
 func shouldAutoReplaceConversationTitle(title string) bool {
 	value := strings.TrimSpace(strings.ToLower(title))
 	switch value {
-	case "", "new conversation", "new chat", "untitled", "新会话", "新对话", "新的对话":
+	case "new chat", "新会话":
 		return true
 	default:
 		return false

--- a/backend/internal/application/conversation/service_metadata_test.go
+++ b/backend/internal/application/conversation/service_metadata_test.go
@@ -10,9 +10,8 @@ import (
 
 func TestBuildConversationMetadataMessagesTruncatesToBudget(t *testing.T) {
 	userMsg := model.Message{Content: strings.Repeat("用户输入内容", 6000)}
-	assistantMsg := model.Message{Content: strings.Repeat("助手回复内容", 6000)}
 
-	got := buildConversationMetadataMessages(userMsg, assistantMsg)
+	got := buildConversationMetadataMessages(userMsg)
 
 	if tokens := estimateTokens(got); tokens > conversationMetadataMessageMaxTokens {
 		t.Fatalf("metadata messages exceeded budget: got %d, want <= %d", tokens, conversationMetadataMessageMaxTokens)
@@ -26,6 +25,19 @@ func TestBuildConversationMetadataMessagesTruncatesToBudget(t *testing.T) {
 	}
 	if !strings.Contains(got, "[truncated]") {
 		t.Fatal("expected metadata messages to mark truncated content")
+	}
+}
+
+func TestBuildConversationMetadataMessagesUsesOnlyUserMessage(t *testing.T) {
+	userMsg := model.Message{Content: "帮我设计一套灰度发布方案"}
+
+	got := buildConversationMetadataMessages(userMsg)
+
+	if !strings.Contains(got, "user:\n帮我设计一套灰度发布方案") {
+		t.Fatalf("expected metadata messages to include user bubble, got %q", got)
+	}
+	if strings.Contains(got, "assistant:") {
+		t.Fatalf("expected metadata messages to exclude assistant content, got %q", got)
 	}
 }
 
@@ -106,7 +118,7 @@ func TestConversationFallbackTitleUsesUnifiedLimit(t *testing.T) {
 }
 
 func TestBuildConversationMetadataMessagesEmptyWhenNoText(t *testing.T) {
-	got := buildConversationMetadataMessages(model.Message{}, model.Message{})
+	got := buildConversationMetadataMessages(model.Message{})
 	if got != "" {
 		t.Fatalf("expected no metadata prompt body for empty messages, got %q", got)
 	}
@@ -117,7 +129,6 @@ func TestConversationMetadataRefreshHint(t *testing.T) {
 		name         string
 		conversation model.Conversation
 		userMsg      model.Message
-		assistantMsg model.Message
 		want         string
 	}{
 		{
@@ -141,7 +152,7 @@ func TestConversationMetadataRefreshHint(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := conversationMetadataRefreshHint(tc.conversation, tc.userMsg, tc.assistantMsg)
+			got := conversationMetadataRefreshHint(tc.conversation, tc.userMsg)
 			if got != tc.want {
 				t.Fatalf("unexpected metadata refresh hint: got %q, want %q", got, tc.want)
 			}
@@ -201,11 +212,11 @@ func TestConversationTitleFromMessagesPrefersLatestUserMessage(t *testing.T) {
 
 func TestConversationMetadataFallsBackToFirstUserMessageTitle(t *testing.T) {
 	resolvedTitle := resolveConversationMetadataTitle(
-		shouldAutoReplaceConversationTitle("新对话"),
+		shouldAutoReplaceConversationTitle("新会话"),
 		"",
 		"设置为跟随后，Grok 4.3 对话标题没有自动生成",
 	)
-	if resolvedTitle == "" || resolvedTitle == "新对话" {
+	if resolvedTitle == "" || resolvedTitle == "新会话" {
 		t.Fatalf("expected first user message fallback title, got %q", resolvedTitle)
 	}
 }
@@ -213,6 +224,9 @@ func TestConversationMetadataFallsBackToFirstUserMessageTitle(t *testing.T) {
 func TestShouldAutoReplaceConversationTitleIncludesEnglishNewChat(t *testing.T) {
 	if !shouldAutoReplaceConversationTitle("New chat") {
 		t.Fatal("expected English localized new chat title to be replaceable")
+	}
+	if shouldAutoReplaceConversationTitle("新对话") {
+		t.Fatal("expected non-persisted Chinese navigation label not to be replaceable")
 	}
 }
 

--- a/backend/internal/infra/persistence/postgres/conversation/repository.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository.go
@@ -493,17 +493,24 @@ func (r *Repo) UpdateConversationTitleByPublicID(
 }
 
 // UpdateConversationMetadata 更新自动生成的会话元数据。
-func (r *Repo) UpdateConversationMetadata(ctx context.Context, conversationID uint, title string, labelsJSON string) (*domainconversation.Conversation, error) {
+func (r *Repo) UpdateConversationMetadata(ctx context.Context, conversationID uint, patch repository.ConversationMetadataPatch) (*domainconversation.Conversation, error) {
 	updates := map[string]interface{}{}
-	if strings.TrimSpace(title) != "" {
+	if strings.TrimSpace(patch.Title) != "" {
+		replaceable := []string{"new chat", "新会话"}
+		for _, item := range patch.ReplaceableTitles {
+			value := strings.TrimSpace(strings.ToLower(item))
+			if value != "" {
+				replaceable = append(replaceable, value)
+			}
+		}
 		updates["title"] = gorm.Expr(
 			fmt.Sprintf("CASE WHEN lower(%s(title)) IN ? THEN ? ELSE title END", r.trimFunctionName()),
-			[]string{"", "new conversation", "new chat", "untitled", "新会话", "新对话", "新的对话"},
-			strings.TrimSpace(title),
+			replaceable,
+			strings.TrimSpace(patch.Title),
 		)
 	}
-	if strings.TrimSpace(labelsJSON) != "" {
-		updates["labels_json"] = strings.TrimSpace(labelsJSON)
+	if strings.TrimSpace(patch.LabelsJSON) != "" {
+		updates["labels_json"] = strings.TrimSpace(patch.LabelsJSON)
 	}
 	if len(updates) == 0 {
 		var current models.Conversation

--- a/backend/internal/infra/persistence/postgres/conversation/repository_test.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/models"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -179,7 +180,7 @@ func TestUpdateConversationMetadataSQLiteUsesPortableTrim(t *testing.T) {
 	conversation := model.Conversation{
 		UserID:     1,
 		PublicID:   "conv_metadata_sqlite",
-		Title:      " 新对话 ",
+		Title:      " 新会话 ",
 		LabelsJSON: "[]",
 		SessionKey: "session_metadata_sqlite",
 		Status:     "active",
@@ -188,7 +189,10 @@ func TestUpdateConversationMetadataSQLiteUsesPortableTrim(t *testing.T) {
 		t.Fatalf("create conversation: %v", err)
 	}
 
-	updated, err := repo.UpdateConversationMetadata(ctx, conversation.ID, "SQLite 标题", `["技术"]`)
+	updated, err := repo.UpdateConversationMetadata(ctx, conversation.ID, repository.ConversationMetadataPatch{
+		Title:      "SQLite 标题",
+		LabelsJSON: `["技术"]`,
+	})
 	if err != nil {
 		t.Fatalf("UpdateConversationMetadata() error = %v", err)
 	}
@@ -197,6 +201,49 @@ func TestUpdateConversationMetadataSQLiteUsesPortableTrim(t *testing.T) {
 	}
 	if updated.LabelsJSON != `["技术"]` {
 		t.Fatalf("updated labels = %q, want %q", updated.LabelsJSON, `["技术"]`)
+	}
+}
+
+func TestUpdateConversationMetadataCanReplaceAutomaticFallbackTitle(t *testing.T) {
+	db := openConversationRepositoryTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	conversation := model.Conversation{
+		UserID:     1,
+		PublicID:   "conv_metadata_fallback",
+		Title:      "画一张城市夜景",
+		LabelsJSON: "[]",
+		SessionKey: "session_metadata_fallback",
+		Status:     "active",
+	}
+	if err := db.Create(&conversation).Error; err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	updated, err := repo.UpdateConversationMetadata(ctx, conversation.ID, repository.ConversationMetadataPatch{
+		Title:             "城市夜景图像生成",
+		ReplaceableTitles: []string{"画一张城市夜景"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateConversationMetadata() error = %v", err)
+	}
+	if updated.Title != "城市夜景图像生成" {
+		t.Fatalf("updated title = %q, want %q", updated.Title, "城市夜景图像生成")
+	}
+
+	if err := db.Model(&model.Conversation{}).Where("id = ?", conversation.ID).Update("title", "手动标题").Error; err != nil {
+		t.Fatalf("set manual title: %v", err)
+	}
+	updated, err = repo.UpdateConversationMetadata(ctx, conversation.ID, repository.ConversationMetadataPatch{
+		Title:             "不应覆盖",
+		ReplaceableTitles: []string{"画一张城市夜景"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateConversationMetadata() error = %v", err)
+	}
+	if updated.Title != "手动标题" {
+		t.Fatalf("manual title was overwritten: got %q", updated.Title)
 	}
 }
 

--- a/backend/internal/repository/conversation_core.go
+++ b/backend/internal/repository/conversation_core.go
@@ -29,6 +29,13 @@ type AssistantMessageCompletionUpdate struct {
 	ErrorMessage    string
 }
 
+// ConversationMetadataPatch 定义自动生成会话元数据的更新字段。
+type ConversationMetadataPatch struct {
+	Title             string
+	LabelsJSON        string
+	ReplaceableTitles []string
+}
+
 // ConversationMetadataRepository 封装会话元信息与用户访问能力。
 type ConversationMetadataRepository interface {
 	CreateConversation(ctx context.Context, item *domainconversation.Conversation) error
@@ -51,7 +58,7 @@ type ConversationMetadataRepository interface {
 	RevokeActiveConversationShares(ctx context.Context, userID uint, conversationIDs []uint) error
 	TouchConversationShareAccess(ctx context.Context, shareID string, accessedAt time.Time) error
 	UpdateConversationTitleByPublicID(ctx context.Context, userID uint, publicID string, title string) (*domainconversation.Conversation, error)
-	UpdateConversationMetadata(ctx context.Context, conversationID uint, title string, labelsJSON string) (*domainconversation.Conversation, error)
+	UpdateConversationMetadata(ctx context.Context, conversationID uint, patch ConversationMetadataPatch) (*domainconversation.Conversation, error)
 	UpdateConversationStarByPublicID(ctx context.Context, userID uint, publicID string, starred bool) (*domainconversation.Conversation, error)
 	UpdateConversationArchiveByPublicID(ctx context.Context, userID uint, publicID string, archived bool) (*domainconversation.Conversation, error)
 	DeleteConversationByPublicID(ctx context.Context, userID uint, publicID string, deleteFiles bool) ([]string, error)

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -163,7 +163,15 @@ function normalizeLabelsJSON(value: string | null | undefined): string {
 
 function isPlaceholderConversationTitle(title: string): boolean {
   const value = title.trim().toLowerCase();
-  return ["", "new conversation", "new chat", "untitled", "新会话", "新对话", "新的对话"].includes(value);
+  return ["new chat", "新会话"].includes(value);
+}
+
+function conversationTitleFromFirstUserMessage(content: string): string {
+  const value = content.trim().replace(/\s+/g, " ").replace(/^[\s"'`“”‘’]+|[\s"'`“”‘’]+$/g, "");
+  if (!value) {
+    return "";
+  }
+  return Array.from(value).slice(0, 16).join("").trim();
 }
 
 function hasPendingGeneratedConversationMetadata(item: ConversationDTO | null): boolean {
@@ -208,6 +216,7 @@ async function refreshGeneratedConversationMetadata(
 ): Promise<void> {
   let elapsedMS = 0;
   let delayMS = CONVERSATION_METADATA_REFRESH_INITIAL_DELAY_MS;
+  let current = previous;
 
   while (elapsedMS < CONVERSATION_METADATA_REFRESH_MAX_WAIT_MS) {
     const nextDelayMS = Math.min(delayMS, CONVERSATION_METADATA_REFRESH_MAX_WAIT_MS - elapsedMS);
@@ -220,9 +229,12 @@ async function refreshGeneratedConversationMetadata(
     } catch {
       continue;
     }
-    if (hasGeneratedConversationMetadataChanged(previous, latest)) {
+    if (hasGeneratedConversationMetadataChanged(current, latest)) {
       touchByPublicID(conversationPublicID, latest);
-      return;
+      current = latest;
+      if (!hasPendingGeneratedConversationMetadata(latest)) {
+        return;
+      }
     }
 
     delayMS = Math.min(
@@ -487,6 +499,7 @@ export function useChatMessageSubmit({
         submitTask === "chat" ? undefined : resolveImageLoadingAspectRatio(sanitizedOptions);
       let targetConversationID = conversationIDRef.current;
       let targetConversation = activeConversationRef.current;
+      let metadataRefreshInFlight = false;
 
       activeGenerationRunsRef?.current.add(clientRunID);
       setShowConversationLayout(true);
@@ -545,6 +558,28 @@ export function useChatMessageSubmit({
             accessToken: token,
           };
         }
+        const startMetadataRefresh = (result?: SendMessageResult | null) => {
+          if (
+            !targetConversationID ||
+            metadataRefreshInFlight ||
+            !shouldPollGeneratedConversationMetadata(targetConversation, result)
+          ) {
+            return;
+          }
+          metadataRefreshInFlight = true;
+          void refreshGeneratedConversationMetadata(
+            token,
+            targetConversationID,
+            targetConversation,
+            touchByPublicID,
+          )
+            .catch(() => {
+              // Metadata refresh failure does not affect this turn; the next list load will fetch server state.
+            })
+            .finally(() => {
+              metadataRefreshInFlight = false;
+            });
+        };
 
         if (!targetConversationID) {
           const created = await prependNewConversation(requestPlatformModelName);
@@ -570,6 +605,22 @@ export function useChatMessageSubmit({
           window.history.replaceState(null, "", `/chat?conversation_id=${created.publicID}`);
           onConversationCreated?.(created.publicID);
         }
+        const optimisticTitle = conversationTitleFromFirstUserMessage(payloadContent);
+        if (
+          targetConversationID &&
+          optimisticTitle &&
+          (!targetConversation || isPlaceholderConversationTitle(targetConversation.title))
+        ) {
+          if (targetConversation) {
+            targetConversation = {
+              ...targetConversation,
+              title: optimisticTitle,
+            };
+            activeConversationRef.current = targetConversation;
+          }
+          touchByPublicID(targetConversationID, { title: optimisticTitle });
+        }
+        startMetadataRefresh(null);
         const commonStreamPayload = {
           model: requestPlatformModelName,
           options: Object.keys(sanitizedOptions).length > 0 ? sanitizedOptions : undefined,
@@ -802,15 +853,8 @@ export function useChatMessageSubmit({
           targetConversationID,
           toConversationPatch(targetConversation, requestPlatformModelName),
         );
-        if (assistantMessageSucceeded && shouldPollGeneratedConversationMetadata(targetConversation, completed)) {
-          void refreshGeneratedConversationMetadata(
-            token,
-            targetConversationID,
-            targetConversation,
-            touchByPublicID,
-          ).catch(() => {
-            // Metadata refresh failure does not affect this turn; the next list load will fetch server state.
-          });
+        if (assistantMessageSucceeded) {
+          startMetadataRefresh(completed);
         }
         releaseAttachments(effectiveAttachments);
         if (assistantMessageSucceeded) {


### PR DESCRIPTION
## Summary

Improve conversation metadata generation so new conversations get useful titles and labels earlier. Title and label generation now starts from the user’s first message when the turn is sent, instead of waiting for the assistant response to finish. A 16-character fallback title is persisted immediately, while LLM-generated title and labels update independently as soon as each task completes.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/application/conversation`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/infra/persistence/postgres/conversation`
- [x] `git diff --check`

## Screenshots, API examples, or logs

No screenshots. Behavior change: new chat titles appear immediately from the first user message, then may be refined by generated metadata.

## Configuration, migration, and compatibility notes

No configuration, migration, public API, or Swagger changes. The new metadata patch type is internal repository-layer code only.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.