### PR TITLE
refactor: update announcement API references and enhance announcement listing functionality

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -75,13 +75,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AdminAnnouncementListResponseDoc"
+                            "$ref": "#/definitions/announcement.AdminAnnouncementListResponseDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -110,7 +110,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.CreateAnnouncementRequest"
+                            "$ref": "#/definitions/announcement.CreateAnnouncementRequest"
                         }
                     }
                 ],
@@ -118,19 +118,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponseDoc"
+                            "$ref": "#/definitions/announcement.AnnouncementResponseDoc"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -167,25 +167,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDeleteResponseDoc"
+                            "$ref": "#/definitions/announcement.AnnouncementDeleteResponseDoc"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -221,7 +221,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.PatchAnnouncementRequestDoc"
+                            "$ref": "#/definitions/announcement.PatchAnnouncementRequestDoc"
                         }
                     }
                 ],
@@ -229,25 +229,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponseDoc"
+                            "$ref": "#/definitions/announcement.AnnouncementResponseDoc"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -4889,17 +4889,25 @@ const docTemplate = `{
                     "announcements"
                 ],
                 "summary": "获取当前公告",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "是否包含今日不再显示的公告",
+                        "name": "include_dismissed",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementListResponseDoc"
+                            "$ref": "#/definitions/announcement.AnnouncementListResponseDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -4937,7 +4945,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementStateRequest"
+                            "$ref": "#/definitions/announcement.AnnouncementStateRequest"
                         }
                     }
                 ],
@@ -4945,25 +4953,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementCloseResponseDoc"
+                            "$ref": "#/definitions/announcement.AnnouncementCloseResponseDoc"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -5001,7 +5009,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementStateRequest"
+                            "$ref": "#/definitions/announcement.AnnouncementStateRequest"
                         }
                     }
                 ],
@@ -5009,25 +5017,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDismissResponseDoc"
+                            "$ref": "#/definitions/announcement.AnnouncementDismissResponseDoc"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -9537,6 +9545,282 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "announcement.AdminAnnouncementListResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/announcement.AnnouncementResponse"
+                            }
+                        },
+                        "total": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementCloseDataResponse": {
+            "type": "object",
+            "properties": {
+                "closed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "announcement.AnnouncementCloseResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/announcement.AnnouncementCloseDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementDataResponse": {
+            "type": "object",
+            "properties": {
+                "announcement": {
+                    "$ref": "#/definitions/announcement.AnnouncementResponse"
+                }
+            }
+        },
+        "announcement.AnnouncementDeleteDataResponse": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "announcement.AnnouncementDeleteResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/announcement.AnnouncementDeleteDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementDismissDataResponse": {
+            "type": "object",
+            "properties": {
+                "dismissed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "announcement.AnnouncementDismissResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/announcement.AnnouncementDismissDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementListResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/announcement.AnnouncementResponse"
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementResponse": {
+            "type": "object",
+            "properties": {
+                "closedAt": {
+                    "type": "string"
+                },
+                "contentMarkdown": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserID": {
+                    "type": "integer"
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "startsAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/announcement.AnnouncementDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementStateRequest": {
+            "type": "object",
+            "required": [
+                "updatedAt"
+            ],
+            "properties": {
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.CreateAnnouncementRequest": {
+            "type": "object",
+            "required": [
+                "contentMarkdown",
+                "title"
+            ],
+            "properties": {
+                "contentMarkdown": {
+                    "type": "string",
+                    "maxLength": 20000,
+                    "minLength": 1
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "startsAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "inactive"
+                    ]
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "minLength": 1
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "critical",
+                        "warning",
+                        "info",
+                        "normal",
+                        "general"
+                    ]
+                }
+            }
+        },
+        "announcement.ErrorDoc": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "details": {},
+                "errorCode": {
+                    "type": "string",
+                    "example": "invalid_request"
+                },
+                "errorMsg": {
+                    "type": "string",
+                    "example": "invalid request"
+                },
+                "requestId": {
+                    "type": "string",
+                    "example": ""
+                }
+            }
+        },
+        "announcement.PatchAnnouncementRequestDoc": {
+            "type": "object",
+            "properties": {
+                "contentMarkdown": {
+                    "type": "string",
+                    "maxLength": 20000
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "startsAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "inactive"
+                    ]
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 120
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "critical",
+                        "warning",
+                        "info",
+                        "normal",
+                        "general"
+                    ]
+                }
+            }
+        },
         "github_com_DEEIX-AI_DEEIX-Chat_backend_internal_shared_response.Envelope": {
             "type": "object",
             "properties": {
@@ -10588,282 +10872,6 @@ const docTemplate = `{
                 },
                 "username": {
                     "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AdminAnnouncementListResponseDoc": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponse"
-                            }
-                        },
-                        "total": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "errorMsg": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementCloseDataResponse": {
-            "type": "object",
-            "properties": {
-                "closed": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementCloseResponseDoc": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementCloseDataResponse"
-                },
-                "errorMsg": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementDataResponse": {
-            "type": "object",
-            "properties": {
-                "announcement": {
-                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponse"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementDeleteDataResponse": {
-            "type": "object",
-            "properties": {
-                "deleted": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementDeleteResponseDoc": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDeleteDataResponse"
-                },
-                "errorMsg": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementDismissDataResponse": {
-            "type": "object",
-            "properties": {
-                "dismissed": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementDismissResponseDoc": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDismissDataResponse"
-                },
-                "errorMsg": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementListResponseDoc": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponse"
-                    }
-                },
-                "errorMsg": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementResponse": {
-            "type": "object",
-            "properties": {
-                "closedAt": {
-                    "type": "string"
-                },
-                "contentMarkdown": {
-                    "type": "string"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "createdByUserID": {
-                    "type": "integer"
-                },
-                "expiresAt": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "pinned": {
-                    "type": "boolean"
-                },
-                "priority": {
-                    "type": "integer"
-                },
-                "startsAt": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "updatedAt": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementResponseDoc": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDataResponse"
-                },
-                "errorMsg": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementStateRequest": {
-            "type": "object",
-            "required": [
-                "updatedAt"
-            ],
-            "properties": {
-                "updatedAt": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.CreateAnnouncementRequest": {
-            "type": "object",
-            "required": [
-                "contentMarkdown",
-                "title"
-            ],
-            "properties": {
-                "contentMarkdown": {
-                    "type": "string",
-                    "maxLength": 20000,
-                    "minLength": 1
-                },
-                "expiresAt": {
-                    "type": "string"
-                },
-                "pinned": {
-                    "type": "boolean"
-                },
-                "priority": {
-                    "type": "integer"
-                },
-                "startsAt": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string",
-                    "enum": [
-                        "active",
-                        "inactive"
-                    ]
-                },
-                "title": {
-                    "type": "string",
-                    "maxLength": 120,
-                    "minLength": 1
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "critical",
-                        "warning",
-                        "info",
-                        "normal",
-                        "general"
-                    ]
-                }
-            }
-        },
-        "internal_transport_http_announcement.ErrorDoc": {
-            "type": "object",
-            "properties": {
-                "data": {},
-                "details": {},
-                "errorCode": {
-                    "type": "string",
-                    "example": "invalid_request"
-                },
-                "errorMsg": {
-                    "type": "string",
-                    "example": "invalid request"
-                },
-                "requestId": {
-                    "type": "string",
-                    "example": ""
-                }
-            }
-        },
-        "internal_transport_http_announcement.PatchAnnouncementRequestDoc": {
-            "type": "object",
-            "properties": {
-                "contentMarkdown": {
-                    "type": "string",
-                    "maxLength": 20000
-                },
-                "expiresAt": {
-                    "type": "string"
-                },
-                "pinned": {
-                    "type": "boolean"
-                },
-                "priority": {
-                    "type": "integer"
-                },
-                "startsAt": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string",
-                    "enum": [
-                        "active",
-                        "inactive"
-                    ]
-                },
-                "title": {
-                    "type": "string",
-                    "maxLength": 120
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "critical",
-                        "warning",
-                        "info",
-                        "normal",
-                        "general"
-                    ]
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -68,13 +68,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AdminAnnouncementListResponseDoc"
+                            "$ref": "#/definitions/announcement.AdminAnnouncementListResponseDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -103,7 +103,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.CreateAnnouncementRequest"
+                            "$ref": "#/definitions/announcement.CreateAnnouncementRequest"
                         }
                     }
                 ],
@@ -111,19 +111,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponseDoc"
+                            "$ref": "#/definitions/announcement.AnnouncementResponseDoc"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -160,25 +160,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDeleteResponseDoc"
+                            "$ref": "#/definitions/announcement.AnnouncementDeleteResponseDoc"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -214,7 +214,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.PatchAnnouncementRequestDoc"
+                            "$ref": "#/definitions/announcement.PatchAnnouncementRequestDoc"
                         }
                     }
                 ],
@@ -222,25 +222,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponseDoc"
+                            "$ref": "#/definitions/announcement.AnnouncementResponseDoc"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -4882,17 +4882,25 @@
                     "announcements"
                 ],
                 "summary": "获取当前公告",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "是否包含今日不再显示的公告",
+                        "name": "include_dismissed",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementListResponseDoc"
+                            "$ref": "#/definitions/announcement.AnnouncementListResponseDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -4930,7 +4938,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementStateRequest"
+                            "$ref": "#/definitions/announcement.AnnouncementStateRequest"
                         }
                     }
                 ],
@@ -4938,25 +4946,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementCloseResponseDoc"
+                            "$ref": "#/definitions/announcement.AnnouncementCloseResponseDoc"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -4994,7 +5002,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementStateRequest"
+                            "$ref": "#/definitions/announcement.AnnouncementStateRequest"
                         }
                     }
                 ],
@@ -5002,25 +5010,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDismissResponseDoc"
+                            "$ref": "#/definitions/announcement.AnnouncementDismissResponseDoc"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_transport_http_announcement.ErrorDoc"
+                            "$ref": "#/definitions/announcement.ErrorDoc"
                         }
                     }
                 }
@@ -9530,6 +9538,282 @@
         }
     },
     "definitions": {
+        "announcement.AdminAnnouncementListResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/announcement.AnnouncementResponse"
+                            }
+                        },
+                        "total": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementCloseDataResponse": {
+            "type": "object",
+            "properties": {
+                "closed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "announcement.AnnouncementCloseResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/announcement.AnnouncementCloseDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementDataResponse": {
+            "type": "object",
+            "properties": {
+                "announcement": {
+                    "$ref": "#/definitions/announcement.AnnouncementResponse"
+                }
+            }
+        },
+        "announcement.AnnouncementDeleteDataResponse": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "announcement.AnnouncementDeleteResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/announcement.AnnouncementDeleteDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementDismissDataResponse": {
+            "type": "object",
+            "properties": {
+                "dismissed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "announcement.AnnouncementDismissResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/announcement.AnnouncementDismissDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementListResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/announcement.AnnouncementResponse"
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementResponse": {
+            "type": "object",
+            "properties": {
+                "closedAt": {
+                    "type": "string"
+                },
+                "contentMarkdown": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserID": {
+                    "type": "integer"
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "startsAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementResponseDoc": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/announcement.AnnouncementDataResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.AnnouncementStateRequest": {
+            "type": "object",
+            "required": [
+                "updatedAt"
+            ],
+            "properties": {
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "announcement.CreateAnnouncementRequest": {
+            "type": "object",
+            "required": [
+                "contentMarkdown",
+                "title"
+            ],
+            "properties": {
+                "contentMarkdown": {
+                    "type": "string",
+                    "maxLength": 20000,
+                    "minLength": 1
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "startsAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "inactive"
+                    ]
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "minLength": 1
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "critical",
+                        "warning",
+                        "info",
+                        "normal",
+                        "general"
+                    ]
+                }
+            }
+        },
+        "announcement.ErrorDoc": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "details": {},
+                "errorCode": {
+                    "type": "string",
+                    "example": "invalid_request"
+                },
+                "errorMsg": {
+                    "type": "string",
+                    "example": "invalid request"
+                },
+                "requestId": {
+                    "type": "string",
+                    "example": ""
+                }
+            }
+        },
+        "announcement.PatchAnnouncementRequestDoc": {
+            "type": "object",
+            "properties": {
+                "contentMarkdown": {
+                    "type": "string",
+                    "maxLength": 20000
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "startsAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "inactive"
+                    ]
+                },
+                "title": {
+                    "type": "string",
+                    "maxLength": 120
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "critical",
+                        "warning",
+                        "info",
+                        "normal",
+                        "general"
+                    ]
+                }
+            }
+        },
         "github_com_DEEIX-AI_DEEIX-Chat_backend_internal_shared_response.Envelope": {
             "type": "object",
             "properties": {
@@ -10581,282 +10865,6 @@
                 },
                 "username": {
                     "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AdminAnnouncementListResponseDoc": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponse"
-                            }
-                        },
-                        "total": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "errorMsg": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementCloseDataResponse": {
-            "type": "object",
-            "properties": {
-                "closed": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementCloseResponseDoc": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementCloseDataResponse"
-                },
-                "errorMsg": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementDataResponse": {
-            "type": "object",
-            "properties": {
-                "announcement": {
-                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponse"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementDeleteDataResponse": {
-            "type": "object",
-            "properties": {
-                "deleted": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementDeleteResponseDoc": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDeleteDataResponse"
-                },
-                "errorMsg": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementDismissDataResponse": {
-            "type": "object",
-            "properties": {
-                "dismissed": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementDismissResponseDoc": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDismissDataResponse"
-                },
-                "errorMsg": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementListResponseDoc": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementResponse"
-                    }
-                },
-                "errorMsg": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementResponse": {
-            "type": "object",
-            "properties": {
-                "closedAt": {
-                    "type": "string"
-                },
-                "contentMarkdown": {
-                    "type": "string"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "createdByUserID": {
-                    "type": "integer"
-                },
-                "expiresAt": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "pinned": {
-                    "type": "boolean"
-                },
-                "priority": {
-                    "type": "integer"
-                },
-                "startsAt": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "updatedAt": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementResponseDoc": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "$ref": "#/definitions/internal_transport_http_announcement.AnnouncementDataResponse"
-                },
-                "errorMsg": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.AnnouncementStateRequest": {
-            "type": "object",
-            "required": [
-                "updatedAt"
-            ],
-            "properties": {
-                "updatedAt": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_transport_http_announcement.CreateAnnouncementRequest": {
-            "type": "object",
-            "required": [
-                "contentMarkdown",
-                "title"
-            ],
-            "properties": {
-                "contentMarkdown": {
-                    "type": "string",
-                    "maxLength": 20000,
-                    "minLength": 1
-                },
-                "expiresAt": {
-                    "type": "string"
-                },
-                "pinned": {
-                    "type": "boolean"
-                },
-                "priority": {
-                    "type": "integer"
-                },
-                "startsAt": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string",
-                    "enum": [
-                        "active",
-                        "inactive"
-                    ]
-                },
-                "title": {
-                    "type": "string",
-                    "maxLength": 120,
-                    "minLength": 1
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "critical",
-                        "warning",
-                        "info",
-                        "normal",
-                        "general"
-                    ]
-                }
-            }
-        },
-        "internal_transport_http_announcement.ErrorDoc": {
-            "type": "object",
-            "properties": {
-                "data": {},
-                "details": {},
-                "errorCode": {
-                    "type": "string",
-                    "example": "invalid_request"
-                },
-                "errorMsg": {
-                    "type": "string",
-                    "example": "invalid request"
-                },
-                "requestId": {
-                    "type": "string",
-                    "example": ""
-                }
-            }
-        },
-        "internal_transport_http_announcement.PatchAnnouncementRequestDoc": {
-            "type": "object",
-            "properties": {
-                "contentMarkdown": {
-                    "type": "string",
-                    "maxLength": 20000
-                },
-                "expiresAt": {
-                    "type": "string"
-                },
-                "pinned": {
-                    "type": "boolean"
-                },
-                "priority": {
-                    "type": "integer"
-                },
-                "startsAt": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string",
-                    "enum": [
-                        "active",
-                        "inactive"
-                    ]
-                },
-                "title": {
-                    "type": "string",
-                    "maxLength": 120
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "critical",
-                        "warning",
-                        "info",
-                        "normal",
-                        "general"
-                    ]
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1,5 +1,191 @@
 basePath: /api/v1
 definitions:
+  announcement.AdminAnnouncementListResponseDoc:
+    properties:
+      data:
+        properties:
+          results:
+            items:
+              $ref: '#/definitions/announcement.AnnouncementResponse'
+            type: array
+          total:
+            type: integer
+        type: object
+      errorMsg:
+        type: string
+    type: object
+  announcement.AnnouncementCloseDataResponse:
+    properties:
+      closed:
+        type: boolean
+    type: object
+  announcement.AnnouncementCloseResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/announcement.AnnouncementCloseDataResponse'
+      errorMsg:
+        type: string
+    type: object
+  announcement.AnnouncementDataResponse:
+    properties:
+      announcement:
+        $ref: '#/definitions/announcement.AnnouncementResponse'
+    type: object
+  announcement.AnnouncementDeleteDataResponse:
+    properties:
+      deleted:
+        type: boolean
+    type: object
+  announcement.AnnouncementDeleteResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/announcement.AnnouncementDeleteDataResponse'
+      errorMsg:
+        type: string
+    type: object
+  announcement.AnnouncementDismissDataResponse:
+    properties:
+      dismissed:
+        type: boolean
+    type: object
+  announcement.AnnouncementDismissResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/announcement.AnnouncementDismissDataResponse'
+      errorMsg:
+        type: string
+    type: object
+  announcement.AnnouncementListResponseDoc:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/announcement.AnnouncementResponse'
+        type: array
+      errorMsg:
+        type: string
+    type: object
+  announcement.AnnouncementResponse:
+    properties:
+      closedAt:
+        type: string
+      contentMarkdown:
+        type: string
+      createdAt:
+        type: string
+      createdByUserID:
+        type: integer
+      expiresAt:
+        type: string
+      id:
+        type: integer
+      pinned:
+        type: boolean
+      priority:
+        type: integer
+      startsAt:
+        type: string
+      status:
+        type: string
+      title:
+        type: string
+      type:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  announcement.AnnouncementResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/announcement.AnnouncementDataResponse'
+      errorMsg:
+        type: string
+    type: object
+  announcement.AnnouncementStateRequest:
+    properties:
+      updatedAt:
+        type: string
+    required:
+    - updatedAt
+    type: object
+  announcement.CreateAnnouncementRequest:
+    properties:
+      contentMarkdown:
+        maxLength: 20000
+        minLength: 1
+        type: string
+      expiresAt:
+        type: string
+      pinned:
+        type: boolean
+      priority:
+        type: integer
+      startsAt:
+        type: string
+      status:
+        enum:
+        - active
+        - inactive
+        type: string
+      title:
+        maxLength: 120
+        minLength: 1
+        type: string
+      type:
+        enum:
+        - critical
+        - warning
+        - info
+        - normal
+        - general
+        type: string
+    required:
+    - contentMarkdown
+    - title
+    type: object
+  announcement.ErrorDoc:
+    properties:
+      data: {}
+      details: {}
+      errorCode:
+        example: invalid_request
+        type: string
+      errorMsg:
+        example: invalid request
+        type: string
+      requestId:
+        example: ""
+        type: string
+    type: object
+  announcement.PatchAnnouncementRequestDoc:
+    properties:
+      contentMarkdown:
+        maxLength: 20000
+        type: string
+      expiresAt:
+        type: string
+      pinned:
+        type: boolean
+      priority:
+        type: integer
+      startsAt:
+        type: string
+      status:
+        enum:
+        - active
+        - inactive
+        type: string
+      title:
+        maxLength: 120
+        type: string
+      type:
+        enum:
+        - critical
+        - warning
+        - info
+        - normal
+        - general
+        type: string
+    type: object
   github_com_DEEIX-AI_DEEIX-Chat_backend_internal_shared_response.Envelope:
     properties:
       data: {}
@@ -700,192 +886,6 @@ definitions:
       updatedAt:
         type: string
       username:
-        type: string
-    type: object
-  internal_transport_http_announcement.AdminAnnouncementListResponseDoc:
-    properties:
-      data:
-        properties:
-          results:
-            items:
-              $ref: '#/definitions/internal_transport_http_announcement.AnnouncementResponse'
-            type: array
-          total:
-            type: integer
-        type: object
-      errorMsg:
-        type: string
-    type: object
-  internal_transport_http_announcement.AnnouncementCloseDataResponse:
-    properties:
-      closed:
-        type: boolean
-    type: object
-  internal_transport_http_announcement.AnnouncementCloseResponseDoc:
-    properties:
-      data:
-        $ref: '#/definitions/internal_transport_http_announcement.AnnouncementCloseDataResponse'
-      errorMsg:
-        type: string
-    type: object
-  internal_transport_http_announcement.AnnouncementDataResponse:
-    properties:
-      announcement:
-        $ref: '#/definitions/internal_transport_http_announcement.AnnouncementResponse'
-    type: object
-  internal_transport_http_announcement.AnnouncementDeleteDataResponse:
-    properties:
-      deleted:
-        type: boolean
-    type: object
-  internal_transport_http_announcement.AnnouncementDeleteResponseDoc:
-    properties:
-      data:
-        $ref: '#/definitions/internal_transport_http_announcement.AnnouncementDeleteDataResponse'
-      errorMsg:
-        type: string
-    type: object
-  internal_transport_http_announcement.AnnouncementDismissDataResponse:
-    properties:
-      dismissed:
-        type: boolean
-    type: object
-  internal_transport_http_announcement.AnnouncementDismissResponseDoc:
-    properties:
-      data:
-        $ref: '#/definitions/internal_transport_http_announcement.AnnouncementDismissDataResponse'
-      errorMsg:
-        type: string
-    type: object
-  internal_transport_http_announcement.AnnouncementListResponseDoc:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/internal_transport_http_announcement.AnnouncementResponse'
-        type: array
-      errorMsg:
-        type: string
-    type: object
-  internal_transport_http_announcement.AnnouncementResponse:
-    properties:
-      closedAt:
-        type: string
-      contentMarkdown:
-        type: string
-      createdAt:
-        type: string
-      createdByUserID:
-        type: integer
-      expiresAt:
-        type: string
-      id:
-        type: integer
-      pinned:
-        type: boolean
-      priority:
-        type: integer
-      startsAt:
-        type: string
-      status:
-        type: string
-      title:
-        type: string
-      type:
-        type: string
-      updatedAt:
-        type: string
-    type: object
-  internal_transport_http_announcement.AnnouncementResponseDoc:
-    properties:
-      data:
-        $ref: '#/definitions/internal_transport_http_announcement.AnnouncementDataResponse'
-      errorMsg:
-        type: string
-    type: object
-  internal_transport_http_announcement.AnnouncementStateRequest:
-    properties:
-      updatedAt:
-        type: string
-    required:
-    - updatedAt
-    type: object
-  internal_transport_http_announcement.CreateAnnouncementRequest:
-    properties:
-      contentMarkdown:
-        maxLength: 20000
-        minLength: 1
-        type: string
-      expiresAt:
-        type: string
-      pinned:
-        type: boolean
-      priority:
-        type: integer
-      startsAt:
-        type: string
-      status:
-        enum:
-        - active
-        - inactive
-        type: string
-      title:
-        maxLength: 120
-        minLength: 1
-        type: string
-      type:
-        enum:
-        - critical
-        - warning
-        - info
-        - normal
-        - general
-        type: string
-    required:
-    - contentMarkdown
-    - title
-    type: object
-  internal_transport_http_announcement.ErrorDoc:
-    properties:
-      data: {}
-      details: {}
-      errorCode:
-        example: invalid_request
-        type: string
-      errorMsg:
-        example: invalid request
-        type: string
-      requestId:
-        example: ""
-        type: string
-    type: object
-  internal_transport_http_announcement.PatchAnnouncementRequestDoc:
-    properties:
-      contentMarkdown:
-        maxLength: 20000
-        type: string
-      expiresAt:
-        type: string
-      pinned:
-        type: boolean
-      priority:
-        type: integer
-      startsAt:
-        type: string
-      status:
-        enum:
-        - active
-        - inactive
-        type: string
-      title:
-        maxLength: 120
-        type: string
-      type:
-        enum:
-        - critical
-        - warning
-        - info
-        - normal
-        - general
         type: string
     type: object
   internal_transport_http_auth.ActiveSessionListResponse:
@@ -4933,11 +4933,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.AdminAnnouncementListResponseDoc'
+            $ref: '#/definitions/announcement.AdminAnnouncementListResponseDoc'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
       security:
       - BearerAuth: []
       summary: 管理员查询公告
@@ -4953,22 +4953,22 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/internal_transport_http_announcement.CreateAnnouncementRequest'
+          $ref: '#/definitions/announcement.CreateAnnouncementRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.AnnouncementResponseDoc'
+            $ref: '#/definitions/announcement.AnnouncementResponseDoc'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
       security:
       - BearerAuth: []
       summary: 管理员创建公告
@@ -4991,19 +4991,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.AnnouncementDeleteResponseDoc'
+            $ref: '#/definitions/announcement.AnnouncementDeleteResponseDoc'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
       security:
       - BearerAuth: []
       summary: 管理员删除公告
@@ -5024,26 +5024,26 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/internal_transport_http_announcement.PatchAnnouncementRequestDoc'
+          $ref: '#/definitions/announcement.PatchAnnouncementRequestDoc'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.AnnouncementResponseDoc'
+            $ref: '#/definitions/announcement.AnnouncementResponseDoc'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
       security:
       - BearerAuth: []
       summary: 管理员更新公告
@@ -7983,17 +7983,22 @@ paths:
       consumes:
       - application/json
       description: 登录用户获取当前可展示的站点公告列表
+      parameters:
+      - description: 是否包含今日不再显示的公告
+        in: query
+        name: include_dismissed
+        type: boolean
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.AnnouncementListResponseDoc'
+            $ref: '#/definitions/announcement.AnnouncementListResponseDoc'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
       security:
       - BearerAuth: []
       summary: 获取当前公告
@@ -8015,26 +8020,26 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/internal_transport_http_announcement.AnnouncementStateRequest'
+          $ref: '#/definitions/announcement.AnnouncementStateRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.AnnouncementCloseResponseDoc'
+            $ref: '#/definitions/announcement.AnnouncementCloseResponseDoc'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
       security:
       - BearerAuth: []
       summary: 关闭公告
@@ -8056,26 +8061,26 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/internal_transport_http_announcement.AnnouncementStateRequest'
+          $ref: '#/definitions/announcement.AnnouncementStateRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.AnnouncementDismissResponseDoc'
+            $ref: '#/definitions/announcement.AnnouncementDismissResponseDoc'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_transport_http_announcement.ErrorDoc'
+            $ref: '#/definitions/announcement.ErrorDoc'
       security:
       - BearerAuth: []
       summary: 今日不再显示公告

--- a/backend/internal/application/announcement/service.go
+++ b/backend/internal/application/announcement/service.go
@@ -26,11 +26,11 @@ func NewService(repo repository.AnnouncementRepository) *Service {
 }
 
 // ListActive 查询当前用户可展示公告。
-func (s *Service) ListActive(ctx context.Context, userID uint, now time.Time) ([]domainannouncement.Announcement, error) {
+func (s *Service) ListActive(ctx context.Context, userID uint, now time.Time, includeDismissed bool) ([]domainannouncement.Announcement, error) {
 	if userID == 0 {
 		return nil, repository.ErrInvalidInput
 	}
-	return s.repo.ListActiveAnnouncements(ctx, userID, now)
+	return s.repo.ListActiveAnnouncements(ctx, userID, now, includeDismissed)
 }
 
 // ListAdmin 查询管理员公告列表。

--- a/backend/internal/application/announcement/service_test.go
+++ b/backend/internal/application/announcement/service_test.go
@@ -67,6 +67,17 @@ func TestDismissTodayRejectsInvalidInput(t *testing.T) {
 	}
 }
 
+func TestListActivePassesIncludeDismissed(t *testing.T) {
+	repo := &fakeRepo{}
+	service := NewService(repo)
+	if _, err := service.ListActive(context.Background(), 1, time.Now(), true); err != nil {
+		t.Fatalf("ListActive() error = %v", err)
+	}
+	if !repo.includeDismissed {
+		t.Fatal("ListActive() did not pass includeDismissed to repository")
+	}
+}
+
 func TestCloseRejectsInvalidInput(t *testing.T) {
 	service := NewService(&fakeRepo{})
 	now := time.Now()
@@ -82,10 +93,12 @@ func TestCloseRejectsInvalidInput(t *testing.T) {
 }
 
 type fakeRepo struct {
-	item domainannouncement.Announcement
+	item             domainannouncement.Announcement
+	includeDismissed bool
 }
 
-func (r *fakeRepo) ListActiveAnnouncements(context.Context, uint, time.Time) ([]domainannouncement.Announcement, error) {
+func (r *fakeRepo) ListActiveAnnouncements(_ context.Context, _ uint, _ time.Time, includeDismissed bool) ([]domainannouncement.Announcement, error) {
+	r.includeDismissed = includeDismissed
 	return []domainannouncement.Announcement{}, nil
 }
 

--- a/backend/internal/infra/persistence/postgres/announcement/repository.go
+++ b/backend/internal/infra/persistence/postgres/announcement/repository.go
@@ -24,13 +24,13 @@ func NewRepo(db *gorm.DB) *Repo {
 }
 
 // ListActiveAnnouncements 查询当前可展示公告。
-func (r *Repo) ListActiveAnnouncements(ctx context.Context, userID uint, now time.Time) ([]domainannouncement.Announcement, error) {
+func (r *Repo) ListActiveAnnouncements(ctx context.Context, userID uint, now time.Time, includeDismissed bool) ([]domainannouncement.Announcement, error) {
 	type announcementRow struct {
 		model.Announcement
 		UserClosedAt *time.Time `gorm:"column:user_closed_at"`
 	}
 	items := make([]announcementRow, 0)
-	if err := r.db.WithContext(ctx).
+	query := r.db.WithContext(ctx).
 		Model(&model.Announcement{}).
 		Select("system_announcements.*, states.closed_at AS user_closed_at").
 		Joins(`LEFT JOIN announcement_user_states states
@@ -40,8 +40,11 @@ func (r *Repo) ListActiveAnnouncements(ctx context.Context, userID uint, now tim
 				AND states.announcement_updated_at = system_announcements.updated_at`, userID).
 		Where("status = ?", domainannouncement.StatusActive).
 		Where("(starts_at IS NULL OR starts_at <= ?)", now).
-		Where("(expires_at IS NULL OR expires_at > ?)", now).
-		Where("(states.dismissed_until IS NULL OR states.dismissed_until <= ?)", now).
+		Where("(expires_at IS NULL OR expires_at > ?)", now)
+	if !includeDismissed {
+		query = query.Where("(states.dismissed_until IS NULL OR states.dismissed_until <= ?)", now)
+	}
+	if err := query.
 		Order("CASE WHEN states.closed_at IS NULL THEN 0 ELSE 1 END ASC, pinned DESC, priority DESC, updated_at DESC, id DESC").
 		Find(&items).Error; err != nil {
 		return nil, translateError(err)

--- a/backend/internal/repository/announcement.go
+++ b/backend/internal/repository/announcement.go
@@ -9,7 +9,7 @@ import (
 
 // AnnouncementRepository 定义公告流程依赖的持久化能力。
 type AnnouncementRepository interface {
-	ListActiveAnnouncements(ctx context.Context, userID uint, now time.Time) ([]domainannouncement.Announcement, error)
+	ListActiveAnnouncements(ctx context.Context, userID uint, now time.Time, includeDismissed bool) ([]domainannouncement.Announcement, error)
 	ListAdminAnnouncements(ctx context.Context, filter AnnouncementListFilter, offset int, limit int) ([]domainannouncement.Announcement, int64, error)
 	CreateAnnouncement(ctx context.Context, item *domainannouncement.Announcement) (*domainannouncement.Announcement, error)
 	PatchAnnouncement(ctx context.Context, id uint, patch AnnouncementPatch) (*domainannouncement.Announcement, error)

--- a/backend/internal/transport/http/announcement/handler.go
+++ b/backend/internal/transport/http/announcement/handler.go
@@ -29,11 +29,13 @@ func NewHandler(service *appannouncement.Service) *Handler {
 // @Accept json
 // @Produce json
 // @Security BearerAuth
+// @Param include_dismissed query bool false "是否包含今日不再显示的公告"
 // @Success 200 {object} AnnouncementListResponseDoc
 // @Failure 500 {object} ErrorDoc
 // @Router /announcements [get]
 func (h *Handler) ListAnnouncements(c *gin.Context) {
-	items, err := h.service.ListActive(c.Request.Context(), middleware.MustUserID(c), time.Now())
+	includeDismissed, _ := strconv.ParseBool(c.Query("include_dismissed"))
+	items, err := h.service.ListActive(c.Request.Context(), middleware.MustUserID(c), time.Now(), includeDismissed)
 	if err != nil {
 		response.Error(c, http.StatusInternalServerError, "list announcements failed")
 		return

--- a/frontend/components/ui/dropdown-menu.tsx
+++ b/frontend/components/ui/dropdown-menu.tsx
@@ -212,7 +212,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 whitespace-nowrap rounded-md px-2 py-1.5 text-xs outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:transition-transform [&_svg]:duration-200 [&_svg]:ease-out data-[highlighted]:[&_svg]:scale-105 data-[highlighted]:[&_svg]:translate-x-[1px] data-[state=open]:[&_svg]:scale-105 [&_svg:not([class*='size-'])]:size-3.5",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 whitespace-nowrap rounded-md px-2 py-1.5 text-xs outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
         className
       )}
       {...props}

--- a/frontend/features/announcements/components/announcement-dialog-host.tsx
+++ b/frontend/features/announcements/components/announcement-dialog-host.tsx
@@ -19,9 +19,11 @@ import { StreamdownRender } from "@/shared/components/markdown/streamdown-render
 import { closeAnnouncement, dismissAnnouncementToday, listAnnouncements } from "@/shared/api/announcements";
 import type { AnnouncementDTO } from "@/shared/api/announcements.types";
 import { useAuthSession } from "@/shared/auth/auth-session-context";
+import { dispatchAnnouncementUnreadChanged, subscribeOpenAnnouncements } from "@/shared/events/announcement-events";
 import { cn } from "@/lib/utils";
 
 type AnnouncementSortMode = "default" | "type" | "time";
+type AnnouncementDialogMode = "auto" | "manual";
 
 function isSkippedPath(pathname: string | null): boolean {
   if (!pathname) {
@@ -115,29 +117,48 @@ export function AnnouncementDialogHost() {
   const locale = useLocale();
   const pathname = usePathname();
   const { accessToken, user, userStatus } = useAuthSession();
-  const [queue, setQueue] = React.useState<AnnouncementDTO[]>([]);
+  const [autoQueue, setAutoQueue] = React.useState<AnnouncementDTO[]>([]);
+  const [manualQueue, setManualQueue] = React.useState<AnnouncementDTO[]>([]);
   const [activeIndex, setActiveIndex] = React.useState(0);
   const [sortMode, setSortMode] = React.useState<AnnouncementSortMode>("default");
   const [stateSaving, setStateSaving] = React.useState(false);
+  const [autoOpen, setAutoOpen] = React.useState(false);
+  const [manualOpen, setManualOpen] = React.useState(false);
+  const [manualLoading, setManualLoading] = React.useState(false);
+  const [dialogMode, setDialogMode] = React.useState<AnnouncementDialogMode>("auto");
+  const autoLoadRequestIDRef = React.useRef(0);
+  const manualLoadRequestIDRef = React.useRef(0);
 
   React.useEffect(() => {
     let cancelled = false;
     if (userStatus !== "ready" || !accessToken || user?.initialSecurityRequired || isSkippedPath(pathname)) {
-      setQueue([]);
+      autoLoadRequestIDRef.current += 1;
+      manualLoadRequestIDRef.current += 1;
+      setAutoQueue([]);
+      setManualQueue([]);
       setActiveIndex(0);
+      setAutoOpen(false);
+      setManualOpen(false);
+      setManualLoading(false);
+      setDialogMode("auto");
       return;
     }
 
     async function load() {
+      const requestID = autoLoadRequestIDRef.current + 1;
+      autoLoadRequestIDRef.current = requestID;
       try {
         const items = await listAnnouncements(accessToken);
-        if (!cancelled) {
-          setQueue(items);
+        if (!cancelled && autoLoadRequestIDRef.current === requestID) {
+          setAutoQueue(items);
+          setAutoOpen(items.some((item) => !isAnnouncementRead(item)));
+          setDialogMode((current) => (current === "manual" ? current : "auto"));
           setActiveIndex(0);
         }
       } catch {
-        if (!cancelled) {
-          setQueue([]);
+        if (!cancelled && autoLoadRequestIDRef.current === requestID) {
+          setAutoQueue([]);
+          setAutoOpen(false);
           setActiveIndex(0);
         }
       }
@@ -149,6 +170,49 @@ export function AnnouncementDialogHost() {
     };
   }, [accessToken, pathname, user?.initialSecurityRequired, userStatus]);
 
+  React.useEffect(() => {
+    let cancelled = false;
+    const unsubscribe = subscribeOpenAnnouncements(() => {
+      if (userStatus !== "ready" || !accessToken || user?.initialSecurityRequired || isSkippedPath(pathname)) {
+        return;
+      }
+      const requestID = manualLoadRequestIDRef.current + 1;
+      manualLoadRequestIDRef.current = requestID;
+      setDialogMode("manual");
+      setAutoOpen(false);
+      setManualOpen(true);
+      setManualLoading(true);
+      setManualQueue([]);
+      setActiveIndex(0);
+      setSortMode("default");
+
+      void listAnnouncements(accessToken, { includeDismissed: true })
+        .then((items) => {
+          if (!cancelled && manualLoadRequestIDRef.current === requestID) {
+            setManualQueue(items);
+            setActiveIndex(0);
+          }
+        })
+        .catch(() => {
+          if (!cancelled && manualLoadRequestIDRef.current === requestID) {
+            setManualQueue([]);
+            toast.error(t("openFailed"));
+          }
+        })
+        .finally(() => {
+          if (!cancelled && manualLoadRequestIDRef.current === requestID) {
+            setManualLoading(false);
+          }
+        });
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [accessToken, pathname, t, user?.initialSecurityRequired, userStatus]);
+
+  const queue = dialogMode === "manual" ? manualQueue : autoQueue;
   const sortedQueue = React.useMemo(() => {
     if (sortMode === "time") {
       return [...queue].sort((a, b) => compareReadState(a, b) || announcementTime(b.updatedAt) - announcementTime(a.updatedAt) || b.id - a.id);
@@ -163,12 +227,31 @@ export function AnnouncementDialogHost() {
     setActiveIndex(0);
   }, [sortMode]);
 
-  const hasUnread = queue.some((item) => !isAnnouncementRead(item));
-  const active = hasUnread ? (sortedQueue[Math.min(activeIndex, Math.max(sortedQueue.length - 1, 0))] ?? null) : null;
-  const open = hasUnread;
+  const hasUnread = autoQueue.some((item) => !isAnnouncementRead(item));
+  React.useEffect(() => {
+    dispatchAnnouncementUnreadChanged(hasUnread);
+  }, [hasUnread]);
+
+  const open = manualOpen || autoOpen;
+  const active = sortedQueue[Math.min(activeIndex, Math.max(sortedQueue.length - 1, 0))] ?? null;
+  const unreadQueue = React.useMemo(() => queue.filter((item) => !isAnnouncementRead(item)), [queue]);
 
   const closeDialog = React.useCallback(() => {
-    setQueue([]);
+    setActiveIndex(0);
+    setAutoOpen(false);
+    setManualOpen(false);
+    setManualLoading(false);
+    dispatchAnnouncementUnreadChanged(false);
+  }, []);
+
+  const closeManualDialog = React.useCallback(() => {
+    setManualOpen(false);
+    setManualLoading(false);
+    setActiveIndex(0);
+  }, []);
+
+  const hideAutoDialog = React.useCallback(() => {
+    setAutoOpen(false);
     setActiveIndex(0);
   }, []);
 
@@ -178,14 +261,14 @@ export function AnnouncementDialogHost() {
     }
     setStateSaving(true);
     try {
-      await Promise.all(queue.map((item) => dismissAnnouncementToday(accessToken, item.id, item.updatedAt)));
+      await Promise.all(unreadQueue.map((item) => dismissAnnouncementToday(accessToken, item.id, item.updatedAt)));
       closeDialog();
     } catch {
       toast.error(t("dismissFailed"));
     } finally {
       setStateSaving(false);
     }
-  }, [accessToken, closeDialog, queue, stateSaving, t]);
+  }, [accessToken, closeDialog, stateSaving, t, unreadQueue]);
 
   const closeAll = React.useCallback(async () => {
     if (!accessToken || stateSaving) {
@@ -193,23 +276,23 @@ export function AnnouncementDialogHost() {
     }
     setStateSaving(true);
     try {
-      await Promise.all(queue.map((item) => closeAnnouncement(accessToken, item.id, item.updatedAt)));
+      await Promise.all(unreadQueue.map((item) => closeAnnouncement(accessToken, item.id, item.updatedAt)));
       closeDialog();
     } catch {
       toast.error(t("closeFailed"));
     } finally {
       setStateSaving(false);
     }
-  }, [accessToken, closeDialog, queue, stateSaving, t]);
-
-  if (!active) {
-    return null;
-  }
+  }, [accessToken, closeDialog, stateSaving, t, unreadQueue]);
 
   return (
     <Dialog open={open} onOpenChange={(nextOpen) => {
       if (!nextOpen) {
-        void closeAll();
+        if (manualOpen) {
+          closeManualDialog();
+        } else {
+          hideAutoDialog();
+        }
       }
     }}>
       <DialogContent className="flex max-h-[min(84svh,720px)] flex-col overflow-hidden sm:max-w-[760px]">
@@ -228,12 +311,12 @@ export function AnnouncementDialogHost() {
               </TabsList>
             </Tabs>
             <div className="flex gap-2 overflow-x-auto px-2 py-2 md:block md:min-h-0 md:flex-1 md:space-y-0.5 md:overflow-y-auto">
-              {sortedQueue.map((item, index) => (
+              {sortedQueue.length > 0 ? sortedQueue.map((item, index) => (
                 <button
                   key={`${item.id}:${item.updatedAt}`}
                   type="button"
                   className={cn(
-                    "relative min-w-36 rounded-md py-1 pl-3.5 pr-5 text-left text-xs transition-colors before:absolute before:left-1.5 before:top-2 before:bottom-2 before:w-0.5 before:rounded-full md:h-[3.125rem] md:w-full",
+                    "relative min-w-36 rounded-md py-1 pl-3.5 pr-8 text-left text-xs transition-colors before:absolute before:left-1.5 before:top-2 before:bottom-2 before:w-0.5 before:rounded-full md:h-[3.125rem] md:w-full",
                     announcementTypeAccentClassName(item.type),
                     isAnnouncementRead(item) && "opacity-55",
                     index === activeIndex
@@ -242,32 +325,53 @@ export function AnnouncementDialogHost() {
                   )}
                   onClick={() => setActiveIndex(index)}
                 >
-                  {item.pinned ? (
-                    <Pin className="absolute right-1.5 top-1.5 size-3 text-muted-foreground/70" />
-                  ) : null}
+                  <span className="absolute right-1.5 top-1.5 flex h-3.5 items-center gap-1">
+                    {!isAnnouncementRead(item) ? <span aria-hidden="true" className="size-1.5 rounded-full bg-red-500" /> : null}
+                    {item.pinned ? <Pin className="size-3 text-muted-foreground/70" /> : null}
+                  </span>
                   <span className="block truncate font-medium">{item.title}</span>
                   <span className="mt-0.5 block text-xs text-muted-foreground">
                     {formatAnnouncementDate(item.updatedAt, locale)}
                   </span>
                 </button>
-              ))}
+              )) : (
+                <div className="flex h-full min-h-24 items-center justify-center px-3 py-6 text-center text-xs text-muted-foreground">
+                  {manualLoading ? t("loading") : t("empty")}
+                </div>
+              )}
             </div>
           </div>
           <div className="min-h-0 overflow-y-auto px-4 py-3">
-            <div className="mb-2 flex min-w-0 items-center justify-between gap-3 text-xs text-muted-foreground">
-              <span className="min-w-0 truncate">{active.title}</span>
-              <span className="shrink-0 tabular-nums">{formatAnnouncementTime(active.updatedAt, locale)}</span>
-            </div>
-            <StreamdownRender content={active.contentMarkdown} className="text-sm" />
+            {active ? (
+              <>
+                <div className="mb-2 flex min-w-0 items-center justify-between gap-3 text-xs text-muted-foreground">
+                  <span className="min-w-0 truncate">{active.title}</span>
+                  <span className="shrink-0 tabular-nums">{formatAnnouncementTime(active.updatedAt, locale)}</span>
+                </div>
+                <StreamdownRender content={active.contentMarkdown} className="text-sm" />
+              </>
+            ) : (
+              <div className="flex min-h-full items-center justify-center text-center text-sm text-muted-foreground">
+                {manualLoading ? t("loading") : t("empty")}
+              </div>
+            )}
           </div>
         </div>
         <DialogFooter className="shrink-0">
-          <Button type="button" variant="ghost" onClick={() => void dismissAllToday()} disabled={stateSaving}>
-            {t("dismissAllToday")}
-          </Button>
-          <Button type="button" onClick={() => void closeAll()} disabled={stateSaving}>
-            {t("close")}
-          </Button>
+          {manualOpen ? (
+            <Button type="button" onClick={() => unreadQueue.length > 0 ? void closeAll() : closeManualDialog()} disabled={stateSaving}>
+              {t("close")}
+            </Button>
+          ) : (
+            <>
+              <Button type="button" variant="ghost" onClick={() => void dismissAllToday()} disabled={stateSaving}>
+                {t("dismissAllToday")}
+              </Button>
+              <Button type="button" onClick={() => void closeAll()} disabled={stateSaving}>
+                {t("close")}
+              </Button>
+            </>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/features/layouts/components/navigation/nav-user.tsx
+++ b/frontend/features/layouts/components/navigation/nav-user.tsx
@@ -36,6 +36,7 @@ import { logout, patchMe } from "@/shared/api/auth"
 import { useAuthSession } from "@/shared/auth/auth-session-context"
 import { clearSessionAndRedirectToLogin } from "@/shared/auth/session"
 import { dispatchUserProfileUpdated } from "@/shared/auth/user-profile-events"
+import { dispatchOpenAnnouncements, getAnnouncementUnread, subscribeAnnouncementUnreadChanged } from "@/shared/events/announcement-events"
 import { useAppLocale } from "@/i18n/app-i18n-provider"
 import { APP_LOCALE_LABELS, APP_LOCALES, type AppLocale } from "@/i18n/config"
 
@@ -57,8 +58,11 @@ export function NavUser({
   const [open, setOpen] = React.useState(false)
   const [loggingOut, setLoggingOut] = React.useState(false)
   const [savingLocale, setSavingLocale] = React.useState<AppLocale | null>(null)
+  const [hasUnreadAnnouncement, setHasUnreadAnnouncement] = React.useState(() => getAnnouncementUnread())
   const skipTriggerFocusRef = React.useRef(false)
   const isAdmin = user.role === "admin" || user.role === "superadmin"
+
+  React.useEffect(() => subscribeAnnouncementUnreadChanged(setHasUnreadAnnouncement), [])
 
   const onLogout = React.useCallback(async () => {
     if (loggingOut) {
@@ -86,6 +90,13 @@ export function NavUser({
     },
     [router],
   )
+
+  const openAnnouncementsFromMenu = React.useCallback((event: Event) => {
+    event.preventDefault()
+    skipTriggerFocusRef.current = true
+    setOpen(false)
+    dispatchOpenAnnouncements()
+  }, [])
 
   const onLocaleSelect = React.useCallback(
     async (nextLocale: AppLocale) => {
@@ -160,6 +171,12 @@ export function NavUser({
             <DropdownMenuGroup>
               <DropdownMenuItem onSelect={navigateFromMenu("/setting/general")}>
                 {t("settings")}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={openAnnouncementsFromMenu}>
+                <span className="min-w-0 flex-1 truncate">{t("announcements")}</span>
+                <span className="ml-auto flex size-4 shrink-0 items-center justify-center">
+                  {hasUnreadAnnouncement ? <span aria-hidden="true" className="size-1.5 rounded-full bg-red-500" /> : null}
+                </span>
               </DropdownMenuItem>
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger className="focus:bg-accent/40 data-[state=open]:bg-accent/40">

--- a/frontend/i18n/messages/en-US/announcements.json
+++ b/frontend/i18n/messages/en-US/announcements.json
@@ -12,6 +12,9 @@
     "type": "Type",
     "time": "Time"
   },
+  "loading": "Loading announcements...",
+  "empty": "No current announcements",
+  "openFailed": "Failed to load announcements",
   "dismissAllToday": "Don't show today",
   "dismissFailed": "Failed to save announcement state",
   "closeFailed": "Failed to save announcement close state",

--- a/frontend/i18n/messages/en-US/common.json
+++ b/frontend/i18n/messages/en-US/common.json
@@ -57,6 +57,7 @@
     "openSidebar": "Open sidebar",
     "toggleSidebar": "Toggle sidebar",
     "settings": "Settings",
+    "announcements": "Announcements",
     "language": "Language",
     "upgradePlan": "Upgrade plan",
     "admin": "Admin",

--- a/frontend/i18n/messages/zh-CN/announcements.json
+++ b/frontend/i18n/messages/zh-CN/announcements.json
@@ -12,6 +12,9 @@
     "type": "类型",
     "time": "时间"
   },
+  "loading": "正在加载公告...",
+  "empty": "暂无当前公告",
+  "openFailed": "公告加载失败",
   "dismissAllToday": "今日不再显示",
   "dismissFailed": "公告状态保存失败",
   "closeFailed": "公告关闭状态保存失败",

--- a/frontend/i18n/messages/zh-CN/common.json
+++ b/frontend/i18n/messages/zh-CN/common.json
@@ -57,6 +57,7 @@
     "openSidebar": "打开侧边栏",
     "toggleSidebar": "切换侧边栏",
     "settings": "设置",
+    "announcements": "公告",
     "language": "语言",
     "upgradePlan": "升级计划",
     "admin": "管理后台",

--- a/frontend/shared/api/announcements.ts
+++ b/frontend/shared/api/announcements.ts
@@ -1,8 +1,13 @@
 import { authedRequest } from "@/shared/api/authed-client";
 import type { AnnouncementDTO } from "@/shared/api/announcements.types";
 
-export async function listAnnouncements(accessToken: string): Promise<AnnouncementDTO[]> {
-  return authedRequest<AnnouncementDTO[]>("/api/v1/announcements", { accessToken }, true);
+type ListAnnouncementsOptions = {
+  includeDismissed?: boolean;
+};
+
+export async function listAnnouncements(accessToken: string, options: ListAnnouncementsOptions = {}): Promise<AnnouncementDTO[]> {
+  const path = options.includeDismissed ? "/api/v1/announcements?include_dismissed=true" : "/api/v1/announcements";
+  return authedRequest<AnnouncementDTO[]>(path, { accessToken }, true);
 }
 
 export async function dismissAnnouncementToday(accessToken: string, announcementID: number, updatedAt: string): Promise<void> {

--- a/frontend/shared/events/announcement-events.ts
+++ b/frontend/shared/events/announcement-events.ts
@@ -1,0 +1,44 @@
+"use client";
+
+const OPEN_ANNOUNCEMENTS_EVENT = "deeix-chat:open-announcements";
+const ANNOUNCEMENT_UNREAD_CHANGED_EVENT = "deeix-chat:announcement-unread-changed";
+
+let announcementUnread = false;
+
+export function dispatchOpenAnnouncements(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.dispatchEvent(new Event(OPEN_ANNOUNCEMENTS_EVENT));
+}
+
+export function dispatchAnnouncementUnreadChanged(hasUnread: boolean): void {
+  announcementUnread = hasUnread;
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.dispatchEvent(new CustomEvent<boolean>(ANNOUNCEMENT_UNREAD_CHANGED_EVENT, { detail: hasUnread }));
+}
+
+export function getAnnouncementUnread(): boolean {
+  return announcementUnread;
+}
+
+export function subscribeOpenAnnouncements(handler: () => void): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+  window.addEventListener(OPEN_ANNOUNCEMENTS_EVENT, handler);
+  return () => window.removeEventListener(OPEN_ANNOUNCEMENTS_EVENT, handler);
+}
+
+export function subscribeAnnouncementUnreadChanged(handler: (hasUnread: boolean) => void): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+  const handleUnreadChanged = (event: Event) => {
+    handler(Boolean((event as CustomEvent<boolean>).detail));
+  };
+  window.addEventListener(ANNOUNCEMENT_UNREAD_CHANGED_EVENT, handleUnreadChanged);
+  return () => window.removeEventListener(ANNOUNCEMENT_UNREAD_CHANGED_EVENT, handleUnreadChanged);
+}


### PR DESCRIPTION
## Summary

Add a user-accessible announcement center from the sidebar user menu so users can reopen current announcements after dismissing or closing the automatic popup.

The announcement flow now separates automatic popup state from manual viewing state. Manual viewing can include announcements dismissed for today, while automatic popup behavior remains unchanged. Unread announcements show a red dot in the user menu and announcement list. Closing from the announcement center marks unread announcements as read, while clicking outside or pressing Esc only hides the dialog temporarily.

Also removes icon motion from nested dropdown menu triggers to keep submenu icons visually stable.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [x] Documentation

## Verification

- [x] `cd frontend && pnpm exec tsc --noEmit --pretty false`
- [x] `cd frontend && pnpm lint`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/application/announcement ./internal/transport/http/announcement ./internal/infra/persistence/postgres/announcement`
- [x] `cd backend && make swagger`

## Screenshots, API examples, or logs

UI behavior changed:

- Sidebar user menu now includes an Announcements entry.
- Unread announcements show a red dot in the menu and dialog list.
- Manual announcement dialog supports viewing current read and unread announcements.

## Configuration, migration, and compatibility notes

Adds optional query parameter:

- `GET /api/v1/announcements?include_dismissed=true`

Default behavior is unchanged. Without the parameter, dismissed-for-today announcements remain filtered from automatic popup loading.

No database migration or deployment configuration change is required.

## Documentation

- [ ] Documentation is not needed for this change.
- [x] Documentation was updated.
- [ ] Documentation still needs to be updated.

Swagger docs were regenerated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.