### PR TITLE
feat: extend mineru document type support

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -215,6 +215,8 @@ geoip:
 - 文本类文件：小文件可全文注入；超出阈值时按配置走 RAG 或回退策略。
 - PDF/Office 等文档：通过内置提取、Tika、Docling、MinerU 或 OCR 引擎提取文本；PDF OCR 回退可单独控制。
 
+MinerU 可在设置中选择处理的文件类型；云端 MinerU 支持 `.doc/.docx/.ppt/.pptx/.xls/.xlsx`，自部署 MinerU 支持 `.docx/.pptx/.xlsx`。
+
 OCR 引擎配置由后台文件设置管理，当前支持 RapidOCR、Tesseract OCR、Paddle OCR、腾讯云 OCR、阿里云 OCR 与 LLM OCR。服务地址、鉴权密钥和超时时间按具体引擎配置。
 
 用户文件存储配额由运行时设置 `storage:user_storage_quota_bytes` 管理，单位为字节。值为 `0` 表示不限制；非零时，上传、分享克隆和文件复用链路都会按用户维度校验并同步最新配额。前端 `/files` 页支持单个删除和批量删除，后端会在删除后释放对应配额。

--- a/backend/internal/application/conversation/service_file_policy.go
+++ b/backend/internal/application/conversation/service_file_policy.go
@@ -11,13 +11,14 @@ import (
 )
 
 const (
-	fileCategoryImage   = "image"
-	fileCategoryVideo   = "video"
-	fileCategoryPDF     = "pdf"
-	fileCategoryWord    = "word"
-	fileCategoryExcel   = "excel"
-	fileCategoryText    = "text"
-	fileCategoryUnknown = "unknown"
+	fileCategoryImage        = "image"
+	fileCategoryVideo        = "video"
+	fileCategoryPDF          = "pdf"
+	fileCategoryWord         = "word"
+	fileCategoryPresentation = "presentation"
+	fileCategoryExcel        = "excel"
+	fileCategoryText         = "text"
+	fileCategoryUnknown      = "unknown"
 )
 
 func normalizeDetectedMIME(detected string, fileName string) string {
@@ -33,6 +34,10 @@ func normalizeDetectedMIME(detected string, fileName string) string {
 		return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 	case "doc":
 		return "application/msword"
+	case "pptx":
+		return "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+	case "ppt":
+		return "application/vnd.ms-powerpoint"
 	case "xlsx":
 		return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 	case "xls":
@@ -55,6 +60,8 @@ func normalizeDetectedMIME(detected string, fileName string) string {
 		switch ext {
 		case "docx":
 			return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+		case "pptx":
+			return "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 		case "xlsx":
 			return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 		}
@@ -117,6 +124,8 @@ func inferFileCategory(mimeType string, fileName string) string {
 		return fileCategoryPDF
 	case strings.Contains(mime, "wordprocessingml") || strings.Contains(mime, "msword") || ext == "docx" || ext == "doc":
 		return fileCategoryWord
+	case strings.Contains(mime, "presentationml") || strings.Contains(mime, "ms-powerpoint") || ext == "pptx" || ext == "ppt":
+		return fileCategoryPresentation
 	case strings.Contains(mime, "spreadsheetml") || strings.Contains(mime, "ms-excel") || mime == "text/csv" || ext == "xlsx" || ext == "xls" || ext == "csv":
 		return fileCategoryExcel
 	case isTextMIMEForEmbed(mime, fileName):
@@ -164,7 +173,7 @@ func supportsInlineExtraction(category string) bool {
 
 func supportsExtraction(category string) bool {
 	switch category {
-	case fileCategoryPDF, fileCategoryWord, fileCategoryExcel, fileCategoryText:
+	case fileCategoryPDF, fileCategoryWord, fileCategoryPresentation, fileCategoryExcel, fileCategoryText:
 		return true
 	default:
 		return false
@@ -173,7 +182,7 @@ func supportsExtraction(category string) bool {
 
 func supportsRAG(category string) bool {
 	switch category {
-	case fileCategoryPDF, fileCategoryWord, fileCategoryExcel, fileCategoryText, fileCategoryImage:
+	case fileCategoryPDF, fileCategoryWord, fileCategoryPresentation, fileCategoryExcel, fileCategoryText, fileCategoryImage:
 		return true
 	default:
 		return false

--- a/backend/internal/application/conversation/service_file_policy_test.go
+++ b/backend/internal/application/conversation/service_file_policy_test.go
@@ -1,0 +1,43 @@
+package conversation
+
+import "testing"
+
+func TestConversationFilePolicyRecognizesPresentations(t *testing.T) {
+	tests := []struct {
+		name     string
+		detected string
+		fileName string
+		wantMIME string
+	}{
+		{
+			name:     "legacy ppt",
+			detected: "application/octet-stream",
+			fileName: "slides.ppt",
+			wantMIME: "application/vnd.ms-powerpoint",
+		},
+		{
+			name:     "openxml pptx",
+			detected: "application/zip",
+			fileName: "slides.pptx",
+			wantMIME: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMIME := normalizeDetectedMIME(tt.detected, tt.fileName)
+			if gotMIME != tt.wantMIME {
+				t.Fatalf("normalizeDetectedMIME() = %q, want %q", gotMIME, tt.wantMIME)
+			}
+			if got := inferFileCategory(gotMIME, tt.fileName); got != fileCategoryPresentation {
+				t.Fatalf("inferFileCategory() = %q, want %q", got, fileCategoryPresentation)
+			}
+			if !supportsExtraction(fileCategoryPresentation) {
+				t.Fatal("presentation should support extraction")
+			}
+			if !supportsRAG(fileCategoryPresentation) {
+				t.Fatal("presentation should support RAG")
+			}
+		})
+	}
+}

--- a/backend/internal/application/embedding/service.go
+++ b/backend/internal/application/embedding/service.go
@@ -100,6 +100,10 @@ func (s *Service) ShouldTrigger(fileObj domainconversation.FileObject) bool {
 	if !cfg.EmbeddingEnabled || !cfg.EmbedTriggerOnUpload || strings.TrimSpace(cfg.RAGModel) == "" || strings.TrimSpace(cfg.EmbeddingHost) == "" {
 		return false
 	}
+	return canEmbedFile(cfg, fileObj)
+}
+
+func canEmbedFile(cfg config.Config, fileObj domainconversation.FileObject) bool {
 	if strings.TrimSpace(fileObj.StoragePath) == "" || strings.ToLower(strings.TrimSpace(fileObj.Status)) != "active" {
 		return false
 	}
@@ -370,7 +374,7 @@ func (s *Service) MarkAllFilesStale(ctx context.Context) (int64, error) {
 	return s.repo.MarkAllEmbeddedFilesStale(ctx)
 }
 
-// ReindexStaleFiles 异步触发所有 stale/failed 文件的重新向量化，返回提交任务数。
+// ReindexStaleFiles 异步触发所有可向量化的 none/stale/failed 文件，返回提交任务数。
 // 实际 embedding 在 goroutine 中执行，调用方立即返回。
 func (s *Service) ReindexStaleFiles(ctx context.Context) (int, error) {
 	if s.repo == nil {
@@ -397,7 +401,7 @@ func (s *Service) ReindexStaleFiles(ctx context.Context) (int, error) {
 			break
 		}
 		for _, f := range files {
-			if !supportsEmbeddingSource(f, cfg) {
+			if !canEmbedFile(cfg, f) {
 				continue
 			}
 			s.Trigger(f)
@@ -420,7 +424,7 @@ func supportsEmbeddingSource(fileObj domainconversation.FileObject, cfg config.C
 	}
 	mime := strings.ToLower(strings.TrimSpace(fileObj.MimeType))
 	name := strings.TrimSpace(fileObj.FileName)
-	return isTextMIMEForEmbed(mime, name) || isPDFMIME(mime, name) || isDocxMIME(mime, name) || isExcelMIME(mime, name)
+	return isTextMIMEForEmbed(mime, name) || isPDFMIME(mime, name) || isWordMIME(mime, name) || isPresentationMIME(mime, name) || isExcelMIME(mime, name)
 }
 
 // postProcessEmbeddings 对批量向量做两步后处理：
@@ -541,7 +545,7 @@ func isTextMIMEForEmbed(mimeType, fileName string) bool {
 	return false
 }
 
-func isDocxMIME(mimeType, fileName string) bool {
+func isWordMIME(mimeType, fileName string) bool {
 	m := strings.ToLower(strings.TrimSpace(mimeType))
 	ext := ""
 	if idx := strings.LastIndex(fileName, "."); idx >= 0 {
@@ -549,6 +553,16 @@ func isDocxMIME(mimeType, fileName string) bool {
 	}
 	return strings.Contains(m, "wordprocessingml") || strings.Contains(m, "msword") ||
 		ext == "docx" || ext == "doc"
+}
+
+func isPresentationMIME(mimeType, fileName string) bool {
+	m := strings.ToLower(strings.TrimSpace(mimeType))
+	ext := ""
+	if idx := strings.LastIndex(fileName, "."); idx >= 0 {
+		ext = strings.ToLower(fileName[idx+1:])
+	}
+	return strings.Contains(m, "presentationml") || strings.Contains(m, "ms-powerpoint") ||
+		ext == "pptx" || ext == "ppt"
 }
 
 func isExcelMIME(mimeType, fileName string) bool {

--- a/backend/internal/application/embedding/service.go
+++ b/backend/internal/application/embedding/service.go
@@ -391,9 +391,9 @@ func (s *Service) ReindexStaleFiles(ctx context.Context) (int, error) {
 
 	const pageSize = 100
 	submitted := 0
-	offset := 0
+	var afterID uint
 	for {
-		files, err := s.repo.ListFilesForReindex(ctx, pageSize, offset)
+		files, err := s.repo.ListFilesForReindex(ctx, pageSize, afterID)
 		if err != nil {
 			return submitted, err
 		}
@@ -410,7 +410,7 @@ func (s *Service) ReindexStaleFiles(ctx context.Context) (int, error) {
 		if len(files) < pageSize {
 			break
 		}
-		offset += pageSize
+		afterID = files[len(files)-1].ID
 	}
 	return submitted, nil
 }

--- a/backend/internal/application/embedding/service_test.go
+++ b/backend/internal/application/embedding/service_test.go
@@ -221,6 +221,38 @@ func TestReindexStaleFilesSkipsUnsupportedCandidates(t *testing.T) {
 	}
 }
 
+func TestReindexStaleFilesAdvancesCursorForUnsupportedCandidates(t *testing.T) {
+	files := make([]domainconversation.FileObject, 0, 101)
+	for i := 1; i <= 101; i++ {
+		files = append(files, domainconversation.FileObject{
+			ID:          uint(i),
+			UserID:      1,
+			FileID:      "file_bin",
+			FileName:    "archive.bin",
+			MimeType:    "application/octet-stream",
+			StoragePath: "uploads/archive.bin",
+			Status:      "active",
+		})
+	}
+	repo := &reindexRepo{vectorAvailable: true, files: files}
+	service := NewService(config.Config{
+		EmbeddingEnabled: true,
+		RAGModel:         "text-embedding-test",
+		EmbeddingHost:    "http://127.0.0.1:8081",
+	}, repo, nil, infraembedding.New(), nil)
+
+	submitted, err := service.ReindexStaleFiles(context.Background())
+	if err != nil {
+		t.Fatalf("expected reindex to succeed, got %v", err)
+	}
+	if submitted != 0 {
+		t.Fatalf("expected unsupported files to be skipped, got %d", submitted)
+	}
+	if len(repo.afterIDs) != 2 || repo.afterIDs[0] != 0 || repo.afterIDs[1] != 100 {
+		t.Fatalf("expected cursor pagination after ids [0 100], got %#v", repo.afterIDs)
+	}
+}
+
 func TestProcessFileDoesNotRequireRAGEnabled(t *testing.T) {
 	repo := &reindexRepo{vectorAvailable: true}
 	service := NewService(config.Config{
@@ -299,6 +331,7 @@ func TestProcessFileSkipsVideos(t *testing.T) {
 type reindexRepo struct {
 	vectorAvailable   bool
 	files             []domainconversation.FileObject
+	afterIDs          []uint
 	listCalls         int
 	updateStatusCalls int
 }
@@ -336,14 +369,18 @@ func (r *reindexRepo) CountFilesByEmbedStatus(context.Context, string) (int64, e
 	return 0, nil
 }
 
-func (r *reindexRepo) ListFilesForReindex(_ context.Context, limit int, offset int) ([]domainconversation.FileObject, error) {
+func (r *reindexRepo) ListFilesForReindex(_ context.Context, limit int, afterID uint) ([]domainconversation.FileObject, error) {
 	r.listCalls++
-	if offset >= len(r.files) {
-		return nil, nil
+	r.afterIDs = append(r.afterIDs, afterID)
+	results := make([]domainconversation.FileObject, 0, limit)
+	for _, file := range r.files {
+		if file.ID <= afterID {
+			continue
+		}
+		results = append(results, file)
+		if len(results) >= limit {
+			break
+		}
 	}
-	end := offset + limit
-	if end > len(r.files) {
-		end = len(r.files)
-	}
-	return r.files[offset:end], nil
+	return results, nil
 }

--- a/backend/internal/application/embedding/service_test.go
+++ b/backend/internal/application/embedding/service_test.go
@@ -98,6 +98,39 @@ func TestShouldTriggerDoesNotRequireRAGEnabled(t *testing.T) {
 	}
 }
 
+func TestShouldTriggerIncludesPresentations(t *testing.T) {
+	service := NewService(config.Config{
+		EmbeddingEnabled:     true,
+		EmbedTriggerOnUpload: true,
+		RAGModel:             "text-embedding-test",
+		EmbeddingHost:        "http://127.0.0.1:8081",
+	}, nil, nil, nil, nil)
+
+	cases := []domainconversation.FileObject{
+		{
+			FileID:       "file_pptx",
+			FileName:     "deck.pptx",
+			MimeType:     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+			FileCategory: "presentation",
+			StoragePath:  "uploads/deck.pptx",
+			Status:       "active",
+		},
+		{
+			FileID:       "file_ppt",
+			FileName:     "legacy.ppt",
+			MimeType:     "application/vnd.ms-powerpoint",
+			FileCategory: "presentation",
+			StoragePath:  "uploads/legacy.ppt",
+			Status:       "active",
+		},
+	}
+	for _, fileObj := range cases {
+		if !service.ShouldTrigger(fileObj) {
+			t.Fatalf("expected %s to trigger embedding", fileObj.FileName)
+		}
+	}
+}
+
 func TestIndexingAvailableDoesNotRequireRAGEnabled(t *testing.T) {
 	repo := &reindexRepo{vectorAvailable: true}
 	service := NewService(config.Config{
@@ -131,6 +164,60 @@ func TestReindexStaleFilesDoesNotRequireRAGEnabled(t *testing.T) {
 	}
 	if repo.listCalls != 1 {
 		t.Fatalf("expected reindex list query to run once, got %d", repo.listCalls)
+	}
+}
+
+func TestCanEmbedFileDoesNotRequireAutoTrigger(t *testing.T) {
+	cfg := config.Config{
+		EmbeddingEnabled:     true,
+		EmbedTriggerOnUpload: false,
+		RAGModel:             "text-embedding-test",
+		EmbeddingHost:        "http://127.0.0.1:8081",
+	}
+	fileObj := domainconversation.FileObject{
+		FileID:      "file_pptx",
+		FileName:    "deck.pptx",
+		MimeType:    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		StoragePath: "uploads/deck.pptx",
+		Status:      "active",
+	}
+
+	service := NewService(cfg, nil, nil, nil, nil)
+	if service.ShouldTrigger(fileObj) {
+		t.Fatal("auto-trigger should honor EmbedTriggerOnUpload=false")
+	}
+	if !canEmbedFile(cfg, fileObj) {
+		t.Fatal("manual reindex eligibility should not depend on EmbedTriggerOnUpload")
+	}
+}
+
+func TestReindexStaleFilesSkipsUnsupportedCandidates(t *testing.T) {
+	repo := &reindexRepo{
+		vectorAvailable: true,
+		files: []domainconversation.FileObject{
+			{
+				ID:          2,
+				UserID:      1,
+				FileID:      "file_bin",
+				FileName:    "archive.bin",
+				MimeType:    "application/octet-stream",
+				StoragePath: "uploads/archive.bin",
+				Status:      "active",
+			},
+		},
+	}
+	service := NewService(config.Config{
+		EmbeddingEnabled: true,
+		RAGModel:         "text-embedding-test",
+		EmbeddingHost:    "http://127.0.0.1:8081",
+	}, repo, nil, infraembedding.New(), nil)
+
+	submitted, err := service.ReindexStaleFiles(context.Background())
+	if err != nil {
+		t.Fatalf("expected reindex to succeed, got %v", err)
+	}
+	if submitted != 0 {
+		t.Fatalf("expected no unsupported files submitted, got %d", submitted)
 	}
 }
 
@@ -211,6 +298,7 @@ func TestProcessFileSkipsVideos(t *testing.T) {
 
 type reindexRepo struct {
 	vectorAvailable   bool
+	files             []domainconversation.FileObject
 	listCalls         int
 	updateStatusCalls int
 }
@@ -248,7 +336,14 @@ func (r *reindexRepo) CountFilesByEmbedStatus(context.Context, string) (int64, e
 	return 0, nil
 }
 
-func (r *reindexRepo) ListFilesForReindex(context.Context, int, int) ([]domainconversation.FileObject, error) {
+func (r *reindexRepo) ListFilesForReindex(_ context.Context, limit int, offset int) ([]domainconversation.FileObject, error) {
 	r.listCalls++
-	return nil, nil
+	if offset >= len(r.files) {
+		return nil, nil
+	}
+	end := offset + limit
+	if end > len(r.files) {
+		end = len(r.files)
+	}
+	return r.files[offset:end], nil
 }

--- a/backend/internal/application/extraction/mineru_support_test.go
+++ b/backend/internal/application/extraction/mineru_support_test.go
@@ -1,0 +1,115 @@
+package extraction
+
+import (
+	"testing"
+
+	domainconversation "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
+	mineruextract "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/extract/mineru"
+)
+
+func TestSupportsMinerUFileUsesSourceSpecificOfficeFormats(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		selected string
+		file     domainconversation.FileObject
+		want     bool
+	}{
+		{
+			name:     "cloud supports legacy doc",
+			source:   mineruextract.SourceCloud,
+			selected: "word",
+			file:     domainconversation.FileObject{FileCategory: "word", FileName: "legacy.doc"},
+			want:     true,
+		},
+		{
+			name:     "self hosted rejects legacy doc",
+			source:   mineruextract.SourceSelfHosted,
+			selected: "word",
+			file:     domainconversation.FileObject{FileCategory: "word", FileName: "legacy.doc"},
+			want:     false,
+		},
+		{
+			name:     "self hosted supports docx",
+			source:   mineruextract.SourceSelfHosted,
+			selected: "word",
+			file:     domainconversation.FileObject{FileCategory: "word", FileName: "report.docx"},
+			want:     true,
+		},
+		{
+			name:     "cloud supports legacy ppt",
+			source:   mineruextract.SourceCloud,
+			selected: "presentation",
+			file:     domainconversation.FileObject{FileCategory: "presentation", FileName: "deck.ppt"},
+			want:     true,
+		},
+		{
+			name:     "self hosted rejects legacy ppt",
+			source:   mineruextract.SourceSelfHosted,
+			selected: "presentation",
+			file:     domainconversation.FileObject{FileCategory: "presentation", FileName: "deck.ppt"},
+			want:     false,
+		},
+		{
+			name:     "self hosted supports pptx",
+			source:   mineruextract.SourceSelfHosted,
+			selected: "presentation",
+			file:     domainconversation.FileObject{FileCategory: "presentation", FileName: "deck.pptx"},
+			want:     true,
+		},
+		{
+			name:     "self hosted supports pptx detected mime without extension",
+			source:   mineruextract.SourceSelfHosted,
+			selected: "presentation",
+			file: domainconversation.FileObject{
+				FileCategory: "presentation",
+				FileName:     "deck",
+				DetectedMIME: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+			},
+			want: true,
+		},
+		{
+			name:     "excel is disabled unless selected",
+			source:   mineruextract.SourceCloud,
+			selected: defaultMinerUFileTypes,
+			file:     domainconversation.FileObject{FileCategory: "excel", FileName: "data.xlsx"},
+			want:     false,
+		},
+		{
+			name:     "cloud supports legacy xls when excel selected",
+			source:   mineruextract.SourceCloud,
+			selected: "excel",
+			file:     domainconversation.FileObject{FileCategory: "excel", FileName: "data.xls"},
+			want:     true,
+		},
+		{
+			name:     "self hosted rejects legacy xls",
+			source:   mineruextract.SourceSelfHosted,
+			selected: "excel",
+			file:     domainconversation.FileObject{FileCategory: "excel", FileName: "data.xls"},
+			want:     false,
+		},
+		{
+			name:     "empty selection uses defaults",
+			source:   mineruextract.SourceCloud,
+			selected: "",
+			file:     domainconversation.FileObject{FileCategory: "presentation", FileName: "deck.pptx"},
+			want:     true,
+		},
+		{
+			name:     "unselected presentation is not supported",
+			source:   mineruextract.SourceCloud,
+			selected: "pdf,word",
+			file:     domainconversation.FileObject{FileCategory: "presentation", FileName: "deck.pptx"},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := supportsMinerUFile(tt.file, tt.source, tt.selected); got != tt.want {
+				t.Fatalf("supportsMinerUFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/application/extraction/service.go
+++ b/backend/internal/application/extraction/service.go
@@ -46,6 +46,8 @@ const (
 	defaultOCREngine   = OCREngineRapidOCR
 )
 
+const defaultMinerUFileTypes = "pdf,word,presentation"
+
 // Service 封装文件提取与文本产物读写能力。
 type Service struct {
 	cfg           *config.Runtime
@@ -268,7 +270,8 @@ func (s *Service) resolvePrimaryEngine() engine {
 		return nil
 	case EngineDocling:
 		return documentParserEngine{
-			name: EngineDocling,
+			name:     EngineDocling,
+			supports: supportsPDFDocumentParser,
 			extract: func(ctx context.Context, input ExtractInput) (string, error) {
 				client := doclingextract.New(doclingextract.ClientConfig{
 					BaseURL:        strings.TrimSpace(snapshot.ExtractDoclingBaseURL),
@@ -288,6 +291,9 @@ func (s *Service) resolvePrimaryEngine() engine {
 	case EngineMinerU:
 		return documentParserEngine{
 			name: EngineMinerU,
+			supports: func(file domainconversation.FileObject) bool {
+				return supportsMinerUFile(file, snapshot.ExtractMinerUSource, snapshot.ExtractMinerUFileTypes)
+			},
 			extract: func(ctx context.Context, input ExtractInput) (string, error) {
 				client := mineruextract.New(mineruextract.ClientConfig{
 					Source:                strings.TrimSpace(snapshot.ExtractMinerUSource),
@@ -340,6 +346,93 @@ func normalizeTikaSource(raw string) string {
 // NormalizeTikaSourceForRuntime 供其他模块复用 Tika 服务来源的标准化逻辑。
 func NormalizeTikaSourceForRuntime(raw string) string {
 	return normalizeTikaSource(raw)
+}
+
+func supportsPDFDocumentParser(file domainconversation.FileObject) bool {
+	return file.FileCategory == "pdf"
+}
+
+func supportsMinerUFile(file domainconversation.FileObject, source string, selectedTypes string) bool {
+	selected := parseMinerUFileTypes(selectedTypes)
+	switch file.FileCategory {
+	case "pdf":
+		return selected["pdf"]
+	case "word":
+		if !selected["word"] {
+			return false
+		}
+		format := documentOfficeFormat(file)
+		return format == "docx" || (format == "doc" && normalizeMinerUSource(source) == mineruextract.SourceCloud)
+	case "presentation":
+		if !selected["presentation"] {
+			return false
+		}
+		format := documentOfficeFormat(file)
+		return format == "pptx" || (format == "ppt" && normalizeMinerUSource(source) == mineruextract.SourceCloud)
+	case "excel":
+		if !selected["excel"] {
+			return false
+		}
+		format := documentOfficeFormat(file)
+		return format == "xlsx" || (format == "xls" && normalizeMinerUSource(source) == mineruextract.SourceCloud)
+	default:
+		return false
+	}
+}
+
+func parseMinerUFileTypes(raw string) map[string]bool {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		value = defaultMinerUFileTypes
+	}
+	result := make(map[string]bool, 4)
+	for _, item := range strings.Split(value, ",") {
+		switch strings.ToLower(strings.TrimSpace(item)) {
+		case "pdf":
+			result["pdf"] = true
+		case "word":
+			result["word"] = true
+		case "presentation":
+			result["presentation"] = true
+		case "excel":
+			result["excel"] = true
+		}
+	}
+	return result
+}
+
+func normalizeMinerUSource(raw string) string {
+	if strings.EqualFold(strings.TrimSpace(raw), mineruextract.SourceSelfHosted) {
+		return mineruextract.SourceSelfHosted
+	}
+	return mineruextract.SourceCloud
+}
+
+func documentExtension(file domainconversation.FileObject) string {
+	return strings.ToLower(strings.TrimPrefix(filepath.Ext(strings.TrimSpace(file.FileName)), "."))
+}
+
+func documentOfficeFormat(file domainconversation.FileObject) string {
+	if ext := documentExtension(file); ext != "" {
+		return ext
+	}
+	mime := strings.ToLower(strings.TrimSpace(file.DetectedMIME))
+	switch {
+	case strings.Contains(mime, "wordprocessingml"):
+		return "docx"
+	case strings.Contains(mime, "msword"):
+		return "doc"
+	case strings.Contains(mime, "presentationml"):
+		return "pptx"
+	case strings.Contains(mime, "ms-powerpoint"):
+		return "ppt"
+	case strings.Contains(mime, "spreadsheetml"):
+		return "xlsx"
+	case strings.Contains(mime, "ms-excel"):
+		return "xls"
+	default:
+		return ""
+	}
 }
 
 func normalizeOCREngine(raw string) string {
@@ -511,7 +604,7 @@ func (e tikaEngine) Supports(file domainconversation.FileObject) bool {
 		return false
 	}
 	switch file.FileCategory {
-	case "text", "word", "excel", "pdf":
+	case "text", "word", "presentation", "excel", "pdf":
 		return true
 	default:
 		return false
@@ -538,8 +631,9 @@ func (e tikaEngine) Extract(ctx context.Context, input ExtractInput) (Result, er
 }
 
 type documentParserEngine struct {
-	name    string
-	extract func(ctx context.Context, input ExtractInput) (string, error)
+	name     string
+	supports func(file domainconversation.FileObject) bool
+	extract  func(ctx context.Context, input ExtractInput) (string, error)
 }
 
 func (e documentParserEngine) Name() string {
@@ -547,7 +641,13 @@ func (e documentParserEngine) Name() string {
 }
 
 func (e documentParserEngine) Supports(file domainconversation.FileObject) bool {
-	return e.extract != nil && file.FileCategory == "pdf"
+	if e.extract == nil {
+		return false
+	}
+	if e.supports == nil {
+		return supportsPDFDocumentParser(file)
+	}
+	return e.supports(file)
 }
 
 func (e documentParserEngine) Extract(ctx context.Context, input ExtractInput) (Result, error) {

--- a/backend/internal/application/processing/service.go
+++ b/backend/internal/application/processing/service.go
@@ -1049,7 +1049,7 @@ func truncateError(message string, limit int) string {
 
 func supportsExtraction(category string) bool {
 	switch category {
-	case "pdf", "word", "excel", "text", "image":
+	case "pdf", "word", "presentation", "excel", "text", "image":
 		return true
 	default:
 		return false
@@ -1058,7 +1058,7 @@ func supportsExtraction(category string) bool {
 
 func supportsRAG(category string) bool {
 	switch category {
-	case "pdf", "word", "excel", "text", "image":
+	case "pdf", "word", "presentation", "excel", "text", "image":
 		return true
 	default:
 		return false

--- a/backend/internal/application/processing/service_timeout_test.go
+++ b/backend/internal/application/processing/service_timeout_test.go
@@ -47,6 +47,15 @@ func TestResolveProcessingExtractTimeoutUsesImageOCRConfig(t *testing.T) {
 	}
 }
 
+func TestProcessingSupportsPresentationExtractionAndRAG(t *testing.T) {
+	if !supportsExtraction("presentation") {
+		t.Fatal("presentation should support extraction")
+	}
+	if !supportsRAG("presentation") {
+		t.Fatal("presentation should support RAG")
+	}
+}
+
 func TestResolveProcessingExtractTimeoutAddsPDFOCRFallbackWindow(t *testing.T) {
 	cfg := config.Config{
 		ExtractEngine:                     extraction.EngineTika,

--- a/backend/internal/application/settings/runtime_settings.go
+++ b/backend/internal/application/settings/runtime_settings.go
@@ -253,6 +253,8 @@ func (r *RuntimeSettings) applyItem(cfg *config.Config, item domainsettings.Syst
 		cfg.ExtractMinerUSource = item.Value
 	case "extract:mineru_base_url":
 		cfg.ExtractMinerUBaseURL = item.Value
+	case "extract:mineru_file_types":
+		cfg.ExtractMinerUFileTypes = item.Value
 	case "extract:mineru_timeout_seconds":
 		cfg.ExtractMinerUTimeoutSeconds = toInt(item.Value, cfg.ExtractMinerUTimeoutSeconds)
 	case "extract:mineru_auth_token":

--- a/backend/internal/application/settings/seed.go
+++ b/backend/internal/application/settings/seed.go
@@ -124,6 +124,7 @@ func defaultSettings() []domainsettings.SystemSetting {
 		{Namespace: "extract", Key: "aliyun_ocr_timeout_seconds", Value: "60", ValueType: "int", Description: "阿里云 OCR 请求超时(秒)，默认 60s"},
 		{Namespace: "extract", Key: "mineru_source", Value: "cloud", ValueType: "string", Description: "MinerU 服务类型(cloud/self_hosted)"},
 		{Namespace: "extract", Key: "mineru_base_url", Value: "https://mineru.net/api/v4", ValueType: "string", Description: "MinerU 服务地址，默认 https://mineru.net/api/v4"},
+		{Namespace: "extract", Key: "mineru_file_types", Value: "pdf,word,presentation", ValueType: "string", Description: "MinerU 处理的文件类型，逗号分隔：pdf,word,presentation,excel"},
 		{Namespace: "extract", Key: "mineru_auth_token", Value: "", ValueType: "string", Description: "MinerU 鉴权 Token"},
 		{Namespace: "extract", Key: "mineru_timeout_seconds", Value: "180", ValueType: "int", Description: "MinerU 请求超时(秒)，默认 180s"},
 		{Namespace: "extract", Key: "llm_ocr_base_url", Value: "", ValueType: "string", Description: "LLM OCR 服务地址（OpenAI 兼容 chat/completions 视觉模型）"},

--- a/backend/internal/application/settings/service.go
+++ b/backend/internal/application/settings/service.go
@@ -431,6 +431,8 @@ func validatePatchItem(item PatchItem) error {
 		default:
 			return fmt.Errorf("%s must be one of: %s, %s", key, mineruextract.SourceCloud, mineruextract.SourceSelfHosted)
 		}
+	case "extract:mineru_file_types":
+		return validateMinerUFileTypes(value, key)
 	case "extract:tika_base_url":
 		if value == "" {
 			return nil
@@ -480,6 +482,25 @@ func validatePatchItem(item PatchItem) error {
 		return validateIntMinMax(value, 0, 5, key)
 	case "mcp:mcp_tool_prompt":
 		return validateStringMax(value, 20000, key)
+	}
+	return nil
+}
+
+func validateMinerUFileTypes(value string, key string) error {
+	allowed := map[string]struct{}{
+		"pdf":          {},
+		"word":         {},
+		"presentation": {},
+		"excel":        {},
+	}
+	for _, part := range strings.Split(value, ",") {
+		item := strings.ToLower(strings.TrimSpace(part))
+		if item == "" {
+			continue
+		}
+		if _, ok := allowed[item]; !ok {
+			return fmt.Errorf("%s contains invalid file type: %s", key, item)
+		}
 	}
 	return nil
 }

--- a/backend/internal/application/settings/service_test.go
+++ b/backend/internal/application/settings/service_test.go
@@ -320,6 +320,26 @@ func TestRuntimeSettingsAppliesConversationDefaultModel(t *testing.T) {
 	}
 }
 
+func TestValidateMinerUFileTypesSetting(t *testing.T) {
+	if err := validatePatchItem(PatchItem{Namespace: "extract", Key: "mineru_file_types", Value: "pdf,word,presentation,excel"}); err != nil {
+		t.Fatalf("expected mineru file types to pass, got %v", err)
+	}
+	if err := validatePatchItem(PatchItem{Namespace: "extract", Key: "mineru_file_types", Value: "pdf,slides"}); err == nil {
+		t.Fatal("expected unsupported mineru file type to fail")
+	}
+}
+
+func TestRuntimeSettingsAppliesMinerUFileTypes(t *testing.T) {
+	runtimeSettings := NewRuntimeSettings(nil, nil, "test-data-encryption-key")
+	cfg := config.Config{ExtractMinerUFileTypes: "pdf,word,presentation"}
+
+	runtimeSettings.applyItem(&cfg, domainsettings.SystemSetting{Namespace: "extract", Key: "mineru_file_types", Value: "pdf,excel"})
+
+	if cfg.ExtractMinerUFileTypes != "pdf,excel" {
+		t.Fatalf("expected mineru file types to apply, got %q", cfg.ExtractMinerUFileTypes)
+	}
+}
+
 func TestValidateFullContextLimitsAllowUnlimitedValues(t *testing.T) {
 	cases := []PatchItem{
 		{Namespace: "file", Key: "full_context_limit_enabled", Value: "true"},

--- a/backend/internal/application/upload/service.go
+++ b/backend/internal/application/upload/service.go
@@ -578,13 +578,14 @@ func (s *Service) OpenFileContent(ctx context.Context, userID uint, fileID strin
 }
 
 const (
-	fileCategoryImage   = "image"
-	fileCategoryVideo   = "video"
-	fileCategoryPDF     = "pdf"
-	fileCategoryWord    = "word"
-	fileCategoryExcel   = "excel"
-	fileCategoryText    = "text"
-	fileCategoryUnknown = "unknown"
+	fileCategoryImage        = "image"
+	fileCategoryVideo        = "video"
+	fileCategoryPDF          = "pdf"
+	fileCategoryWord         = "word"
+	fileCategoryPresentation = "presentation"
+	fileCategoryExcel        = "excel"
+	fileCategoryText         = "text"
+	fileCategoryUnknown      = "unknown"
 )
 
 var dangerousMIMETypes = map[string]struct{}{
@@ -704,6 +705,10 @@ func normalizeDetectedMIME(detected string, fileName string) string {
 		return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 	case "doc":
 		return "application/msword"
+	case "pptx":
+		return "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+	case "ppt":
+		return "application/vnd.ms-powerpoint"
 	case "xlsx":
 		return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 	case "xls":
@@ -730,6 +735,8 @@ func normalizeDetectedMIME(detected string, fileName string) string {
 		switch ext {
 		case "docx":
 			return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+		case "pptx":
+			return "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 		case "xlsx":
 			return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 		}
@@ -792,6 +799,8 @@ func inferFileCategory(mimeType string, fileName string) string {
 		return fileCategoryPDF
 	case strings.Contains(mimeType, "wordprocessingml") || strings.Contains(mimeType, "msword") || ext == "docx" || ext == "doc":
 		return fileCategoryWord
+	case strings.Contains(mimeType, "presentationml") || strings.Contains(mimeType, "ms-powerpoint") || ext == "pptx" || ext == "ppt":
+		return fileCategoryPresentation
 	case strings.Contains(mimeType, "spreadsheetml") || strings.Contains(mimeType, "ms-excel") || mimeType == "text/csv" || ext == "xlsx" || ext == "xls" || ext == "csv":
 		return fileCategoryExcel
 	case isTextMIMEForEmbed(mimeType, fileName):
@@ -830,7 +839,7 @@ func maxBytesForCategory(category string, cfg config.Config) int64 {
 
 func fileCategoryRequiresProcessing(category string) bool {
 	switch category {
-	case fileCategoryPDF, fileCategoryWord, fileCategoryExcel, fileCategoryText:
+	case fileCategoryPDF, fileCategoryWord, fileCategoryPresentation, fileCategoryExcel, fileCategoryText:
 		return true
 	default:
 		return false
@@ -839,7 +848,7 @@ func fileCategoryRequiresProcessing(category string) bool {
 
 func supportsRAG(category string) bool {
 	switch category {
-	case fileCategoryPDF, fileCategoryWord, fileCategoryExcel, fileCategoryText, fileCategoryImage:
+	case fileCategoryPDF, fileCategoryWord, fileCategoryPresentation, fileCategoryExcel, fileCategoryText, fileCategoryImage:
 		return true
 	default:
 		return false

--- a/backend/internal/application/upload/service_test.go
+++ b/backend/internal/application/upload/service_test.go
@@ -277,6 +277,34 @@ func TestNormalizeDetectedMIMERecognizesVideoExtensions(t *testing.T) {
 	}
 }
 
+func TestNormalizeDetectedMIMERecognizesPresentations(t *testing.T) {
+	tests := []struct {
+		detected string
+		fileName string
+		wantMIME string
+	}{
+		{
+			detected: "application/octet-stream",
+			fileName: "slides.ppt",
+			wantMIME: "application/vnd.ms-powerpoint",
+		},
+		{
+			detected: "application/zip",
+			fileName: "slides.pptx",
+			wantMIME: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		},
+	}
+
+	for _, tt := range tests {
+		if got := normalizeDetectedMIME(tt.detected, tt.fileName); got != tt.wantMIME {
+			t.Fatalf("normalizeDetectedMIME(%q, %q) = %q, want %q", tt.detected, tt.fileName, got, tt.wantMIME)
+		}
+		if got := inferFileCategory(tt.wantMIME, tt.fileName); got != fileCategoryPresentation {
+			t.Fatalf("inferFileCategory(%q, %q) = %q, want %q", tt.wantMIME, tt.fileName, got, fileCategoryPresentation)
+		}
+	}
+}
+
 func TestUploadFileAllowsMP4WhenVideoMP4IsAllowed(t *testing.T) {
 	ctx := context.Background()
 	repo := newUploadTestRepo()

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -423,6 +423,7 @@ type Config struct {
 	ExtractAliyunOCRTimeoutSeconds    int    // 阿里云 OCR 请求超时(秒)
 	ExtractMinerUSource               string // MinerU 服务类型(cloud/self_hosted)
 	ExtractMinerUBaseURL              string // MinerU 服务地址
+	ExtractMinerUFileTypes            string // MinerU 处理的文件类型（逗号分隔）
 	ExtractMinerUTimeoutSeconds       int    // MinerU 请求超时(秒)
 	ExtractMinerUAuthToken            string // MinerU 鉴权 Token
 	ExtractLLMOCRBaseURL              string // LLM OCR 服务地址
@@ -642,6 +643,7 @@ func Load() Config {
 		ExtractAliyunOCRTimeoutSeconds:    60,
 		ExtractMinerUSource:               "cloud",
 		ExtractMinerUBaseURL:              "https://mineru.net/api/v4",
+		ExtractMinerUFileTypes:            "pdf,word,presentation",
 		ExtractMinerUTimeoutSeconds:       180,
 		ExtractMinerUAuthToken:            "",
 		ExtractLLMOCRBaseURL:              "",

--- a/backend/internal/infra/persistence/models/chat.go
+++ b/backend/internal/infra/persistence/models/chat.go
@@ -156,7 +156,7 @@ type FileObject struct {
 	FileName               string     `gorm:"size:255;not null;default:'';comment:文件名"`
 	MimeType               string     `gorm:"size:128;not null;default:'';comment:客户端声明媒体类型"`
 	DetectedMIME           string     `gorm:"size:128;not null;default:'';index:idx_file_objects_detected_mime;comment:后端探测媒体类型"`
-	FileCategory           string     `gorm:"size:32;not null;default:'unknown';index:idx_file_objects_file_category;comment:文件分类(image/pdf/word/excel/text/unknown)"`
+	FileCategory           string     `gorm:"size:32;not null;default:'unknown';index:idx_file_objects_file_category;comment:文件分类(image/pdf/word/presentation/excel/text/unknown)"`
 	SizeBytes              int64      `gorm:"not null;default:0;comment:文件大小(Byte)"`
 	SHA256                 string     `gorm:"size:64;not null;default:'';index:idx_file_objects_sha256;comment:文件SHA256"`
 	StoragePath            string     `gorm:"size:512;not null;default:'';comment:存储路径"`

--- a/backend/internal/infra/persistence/postgres/conversation/repository.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository.go
@@ -4156,14 +4156,14 @@ func (r *Repo) MarkTimedOutFileEmbeddingsFailed(ctx context.Context, userID uint
 	return result.RowsAffected, translateError(result.Error)
 }
 
-// ListFilesForReindex 分页返回需要重建向量的文件（embed_status 为 stale 或 failed）。
+// ListFilesForReindex 分页返回需要重建向量的文件（embed_status 为 none、stale 或 failed）。
 func (r *Repo) ListFilesForReindex(ctx context.Context, limit int, offset int) ([]domainconversation.FileObject, error) {
 	if limit <= 0 {
 		limit = 50
 	}
 	var entities []models.FileObject
 	err := r.db.WithContext(ctx).
-		Where("embed_status IN ? AND status = ?", []string{"stale", "failed"}, "active").
+		Where("embed_status IN ? AND status = ?", []string{"none", "stale", "failed"}, "active").
 		Order("updated_at ASC").
 		Limit(limit).
 		Offset(offset).

--- a/backend/internal/infra/persistence/postgres/conversation/repository.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository.go
@@ -4157,16 +4157,15 @@ func (r *Repo) MarkTimedOutFileEmbeddingsFailed(ctx context.Context, userID uint
 }
 
 // ListFilesForReindex 分页返回需要重建向量的文件（embed_status 为 none、stale 或 failed）。
-func (r *Repo) ListFilesForReindex(ctx context.Context, limit int, offset int) ([]domainconversation.FileObject, error) {
+func (r *Repo) ListFilesForReindex(ctx context.Context, limit int, afterID uint) ([]domainconversation.FileObject, error) {
 	if limit <= 0 {
 		limit = 50
 	}
 	var entities []models.FileObject
 	err := r.db.WithContext(ctx).
-		Where("embed_status IN ? AND status = ?", []string{"none", "stale", "failed"}, "active").
-		Order("updated_at ASC").
+		Where("id > ? AND embed_status IN ? AND status = ?", afterID, []string{"none", "stale", "failed"}, "active").
+		Order("id ASC").
 		Limit(limit).
-		Offset(offset).
 		Find(&entities).Error
 	if err != nil {
 		return nil, translateError(err)

--- a/backend/internal/repository/conversation_file.go
+++ b/backend/internal/repository/conversation_file.go
@@ -62,7 +62,7 @@ type EmbeddingRepository interface {
 	MarkAllEmbeddedFilesStale(ctx context.Context) (int64, error)
 	// CountFilesByEmbedStatus 统计指定 embed_status 的文件数量。
 	CountFilesByEmbedStatus(ctx context.Context, status string) (int64, error)
-	// ListFilesForReindex 分页返回需要重建向量的文件（embed_status 为 stale 或 failed）。
+	// ListFilesForReindex 分页返回需要重建向量的文件（embed_status 为 none、stale 或 failed）。
 	ListFilesForReindex(ctx context.Context, limit int, offset int) ([]domainconversation.FileObject, error)
 }
 

--- a/backend/internal/repository/conversation_file.go
+++ b/backend/internal/repository/conversation_file.go
@@ -63,7 +63,7 @@ type EmbeddingRepository interface {
 	// CountFilesByEmbedStatus 统计指定 embed_status 的文件数量。
 	CountFilesByEmbedStatus(ctx context.Context, status string) (int64, error)
 	// ListFilesForReindex 分页返回需要重建向量的文件（embed_status 为 none、stale 或 failed）。
-	ListFilesForReindex(ctx context.Context, limit int, offset int) ([]domainconversation.FileObject, error)
+	ListFilesForReindex(ctx context.Context, limit int, afterID uint) ([]domainconversation.FileObject, error)
 }
 
 // RAGRepository 封装向量检索能力。

--- a/backend/internal/transport/http/settings/handler_embedding_test.go
+++ b/backend/internal/transport/http/settings/handler_embedding_test.go
@@ -75,6 +75,6 @@ func (testEmbeddingRepo) CountFilesByEmbedStatus(context.Context, string) (int64
 	return 0, nil
 }
 
-func (testEmbeddingRepo) ListFilesForReindex(context.Context, int, int) ([]domainconversation.FileObject, error) {
+func (testEmbeddingRepo) ListFilesForReindex(context.Context, int, uint) ([]domainconversation.FileObject, error) {
 	return nil, nil
 }

--- a/frontend/features/admin/components/sections/files/admin-files.tsx
+++ b/frontend/features/admin/components/sections/files/admin-files.tsx
@@ -31,7 +31,10 @@ import {
   isEmbeddingServiceConfigured,
   isServiceDirty,
   isSettingsValueField,
+  mergeAllowedMIMETypes,
+  normalizeMinerUFileTypes,
   OCR_ENGINES,
+  resolveMissingMinerUMIMETypes,
   resolveActiveServices,
   resolveFieldID,
   resolveMinerUSource,
@@ -226,10 +229,13 @@ export function AdminFilesSettingsPage() {
 
   const handleFieldChange = React.useCallback((fieldID: string, value: string) => {
     setSettingsMap((prev) => {
-      let next =
-        fieldID === "extract.mineru_source"
-          ? { ...prev, [fieldID]: value }
-          : { ...prev, [fieldID]: value };
+      let next = { ...prev, [fieldID]: value };
+      if (fieldID === "extract.engine" && value === EXTRACT_ENGINE_POLICIES.MINERU) {
+        next["extract.mineru_file_types"] = normalizeMinerUFileTypes(next["extract.mineru_file_types"] ?? "");
+      }
+      if (fieldID === "extract.mineru_file_types") {
+        next["extract.mineru_file_types"] = normalizeMinerUFileTypes(value);
+      }
       if ((fieldID === "file.embedding_enabled" || fieldID === "file.embedding_host" || fieldID === "file.rag_model") && !isEmbeddingServiceConfigured(next)) {
         next = {
           ...next,
@@ -259,6 +265,37 @@ export function AdminFilesSettingsPage() {
       return next;
     });
   }, [t]);
+
+  const handleSaveAllowedMIMETypes = React.useCallback(
+    async (nextValue: string) => {
+      setSaving(true);
+      try {
+        const token = await resolveAccessToken();
+        if (!token) {
+          toast.error(t("toast.sessionExpired"), { description: t("toast.sessionExpiredDescription") });
+          return;
+        }
+        const grouped = await patchAdminSettings(token, {
+          items: [{ namespace: "file", key: "allowed_mime_types", value: nextValue }],
+        });
+        const flattened = applySettingsDefaults(flattenSettings(SETTINGS_GROUPS, grouped));
+        const savedValue = flattened["file.allowed_mime_types"] ?? nextValue;
+        setConfiguredMap(configuredSettingsMap(grouped));
+        setSettingsMap((current) => ({
+          ...current,
+          "file.allowed_mime_types": savedValue,
+        }));
+        setSavedMap(flattened);
+        syncServiceRuntimes(flattened);
+        toast.success(t("toast.mimeTypesUpdated"));
+      } catch (error) {
+        toast.error(t("toast.saveFailed"), { description: resolveAdminErrorMessage(error, t("toast.unknownError")) });
+      } finally {
+        setSaving(false);
+      }
+    },
+    [syncServiceRuntimes, t],
+  );
 
   const resolveServiceRuntime = React.useCallback(
     (name: ServiceName): SettingsFieldServiceRuntime => {
@@ -399,6 +436,7 @@ export function AdminFilesSettingsPage() {
         for (const item of [
           { namespace: "extract", key: "mineru_source", value: resolveMinerUSource(nextSettingsMap["extract.mineru_source"] ?? "") },
           { namespace: "extract", key: "mineru_base_url", value: nextSettingsMap["extract.mineru_base_url"] ?? "" },
+          { namespace: "extract", key: "mineru_file_types", value: nextSettingsMap["extract.mineru_file_types"] ?? "" },
           { namespace: "extract", key: "mineru_timeout_seconds", value: nextSettingsMap["extract.mineru_timeout_seconds"] ?? "180" },
         ] as PatchSettingItem[]) {
           if (!existingKeys.has(`${item.namespace}.${item.key}`)) items.push(item);
@@ -499,6 +537,35 @@ export function AdminFilesSettingsPage() {
     void handleSaveGroup(group);
   }, [handleSaveGroup]);
 
+  const minerUMIMEHint = React.useMemo(() => {
+    if ((settingsMap["extract.engine"] ?? "") !== EXTRACT_ENGINE_POLICIES.MINERU) {
+      return null;
+    }
+    const missing = resolveMissingMinerUMIMETypes(settingsMap);
+    if (missing.length === 0) {
+      return null;
+    }
+    const labels = missing.map((item) => item.format).join(", ");
+    const nextAllowlist = mergeAllowedMIMETypes(settingsMap["file.allowed_mime_types"] ?? "", missing);
+    return (
+      <div className="min-w-0 rounded-md border border-amber-200/70 bg-amber-50/60 p-3 text-[11px] text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-300">
+        <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <p className="min-w-0">{t("mineruMimeHint.missing", { formats: labels })}</p>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 shrink-0 rounded-md border-amber-300/70 bg-background/70 px-2.5 text-[11px] font-normal text-amber-800 shadow-none hover:bg-amber-100/70 dark:border-amber-800/60 dark:text-amber-300 dark:hover:bg-amber-950/40"
+            disabled={loading || saving}
+            onClick={() => void handleSaveAllowedMIMETypes(nextAllowlist)}
+          >
+            {t("mineruMimeHint.addAndSave")}
+          </Button>
+        </div>
+      </div>
+    );
+  }, [handleSaveAllowedMIMETypes, loading, saving, settingsMap, t]);
+
   const embeddingEnabled = settingsMap["file.embedding_enabled"] === EMBEDDING_MODES.ON;
 
   return (
@@ -539,6 +606,7 @@ export function AdminFilesSettingsPage() {
                               configured={configuredMap[fieldID]}
                               dirty={(settingsMap[fieldID] ?? "") !== (savedMap[fieldID] ?? "")}
                               disabled={loading || saving}
+                              afterControl={fieldID === "extract.mineru_file_types" ? minerUMIMEHint : undefined}
                               onChange={(value) => handleFieldChange(fieldID, value)}
                             />
                           </SettingsFieldItem>
@@ -574,6 +642,7 @@ export function AdminFilesSettingsPage() {
                                         configured={configuredMap[fieldID]}
                                         dirty={(settingsMap[fieldID] ?? "") !== (savedMap[fieldID] ?? "")}
                                         disabled={loading || saving}
+                                        afterControl={fieldID === "extract.mineru_file_types" ? minerUMIMEHint : undefined}
                                         onChange={(value) => handleFieldChange(fieldID, value)}
                                       />
                                     );

--- a/frontend/features/admin/components/sections/files/admin-files.tsx
+++ b/frontend/features/admin/components/sections/files/admin-files.tsx
@@ -563,21 +563,17 @@ export function AdminFilesSettingsPage() {
     const labels = missing.map((item) => item.format).join(", ");
     const nextAllowlist = mergeAllowedMIMETypes(settingsMap["file.allowed_mime_types"] ?? "", missing);
     return (
-      <div className="min-w-0 rounded-md border border-amber-200/70 bg-amber-50/60 p-3 text-[11px] text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-300">
-        <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <p className="min-w-0">{t("mineruMimeHint.missing", { formats: labels })}</p>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="h-7 shrink-0 rounded-md border-amber-300/70 bg-background/70 px-2.5 text-[11px] font-normal text-amber-800 shadow-none hover:bg-amber-100/70 dark:border-amber-800/60 dark:text-amber-300 dark:hover:bg-amber-950/40"
-            disabled={loading || saving}
-            onClick={() => void handleSaveAllowedMIMETypes(nextAllowlist)}
-          >
-            {t("mineruMimeHint.addAndSave")}
-          </Button>
-        </div>
-      </div>
+      <p className="min-w-0 text-[11px] leading-5 text-muted-foreground">
+        {t("mineruMimeHint.missing", { formats: labels })}
+        <button
+          type="button"
+          className="ml-2 inline-flex text-foreground/70 underline underline-offset-4 transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={loading || saving}
+          onClick={() => void handleSaveAllowedMIMETypes(nextAllowlist)}
+        >
+          {t("mineruMimeHint.addAndSave")}
+        </button>
+      </p>
     );
   }, [handleSaveAllowedMIMETypes, loading, saving, settingsMap, t]);
 
@@ -622,6 +618,7 @@ export function AdminFilesSettingsPage() {
                               dirty={(settingsMap[fieldID] ?? "") !== (savedMap[fieldID] ?? "")}
                               disabled={loading || saving}
                               afterControl={fieldID === "extract.mineru_file_types" ? minerUMIMEHint : undefined}
+                              animateLayout={fieldID !== "extract.mineru_file_types"}
                               onChange={(value) => handleFieldChange(fieldID, value)}
                             />
                           </SettingsFieldItem>
@@ -658,6 +655,7 @@ export function AdminFilesSettingsPage() {
                                         dirty={(settingsMap[fieldID] ?? "") !== (savedMap[fieldID] ?? "")}
                                         disabled={loading || saving}
                                         afterControl={fieldID === "extract.mineru_file_types" ? minerUMIMEHint : undefined}
+                                        animateLayout={fieldID !== "extract.mineru_file_types"}
                                         onChange={(value) => handleFieldChange(fieldID, value)}
                                       />
                                     );

--- a/frontend/features/admin/components/sections/files/admin-files.tsx
+++ b/frontend/features/admin/components/sections/files/admin-files.tsx
@@ -37,6 +37,7 @@ import {
   resolveMissingMinerUMIMETypes,
   resolveActiveServices,
   resolveFieldID,
+  resolveMinerUFileTypeFormats,
   resolveMinerUSource,
   resolveOCREngine,
   resolveVisibleFieldBlocks,
@@ -79,19 +80,33 @@ const SERVICE_LOADERS: Record<ServiceName, (token: string) => Promise<ServiceRun
   embedding: getAdminEmbeddingRuntime,
 };
 
-function toEditorField(field: SettingsField, translate: (key: string) => string) {
+function resolveMinerUFileTypeOptionMeta(value: string, label: string, settingsMap: Record<string, string>) {
+  const meta = resolveMinerUFileTypeFormats(value, settingsMap["extract.mineru_source"] ?? "").join("/");
+  return meta && meta !== label ? meta : undefined;
+}
+
+function toEditorField(field: SettingsField, translate: (key: string) => string, settingsMap: Record<string, string>) {
   const fieldKey = `fields.${field.namespace}.${field.key}`;
+  const fieldID = resolveFieldID(field);
   return {
-    id: resolveFieldID(field),
+    id: fieldID,
     label: translate(`${fieldKey}.label`),
     description: translate(`${fieldKey}.description`),
     type: field.type,
     placeholder: field.placeholder ? translate(`${fieldKey}.placeholder`) : undefined,
     valueUnit: field.valueUnit,
-    options: field.options?.map((option) => ({
-      ...option,
-      label: translate(`${fieldKey}.options.${option.value}`),
-    })),
+    options: field.options?.map((option) => {
+      const label = translate(`${fieldKey}.options.${option.value}`);
+      const meta =
+        fieldID === "extract.mineru_file_types"
+          ? resolveMinerUFileTypeOptionMeta(option.value, label, settingsMap)
+          : undefined;
+      return {
+        ...option,
+        label,
+        meta,
+      };
+    }),
   } as const;
 }
 
@@ -597,7 +612,7 @@ export function AdminFilesSettingsPage() {
                           <SettingsFieldItem key={fieldID} index={blockIndex}>
                             <SettingsFieldEditor
                               field={{
-                                ...toEditorField(block.field, t),
+                                ...toEditorField(block.field, t, settingsMap),
                                 ...(block.field.runtimeService
                                   ? { serviceRuntime: resolveServiceRuntime(block.field.runtimeService) }
                                   : {}),
@@ -633,7 +648,7 @@ export function AdminFilesSettingsPage() {
                                       <SettingsFieldEditor
                                         key={fieldID}
                                         field={{
-                                          ...toEditorField(field, t),
+                                          ...toEditorField(field, t, settingsMap),
                                           ...(field.runtimeService
                                             ? { serviceRuntime: resolveServiceRuntime(field.runtimeService) }
                                             : {}),

--- a/frontend/features/admin/components/sections/shared/settings-runtime-panel.tsx
+++ b/frontend/features/admin/components/sections/shared/settings-runtime-panel.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -18,7 +19,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { cn } from "@/lib/utils";
 import { JsonCodeEditor } from "@/shared/components/json-code-editor";
 
-export type SettingsFieldType = "int" | "bool" | "string" | "password" | "textarea" | "json" | "select" | "tabs" | "button";
+export type SettingsFieldType = "int" | "bool" | "string" | "password" | "textarea" | "json" | "select" | "tabs" | "multi-check" | "button";
 
 export type SettingsFieldOption = {
   label: string;
@@ -46,6 +47,13 @@ export type SettingsFieldDefinition = {
   statusBadge?: ServiceRuntimeStatusBadge;
   loading?: boolean;
   serviceRuntime?: SettingsFieldServiceRuntime;
+};
+
+type MultiCheckFieldProps = {
+  field: SettingsFieldDefinition;
+  value: string;
+  disabled?: boolean;
+  onChange?: (value: string) => void;
 };
 
 export type ServiceRuntimeAction = SettingsFieldAction;
@@ -274,6 +282,50 @@ function resolveRuntimeIcon(icon: ServiceRuntimeIconKey) {
   return RUNTIME_ICON_MAP[icon];
 }
 
+function MultiCheckField({ field, value, disabled, onChange }: MultiCheckFieldProps) {
+  const selected = React.useMemo(
+    () => new Set(value.split(",").map((item) => item.trim()).filter(Boolean)),
+    [value],
+  );
+
+  return (
+    <div className="grid min-w-0 gap-2 rounded-md border border-border/50 bg-muted/20 p-2">
+      {(field.options ?? []).map((option) => {
+        const checked = selected.has(option.value);
+        const optionDisabled = disabled || (checked && selected.size <= 1);
+        return (
+          <label
+            key={option.value}
+            className={cn(
+              "flex min-w-0 items-center justify-between gap-2 text-[12px] text-foreground",
+              optionDisabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
+            )}
+          >
+            <span className="truncate">{option.label}</span>
+            <Checkbox
+              checked={checked}
+              disabled={optionDisabled}
+              aria-label={option.label}
+              onCheckedChange={(nextChecked) => {
+                const next = new Set(selected);
+                if (nextChecked) {
+                  next.add(option.value);
+                } else {
+                  next.delete(option.value);
+                }
+                const ordered = (field.options ?? [])
+                  .map((item) => item.value)
+                  .filter((item) => next.has(item));
+                onChange?.(ordered.join(","));
+              }}
+            />
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
 const layoutTransition = { duration: 0.2, ease: [0.22, 1, 0.36, 1] } as const;
 
 function SettingsFieldFrame({
@@ -444,99 +496,104 @@ export function SettingsFieldEditor({
   return (
     <SettingsFieldFrame animateLayout={animateLayout}>
       <Field>
-        <div className="flex min-w-0 flex-col gap-2 md:flex-row md:items-start md:gap-4 xl:gap-6">
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <FieldLabel htmlFor={field.id}>{field.label}</FieldLabel>
-              {labelMetaNode}
-              {dirtyBadge}
+        <div className="min-w-0 space-y-2">
+          <div className="flex min-w-0 flex-col gap-2 md:flex-row md:items-start md:gap-4 xl:gap-6">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <FieldLabel htmlFor={field.id}>{field.label}</FieldLabel>
+                {labelMetaNode}
+                {dirtyBadge}
+              </div>
+              {field.description ? <FieldDescription className="text-[11px]">{field.description}</FieldDescription> : null}
             </div>
-            {field.description ? <FieldDescription className="text-[11px]">{field.description}</FieldDescription> : null}
-          </div>
 
-          <div className="w-full min-w-0 md:w-44 md:shrink-0 xl:w-52">
-            {field.type === "bool" ? (
-              <div className="flex items-end justify-start md:justify-end">
-                <Switch id={field.id} checked={value === "true"} onCheckedChange={(checked) => onChange?.(checked ? "true" : "false")} disabled={disabled} />
-              </div>
-            ) : field.type === "tabs" ? (
-              <Tabs value={value} onValueChange={(next) => onChange?.(next)} className="w-full">
-                <TabsList className="grid h-8 w-full grid-cols-2">
-                  {(field.options ?? []).map((option) => (
-                    <TabsTrigger key={option.value} value={option.value} disabled={disabled}>
-                      {option.label}
-                    </TabsTrigger>
-                  ))}
-                </TabsList>
-              </Tabs>
-            ) : field.type === "button" ? (
-              <div className="flex items-center justify-start gap-2 md:justify-end">
-                {(inlineRuntimeActions ?? []).map((action) => {
-                  const Icon = action.icon;
-                  return (
-                    <Button
-                      key={action.key}
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="h-7 rounded-md border-border/50 px-2.5 text-[12px] font-normal shadow-none hover:bg-accent/40"
-                      disabled={disabled || action.disabled}
-                      onClick={action.onClick}
-                    >
-                      {Icon ? <Icon className={cn("size-3.5 stroke-1", action.spinning ? "animate-spin" : "")} /> : null}
-                      {action.label}
-                    </Button>
-                  );
-                })}
-              </div>
-            ) : field.type === "select" ? (
-              <Select value={value} onValueChange={(next) => onChange?.(next)} disabled={disabled}>
-                <SelectTrigger
-                  id={field.id}
-                  size="sm"
-                  className="text-left md:text-right *:data-[slot=select-value]:flex-1 *:data-[slot=select-value]:justify-start md:*:data-[slot=select-value]:justify-end"
-                >
-                  <SelectValue placeholder={field.placeholder ?? t("select.placeholder")} />
-                </SelectTrigger>
-                <SelectContent align="start">
-                  {(field.options ?? []).map((option) => (
-                    <SelectItem key={option.value} value={option.value} className="text-left md:text-right">
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            ) : (
-              <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1">
-                <Input
-                  id={field.id}
-                  type={field.type === "password" ? "password" : "text"}
-                  value={value}
-                  onChange={(event) => onChange?.(event.target.value)}
-                  placeholder={field.type === "password" && configured && !value ? t("input.configuredPasswordPlaceholder") : field.placeholder}
-                  inputMode={field.valueUnit === "mb" ? "decimal" : field.type === "int" ? "numeric" : "text"}
-                  disabled={disabled}
-                  className="min-w-0 text-left md:text-right"
-                />
-                {(inlineRuntimeActions ?? []).map((action) => {
-                  const Icon = action.icon;
-                  return (
-                    <Button
-                      key={action.key}
-                      type="button"
-                      variant="secondary"
-                      size="icon"
-                      className="size-8 shrink-0 rounded-md shadow-none active:scale-90 transition-transform"
-                      disabled={disabled || action.disabled}
-                      onClick={action.onClick}
-                    >
-                      {Icon ? <Icon className={cn("size-3.5 stroke-1", action.spinning ? "animate-spin" : "")} /> : null}
-                    </Button>
-                  );
-                })}
-              </div>
-            )}
+            <div className="w-full min-w-0 md:w-44 md:shrink-0 xl:w-52">
+              {field.type === "bool" ? (
+                <div className="flex items-end justify-start md:justify-end">
+                  <Switch id={field.id} checked={value === "true"} onCheckedChange={(checked) => onChange?.(checked ? "true" : "false")} disabled={disabled} />
+                </div>
+              ) : field.type === "multi-check" ? (
+                <MultiCheckField field={field} value={value} disabled={disabled} onChange={onChange} />
+              ) : field.type === "tabs" ? (
+                <Tabs value={value} onValueChange={(next) => onChange?.(next)} className="w-full">
+                  <TabsList className="grid h-8 w-full grid-cols-2">
+                    {(field.options ?? []).map((option) => (
+                      <TabsTrigger key={option.value} value={option.value} disabled={disabled}>
+                        {option.label}
+                      </TabsTrigger>
+                    ))}
+                  </TabsList>
+                </Tabs>
+              ) : field.type === "button" ? (
+                <div className="flex items-center justify-start gap-2 md:justify-end">
+                  {(inlineRuntimeActions ?? []).map((action) => {
+                    const Icon = action.icon;
+                    return (
+                      <Button
+                        key={action.key}
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-7 rounded-md border-border/50 px-2.5 text-[12px] font-normal shadow-none hover:bg-accent/40"
+                        disabled={disabled || action.disabled}
+                        onClick={action.onClick}
+                      >
+                        {Icon ? <Icon className={cn("size-3.5 stroke-1", action.spinning ? "animate-spin" : "")} /> : null}
+                        {action.label}
+                      </Button>
+                    );
+                  })}
+                </div>
+              ) : field.type === "select" ? (
+                <Select value={value} onValueChange={(next) => onChange?.(next)} disabled={disabled}>
+                  <SelectTrigger
+                    id={field.id}
+                    size="sm"
+                    className="text-left md:text-right *:data-[slot=select-value]:flex-1 *:data-[slot=select-value]:justify-start md:*:data-[slot=select-value]:justify-end"
+                  >
+                    <SelectValue placeholder={field.placeholder ?? t("select.placeholder")} />
+                  </SelectTrigger>
+                  <SelectContent align="start">
+                    {(field.options ?? []).map((option) => (
+                      <SelectItem key={option.value} value={option.value} className="text-left md:text-right">
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1">
+                  <Input
+                    id={field.id}
+                    type={field.type === "password" ? "password" : "text"}
+                    value={value}
+                    onChange={(event) => onChange?.(event.target.value)}
+                    placeholder={field.type === "password" && configured && !value ? t("input.configuredPasswordPlaceholder") : field.placeholder}
+                    inputMode={field.valueUnit === "mb" ? "decimal" : field.type === "int" ? "numeric" : "text"}
+                    disabled={disabled}
+                    className="min-w-0 text-left md:text-right"
+                  />
+                  {(inlineRuntimeActions ?? []).map((action) => {
+                    const Icon = action.icon;
+                    return (
+                      <Button
+                        key={action.key}
+                        type="button"
+                        variant="secondary"
+                        size="icon"
+                        className="size-8 shrink-0 rounded-md shadow-none transition-transform active:scale-90"
+                        disabled={disabled || action.disabled}
+                        onClick={action.onClick}
+                      >
+                        {Icon ? <Icon className={cn("size-3.5 stroke-1", action.spinning ? "animate-spin" : "")} /> : null}
+                      </Button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
           </div>
+          {afterControl}
         </div>
       </Field>
     </SettingsFieldFrame>

--- a/frontend/features/admin/components/sections/shared/settings-runtime-panel.tsx
+++ b/frontend/features/admin/components/sections/shared/settings-runtime-panel.tsx
@@ -290,7 +290,7 @@ function MultiCheckField({ field, value, disabled, onChange }: MultiCheckFieldPr
   );
 
   return (
-    <div className="grid min-w-0 gap-2 rounded-md border border-border/50 bg-muted/20 p-2">
+    <div className="grid min-w-0 gap-1">
       {(field.options ?? []).map((option) => {
         const checked = selected.has(option.value);
         const optionDisabled = disabled || (checked && selected.size <= 1);
@@ -299,7 +299,8 @@ function MultiCheckField({ field, value, disabled, onChange }: MultiCheckFieldPr
           <label
             key={option.value}
             className={cn(
-              "flex min-w-0 items-center justify-between gap-2 text-[12px] text-foreground",
+              "flex min-h-6 min-w-0 items-center justify-between gap-2 text-[12px] text-muted-foreground",
+              checked && "text-foreground",
               optionDisabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
             )}
           >

--- a/frontend/features/admin/components/sections/shared/settings-runtime-panel.tsx
+++ b/frontend/features/admin/components/sections/shared/settings-runtime-panel.tsx
@@ -24,6 +24,7 @@ export type SettingsFieldType = "int" | "bool" | "string" | "password" | "textar
 export type SettingsFieldOption = {
   label: string;
   value: string;
+  meta?: string;
 };
 
 export type SettingsFieldAction = {
@@ -293,6 +294,7 @@ function MultiCheckField({ field, value, disabled, onChange }: MultiCheckFieldPr
       {(field.options ?? []).map((option) => {
         const checked = selected.has(option.value);
         const optionDisabled = disabled || (checked && selected.size <= 1);
+        const label = option.meta ? `${option.label} ${option.meta}` : option.label;
         return (
           <label
             key={option.value}
@@ -301,11 +303,16 @@ function MultiCheckField({ field, value, disabled, onChange }: MultiCheckFieldPr
               optionDisabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
             )}
           >
-            <span className="truncate">{option.label}</span>
+            <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
+              <span className="truncate">{option.label}</span>
+              {option.meta ? (
+                <span className="shrink-0 whitespace-nowrap text-[10px] leading-none text-muted-foreground">{option.meta}</span>
+              ) : null}
+            </span>
             <Checkbox
               checked={checked}
               disabled={optionDisabled}
-              aria-label={option.label}
+              aria-label={label}
               onCheckedChange={(nextChecked) => {
                 const next = new Set(selected);
                 if (nextChecked) {

--- a/frontend/features/admin/model/files-settings.ts
+++ b/frontend/features/admin/model/files-settings.ts
@@ -1,7 +1,7 @@
 import type { SettingsGrouped } from "@/shared/api/settings.types";
 import type { AdminServiceRuntimeView } from "@/features/admin/api/admin.types";
 
-export type SettingsFieldType = "int" | "bool" | "string" | "password" | "textarea" | "select" | "tabs" | "button";
+export type SettingsFieldType = "int" | "bool" | "string" | "password" | "textarea" | "select" | "tabs" | "multi-check" | "button";
 
 export type VisibilityRule =
   | { field: string; equals: string }
@@ -92,6 +92,61 @@ export const MINERU_SERVICE_SOURCES = {
   SELF_HOSTED: "self_hosted",
 } as const;
 
+export const MINERU_FILE_TYPES = {
+  PDF: "pdf",
+  WORD: "word",
+  PRESENTATION: "presentation",
+  EXCEL: "excel",
+} as const;
+
+export const DEFAULT_MINERU_FILE_TYPES = [
+  MINERU_FILE_TYPES.PDF,
+  MINERU_FILE_TYPES.WORD,
+  MINERU_FILE_TYPES.PRESENTATION,
+].join(",");
+
+export type MinerUFileType = (typeof MINERU_FILE_TYPES)[keyof typeof MINERU_FILE_TYPES];
+
+export type MinerUMIMERequirement = {
+  type: MinerUFileType;
+  format: string;
+  mime: string;
+};
+
+const MINERU_MIME_REQUIREMENTS: Record<MinerUFileType, Record<string, MinerUMIMERequirement[]>> = {
+  [MINERU_FILE_TYPES.PDF]: {
+    cloud: [{ type: MINERU_FILE_TYPES.PDF, format: "PDF", mime: "application/pdf" }],
+    self_hosted: [{ type: MINERU_FILE_TYPES.PDF, format: "PDF", mime: "application/pdf" }],
+  },
+  [MINERU_FILE_TYPES.WORD]: {
+    cloud: [
+      { type: MINERU_FILE_TYPES.WORD, format: "DOC", mime: "application/msword" },
+      { type: MINERU_FILE_TYPES.WORD, format: "DOCX", mime: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" },
+    ],
+    self_hosted: [
+      { type: MINERU_FILE_TYPES.WORD, format: "DOCX", mime: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" },
+    ],
+  },
+  [MINERU_FILE_TYPES.PRESENTATION]: {
+    cloud: [
+      { type: MINERU_FILE_TYPES.PRESENTATION, format: "PPT", mime: "application/vnd.ms-powerpoint" },
+      { type: MINERU_FILE_TYPES.PRESENTATION, format: "PPTX", mime: "application/vnd.openxmlformats-officedocument.presentationml.presentation" },
+    ],
+    self_hosted: [
+      { type: MINERU_FILE_TYPES.PRESENTATION, format: "PPTX", mime: "application/vnd.openxmlformats-officedocument.presentationml.presentation" },
+    ],
+  },
+  [MINERU_FILE_TYPES.EXCEL]: {
+    cloud: [
+      { type: MINERU_FILE_TYPES.EXCEL, format: "XLS", mime: "application/vnd.ms-excel" },
+      { type: MINERU_FILE_TYPES.EXCEL, format: "XLSX", mime: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" },
+    ],
+    self_hosted: [
+      { type: MINERU_FILE_TYPES.EXCEL, format: "XLSX", mime: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" },
+    ],
+  },
+};
+
 export const EMBEDDING_READY_RULE: VisibilityRule = {
   all: [
     { field: "file.embedding_enabled", equals: EMBEDDING_MODES.ON },
@@ -121,7 +176,7 @@ export const SERVICE_LABELS: Record<ServiceName, string> = {
 export const SERVICE_DIRTY_FIELDS: Record<ServiceName, string[]> = {
   tika: ["extract.engine", "extract.tika_base_url", "extract.tika_timeout_seconds", "extract.tika_auth_token"],
   docling: ["extract.engine", "extract.docling_base_url", "extract.docling_timeout_seconds", "extract.docling_auth_token"],
-  mineru: ["extract.engine", "extract.mineru_source", "extract.mineru_base_url", "extract.mineru_timeout_seconds", "extract.mineru_auth_token"],
+  mineru: ["extract.engine", "extract.mineru_source", "extract.mineru_file_types", "extract.mineru_base_url", "extract.mineru_timeout_seconds", "extract.mineru_auth_token"],
   tesseract: ["extract.tesseract_ocr_base_url", "extract.tesseract_ocr_timeout_seconds", "extract.tesseract_ocr_auth_token"],
   rapidocr: ["extract.rapidocr_base_url", "extract.rapidocr_timeout_seconds", "extract.rapidocr_auth_token"],
   embedding: ["file.embedding_enabled", "file.embedding_host", "file.embedding_key", "file.rag_model", "file.embedding_timeout_seconds"],
@@ -280,6 +335,21 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
         visibleWhen: { field: "extract.engine", equals: EXTRACT_ENGINE_POLICIES.MINERU },
         subgroupKey: "mineru",
         runtimeService: "mineru",
+      },
+      {
+        namespace: "extract",
+        key: "mineru_file_types",
+        label: "MinerU file types",
+        description: "Select file categories sent to MinerU.",
+        type: "multi-check",
+        options: [
+          { label: "PDF", value: MINERU_FILE_TYPES.PDF },
+          { label: "Word", value: MINERU_FILE_TYPES.WORD },
+          { label: "Presentation", value: MINERU_FILE_TYPES.PRESENTATION },
+          { label: "Excel", value: MINERU_FILE_TYPES.EXCEL },
+        ],
+        visibleWhen: { field: "extract.engine", equals: EXTRACT_ENGINE_POLICIES.MINERU },
+        subgroupKey: "mineru",
       },
       {
         namespace: "extract",
@@ -809,10 +879,73 @@ export function resolveMinerUSource(source: string): string {
   return source === MINERU_SERVICE_SOURCES.SELF_HOSTED ? MINERU_SERVICE_SOURCES.SELF_HOSTED : MINERU_SERVICE_SOURCES.CLOUD;
 }
 
+export function normalizeMinerUFileTypes(raw: string): string {
+  const allowed = new Set<string>(Object.values(MINERU_FILE_TYPES));
+  const selected: string[] = [];
+  const source = raw.trim() ? raw : DEFAULT_MINERU_FILE_TYPES;
+  for (const item of source.split(",")) {
+    const value = item.trim().toLowerCase();
+    if (!allowed.has(value) || selected.includes(value)) {
+      continue;
+    }
+    selected.push(value);
+  }
+  return selected.length > 0 ? selected.join(",") : DEFAULT_MINERU_FILE_TYPES;
+}
+
 export function resolveMinerUDefaultBaseURL(source: string): string {
   return resolveMinerUSource(source) === MINERU_SERVICE_SOURCES.SELF_HOSTED
     ? "http://127.0.0.1:8000"
     : "https://mineru.net/api/v4";
+}
+
+export function resolveMinerUMIMERequirements(settings: Record<string, string>): MinerUMIMERequirement[] {
+  const source = resolveMinerUSource(settings["extract.mineru_source"] ?? "");
+  const selected = normalizeMinerUFileTypes(settings["extract.mineru_file_types"] ?? "").split(",");
+  const result: MinerUMIMERequirement[] = [];
+  for (const type of selected) {
+    const requirements = MINERU_MIME_REQUIREMENTS[type as MinerUFileType]?.[source] ?? [];
+    result.push(...requirements);
+  }
+  return result;
+}
+
+export function parseAllowedMIMETypes(raw: string): Set<string> {
+  const result = new Set<string>();
+  for (const item of raw.split(",")) {
+    const value = item.trim().toLowerCase();
+    if (value) {
+      result.add(value);
+    }
+  }
+  return result;
+}
+
+export function resolveMissingMinerUMIMETypes(settings: Record<string, string>): MinerUMIMERequirement[] {
+  const allowlist = settings["file.allowed_mime_types"] ?? "";
+  if (!allowlist.trim()) {
+    return [];
+  }
+  const allowed = parseAllowedMIMETypes(allowlist);
+  return resolveMinerUMIMERequirements(settings).filter((item) => !allowed.has(item.mime.toLowerCase()));
+}
+
+export function mergeAllowedMIMETypes(raw: string, items: MinerUMIMERequirement[]): string {
+  const existing = raw
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  const seen = new Set(existing.map((item) => item.toLowerCase()));
+  const merged = [...existing];
+  for (const item of items) {
+    const mime = item.mime.trim();
+    if (!mime || seen.has(mime.toLowerCase())) {
+      continue;
+    }
+    merged.push(mime);
+    seen.add(mime.toLowerCase());
+  }
+  return merged.join(",");
 }
 
 export function resolveActiveServices(settings: Record<string, string>): Set<ServiceName> {
@@ -998,6 +1131,7 @@ export function applySettingsDefaults(next: Record<string, string>): Record<stri
   }
   if ((result["extract.engine"] ?? "") === EXTRACT_ENGINE_POLICIES.MINERU) {
     result["extract.mineru_source"] = resolveMinerUSource(result["extract.mineru_source"] ?? "");
+    result["extract.mineru_file_types"] = normalizeMinerUFileTypes(result["extract.mineru_file_types"] ?? "");
     if (!(result["extract.mineru_timeout_seconds"] ?? "").trim()) {
       result["extract.mineru_timeout_seconds"] = "180";
     }

--- a/frontend/features/admin/model/files-settings.ts
+++ b/frontend/features/admin/model/files-settings.ts
@@ -910,6 +910,10 @@ export function resolveMinerUMIMERequirements(settings: Record<string, string>):
   return result;
 }
 
+export function resolveMinerUFileTypeFormats(type: string, source: string): string[] {
+  return (MINERU_MIME_REQUIREMENTS[type as MinerUFileType]?.[resolveMinerUSource(source)] ?? []).map((item) => item.format);
+}
+
 export function parseAllowedMIMETypes(raw: string): Set<string> {
   const result = new Set<string>();
   for (const item of raw.split(",")) {

--- a/frontend/i18n/messages/en-US/admin-files.json
+++ b/frontend/i18n/messages/en-US/admin-files.json
@@ -54,7 +54,12 @@
     "reindexFailed": "Failed to rebuild index",
     "embeddingModelChanged": "Embedding model changed",
     "embeddingModelChangedDescription": "Existing vectors were marked stale. Rebuild the index in the status panel to vectorize all files again.",
+    "mimeTypesUpdated": "Attachment MIME allowlist updated",
     "groupUpdated": "{group} updated"
+  },
+  "mineruMimeHint": {
+    "missing": "Upload allowlist is missing MIME types required for selected MinerU formats: {formats}.",
+    "addAndSave": "Add and save missing MIME types"
   },
   "validation": {
     "embeddingRequired": "Enable vector retrieval and configure both the Embedding service URL and model first.",
@@ -237,6 +242,16 @@
         "label": "MinerU service URL *",
         "description": "MinerU service URL.",
         "placeholder": "Service URL"
+      },
+      "mineru_file_types": {
+        "label": "MinerU file types",
+        "description": "Select file categories sent to MinerU.",
+        "options": {
+          "pdf": "PDF",
+          "word": "Word",
+          "presentation": "Presentation",
+          "excel": "Excel"
+        }
       },
       "mineru_auth_token": {
         "label": "MinerU auth key",

--- a/frontend/i18n/messages/en-US/admin-files.json
+++ b/frontend/i18n/messages/en-US/admin-files.json
@@ -249,7 +249,7 @@
         "options": {
           "pdf": "PDF",
           "word": "Word",
-          "presentation": "Presentation",
+          "presentation": "PowerPoint",
           "excel": "Excel"
         }
       },

--- a/frontend/i18n/messages/zh-CN/admin-files.json
+++ b/frontend/i18n/messages/zh-CN/admin-files.json
@@ -54,7 +54,12 @@
     "reindexFailed": "重建索引失败",
     "embeddingModelChanged": "Embedding 模型已变更",
     "embeddingModelChangedDescription": "旧向量已标记为失效，请在索引状态面板中点击「重建索引」以重新向量化所有文件。",
+    "mimeTypesUpdated": "附件 MIME 白名单已更新",
     "groupUpdated": "{group}已更新"
+  },
+  "mineruMimeHint": {
+    "missing": "上传白名单缺少已选 MinerU 格式所需的 MIME 类型：{formats}。",
+    "addAndSave": "补充并保存缺失 MIME"
   },
   "validation": {
     "embeddingRequired": "请先在「向量化检索」中开启并配置 Embedding 服务地址和请求模型。",
@@ -237,6 +242,16 @@
         "label": "MinerU 服务地址 *",
         "description": "用于配置 MinerU 服务地址。",
         "placeholder": "服务地址"
+      },
+      "mineru_file_types": {
+        "label": "MinerU 文件类型",
+        "description": "用于选择哪些文件类型交给 MinerU 解析。",
+        "options": {
+          "pdf": "PDF",
+          "word": "Word",
+          "presentation": "演示文稿",
+          "excel": "Excel"
+        }
       },
       "mineru_auth_token": {
         "label": "MinerU 鉴权密钥",

--- a/frontend/i18n/messages/zh-CN/admin-files.json
+++ b/frontend/i18n/messages/zh-CN/admin-files.json
@@ -249,7 +249,7 @@
         "options": {
           "pdf": "PDF",
           "word": "Word",
-          "presentation": "演示文稿",
+          "presentation": "PowerPoint",
           "excel": "Excel"
         }
       },


### PR DESCRIPTION
## Summary

本 PR 扩展 MinerU 文档解析类型配置，并补齐 PPT/PPTX 在文件上传、文档处理和向量化检索链路中的支持。

主要改动：

- 新增 `extract:mineru_file_types` 运行时设置，默认 `pdf,word,presentation`
- MinerU 按服务来源判断可处理格式：
  - cloud: `.doc/.docx/.ppt/.pptx/.xls/.xlsx`
  - self-hosted: `.docx/.pptx/.xlsx`
- 让 PPT/PPTX 上传后被识别为演示文稿，并能进入文档处理、RAG 和向量化流程
- 允许 Tika 处理新识别出的演示文稿分类
- 手动重建向量索引时，除 `stale/failed` 外额外纳入 `none` 状态的可向量化文件
- 管理后台新增 MinerU 文件类型选择控件
- 管理后台在 MIME 白名单缺少所选 MinerU 格式时提示并支持一键补齐

## Change type

- [ ] Bug fix
- [x] Feature
- [x] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [x] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [x] Documentation

## Verification

- [x] `git diff --check origin/dev...HEAD`
- [x] `cd frontend && pnpm lint`
- [x] `cd backend && go test ./internal/application/embedding ./internal/application/processing ./internal/application/extraction ./internal/application/upload ./internal/application/settings ./internal/application/conversation ./internal/infra/persistence/models`
- [ ] Not run; reason:

## Screenshots, API examples, or logs

N/A

## Configuration, migration, and compatibility notes

- 新增运行时设置 `extract:mineru_file_types`，默认值为 `pdf,word,presentation`。
- MIME 白名单不会被自动删除或替换；管理后台只在缺少所选 MinerU 文件类型对应 MIME 时追加缺失项。
- Spreadsheet 类型保留为可选项，默认不交给 MinerU。
- Docling 仍按现有 PDF-only 规则处理。

## Documentation

- [ ] Documentation is not needed for this change.
- [x] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.