### PR TITLE
feat: add custom prompt settings for MCP tools and skills

### DIFF
--- a/backend/internal/application/conversation/prompt_plan.go
+++ b/backend/internal/application/conversation/prompt_plan.go
@@ -149,7 +149,7 @@ func buildPromptPlan(ctx context.Context, input promptPlanInput) PromptPlan {
 	}
 
 	before = len(messages)
-	messages = injectMCPToolGuidance(messages, input.ToolRuntime)
+	messages = injectMCPToolGuidance(messages, input.ToolRuntime, input.Config.MCPToolPrompt)
 	if len(messages) > before {
 		inserted := findToolGuidanceMessage(messages)
 		tokenEstimate := int64(0)

--- a/backend/internal/application/conversation/service_mcp_tools.go
+++ b/backend/internal/application/conversation/service_mcp_tools.go
@@ -22,11 +22,28 @@ type selectedToolRuntime struct {
 	schemas     map[string]json.RawMessage
 }
 
-func injectMCPToolGuidance(messages []llm.Message, runtime selectedToolRuntime) []llm.Message {
+func injectMCPToolGuidance(messages []llm.Message, runtime selectedToolRuntime, customPrompt string) []llm.Message {
 	if len(runtime.definitions) == 0 {
 		return messages
 	}
 
+	content := strings.TrimSpace(customPrompt)
+	if content == "" {
+		content = defaultMCPToolGuidancePrompt()
+	}
+
+	insertAt := 0
+	for insertAt < len(messages) && messages[insertAt].Role == "system" {
+		insertAt++
+	}
+	next := make([]llm.Message, 0, len(messages)+1)
+	next = append(next, messages[:insertAt]...)
+	next = append(next, llm.Message{Role: "system", Content: content})
+	next = append(next, messages[insertAt:]...)
+	return next
+}
+
+func defaultMCPToolGuidancePrompt() string {
 	var builder strings.Builder
 	builder.WriteString("# tool_use\n")
 	builder.WriteString("- Tools are declared separately via the API schema; follow that schema exactly.\n")
@@ -35,16 +52,7 @@ func injectMCPToolGuidance(messages []llm.Message, runtime selectedToolRuntime) 
 	builder.WriteString("- Do not repeat an identical failed call. Adjust arguments, use another tool, or answer from available evidence.\n")
 	builder.WriteString("- If tools fail or lack enough data, state the gap in the final answer.\n")
 	builder.WriteString("- Do not expose raw tool JSON, internal fields, or tool logs unless the user asks.\n")
-
-	insertAt := 0
-	for insertAt < len(messages) && messages[insertAt].Role == "system" {
-		insertAt++
-	}
-	next := make([]llm.Message, 0, len(messages)+1)
-	next = append(next, messages[:insertAt]...)
-	next = append(next, llm.Message{Role: "system", Content: strings.TrimSpace(builder.String())})
-	next = append(next, messages[insertAt:]...)
-	return next
+	return strings.TrimSpace(builder.String())
 }
 
 func summarizeToolInputSchema(raw json.RawMessage) string {

--- a/backend/internal/application/conversation/service_mcp_tools_test.go
+++ b/backend/internal/application/conversation/service_mcp_tools_test.go
@@ -17,7 +17,7 @@ func TestInjectMCPToolGuidanceOnlyAddsPolicy(t *testing.T) {
 		}},
 	}
 
-	result := injectMCPToolGuidance(messages, runtime)
+	result := injectMCPToolGuidance(messages, runtime, "")
 	if len(result) != 2 {
 		t.Fatalf("expected guidance message to be injected, got %#v", result)
 	}
@@ -31,5 +31,20 @@ func TestInjectMCPToolGuidanceOnlyAddsPolicy(t *testing.T) {
 		if strings.Contains(guidance, unwanted) {
 			t.Fatalf("expected guidance not to duplicate tool schema %q, got %q", unwanted, guidance)
 		}
+	}
+}
+
+func TestInjectMCPToolGuidanceUsesCustomPrompt(t *testing.T) {
+	messages := []llm.Message{{Role: "user", Content: "搜索 DEEIX Chat"}}
+	runtime := selectedToolRuntime{
+		definitions: []llm.ToolDefinition{{Name: "bing_search"}},
+	}
+
+	result := injectMCPToolGuidance(messages, runtime, "Use MCP tools only after checking user intent.")
+	if len(result) != 2 {
+		t.Fatalf("expected guidance message to be injected, got %#v", result)
+	}
+	if result[0].Content != "Use MCP tools only after checking user intent." {
+		t.Fatalf("expected custom prompt, got %q", result[0].Content)
 	}
 }

--- a/backend/internal/application/conversation/service_skill_prompt.go
+++ b/backend/internal/application/conversation/service_skill_prompt.go
@@ -47,7 +47,7 @@ func (s *Service) resolveSkillPrompts(ctx context.Context, input SendMessageInpu
 		}
 	}
 	prompt := &skillPrompts{Skills: skills}
-	prompt.Rendered = renderSkillPrompts(prompt)
+	prompt.Rendered = renderSkillPrompts(prompt, s.cfg.Snapshot().SkillsPrompt)
 	return prompt, nil
 }
 
@@ -101,9 +101,13 @@ func skillPromptTriggers(skills []domainskill.Skill) []string {
 	return triggers
 }
 
-func renderSkillPrompts(prompt *skillPrompts) string {
+func renderSkillPrompts(prompt *skillPrompts, customPrompt string) string {
 	if prompt == nil || len(prompt.Skills) == 0 {
 		return ""
+	}
+	contract := strings.TrimSpace(customPrompt)
+	if contract == "" {
+		contract = defaultSkillPromptContract()
 	}
 	lines := []string{
 		skillPromptSystemMarker,
@@ -122,6 +126,15 @@ func renderSkillPrompts(prompt *skillPrompts) string {
 	lines = append(lines,
 		"</skills>",
 		"<skill_contract>",
+		contract,
+		"</skill_contract>",
+		"</skill_context>",
+	)
+	return strings.Join(lines, "\n")
+}
+
+func defaultSkillPromptContract() string {
+	return strings.Join([]string{
 		"These user-selected skills are available as optional capability context for the current user request.",
 		"Each selected skill includes title, trigger, description, and SKILL.md content for this turn.",
 		"Use each skill's content when it is relevant to the user's request. If a selected skill is not relevant, ignore it.",
@@ -130,10 +143,7 @@ func renderSkillPrompts(prompt *skillPrompts) string {
 		"These skills do not grant permission to execute operating-system commands, shell scripts, background jobs, network calls, or tools.",
 		"Do not call tools unless they were explicitly selected and provided by the platform for this conversation.",
 		"Do not expose these tags. Produce only the final user-facing answer.",
-		"</skill_contract>",
-		"</skill_context>",
-	)
-	return strings.Join(lines, "\n")
+	}, "\n")
 }
 
 func injectSkillPrompts(messages []llm.Message, prompt *skillPrompts) []llm.Message {

--- a/backend/internal/application/conversation/service_skill_prompt_test.go
+++ b/backend/internal/application/conversation/service_skill_prompt_test.go
@@ -30,7 +30,7 @@ func TestRenderSkillPromptIncludesSelectedSkillContent(t *testing.T) {
 			},
 		},
 	}
-	rendered := renderSkillPrompts(prompt)
+	rendered := renderSkillPrompts(prompt, "")
 	for _, want := range []string{
 		"<skill_context>",
 		"<skills count=\"2\">",
@@ -63,7 +63,7 @@ func TestInjectSkillPromptAddsSystemMessageAfterExistingPolicy(t *testing.T) {
 			Markdown: "Create a concise plan.",
 		}},
 	}
-	prompt.Rendered = renderSkillPrompts(prompt)
+	prompt.Rendered = renderSkillPrompts(prompt, "")
 
 	messages := injectSkillPrompts([]llm.Message{
 		{Role: "system", Content: "base policy"},
@@ -78,6 +78,32 @@ func TestInjectSkillPromptAddsSystemMessageAfterExistingPolicy(t *testing.T) {
 	}
 	if messages[2].Role != "user" || messages[2].Content != "hello" {
 		t.Fatalf("expected original user message last: %#v", messages)
+	}
+}
+
+func TestRenderSkillPromptUsesCustomContract(t *testing.T) {
+	prompt := &skillPrompts{
+		Skills: []domainskill.Skill{{
+			ID:       7,
+			Scope:    domainskill.ScopeBuiltin,
+			Title:    "Plan",
+			Trigger:  "plan",
+			Markdown: "Create a concise plan.",
+		}},
+	}
+
+	rendered := renderSkillPrompts(prompt, "Use selected skills only when they directly match the user request.")
+	for _, want := range []string{
+		"<skills count=\"1\">",
+		"<content>Create a concise plan.</content>",
+		"Use selected skills only when they directly match the user request.",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("expected rendered prompt to contain %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, "These user-selected skills are available") {
+		t.Fatalf("expected custom contract to replace default contract:\n%s", rendered)
 	}
 }
 

--- a/backend/internal/application/settings/runtime_settings.go
+++ b/backend/internal/application/settings/runtime_settings.go
@@ -146,6 +146,8 @@ func (r *RuntimeSettings) applyItem(cfg *config.Config, item domainsettings.Syst
 		cfg.ConversationLabelsPrompt = item.Value
 	case "chat:default_system_prompt":
 		cfg.DefaultSystemPrompt = item.Value
+	case "chat:skills_prompt":
+		cfg.SkillsPrompt = item.Value
 	case "chat:model_option_policy_mode":
 		cfg.ModelOptionPolicyMode = strings.TrimSpace(item.Value)
 	case "chat:model_option_allowed_paths":
@@ -348,6 +350,8 @@ func (r *RuntimeSettings) applyItem(cfg *config.Config, item domainsettings.Syst
 		cfg.MCPMaxLLMCallsPerRun = toInt(item.Value, cfg.MCPMaxLLMCallsPerRun)
 	case "mcp:mcp_max_tool_calls_per_run":
 		cfg.MCPMaxToolCallsPerRun = toInt(item.Value, cfg.MCPMaxToolCallsPerRun)
+	case "mcp:mcp_tool_prompt":
+		cfg.MCPToolPrompt = item.Value
 
 	}
 }

--- a/backend/internal/application/settings/seed.go
+++ b/backend/internal/application/settings/seed.go
@@ -70,6 +70,7 @@ func defaultSettings() []domainsettings.SystemSetting {
 		{Namespace: "chat", Key: "conversation_title_prompt", Value: "", ValueType: "string", Description: "会话标题生成提示词，支持 {{MESSAGES}} 占位符；空串使用内置默认值"},
 		{Namespace: "chat", Key: "conversation_labels_prompt", Value: "", ValueType: "string", Description: "会话标签生成提示词，支持 {{MESSAGES}} 占位符；空串使用内置默认值"},
 		{Namespace: "chat", Key: "default_system_prompt", Value: "", ValueType: "string", Description: "全局默认系统提示词，仅对聊天任务生效；空串表示不注入"},
+		{Namespace: "chat", Key: "skills_prompt", Value: "", ValueType: "string", Description: "Skills 调用提示词；空串使用内置默认值"},
 		{Namespace: "chat", Key: "model_option_policy_mode", Value: "allowlist", ValueType: "string", Description: "模型 options 透传策略：allowlist=仅白名单，denylist=黑名单拦截，disabled=禁止透传"},
 		{Namespace: "chat", Key: "model_option_allowed_paths", Value: config.DefaultModelOptionAllowedPathsJSON(), ValueType: "json", Description: "模型 options 白名单路径 JSON，default 对所有协议生效"},
 		{Namespace: "chat", Key: "model_option_denied_paths", Value: config.DefaultModelOptionDeniedPathsJSON(), ValueType: "json", Description: "模型 options 黑名单路径 JSON，default 对所有协议生效"},
@@ -176,6 +177,7 @@ func defaultSettings() []domainsettings.SystemSetting {
 		{Namespace: "mcp", Key: "mcp_max_selected_tools_per_message", Value: "32", ValueType: "int", Description: "单次消息最多可选择的 MCP 工具数量"},
 		{Namespace: "mcp", Key: "mcp_max_llm_calls_per_run", Value: "5", ValueType: "int", Description: "单次 MCP 工具运行最大 LLM 请求次数（最小 2，首次请求 + 工具后续请求 + 最终总结）"},
 		{Namespace: "mcp", Key: "mcp_max_tool_calls_per_run", Value: "8", ValueType: "int", Description: "单次 MCP 工具运行最大 MCP Tool Call 次数"},
+		{Namespace: "mcp", Key: "mcp_tool_prompt", Value: "", ValueType: "string", Description: "MCP Tool 调用提示词；空串使用内置默认值"},
 
 		// 熔断配置
 		{Namespace: "circuit", Key: "channel_failure_threshold", Value: "3", ValueType: "int", Description: "熔断触发次数"},

--- a/backend/internal/application/settings/service.go
+++ b/backend/internal/application/settings/service.go
@@ -290,7 +290,7 @@ func validatePatchItem(item PatchItem) error {
 		return validateStringMax(value, 255, key)
 	case "auth:turnstile_site_key", "auth:turnstile_secret_key":
 		return validateStringMax(value, 512, key)
-	case "chat:default_system_prompt":
+	case "chat:default_system_prompt", "chat:skills_prompt":
 		return validateStringMax(value, 20000, key)
 	case "auth:smtp_port":
 		return validateIntMinMax(value, 1, 65535, key)
@@ -418,6 +418,8 @@ func validatePatchItem(item PatchItem) error {
 		return validateIntMinMax(value, 1, 120, key)
 	case "mcp:mcp_tool_retry_count":
 		return validateIntMinMax(value, 0, 5, key)
+	case "mcp:mcp_tool_prompt":
+		return validateStringMax(value, 20000, key)
 	}
 	return nil
 }

--- a/backend/internal/application/settings/service_test.go
+++ b/backend/internal/application/settings/service_test.go
@@ -283,6 +283,32 @@ func TestValidateMCPSelectedToolsSetting(t *testing.T) {
 	}
 }
 
+func TestValidateCustomPromptSettings(t *testing.T) {
+	for _, item := range []PatchItem{
+		{Namespace: "mcp", Key: "mcp_tool_prompt", Value: "Use MCP tools carefully."},
+		{Namespace: "chat", Key: "skills_prompt", Value: "Use selected skills only when relevant."},
+	} {
+		if err := validatePatchItem(item); err != nil {
+			t.Fatalf("expected %s:%s to pass, got %v", item.Namespace, item.Key, err)
+		}
+	}
+}
+
+func TestRuntimeSettingsAppliesCustomPromptSettings(t *testing.T) {
+	runtimeSettings := NewRuntimeSettings(nil, nil, "test-data-encryption-key")
+	cfg := config.Config{}
+
+	runtimeSettings.applyItem(&cfg, domainsettings.SystemSetting{Namespace: "mcp", Key: "mcp_tool_prompt", Value: "Use MCP tools carefully."})
+	runtimeSettings.applyItem(&cfg, domainsettings.SystemSetting{Namespace: "chat", Key: "skills_prompt", Value: "Use selected skills only when relevant."})
+
+	if cfg.MCPToolPrompt != "Use MCP tools carefully." {
+		t.Fatalf("expected MCP tool prompt to be applied, got %q", cfg.MCPToolPrompt)
+	}
+	if cfg.SkillsPrompt != "Use selected skills only when relevant." {
+		t.Fatalf("expected skills prompt to be applied, got %q", cfg.SkillsPrompt)
+	}
+}
+
 func TestValidateFullContextLimitsAllowUnlimitedValues(t *testing.T) {
 	cases := []PatchItem{
 		{Namespace: "file", Key: "full_context_limit_enabled", Value: "true"},

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -346,6 +346,7 @@ type Config struct {
 	ConversationTitlePrompt  string
 	ConversationLabelsPrompt string
 	DefaultSystemPrompt      string
+	SkillsPrompt             string
 	ModelOptionPolicyMode    string
 	ModelOptionAllowedPaths  string
 	ModelOptionDeniedPaths   string
@@ -451,6 +452,7 @@ type Config struct {
 	MCPMaxSelectedToolsPerMessage int
 	MCPMaxLLMCallsPerRun          int
 	MCPMaxToolCallsPerRun         int
+	MCPToolPrompt                 string
 }
 
 // defaultYAMLPaths 固定读取仓库根目录的 config.yaml。
@@ -564,6 +566,7 @@ func Load() Config {
 		ConversationTitlePrompt:           "",
 		ConversationLabelsPrompt:          "",
 		DefaultSystemPrompt:               "",
+		SkillsPrompt:                      "",
 		ModelOptionPolicyMode:             "allowlist",
 		ModelOptionAllowedPaths:           DefaultModelOptionAllowedPathsJSON(),
 		ModelOptionDeniedPaths:            DefaultModelOptionDeniedPathsJSON(),
@@ -658,6 +661,7 @@ func Load() Config {
 		MCPMaxSelectedToolsPerMessage:     DefaultMCPMaxSelectedToolsPerMessage,
 		MCPMaxLLMCallsPerRun:              5,
 		MCPMaxToolCallsPerRun:             8,
+		MCPToolPrompt:                     "",
 	}
 }
 

--- a/frontend/features/admin/components/sections/conversation/conversation-prompt-presets.tsx
+++ b/frontend/features/admin/components/sections/conversation/conversation-prompt-presets.tsx
@@ -142,6 +142,7 @@ function PromptLibraryTable<T extends PromptLibraryRow>({
   const t = useTranslations("adminPrompts");
   const locale = useLocale();
   const initialLoading = loading && items.length === 0;
+  const showRows = items.length > 0;
   const virtualRows = useVirtualTableRows(items, {
     estimateSize: 40,
   });
@@ -167,10 +168,11 @@ function PromptLibraryTable<T extends PromptLibraryRow>({
 
         {items.length === 0 && !loading ? (
           <TableEmptyRow colSpan={PROMPT_PRESET_TABLE_COLUMN_COUNT}>{emptyLabel}</TableEmptyRow>
-        ) : (
-          <>
-            <VirtualTablePaddingRow colSpan={PROMPT_PRESET_TABLE_COLUMN_COUNT} height={virtualRows.paddingTop} />
-            {virtualRows.rows.map(({ item }) => {
+        ) : null}
+
+        {showRows ? <VirtualTablePaddingRow colSpan={PROMPT_PRESET_TABLE_COLUMN_COUNT} height={virtualRows.paddingTop} /> : null}
+        {showRows
+          ? virtualRows.rows.map(({ item }) => {
               const displayName = item.trigger || item.title;
               const summary = getSummary(item);
 
@@ -219,10 +221,9 @@ function PromptLibraryTable<T extends PromptLibraryRow>({
                   </TableCell>
                 </TableRow>
               );
-            })}
-            <VirtualTablePaddingRow colSpan={PROMPT_PRESET_TABLE_COLUMN_COUNT} height={virtualRows.paddingBottom} />
-          </>
-        )}
+            })
+          : null}
+        {showRows ? <VirtualTablePaddingRow colSpan={PROMPT_PRESET_TABLE_COLUMN_COUNT} height={virtualRows.paddingBottom} /> : null}
       </TableBody>
     </Table>
   );

--- a/frontend/features/admin/components/sections/conversation/conversation-prompt-presets.tsx
+++ b/frontend/features/admin/components/sections/conversation/conversation-prompt-presets.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import * as React from "react";
-import { Box, FileBox, Plus, Trash2 } from "lucide-react";
+import { Box, FileBox, Plus, Save, Trash2 } from "lucide-react";
 import { useLocale } from "next-intl";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 
+import { SettingsFieldEditor } from "../shared/settings-runtime-panel";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -45,12 +47,20 @@ import {
 import { TablePagination, TableToolbar } from "@/components/ui/table-tools";
 import { Textarea } from "@/components/ui/textarea";
 import { useVirtualTableRows, VirtualTablePaddingRow } from "@/components/ui/virtual-table";
-import { SettingsSection } from "@/shared/components/settings-layout";
+import { listAdminSettingsByNamespace, patchAdminSettings } from "@/features/admin/api";
 import { useAdminSkills } from "@/features/admin/hooks/use-admin-skills";
 import { useAdminPromptPresets } from "@/features/admin/hooks/use-admin-prompt-presets";
+import { resolveAdminErrorMessage } from "@/features/admin/utils/admin-error";
 import { formatDateTime } from "@/features/admin/utils/account-display";
 import type { PromptPresetDTO } from "@/shared/api/prompt-presets.types";
 import type { SkillDTO } from "@/shared/api/skills.types";
+import type { PatchSettingItem } from "@/shared/api/settings.types";
+import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
+import {
+  SettingsFieldItem,
+  SettingsFieldList,
+  SettingsSection,
+} from "@/shared/components/settings-layout";
 import { PROMPT_PRESET_LIMITS } from "@/shared/model/prompt-presets";
 import { SKILL_LIMITS } from "@/shared/model/skills";
 
@@ -66,6 +76,49 @@ type PromptLibraryRow = {
   createdAt: string;
   updatedAt: string;
 };
+
+function SkillsPromptSettings({
+  action,
+  dirty,
+  disabled,
+  onChange,
+  value,
+}: {
+  action?: React.ReactNode;
+  dirty: boolean;
+  disabled: boolean;
+  onChange: (value: string) => void;
+  value: string;
+}) {
+  const t = useTranslations("adminPrompts");
+  const field = React.useMemo(
+    () => ({
+      id: "chat.skills_prompt",
+      label: t("settings.skillsPrompt.label"),
+      description: t("settings.skillsPrompt.description"),
+      type: "textarea" as const,
+      placeholder: t("settings.defaultPromptPlaceholder"),
+    }),
+    [t],
+  );
+
+  return (
+    <div className="relative">
+      <SettingsFieldList>
+        <SettingsFieldItem>
+          <SettingsFieldEditor
+            field={field}
+            value={value}
+            dirty={dirty}
+            disabled={disabled}
+            onChange={onChange}
+          />
+        </SettingsFieldItem>
+      </SettingsFieldList>
+      {action ? <div className="absolute right-0 top-0 z-10">{action}</div> : null}
+    </div>
+  );
+}
 
 function PromptLibraryTable<T extends PromptLibraryRow>({
   emptyLabel,
@@ -177,7 +230,12 @@ function PromptLibraryTable<T extends PromptLibraryRow>({
 
 export function ConversationPromptPresetsSection() {
   const t = useTranslations("adminPrompts");
+  const commonT = useTranslations("common");
   const [activeType, setActiveType] = React.useState<PromptLibraryType>("skills");
+  const [skillsPromptValue, setSkillsPromptValue] = React.useState("");
+  const [savedSkillsPromptValue, setSavedSkillsPromptValue] = React.useState("");
+  const [skillsPromptLoading, setSkillsPromptLoading] = React.useState(true);
+  const [skillsPromptSaving, setSkillsPromptSaving] = React.useState(false);
   const prompts = useAdminPromptPresets();
   const skills = useAdminSkills();
   const activeLoading = activeType === "skills" ? skills.loading : prompts.loading;
@@ -188,38 +246,133 @@ export function ConversationPromptPresetsSection() {
   const activeTotal = activeType === "skills" ? skills.total : prompts.total;
   const activeSearchPlaceholder = activeType === "skills" ? t("skillsSearchPlaceholder") : t("searchPlaceholder");
   const activeCreateLabel = activeType === "skills" ? t("createSkill") : t("create");
+  const skillsPromptDirty = skillsPromptValue !== savedSkillsPromptValue;
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setSkillsPromptLoading(true);
+      try {
+        const token = await resolveAccessToken();
+        if (!token) {
+          toast.error(t("toast.sessionExpired"), { description: t("toast.signInAgain") });
+          return;
+        }
+        const settings = await listAdminSettingsByNamespace(token, "chat");
+        if (cancelled) {
+          return;
+        }
+        const nextValue = settings.find((item) => item.key === "skills_prompt")?.value ?? "";
+        setSkillsPromptValue(nextValue);
+        setSavedSkillsPromptValue(nextValue);
+      } catch (error) {
+        if (!cancelled) {
+          toast.error(t("toast.settingsLoadFailed"), { description: resolveAdminErrorMessage(error) });
+        }
+      } finally {
+        if (!cancelled) {
+          setSkillsPromptLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [t]);
+
+  const saveSkillsPrompt = React.useCallback(async () => {
+    if (!skillsPromptDirty) {
+      return;
+    }
+
+    setSkillsPromptSaving(true);
+    try {
+      const token = await resolveAccessToken();
+      if (!token) {
+        toast.error(t("toast.sessionExpired"), { description: t("toast.signInAgain") });
+        return;
+      }
+      const items: PatchSettingItem[] = [
+        {
+          namespace: "chat",
+          key: "skills_prompt",
+          value: skillsPromptValue,
+        },
+      ];
+      const grouped = await patchAdminSettings(token, { items });
+      const nextValue = grouped.chat?.find((item) => item.key === "skills_prompt")?.value ?? skillsPromptValue;
+      setSkillsPromptValue(nextValue);
+      setSavedSkillsPromptValue(nextValue);
+      toast.success(t("toast.settingsUpdated"));
+    } catch (error) {
+      toast.error(t("toast.settingsSaveFailed"), { description: resolveAdminErrorMessage(error) });
+    } finally {
+      setSkillsPromptSaving(false);
+    }
+  }, [skillsPromptDirty, skillsPromptValue, t]);
+  const skillsPromptAction = activeType === "skills" && skillsPromptDirty ? (
+    <Button
+      type="button"
+      size="sm"
+      className="h-7 gap-1 px-2.5 text-xs"
+      disabled={skillsPromptLoading || skillsPromptSaving}
+      onClick={() => void saveSkillsPrompt()}
+    >
+      <Save className="size-3.5" />
+      {commonT("actions.save")}
+    </Button>
+  ) : null;
+  const sectionActions = (
+    <Tabs value={activeType} onValueChange={(value) => setActiveType(value as PromptLibraryType)}>
+      <TabsList>
+        <TabsTrigger value="skills">{t("types.skills")}</TabsTrigger>
+        <TabsTrigger value="prompts">{t("types.prompts")}</TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
 
   return (
     <>
-      <SettingsSection title={t("title")}>
+      <SettingsSection title={t("title")} actions={sectionActions}>
         <div className="space-y-4">
-          <div className="flex items-center px-0.5">
-            <Tabs value={activeType} onValueChange={(value) => setActiveType(value as PromptLibraryType)}>
-              <TabsList>
-                <TabsTrigger value="skills">{t("types.skills")}</TabsTrigger>
-                <TabsTrigger value="prompts">{t("types.prompts")}</TabsTrigger>
-              </TabsList>
-            </Tabs>
-          </div>
+          {activeType === "skills" ? (
+            <SkillsPromptSettings
+              value={skillsPromptValue}
+              action={skillsPromptAction}
+              dirty={skillsPromptDirty}
+              disabled={skillsPromptLoading || skillsPromptSaving}
+              onChange={setSkillsPromptValue}
+            />
+          ) : null}
 
-          <TableToolbar
-            query={activeQuery}
-            queryPlaceholder={activeSearchPlaceholder}
-            onQueryChange={activeType === "skills" ? skills.setQuery : prompts.setQuery}
-            loading={activeLoading}
-            onRefresh={() => void (activeType === "skills" ? skills.load() : prompts.load())}
-          >
-            <Button
-              type="button"
-              size="sm"
-              className="h-7 gap-1 text-xs"
-              onClick={activeType === "skills" ? skills.openCreate : prompts.openCreate}
-              disabled={activeLoading}
+          <div className="space-y-2">
+            <div className="px-0.5">
+              <p className="text-xs font-medium leading-snug text-foreground/80">
+                {activeType === "skills" ? t("libraryTitle.skills") : t("libraryTitle.prompts")}
+              </p>
+            </div>
+
+            <TableToolbar
+              query={activeQuery}
+              queryPlaceholder={activeSearchPlaceholder}
+              onQueryChange={activeType === "skills" ? skills.setQuery : prompts.setQuery}
+              loading={activeLoading}
+              onRefresh={() => void (activeType === "skills" ? skills.load() : prompts.load())}
             >
-              <Plus className="size-3.5 stroke-1" />
-              {activeCreateLabel}
-            </Button>
-          </TableToolbar>
+              <Button
+                type="button"
+                size="sm"
+                className="h-7 gap-1 text-xs"
+                onClick={activeType === "skills" ? skills.openCreate : prompts.openCreate}
+                disabled={activeLoading}
+              >
+                <Plus className="size-3.5 stroke-1" />
+                {activeCreateLabel}
+              </Button>
+            </TableToolbar>
+          </div>
 
           {activeType === "skills" ? (
             <PromptLibraryTable<SkillDTO>

--- a/frontend/features/admin/components/sections/tools/admin-tools.tsx
+++ b/frontend/features/admin/components/sections/tools/admin-tools.tsx
@@ -190,8 +190,12 @@ export function AdminToolsPage() {
     () => TOOL_SETTINGS_FIELDS.find((field) => field.key === "mcp_enable"),
     [],
   );
+  const mcpToolPromptField = React.useMemo(
+    () => TOOL_SETTINGS_FIELDS.find((field) => field.key === "mcp_tool_prompt"),
+    [],
+  );
   const mcpRuntimeFields = React.useMemo(
-    () => TOOL_SETTINGS_FIELDS.filter((field) => field.key !== "mcp_enable"),
+    () => TOOL_SETTINGS_FIELDS.filter((field) => field.key !== "mcp_enable" && field.key !== "mcp_tool_prompt"),
     [],
   );
 
@@ -663,6 +667,7 @@ export function AdminToolsPage() {
   }, [schemaTool]);
 
   const mcpEnableFieldID = mcpEnableField ? toolFieldID(mcpEnableField) : "";
+  const mcpToolPromptFieldID = mcpToolPromptField ? toolFieldID(mcpToolPromptField) : "";
 
   return (
     <SettingsPage>
@@ -690,7 +695,7 @@ export function AdminToolsPage() {
               />
             </SettingsFieldItem>
           ) : null}
-          <CollapsibleMotionContent open={mcpEnabled}>
+          <CollapsibleMotionContent open={mcpEnabled} contentClassName="-mx-px px-px pb-px">
             {mcpRuntimeFields.map((field, index) => {
               const id = toolFieldID(field);
               return (
@@ -705,6 +710,17 @@ export function AdminToolsPage() {
                 </SettingsFieldItem>
               );
             })}
+            {mcpToolPromptField ? (
+              <SettingsFieldItem key={mcpToolPromptFieldID} index={mcpRuntimeFields.length + 1}>
+                <SettingsFieldEditor
+                  field={toToolEditorField(mcpToolPromptField, (key) => t(`fields.${key}`))}
+                  value={settingsMap[mcpToolPromptFieldID] ?? ""}
+                  dirty={(settingsMap[mcpToolPromptFieldID] ?? "") !== (savedMap[mcpToolPromptFieldID] ?? "")}
+                  disabled={loading || saving}
+                  onChange={(value) => setSettingsMap((prev) => ({ ...prev, [mcpToolPromptFieldID]: value }))}
+                />
+              </SettingsFieldItem>
+            ) : null}
           </CollapsibleMotionContent>
         </SettingsFieldList>
 

--- a/frontend/features/admin/model/tool-settings.ts
+++ b/frontend/features/admin/model/tool-settings.ts
@@ -1,6 +1,6 @@
 import type { SettingsGrouped } from "@/shared/api/settings.types";
 
-export type ToolSettingsFieldType = "int" | "bool";
+export type ToolSettingsFieldType = "int" | "bool" | "textarea";
 
 export type ToolSettingsField = {
   namespace: "mcp";
@@ -11,11 +11,13 @@ export type ToolSettingsField = {
     | "mcp_max_concurrent_calls"
     | "mcp_max_selected_tools_per_message"
     | "mcp_max_llm_calls_per_run"
-    | "mcp_max_tool_calls_per_run";
+    | "mcp_max_tool_calls_per_run"
+    | "mcp_tool_prompt";
   labelKey: string;
   descriptionKey: string;
   type: ToolSettingsFieldType;
   placeholder?: string;
+  placeholderKey?: string;
 };
 
 export const TOOL_SETTINGS_FIELDS: ToolSettingsField[] = [
@@ -25,6 +27,14 @@ export const TOOL_SETTINGS_FIELDS: ToolSettingsField[] = [
     labelKey: "mcpEnable.label",
     descriptionKey: "mcpEnable.description",
     type: "bool",
+  },
+  {
+    namespace: "mcp",
+    key: "mcp_tool_prompt",
+    labelKey: "toolPrompt.label",
+    descriptionKey: "toolPrompt.description",
+    type: "textarea",
+    placeholderKey: "defaultPromptPlaceholder",
   },
   {
     namespace: "mcp",
@@ -92,6 +102,7 @@ export function applyToolSettingsDefaults(settings: Record<string, string>): Rec
   return {
     ...settings,
     "mcp.mcp_enable": settings["mcp.mcp_enable"] || "false",
+    "mcp.mcp_tool_prompt": settings["mcp.mcp_tool_prompt"] ?? "",
     "mcp.mcp_max_selected_tools_per_message": settings["mcp.mcp_max_selected_tools_per_message"] || "32",
     "mcp.mcp_max_llm_calls_per_run": settings["mcp.mcp_max_llm_calls_per_run"] || "5",
     "mcp.mcp_max_tool_calls_per_run": settings["mcp.mcp_max_tool_calls_per_run"] || "8",
@@ -110,6 +121,6 @@ export function toToolEditorField(
     label: translate(field.labelKey),
     description: translate(field.descriptionKey),
     type: field.type,
-    placeholder: field.placeholder,
+    placeholder: field.placeholderKey ? translate(field.placeholderKey) : field.placeholder,
   } as const;
 }

--- a/frontend/i18n/messages/en-US/admin-prompts.json
+++ b/frontend/i18n/messages/en-US/admin-prompts.json
@@ -4,6 +4,10 @@
     "prompts": "Prompts",
     "skills": "Skills"
   },
+  "libraryTitle": {
+    "prompts": "Prompts Library",
+    "skills": "Skills Library"
+  },
   "create": "New",
   "createSkill": "New Skill",
   "edit": "Edit",
@@ -27,6 +31,13 @@
   "deleteSkillDescription": "The built-in skill will no longer be shown to users. User custom skills are not affected.",
   "empty": "No built-in prompts",
   "skillsEmpty": "No built-in skills",
+  "settings": {
+    "skillsPrompt": {
+      "label": "Skills prompt",
+      "description": "Controls how the model interprets and uses loaded skills. Leave empty to use the built-in default prompt."
+    },
+    "defaultPromptPlaceholder": "Leave empty to use the built-in default prompt"
+  },
   "fields": {
     "name": "Name",
     "description": "Description",
@@ -54,6 +65,11 @@
     "skillUpdated": "Skill updated",
     "skillUpdateFailed": "Failed to update skill",
     "skillDeleted": "Skill deleted",
-    "skillDeleteFailed": "Failed to delete skill"
+    "skillDeleteFailed": "Failed to delete skill",
+    "settingsLoadFailed": "Failed to load prompt settings",
+    "settingsUpdated": "Prompt settings updated",
+    "settingsSaveFailed": "Failed to save prompt settings",
+    "sessionExpired": "Your session has expired.",
+    "signInAgain": "Please sign in again to continue."
   }
 }

--- a/frontend/i18n/messages/en-US/admin-tools.json
+++ b/frontend/i18n/messages/en-US/admin-tools.json
@@ -10,6 +10,11 @@
       "label": "Enable MCP tools",
       "description": "Allow users to select enabled MCP tools in conversations."
     },
+    "toolPrompt": {
+      "label": "MCP tool prompt",
+      "description": "Controls when and how the model calls MCP tools. Leave empty to use the built-in default prompt."
+    },
+    "defaultPromptPlaceholder": "Leave empty to use the built-in default prompt",
     "maxSelectedTools": {
       "label": "Selectable tools per message",
       "description": "Maximum MCP tools a user can select for one message. Default 32, maximum 128."

--- a/frontend/i18n/messages/zh-CN/admin-prompts.json
+++ b/frontend/i18n/messages/zh-CN/admin-prompts.json
@@ -4,6 +4,10 @@
     "prompts": "Prompts",
     "skills": "Skills"
   },
+  "libraryTitle": {
+    "prompts": "Prompts 库",
+    "skills": "Skills 库"
+  },
   "create": "新建",
   "createSkill": "新建 Skill",
   "edit": "编辑",
@@ -27,6 +31,13 @@
   "deleteSkillDescription": "删除后该内置 Skill 不再对用户展示，不影响用户自己的自定义 Skills。",
   "empty": "暂无内置提示词",
   "skillsEmpty": "暂无内置 Skills",
+  "settings": {
+    "skillsPrompt": {
+      "label": "Skills 调用提示词",
+      "description": "控制模型如何理解和使用已装载的 Skills。留空使用内置默认提示词。"
+    },
+    "defaultPromptPlaceholder": "留空使用内置默认提示词"
+  },
   "fields": {
     "name": "名称",
     "description": "说明",
@@ -54,6 +65,11 @@
     "skillUpdated": "Skill 已更新",
     "skillUpdateFailed": "更新 Skill 失败",
     "skillDeleted": "Skill 已删除",
-    "skillDeleteFailed": "删除 Skill 失败"
+    "skillDeleteFailed": "删除 Skill 失败",
+    "settingsLoadFailed": "加载调用提示词配置失败",
+    "settingsUpdated": "调用提示词配置已更新",
+    "settingsSaveFailed": "保存调用提示词配置失败",
+    "sessionExpired": "登录状态已失效",
+    "signInAgain": "请重新登录后再继续操作。"
   }
 }

--- a/frontend/i18n/messages/zh-CN/admin-tools.json
+++ b/frontend/i18n/messages/zh-CN/admin-tools.json
@@ -10,6 +10,11 @@
       "label": "启用 MCP 工具",
       "description": "允许用户在对话中选择已启用的 MCP 工具。"
     },
+    "toolPrompt": {
+      "label": "MCP Tool 调用提示词",
+      "description": "控制模型何时以及如何调用 MCP 工具。留空使用内置默认提示词。"
+    },
+    "defaultPromptPlaceholder": "留空使用内置默认提示词",
     "maxSelectedTools": {
       "label": "单消息可选工具数量",
       "description": "单次消息最多可选择的 MCP 工具数量。默认 32，最大 128。"


### PR DESCRIPTION
## Summary

Add admin-configurable prompts for MCP tool usage and Skills usage. The new settings are stored through the existing system settings flow, applied at runtime, and fall back to the built-in prompts when left empty, so existing behavior remains unchanged.

## Change type

- [x] Feature

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [x] Conversations / streaming
- [x] MCP / tools
- [x] Admin console

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/application/conversation ./internal/application/settings`
- [x] `cd frontend && ./node_modules/.bin/eslint features/admin/model/tool-settings.ts features/admin/components/sections/tools/admin-tools.tsx features/admin/components/sections/conversation/conversation-prompt-presets.tsx`
- [x] `cd frontend && ./node_modules/.bin/tsc --noEmit --pretty false`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Not included.

## Configuration, migration, and compatibility notes

Adds two optional system settings:

- `mcp.mcp_tool_prompt`
- `chat.skills_prompt`

Both default to an empty string. Empty values keep using the built-in default prompts. No API contract or Swagger update is required because the existing admin settings API is reused.

## Documentation

- [x] Documentation is not needed for this change.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including provider routing, MCP/tool prompting, and admin settings validation.

## Checklist

- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.