### PR TITLE
fix: 修复移动端对话深链中的导航状态

### DIFF
--- a/frontend/features/layouts/components/navigation/app-sidebar.tsx
+++ b/frontend/features/layouts/components/navigation/app-sidebar.tsx
@@ -34,7 +34,12 @@ function SidebarSectionFallback() {
   )
 }
 
-export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+export function AppSidebar({
+  onCreateConversation,
+  ...props
+}: React.ComponentProps<typeof Sidebar> & {
+  onCreateConversation: () => void
+}) {
   const sidebarData = useLayoutSidebarData()
   const user = sidebarData.user ?? data.user
 
@@ -44,7 +49,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <NavControl />
       </SidebarHeader>
       <SidebarContent className="min-h-0 overflow-hidden group-data-[collapsible=icon]:bg-background">
-        <NavMain />
+        <NavMain onCreateConversation={onCreateConversation} />
         <motion.div
           layoutScroll
           data-sidebar-scroll-root="true"

--- a/frontend/features/layouts/components/navigation/nav-main.tsx
+++ b/frontend/features/layouts/components/navigation/nav-main.tsx
@@ -1,11 +1,9 @@
 "use client"
 
 import * as React from "react"
-import { usePathname, useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 
 import { SidebarGroup, SidebarMenu, useSidebar } from "@/components/ui/sidebar"
-import { useChatSession } from "@/features/chat/context/chat-session-context"
 import {
   useLayoutNavigationSearch,
   useLayoutNavigationShortcuts,
@@ -17,12 +15,9 @@ import { useSidebarRecents } from "@/features/recent/context/sidebar-recents-con
 
 const MAX_SEARCH_RESULTS = 8
 
-export function NavMain() {
+export function NavMain({ onCreateConversation }: { onCreateConversation: () => void }) {
   const t = useTranslations("common.navigation")
   const { state, isMobile, setOpenMobile } = useSidebar()
-  const router = useRouter()
-  const pathname = usePathname()
-  const { requestNewConversation } = useChatSession()
   const { items } = useSidebarRecents()
   const isCollapsed = !isMobile && state === "collapsed"
 
@@ -34,15 +29,6 @@ export function NavMain() {
   const onCloseMobileSidebar = React.useCallback(() => {
     setOpenMobile(false)
   }, [setOpenMobile])
-
-  const onCreateConversation = React.useCallback(() => {
-    requestNewConversation({ projectID: "" })
-    if (pathname === "/chat") {
-      window.history.pushState(null, "", "/chat")
-      return
-    }
-    router.push("/chat")
-  }, [pathname, requestNewConversation, router])
 
   useLayoutNavigationShortcuts({
     onCreateConversation,

--- a/frontend/features/layouts/components/sections/mobile-header.tsx
+++ b/frontend/features/layouts/components/sections/mobile-header.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useTranslations } from "next-intl";
 
 import { PanelRight } from "@/components/animate-ui/icons/panel-right";
@@ -9,7 +8,7 @@ import { PlusIcon } from "@/components/ui/plus";
 import { useSidebar } from "@/components/ui/sidebar";
 import { AppLogo } from "@/shared/components/app-logo";
 
-export function MobileHeader() {
+export function MobileHeader({ onCreateConversation }: { onCreateConversation: () => void }) {
   const t = useTranslations("common.navigation");
   const { toggleSidebar } = useSidebar();
 
@@ -32,11 +31,9 @@ export function MobileHeader() {
       </div>
 
       <div className="flex justify-end">
-        <Button variant="ghost" size="icon" className="size-6" asChild>
-          <Link href="/chat">
-            <PlusIcon size={16} strokeWidth={1.6} />
-            <span className="sr-only">{t("newChat")}</span>
-          </Link>
+        <Button variant="ghost" size="icon" className="size-6" onClick={onCreateConversation}>
+          <PlusIcon size={16} strokeWidth={1.6} />
+          <span className="sr-only">{t("newChat")}</span>
         </Button>
       </div>
     </header>

--- a/frontend/features/layouts/components/sections/project-layout.tsx
+++ b/frontend/features/layouts/components/sections/project-layout.tsx
@@ -1,14 +1,48 @@
+"use client";
+
 import * as React from "react";
+import { usePathname, useRouter } from "next/navigation";
+
 import { AnnouncementDialogHost } from "@/features/announcements/components/announcement-dialog-host";
 import { AppearancePreferencesSync } from "@/features/settings/components/appearance-preferences-sync";
 import { AppSidebar } from "@/features/layouts/components/navigation/app-sidebar";
 import { InitialSecurityGuard } from "@/features/layouts/components/sections/initial-security-guard";
 import { MobileHeader } from "@/features/layouts/components/sections/mobile-header";
 import { SidebarRouteCloser } from "@/features/layouts/components/sections/sidebar-route-closer";
-import { ChatSessionProvider } from "@/features/chat/context/chat-session-context";
+import { ChatSessionProvider, useChatSession } from "@/features/chat/context/chat-session-context";
 import { SidebarRecentsProvider } from "@/features/recent/context/sidebar-recents-context";
 import { UserLocaleSync } from "@/i18n/user-locale-sync";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+
+function ProjectLayoutContent({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { requestNewConversation } = useChatSession();
+
+  const onCreateConversation = React.useCallback(() => {
+    requestNewConversation({ projectID: "" });
+    if (pathname === "/chat") {
+      window.history.pushState(null, "", "/chat");
+      return;
+    }
+    router.push("/chat");
+  }, [pathname, requestNewConversation, router]);
+
+  return (
+    <>
+      <UserLocaleSync />
+      <AppearancePreferencesSync />
+      <InitialSecurityGuard />
+      <AnnouncementDialogHost />
+      <SidebarRouteCloser />
+      <AppSidebar onCreateConversation={onCreateConversation} />
+      <SidebarInset>
+        <MobileHeader onCreateConversation={onCreateConversation} />
+        <div className="flex h-full min-h-0 flex-1 flex-col gap-4 overflow-hidden px-0 pb-2 pt-0 md:p-4 md:pt-0">{children}</div>
+      </SidebarInset>
+    </>
+  );
+}
 
 export function ProjectLayout({
   children,
@@ -21,16 +55,7 @@ export function ProjectLayout({
     <SidebarProvider className="h-svh overflow-hidden" defaultOpen={defaultSidebarOpen}>
       <SidebarRecentsProvider>
         <ChatSessionProvider>
-          <UserLocaleSync />
-          <AppearancePreferencesSync />
-          <InitialSecurityGuard />
-          <AnnouncementDialogHost />
-          <SidebarRouteCloser />
-          <AppSidebar />
-          <SidebarInset>
-            <MobileHeader />
-            <div className="flex h-full min-h-0 flex-1 flex-col gap-4 overflow-hidden px-0 pb-2 pt-0 md:p-4 md:pt-0">{children}</div>
-          </SidebarInset>
+          <ProjectLayoutContent>{children}</ProjectLayoutContent>
         </ChatSessionProvider>
       </SidebarRecentsProvider>
     </SidebarProvider>


### PR DESCRIPTION
## 问题复现

移动端视口下，直接访问某个对话链接：

`/chat?conversation_id=xxx`

部署环境中可观察到导航状态异常：点击右上角的新对话按钮不会进入新对话，URL 仍停留在原来的 `conversation_id`；同一场景下切换侧边栏中的其他对话也可能表现为没有跳转。

其中右上角新对话按钮的问题可以稳定复现：侧边栏“新对话”入口会调用现有的新对话状态更新逻辑，而移动端头部按钮此前只是普通 `/chat` 链接，没有复用这套逻辑。

## 修改内容

- 将原本位于侧边栏导航中的新对话处理逻辑提升到 `ProjectLayout` 内部。
- 将同一个 `onCreateConversation` 回调传给侧边栏导航和移动端头部按钮。
- 移动端头部右上角新对话按钮改为调用统一回调，确保从 `/chat?conversation_id=xxx` 进入时会清理当前会话参数并进入新对话状态。

## 验证

- `pnpm lint`
- `NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:18080 pnpm exec next build --turbopack`
- 静态导出环境移动端验证：
  - 打开 `/chat?conversation_id=xxx`
  - 点击移动端右上角新对话按钮，URL 变为 `/chat`
  - 打开移动端侧边栏并切换已有对话，URL 能正常变为对应的 `/chat?conversation_id=...`