### PR TITLE
feat: enhance Streamdown rendering with custom rehype plugins

### DIFF
--- a/frontend/shared/components/markdown/streamdown-render.tsx
+++ b/frontend/shared/components/markdown/streamdown-render.tsx
@@ -3,7 +3,14 @@
 import * as React from "react";
 import { cjk } from "@streamdown/cjk";
 import { createMathPlugin } from "@streamdown/math";
-import { type AllowedTags, type Components, type PluginConfig, Streamdown } from "streamdown";
+import {
+  defaultRehypePlugins,
+  type AllowedTags,
+  type Components,
+  type PluginConfig,
+  Streamdown,
+  type StreamdownProps,
+} from "streamdown";
 import { useTranslations } from "next-intl";
 
 import { ChevronDown } from "@/components/animate-ui/icons/chevron-down";
@@ -52,6 +59,7 @@ import {
   containsMarkdownMath,
   type RenderSegment,
 } from "./streamdown-content";
+import { normalizeBareURLRehypePlugin } from "./streamdown-url-normalize";
 
 type StreamdownRenderProps = {
   content: unknown;
@@ -114,6 +122,36 @@ const STREAMDOWN_ALLOWED_HTML_TAGS = {
   span: ["style"],
   summary: ["style"],
 } satisfies AllowedTags;
+type RehypeSanitizeSchema = {
+  tagNames?: string[];
+  attributes?: Record<string, unknown>;
+};
+type StreamdownRehypePlugins = NonNullable<StreamdownProps["rehypePlugins"]>;
+type StreamdownRehypePlugin = StreamdownRehypePlugins[number];
+type RehypeSanitizePlugin = [StreamdownRehypePlugin, RehypeSanitizeSchema];
+function buildStreamdownRehypePlugins(): StreamdownRehypePlugins {
+  const [sanitizePlugin, sanitizeSchema] = defaultRehypePlugins.sanitize as RehypeSanitizePlugin;
+  const extraTagNames = Object.keys(STREAMDOWN_ALLOWED_HTML_TAGS);
+  const tagNames = Array.from(new Set([...(sanitizeSchema.tagNames ?? []), ...extraTagNames]));
+  const schema = {
+    ...sanitizeSchema,
+    tagNames,
+    attributes: {
+      ...sanitizeSchema.attributes,
+      ...STREAMDOWN_ALLOWED_HTML_TAGS,
+    },
+  };
+
+  const sanitizeWithAllowedTags = [sanitizePlugin, schema] as StreamdownRehypePlugin;
+
+  return [
+    defaultRehypePlugins.raw,
+    sanitizeWithAllowedTags,
+    normalizeBareURLRehypePlugin,
+    defaultRehypePlugins.harden,
+  ];
+}
+const STREAMDOWN_REHYPE_PLUGINS = buildStreamdownRehypePlugins();
 const FENCED_CODE_BLOCK_RE = /(?:^|\n)[ \t]*(?:```|~~~)(?!\s*(?:mermaid|mmd)\b)[^\n]*(?:\n|$)/i;
 const MERMAID_CODE_BLOCK_RE = /(?:^|\n)[ \t]*(?:```|~~~)\s*(?:mermaid|mmd)\b/i;
 
@@ -420,6 +458,7 @@ function ThinkingSegmentBlock({
               components={THINKING_STREAMDOWN_COMPONENTS}
               controls={STREAMDOWN_CONTROLS}
               plugins={plugins}
+              rehypePlugins={STREAMDOWN_REHYPE_PLUGINS}
               remend={STREAMDOWN_REMEND}
               mode={streaming ? "streaming" : "static"}
               parseIncompleteMarkdown={streaming || incomplete}
@@ -456,6 +495,7 @@ function HTMLMarkdownRenderProvider({
           components={components}
           controls={STREAMDOWN_CONTROLS}
           plugins={plugins}
+          rehypePlugins={STREAMDOWN_REHYPE_PLUGINS}
           remend={STREAMDOWN_REMEND}
           linkSafety={STREAMDOWN_LINK_SAFETY}
           mode="static"
@@ -553,6 +593,7 @@ export const StreamdownRender = React.memo(function StreamdownRender({
                 components={components}
                 controls={STREAMDOWN_CONTROLS}
                 plugins={plugins}
+                rehypePlugins={STREAMDOWN_REHYPE_PLUGINS}
                 remend={STREAMDOWN_REMEND}
                 linkSafety={STREAMDOWN_LINK_SAFETY}
                 caret={streaming ? STREAMDOWN_CARET : undefined}

--- a/frontend/shared/components/markdown/streamdown-url-normalize.ts
+++ b/frontend/shared/components/markdown/streamdown-url-normalize.ts
@@ -1,0 +1,63 @@
+const URL_PROTOCOL_RE = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+const BARE_DOMAIN_URL_RE = /^(?:www\.)?(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}(?::\d{2,5})?(?:[/?#][^\s]*)?$/;
+
+type HASTNode = {
+  type?: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  children?: HASTNode[];
+};
+
+function normalizeBareURL(value: unknown): string | undefined {
+  if (typeof value !== "string" || value === "") {
+    return undefined;
+  }
+
+  if (value.startsWith("//")) {
+    const withoutSlashes = value.slice(2);
+    return BARE_DOMAIN_URL_RE.test(withoutSlashes) ? `https:${value}` : value;
+  }
+
+  if (
+    URL_PROTOCOL_RE.test(value) ||
+    value.startsWith("#") ||
+    value.startsWith("/") ||
+    value.startsWith("./") ||
+    value.startsWith("../")
+  ) {
+    return value;
+  }
+
+  return BARE_DOMAIN_URL_RE.test(value) ? `https://${value}` : value;
+}
+
+function normalizeURLProperty(node: HASTNode, property: "href" | "src") {
+  if (!node.properties) {
+    return;
+  }
+
+  const normalized = normalizeBareURL(node.properties[property]);
+  if (normalized) {
+    node.properties[property] = normalized;
+  }
+}
+
+function visitElementNodes(node: HASTNode) {
+  if (node.type === "element") {
+    if (node.tagName === "a") {
+      normalizeURLProperty(node, "href");
+    } else if (node.tagName === "img") {
+      normalizeURLProperty(node, "src");
+    }
+  }
+
+  for (const child of node.children ?? []) {
+    visitElementNodes(child);
+  }
+}
+
+export function normalizeBareURLRehypePlugin() {
+  return (tree: HASTNode) => {
+    visitElementNodes(tree);
+  };
+}


### PR DESCRIPTION
## Summary

Fix Markdown link rendering for bare-domain URLs such as `[DEEIX](www.example.com)`.

The Markdown renderer now normalizes bare-domain `href` / `src` values at the rehype AST layer before `rehype-harden` runs, so common Markdown links without protocol are rendered as valid `https://` links instead of being shown as `[blocked]`. Existing protocols, relative paths, anchors, and unsafe protocols remain unchanged so the hardening layer can continue enforcing link safety.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && ./node_modules/.bin/eslint shared/components/markdown/streamdown-render.tsx shared/components/markdown/streamdown-url-normalize.ts`
- [x] `cd frontend && ./node_modules/.bin/tsc --noEmit --pretty false`
- [x] `git diff --check`
- [x] Manually verified URL normalization boundaries for bare domains, protocol-relative URLs, existing protocols, relative paths, anchors, and unsafe protocols.

## Screenshots, API examples, or logs

Before: `[DEEIX](www.example.com)` could render as `DEEIX [blocked]`.

After: bare-domain Markdown links are normalized to `https://www.example.com` and render normally.

## Configuration, migration, and compatibility notes

No configuration, migration, database, Docker, or API contract changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.