### PR TITLE
fix: strip large tool outputs from streaming trace snapshots

### DIFF
--- a/backend/internal/application/conversation/service_trace.go
+++ b/backend/internal/application/conversation/service_trace.go
@@ -595,6 +595,59 @@ func (r *messageTraceRecorder) snapshot() *model.MessageProcessTrace {
 	}
 }
 
+func (r *messageTraceRecorder) streamingSnapshot() *model.MessageProcessTrace {
+	trace := r.snapshot()
+	if trace == nil {
+		return nil
+	}
+	lightEvents := make([]model.MessageTraceEvent, len(trace.Events))
+	for i, event := range trace.Events {
+		lightEvents[i] = event
+		lightEvents[i].PayloadJSON = stripLargeTracePayloadFields(event.PayloadJSON)
+	}
+	trace.Events = lightEvents
+	return trace
+}
+
+const streamingTraceFieldMaxBytes = 512
+
+func stripLargeTracePayloadFields(payloadJSON string) string {
+	if len(payloadJSON) <= streamingTraceFieldMaxBytes {
+		return payloadJSON
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+		return payloadJSON
+	}
+	toolCalls, ok := payload["tool_calls"].([]interface{})
+	if !ok || len(toolCalls) == 0 {
+		return payloadJSON
+	}
+	modified := false
+	for _, tc := range toolCalls {
+		call, ok := tc.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, key := range []string{"output", "output_text", "input"} {
+			if val, exists := call[key]; exists {
+				if str, ok := val.(string); ok && len(str) > streamingTraceFieldMaxBytes {
+					delete(call, key)
+					modified = true
+				}
+			}
+		}
+	}
+	if !modified {
+		return payloadJSON
+	}
+	result, err := json.Marshal(payload)
+	if err != nil {
+		return payloadJSON
+	}
+	return string(result)
+}
+
 func (r *messageTraceRecorder) persistDraft(draft *messageTraceDraft, force bool) {
 	r.persistDraftCtx(r.ctx, draft, force)
 }
@@ -771,7 +824,7 @@ func (r *messageTraceRecorder) emitProcessUpdate() {
 	emitEvent(r.onEvent, "process_update", map[string]interface{}{
 		"status": r.process.status,
 		"block":  traceDraftToBlock(r.process),
-		"trace":  r.snapshot(),
+		"trace":  r.streamingSnapshot(),
 	})
 }
 
@@ -782,7 +835,7 @@ func (r *messageTraceRecorder) emitToolUpdate() {
 	emitEvent(r.onEvent, "process_update", map[string]interface{}{
 		"status": r.tools.status,
 		"block":  traceDraftToBlock(r.tools),
-		"trace":  r.snapshot(),
+		"trace":  r.streamingSnapshot(),
 	})
 }
 
@@ -793,7 +846,7 @@ func (r *messageTraceRecorder) emitUpstreamThinkDelta(reasoning map[string]inter
 	payload := map[string]interface{}{
 		"status": r.upstreamThink.status,
 		"block":  traceDraftToBlock(r.upstreamThink),
-		"trace":  r.snapshot(),
+		"trace":  r.streamingSnapshot(),
 	}
 	if len(reasoning) > 0 {
 		payload["reasoning"] = reasoning

--- a/backend/internal/application/conversation/service_trace_tool_test.go
+++ b/backend/internal/application/conversation/service_trace_tool_test.go
@@ -455,3 +455,47 @@ func TestBudgetToolOutputForModelWrapsLargeResults(t *testing.T) {
 		t.Fatalf("expected retention note, got %q", got)
 	}
 }
+
+func TestStripLargeTracePayloadFieldsRemovesOversizedToolOutput(t *testing.T) {
+	largeOutput := strings.Repeat("x", 2000)
+	payload := map[string]interface{}{
+		"tool_calls": []interface{}{
+			map[string]interface{}{
+				"name":           "fetch",
+				"output":         largeOutput,
+				"output_text":    largeOutput,
+				"output_preview": "short preview",
+				"input":          "small input",
+			},
+		},
+	}
+	raw, _ := json.Marshal(payload)
+	got := stripLargeTracePayloadFields(string(raw))
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(got), &result); err != nil {
+		t.Fatalf("invalid JSON after strip: %v", err)
+	}
+	calls := result["tool_calls"].([]interface{})
+	call := calls[0].(map[string]interface{})
+	if _, exists := call["output"]; exists {
+		t.Fatal("expected 'output' to be stripped from streaming payload")
+	}
+	if _, exists := call["output_text"]; exists {
+		t.Fatal("expected 'output_text' to be stripped from streaming payload")
+	}
+	if preview, ok := call["output_preview"].(string); !ok || preview != "short preview" {
+		t.Fatalf("expected output_preview to be preserved, got %v", call["output_preview"])
+	}
+	if input, ok := call["input"].(string); !ok || input != "small input" {
+		t.Fatal("expected small input to be preserved")
+	}
+}
+
+func TestStripLargeTracePayloadFieldsPreservesSmallPayloads(t *testing.T) {
+	payload := `{"tool_calls":[{"name":"echo","output":"ok","input":"hi"}]}`
+	got := stripLargeTracePayloadFields(payload)
+	if got != payload {
+		t.Fatalf("expected small payload to be unchanged, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `streamingSnapshot()` that strips large tool output fields (`output`, `output_text`, `input` > 512 bytes) from trace event payloads before streaming to Redis
- Preserves `output_preview` (260-char truncation) so the frontend trace UI continues to show tool result summaries
- Full `snapshot()` used by `attachToMessage()` for database persistence is **unchanged** — no data loss in the final saved trace
- Changes only 3 call sites: `emitProcessUpdate`, `emitToolUpdate`, `emitUpstreamThinkDelta`

## Root cause

Every streaming delta (per-token reasoning updates, tool status changes) called `snapshot()` → serialized the full accumulated trace including unbounded `OutputJSON` from tool calls → JSON-marshaled → Redis XADD. A 2MB tool output × 500 token deltas = ~1GB Redis memory for a single conversation.

```
appendUpstreamReasoning (per token)
  → emitUpstreamThinkDelta
    → snapshot()           ← full tool outputs included
      → publish → Redis XADD
```

## Fix approach

```
emitUpstreamThinkDelta
  → streamingSnapshot()   ← strips output/output_text/input > 512B
    → publish → Redis XADD (now bounded)
```

| Path | Before | After |
|------|--------|-------|
| Streaming (Redis) | Full tool output every delta | `output_preview` only (260 chars) |
| Persistence (DB) | Full tool output | Full tool output (unchanged) |
| Frontend trace UI | Shows `output_preview` | Shows `output_preview` (unchanged) |

## Test plan

- [x] `TestStripLargeTracePayloadFieldsRemovesOversizedToolOutput` — verifies large output/output_text stripped, preview preserved
- [x] `TestStripLargeTracePayloadFieldsPreservesSmallPayloads` — verifies small payloads pass through unchanged
- [x] All existing conversation tests pass
- [x] Backend compiles
- [ ] Manual: trigger MCP tool with large output, monitor Redis memory stays bounded

Fixes #391