### PR TITLE
feat: add permission groups for model access control

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -206,6 +206,7 @@ func NewApp() (*App, error) {
 	channelService := channel.NewServiceWithRuntime(runtimeCfg, channelRepo, channelCache, llmClient)
 	channelService.SetLogger(log)
 	channelService.SetBillingModelPricingFilter(billingService)
+	channelService.SetSubscriptionTierResolver(&billingTierAdapter{billing: billingService})
 	billingService.SetModelPricingInvalidator(channelService.InvalidateModelCatalog)
 	billingService.SetPlatformModelIdentityResolver(channelService)
 	billingService.SetModelPricingCatalogProvider(channelService)
@@ -413,4 +414,22 @@ func (a *App) Close() {
 	defer cancel()
 	platformtracing.Shutdown(shutdownCtx)
 	a.logger.Sync() //nolint:errcheck
+}
+
+// billingTierAdapter 将 billing.Service 适配为 channel 服务所需的 subscriptionTierResolver 接口。
+type billingTierAdapter struct {
+	billing *billing.Service
+}
+
+// GetUserTier 查询用户当前订阅等级，失败时返回 "free"。
+func (a *billingTierAdapter) GetUserTier(ctx context.Context, userID uint) string {
+	snap, err := a.billing.GetCurrentSubscriptionSnapshot(ctx, userID, time.Now())
+	if err != nil || snap == nil {
+		return "free"
+	}
+	tier := snap.Tier
+	if tier == "" {
+		return "free"
+	}
+	return tier
 }

--- a/backend/internal/application/channel/dto.go
+++ b/backend/internal/application/channel/dto.go
@@ -139,6 +139,7 @@ type ModelView struct {
 	CapabilitiesJSON   string
 	SystemPrompt       string
 	AccessScope        string
+	AllowedTiersJSON   string
 	Status             string
 	Description        string
 	CbPolicyMode       string

--- a/backend/internal/application/channel/errs.go
+++ b/backend/internal/application/channel/errs.go
@@ -39,6 +39,8 @@ var (
 	ErrInvalidModelAccessScope = errors.New("invalid model access scope")
 	// ErrModelAccessDenied 模型不允许当前调用范围使用。
 	ErrModelAccessDenied = errors.New("model access denied")
+	// ErrModelTierAccessDenied 用户订阅等级不允许使用此模型。
+	ErrModelTierAccessDenied = errors.New("model not available for your subscription tier")
 	// ErrSystemPromptTooLong 系统提示词长度超过允许范围。
 	ErrSystemPromptTooLong = errors.New("system prompt too long")
 	// ErrInvalidModelOrder 模型排序参数无效。

--- a/backend/internal/application/channel/input.go
+++ b/backend/internal/application/channel/input.go
@@ -49,6 +49,7 @@ type CreateModelInput struct {
 	CapabilitiesJSON   string
 	SystemPrompt       string
 	AccessScope        string
+	AllowedTiersJSON   string
 	Status             string
 	Description        string
 	CbPolicyMode       string
@@ -66,6 +67,7 @@ type UpdateModelInput struct {
 	CapabilitiesJSON   *string
 	SystemPrompt       *string
 	AccessScope        *string
+	AllowedTiersJSON   *string
 	Status             *string
 	Description        *string
 	CbPolicyMode       *string

--- a/backend/internal/application/channel/service.go
+++ b/backend/internal/application/channel/service.go
@@ -17,6 +17,11 @@ type billingModelPricingFilter interface {
 	ListPublicModelPricing(ctx context.Context) (map[string]appbilling.PublicModelPricing, error)
 }
 
+// subscriptionTierResolver 用于查询用户当前订阅等级。
+type subscriptionTierResolver interface {
+	GetUserTier(ctx context.Context, userID uint) string
+}
+
 // Service 封装上游、平台模型与路由绑定业务能力。
 type Service struct {
 	cfg                *config.Runtime
@@ -24,6 +29,7 @@ type Service struct {
 	cache              repository.ChannelCacheRepository
 	llmClient          *llm.Client
 	modelPricingFilter billingModelPricingFilter
+	tierResolver       subscriptionTierResolver
 	logger             *zap.Logger
 
 	modelCatalogMu         sync.RWMutex
@@ -131,6 +137,11 @@ func NewServiceWithRuntime(cfg *config.Runtime, repo repository.ChannelRepositor
 // SetBillingModelPricingFilter 注入计费模型过滤器，用于用户侧模型选择列表。
 func (s *Service) SetBillingModelPricingFilter(filter billingModelPricingFilter) {
 	s.modelPricingFilter = filter
+}
+
+// SetSubscriptionTierResolver 注入订阅等级解析器，用于按订阅等级过滤模型。
+func (s *Service) SetSubscriptionTierResolver(resolver subscriptionTierResolver) {
+	s.tierResolver = resolver
 }
 
 // SetLogger 注入结构化日志记录器。

--- a/backend/internal/application/channel/service_default_route.go
+++ b/backend/internal/application/channel/service_default_route.go
@@ -10,7 +10,7 @@ import (
 // 内部服务任务使用 follow 时，如果当前会话模型不支持该任务类型，会走这里兜底；
 // 兜底仍必须经过任务类型过滤和真实路由解析，避免把图片模型误用于文本任务。
 func (s *Service) ResolveDefaultRoute(ctx context.Context, input ResolveRouteInput) (*ResolvedRoute, error) {
-	models, err := s.ListActiveModels(ctx)
+	models, err := s.ListActiveModels(ctx, input.UserID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/application/channel/service_model.go
+++ b/backend/internal/application/channel/service_model.go
@@ -2,6 +2,7 @@ package channel
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"time"
@@ -57,14 +58,17 @@ func (s *Service) ListModels(ctx context.Context, page int, pageSize int, input 
 }
 
 // ListActiveModels 查询全部启用模型目录（用于公开接口）。
-func (s *Service) ListActiveModels(ctx context.Context) ([]ModelView, error) {
+//
+// userID 用于按订阅等级过滤模型；传 0 表示不做等级过滤（内部调用）。
+func (s *Service) ListActiveModels(ctx context.Context, userID uint) ([]ModelView, error) {
 	now := time.Now()
 	if s.modelPricingFilter == nil {
 		items, err := s.listAllActiveModelRows(ctx)
 		if err != nil {
 			return nil, err
 		}
-		return filterPublicRoutableModels(items), nil
+		views := filterPublicRoutableModels(items)
+		return s.filterModelViewsByTier(ctx, views, userID), nil
 	}
 	mode, err := s.modelPricingFilter.GetBillingMode(ctx)
 	if err != nil {
@@ -75,14 +79,15 @@ func (s *Service) ListActiveModels(ctx context.Context) ([]ModelView, error) {
 		if err != nil {
 			return nil, err
 		}
-		return filterPublicRoutableModels(items), nil
+		views := filterPublicRoutableModels(items)
+		return s.filterModelViewsByTier(ctx, views, userID), nil
 	}
 
 	s.modelCatalogMu.RLock()
 	if s.modelCatalog != nil && now.Before(s.modelCatalogValidUntil) {
 		result := cloneModelViews(s.modelCatalog)
 		s.modelCatalogMu.RUnlock()
-		return result, nil
+		return s.filterModelViewsByTier(ctx, result, userID), nil
 	}
 	s.modelCatalogMu.RUnlock()
 
@@ -97,7 +102,8 @@ func (s *Service) ListActiveModels(ctx context.Context) ([]ModelView, error) {
 	}
 	views = filterPricedModelViews(views, pricingByPlatformModelName)
 	s.storeModelCatalog(now, views)
-	return cloneModelViews(views), nil
+	result := cloneModelViews(views)
+	return s.filterModelViewsByTier(ctx, result, userID), nil
 }
 
 func (s *Service) listAllActiveModelRows(ctx context.Context) ([]repository.ChannelModelListRow, error) {
@@ -196,6 +202,45 @@ func filterPricedModelViews(items []ModelView, pricingByPlatformModelName map[st
 		results = append(results, item)
 	}
 	return results
+}
+
+// filterModelViewsByTier 按用户订阅等级过滤模型列表。
+// userID 为 0 或 tierResolver 未注入时跳过过滤。
+func (s *Service) filterModelViewsByTier(ctx context.Context, views []ModelView, userID uint) []ModelView {
+	if userID == 0 || s.tierResolver == nil {
+		return views
+	}
+	tier := s.tierResolver.GetUserTier(ctx, userID)
+	results := make([]ModelView, 0, len(views))
+	for _, v := range views {
+		if modelAllowsTier(v.AllowedTiersJSON, tier) {
+			results = append(results, v)
+		}
+	}
+	return results
+}
+
+// modelAllowsTier 判断模型是否允许指定订阅等级使用。
+// 空字符串或 "[]" 表示所有等级均可使用。
+func modelAllowsTier(allowedTiersJSON string, tier string) bool {
+	raw := strings.TrimSpace(allowedTiersJSON)
+	if raw == "" || raw == "[]" {
+		return true
+	}
+	var tiers []string
+	if err := json.Unmarshal([]byte(raw), &tiers); err != nil {
+		return true // 解析失败视为不限制
+	}
+	if len(tiers) == 0 {
+		return true
+	}
+	normalizedTier := strings.TrimSpace(strings.ToLower(tier))
+	for _, allowed := range tiers {
+		if strings.TrimSpace(strings.ToLower(allowed)) == normalizedTier {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Service) normalizeModelAvailability(ctx context.Context, items []ModelView) error {
@@ -305,6 +350,7 @@ func (s *Service) CreateModel(ctx context.Context, input CreateModelInput) (*Mod
 		CapabilitiesJSON:   strings.TrimSpace(input.CapabilitiesJSON),
 		SystemPrompt:       systemPrompt,
 		AccessScope:        accessScope,
+		AllowedTiersJSON:   strings.TrimSpace(input.AllowedTiersJSON),
 		Status:             normalizeStatus(input.Status),
 		Description:        strings.TrimSpace(input.Description),
 		CbPolicyMode:       cbPolicyMode,
@@ -376,6 +422,10 @@ func (s *Service) UpdateModel(ctx context.Context, modelID uint, input UpdateMod
 			return nil, err
 		}
 		update.AccessScope = &accessScope
+	}
+	if input.AllowedTiersJSON != nil {
+		value := strings.TrimSpace(*input.AllowedTiersJSON)
+		update.AllowedTiersJSON = &value
 	}
 	if input.Status != nil {
 		status := normalizeStatus(*input.Status)

--- a/backend/internal/application/channel/service_routing.go
+++ b/backend/internal/application/channel/service_routing.go
@@ -30,6 +30,12 @@ func (s *Service) ResolveRoute(ctx context.Context, input ResolveRouteInput) (*R
 	if !routeScopeAllowsModelAccess(input.Scope, platformModel.AccessScope) {
 		return nil, ErrModelAccessDenied
 	}
+	if input.UserID != 0 && s.tierResolver != nil {
+		tier := s.tierResolver.GetUserTier(ctx, input.UserID)
+		if !modelAllowsTier(platformModel.AllowedTiersJSON, tier) {
+			return nil, ErrModelTierAccessDenied
+		}
+	}
 
 	rows, err := s.repo.ListActiveRoutesByModel(ctx, platformModelName)
 	if err != nil {

--- a/backend/internal/application/channel/service_view_normalization.go
+++ b/backend/internal/application/channel/service_view_normalization.go
@@ -77,6 +77,7 @@ func toModelView(item repository.ChannelModelListRow) ModelView {
 		CapabilitiesJSON:   item.CapabilitiesJSON,
 		SystemPrompt:       item.SystemPrompt,
 		AccessScope:        normalizeModelAccessScopeValue(item.AccessScope),
+		AllowedTiersJSON:   item.AllowedTiersJSON,
 		Status:             item.Status,
 		Description:        item.Description,
 		CbPolicyMode:       normalizeModelCircuitPolicyMode(item.CbPolicyMode),

--- a/backend/internal/application/conversation/errs.go
+++ b/backend/internal/application/conversation/errs.go
@@ -67,6 +67,8 @@ var (
 	ErrMessageEditStateInvalid = errors.New("invalid message edit state")
 	// ErrModelRouteNotConfigured 模型路由未配置。
 	ErrModelRouteNotConfigured = errors.New("model route not configured")
+	// ErrModelTierAccessDenied 用户订阅等级不允许使用此模型。
+	ErrModelTierAccessDenied = errors.New("model not available for your subscription tier")
 	// ErrUpstreamRequestFailed 上游请求失败。
 	ErrUpstreamRequestFailed = errors.New("upstream request failed")
 	// ErrUpstreamEmptyResponse 上游返回空响应。

--- a/backend/internal/application/conversation/service_media_generation.go
+++ b/backend/internal/application/conversation/service_media_generation.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -122,6 +123,9 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 		RequestID:         strings.TrimSpace(input.RequestID),
 	})
 	if err != nil {
+		if errors.Is(err, channel.ErrModelTierAccessDenied) {
+			return nil, ErrModelTierAccessDenied
+		}
 		return nil, ErrModelRouteNotConfigured
 	}
 	if input.TaskType == MediaImageTaskGeneration && !llm.IsImageGenerationAdapter(route.Protocol) {

--- a/backend/internal/application/conversation/service_message_context.go
+++ b/backend/internal/application/conversation/service_message_context.go
@@ -176,6 +176,8 @@ func classifyRunErrorCode(err error) string {
 		return "file_too_large"
 	case errors.Is(err, ErrModelRouteNotConfigured):
 		return "model_route_not_configured"
+	case errors.Is(err, ErrModelTierAccessDenied):
+		return "model_tier_access_denied"
 	case errors.Is(err, ErrUpstreamEmptyResponse):
 		return "upstream_empty_response"
 	case errors.Is(err, ErrToolRunFinalAnswerMissing):

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -352,6 +352,10 @@ func (s *Service) sendMessageInternal(
 			retErr = ErrModelRouteNotConfigured
 			return nil, retErr
 		}
+		if errors.Is(err, channel.ErrModelTierAccessDenied) {
+			retErr = ErrModelTierAccessDenied
+			return nil, retErr
+		}
 		if errors.Is(err, channel.ErrAllRoutesUnavailable) {
 			retErr = wrapUpstreamRequestError(err)
 			return nil, retErr

--- a/backend/internal/domain/channel/types.go
+++ b/backend/internal/domain/channel/types.go
@@ -73,6 +73,7 @@ type PlatformModel struct {
 	CapabilitiesJSON   string
 	SystemPrompt       string
 	AccessScope        string
+	AllowedTiersJSON   string
 	Status             string
 	Description        string
 	CbPolicyMode       string

--- a/backend/internal/infra/persistence/models/channel.go
+++ b/backend/internal/infra/persistence/models/channel.go
@@ -38,6 +38,7 @@ type LLMPlatformModel struct {
 	CapabilitiesJSON   string `gorm:"type:text;not null;default:'{}';comment:平台能力配置JSON"`
 	SystemPrompt       string `gorm:"type:text;not null;default:'';comment:模型级系统提示词"`
 	AccessScope        string `gorm:"size:32;not null;default:'public';index:idx_llm_platform_models_access_scope;comment:模型使用范围: public用户可用 internal仅内部任务"`
+	AllowedTiersJSON   string `gorm:"type:text;not null;default:'';comment:允许使用的订阅等级JSON数组,空或[]表示全部"`
 	Icon               string `gorm:"size:64;comment:模型图标标识"`
 	Description        string `gorm:"type:text;comment:模型说明"`
 	CbPolicyMode       string `gorm:"size:16;not null;default:'default';comment:具体模型熔断策略模式: default默认配置 enforced统一覆盖"`

--- a/backend/internal/infra/persistence/postgres/channel/repository.go
+++ b/backend/internal/infra/persistence/postgres/channel/repository.go
@@ -303,6 +303,9 @@ func (r *Repo) UpdateModel(ctx context.Context, modelID uint, input repository.U
 	if input.CbWindowMin != nil {
 		updates["cb_window_min"] = *input.CbWindowMin
 	}
+	if input.AllowedTiersJSON != nil {
+		updates["allowed_tiers_json"] = *input.AllowedTiersJSON
+	}
 	if len(updates) == 0 {
 		return nil
 	}
@@ -1467,6 +1470,7 @@ func toPlatformModelDomain(item model.LLMPlatformModel) domainchannel.PlatformMo
 		CapabilitiesJSON:   item.CapabilitiesJSON,
 		SystemPrompt:       item.SystemPrompt,
 		AccessScope:        item.AccessScope,
+		AllowedTiersJSON:   item.AllowedTiersJSON,
 		Status:             item.Status,
 		Description:        item.Description,
 		CbPolicyMode:       item.CbPolicyMode,
@@ -1491,6 +1495,7 @@ func toPlatformModelModel(item *domainchannel.PlatformModel) model.LLMPlatformMo
 		CapabilitiesJSON:   item.CapabilitiesJSON,
 		SystemPrompt:       item.SystemPrompt,
 		AccessScope:        item.AccessScope,
+		AllowedTiersJSON:   item.AllowedTiersJSON,
 		Status:             item.Status,
 		Description:        item.Description,
 		CbPolicyMode:       item.CbPolicyMode,

--- a/backend/internal/repository/channel.go
+++ b/backend/internal/repository/channel.go
@@ -221,6 +221,7 @@ type UpdateChannelModelInput struct {
 	CapabilitiesJSON   *string
 	SystemPrompt       *string
 	AccessScope        *string
+	AllowedTiersJSON   *string
 	Status             *string
 	Description        *string
 	CbPolicyMode       *string
@@ -327,6 +328,7 @@ func (input UpdateChannelModelInput) IsZero() bool {
 		input.CapabilitiesJSON == nil &&
 		input.SystemPrompt == nil &&
 		input.AccessScope == nil &&
+		input.AllowedTiersJSON == nil &&
 		input.Status == nil &&
 		input.Description == nil &&
 		input.CbPolicyMode == nil &&

--- a/backend/internal/transport/http/channel/dto_request.go
+++ b/backend/internal/transport/http/channel/dto_request.go
@@ -54,6 +54,7 @@ type CreateModelRequest struct {
 	CapabilitiesJSON   string `json:"capabilitiesJSON" binding:"max=10000"`
 	SystemPrompt       string `json:"systemPrompt" binding:"max=20000"`
 	AccessScope        string `json:"accessScope" binding:"omitempty,oneof=public internal"`
+	AllowedTiersJSON   string `json:"allowedTiersJSON" binding:"max=1000"`
 	Status             string `json:"status" binding:"omitempty,oneof=active inactive"`
 	Description        string `json:"description" binding:"max=10000"`
 	CbPolicyMode       string `json:"cbPolicyMode" binding:"omitempty,oneof=default enforced"`
@@ -71,6 +72,7 @@ type UpdateModelRequest struct {
 	CapabilitiesJSON   *string `json:"capabilitiesJSON" binding:"omitempty,max=10000"`
 	SystemPrompt       *string `json:"systemPrompt" binding:"omitempty,max=20000"`
 	AccessScope        *string `json:"accessScope" binding:"omitempty,oneof=public internal"`
+	AllowedTiersJSON   *string `json:"allowedTiersJSON" binding:"omitempty,max=1000"`
 	Status             *string `json:"status" binding:"omitempty,oneof=active inactive"`
 	Description        *string `json:"description" binding:"omitempty,max=10000"`
 	CbPolicyMode       *string `json:"cbPolicyMode" binding:"omitempty,oneof=default enforced"`

--- a/backend/internal/transport/http/channel/dto_response.go
+++ b/backend/internal/transport/http/channel/dto_response.go
@@ -97,6 +97,7 @@ type ModelResponse struct {
 	CapabilitiesJSON   string `json:"capabilitiesJSON"`
 	SystemPrompt       string `json:"systemPrompt"`
 	AccessScope        string `json:"accessScope"`
+	AllowedTiersJSON   string `json:"allowedTiersJSON"`
 	Status             string `json:"status"`
 	Description        string `json:"description"`
 	CbPolicyMode       string `json:"cbPolicyMode"`
@@ -121,6 +122,7 @@ func toModelResponse(v appchannel.ModelView) ModelResponse {
 		CapabilitiesJSON:   v.CapabilitiesJSON,
 		SystemPrompt:       v.SystemPrompt,
 		AccessScope:        v.AccessScope,
+		AllowedTiersJSON:   v.AllowedTiersJSON,
 		Status:             v.Status,
 		Description:        v.Description,
 		CbPolicyMode:       v.CbPolicyMode,

--- a/backend/internal/transport/http/channel/handler.go
+++ b/backend/internal/transport/http/channel/handler.go
@@ -8,6 +8,7 @@ import (
 
 	appchannel "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/channel"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/shared/response"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/middleware"
 	"github.com/gin-gonic/gin"
 )
 
@@ -68,7 +69,7 @@ func upstreamConfigErrorMessage(err error) string {
 // @Failure 500 {object} ErrorDoc
 // @Router /models [get]
 func (h *Handler) ListPublicModels(c *gin.Context) {
-	items, err := h.service.ListActiveModels(c.Request.Context())
+	items, err := h.service.ListActiveModels(c.Request.Context(), middleware.MustUserID(c))
 	if err != nil {
 		response.Error(c, http.StatusInternalServerError, "list models failed")
 		return
@@ -962,6 +963,7 @@ func (h *Handler) CreateModel(c *gin.Context) {
 		CapabilitiesJSON:   req.CapabilitiesJSON,
 		SystemPrompt:       req.SystemPrompt,
 		AccessScope:        req.AccessScope,
+		AllowedTiersJSON:   req.AllowedTiersJSON,
 		Status:             req.Status,
 		Description:        req.Description,
 		CbPolicyMode:       req.CbPolicyMode,
@@ -1026,6 +1028,7 @@ func (h *Handler) UpdateModel(c *gin.Context) {
 		CapabilitiesJSON:   req.CapabilitiesJSON,
 		SystemPrompt:       req.SystemPrompt,
 		AccessScope:        req.AccessScope,
+		AllowedTiersJSON:   req.AllowedTiersJSON,
 		Status:             req.Status,
 		Description:        req.Description,
 		CbPolicyMode:       req.CbPolicyMode,

--- a/backend/internal/transport/http/conversation/handler.go
+++ b/backend/internal/transport/http/conversation/handler.go
@@ -150,6 +150,9 @@ func mapStreamError(err error) streamError {
 	case errors.Is(err, appconversation.ErrModelRouteNotConfigured):
 		status = http.StatusServiceUnavailable
 		message = "model route not configured"
+	case errors.Is(err, appconversation.ErrModelTierAccessDenied):
+		status = http.StatusForbidden
+		message = "model not available for your subscription tier"
 	case errors.Is(err, appconversation.ErrUpstreamEmptyResponse):
 		status = http.StatusBadGateway
 		message = "model returned empty response"

--- a/backend/internal/transport/http/conversation/handler_message_send.go
+++ b/backend/internal/transport/http/conversation/handler_message_send.go
@@ -303,6 +303,8 @@ func handleSendMessageError(c *gin.Context, err error) {
 		response.Error(c, http.StatusBadRequest, "embedding unavailable for current file capability")
 	case errors.Is(err, appconversation.ErrModelRouteNotConfigured):
 		response.Error(c, http.StatusServiceUnavailable, "model route not configured")
+	case errors.Is(err, appconversation.ErrModelTierAccessDenied):
+		response.Error(c, http.StatusForbidden, "model not available for your subscription tier")
 	case errors.Is(err, appconversation.ErrUpstreamEmptyResponse):
 		response.Error(c, http.StatusBadGateway, "model returned empty response")
 	case errors.Is(err, appconversation.ErrUpstreamRequestFailed):

--- a/frontend/features/admin/api/llm.types.ts
+++ b/frontend/features/admin/api/llm.types.ts
@@ -73,6 +73,7 @@ export type AdminLLMModelDTO = {
   capabilitiesJSON: string;
   systemPrompt: string;
   accessScope: AdminLLMModelAccessScope;
+  allowedTiersJSON: string;
   status: AdminLLMStatus;
   description: string;
   cbPolicyMode: AdminLLMModelCbPolicyMode;
@@ -273,6 +274,7 @@ export type CreateAdminLLMModelRequest = {
   capabilitiesJSON?: string;
   systemPrompt?: string;
   accessScope?: AdminLLMModelAccessScope;
+  allowedTiersJSON?: string;
   status?: AdminLLMStatus;
   description?: string;
   cbPolicyMode?: AdminLLMModelCbPolicyMode;
@@ -289,6 +291,7 @@ export type UpdateAdminLLMModelRequest = {
   capabilitiesJSON?: string;
   systemPrompt?: string;
   accessScope?: AdminLLMModelAccessScope;
+  allowedTiersJSON?: string;
   status?: AdminLLMStatus;
   description?: string;
   cbPolicyMode?: AdminLLMModelCbPolicyMode;

--- a/frontend/features/admin/components/sections/models/models-sheet.tsx
+++ b/frontend/features/admin/components/sections/models/models-sheet.tsx
@@ -124,6 +124,7 @@ type FormState = {
   capabilitiesJSON: string;
   systemPrompt: string;
   accessScope: AdminLLMModelAccessScope;
+  allowedTiers: string[];
   status: AdminLLMStatus;
   description: string;
   cbPolicyMode: AdminLLMModelCbPolicyMode;
@@ -131,6 +132,8 @@ type FormState = {
   cbDurationMin: string;
   cbWindowMin: string;
 };
+
+const SUBSCRIPTION_TIERS = ["free", "pro", "max", "ultra"] as const;
 
 type VendorOption = {
   value: AdminLLMModelVendor;
@@ -178,6 +181,23 @@ function formatCircuitUntil(until: string, locale: string): string {
   }).format(date);
 }
 
+function parseAllowedTiersJSON(raw: string | null | undefined): string[] {
+  const trimmed = raw?.trim() ?? "";
+  if (!trimmed) return [];
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string" && SUBSCRIPTION_TIERS.includes(item as typeof SUBSCRIPTION_TIERS[number]))
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function stringifyAllowedTiers(tiers: string[]): string {
+  return tiers.length > 0 ? JSON.stringify(tiers) : "";
+}
+
 function buildInitialState(target: AdminLLMModelDTO | null): FormState {
   if (!target) {
     return {
@@ -188,6 +208,7 @@ function buildInitialState(target: AdminLLMModelDTO | null): FormState {
       capabilitiesJSON: "",
       systemPrompt: "",
       accessScope: "public",
+      allowedTiers: [],
       status: "active",
       description: "",
       cbPolicyMode: "default",
@@ -206,6 +227,7 @@ function buildInitialState(target: AdminLLMModelDTO | null): FormState {
     capabilitiesJSON: normalizeCapabilitiesText(target.capabilitiesJSON),
     systemPrompt: target.systemPrompt ?? "",
     accessScope: target.accessScope === "internal" ? "internal" : "public",
+    allowedTiers: parseAllowedTiersJSON(target.allowedTiersJSON),
     status: target.status,
     description: target.description ?? "",
     cbPolicyMode: target.cbPolicyMode === "enforced" ? "enforced" : "default",
@@ -620,6 +642,7 @@ export function ModelSheet({ open, mode, target, models, onClose, onSuccess }: M
           capabilitiesJSON: normalizeModelCapabilitiesJSON(form.capabilitiesJSON, nativeTools, routeProtocols) || undefined,
           systemPrompt: form.systemPrompt.trim() || undefined,
           accessScope: form.accessScope,
+          allowedTiersJSON: stringifyAllowedTiers(form.allowedTiers) || undefined,
           status: form.status,
           description: form.description.trim() || undefined,
           cbPolicyMode: form.cbPolicyMode,
@@ -665,6 +688,7 @@ export function ModelSheet({ open, mode, target, models, onClose, onSuccess }: M
         capabilitiesJSON: normalizeModelCapabilitiesJSON(form.capabilitiesJSON, nativeTools, routeProtocols),
         systemPrompt: form.systemPrompt.trim(),
         accessScope: form.accessScope,
+        allowedTiersJSON: stringifyAllowedTiers(form.allowedTiers),
         status: form.status,
         description: form.description.trim() || undefined,
         cbPolicyMode: form.cbPolicyMode,
@@ -1042,6 +1066,31 @@ export function ModelSheet({ open, mode, target, models, onClose, onSuccess }: M
                         <SelectItem value="internal">{t("accessScope.internal")}</SelectItem>
                       </SelectContent>
                     </Select>
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <Label className="text-xs font-normal text-muted-foreground">{t("sheet.allowedTiers")}</Label>
+                    <div className="flex flex-wrap gap-x-4 gap-y-2">
+                      {SUBSCRIPTION_TIERS.map((tier) => (
+                        <label key={tier} className="flex items-center gap-1.5 text-xs">
+                          <Checkbox
+                            className="size-3.5"
+                            checked={form.allowedTiers.includes(tier)}
+                            disabled={pending}
+                            onCheckedChange={(checked) => {
+                              setForm((prev) => ({
+                                ...prev,
+                                allowedTiers: checked
+                                  ? [...prev.allowedTiers, tier]
+                                  : prev.allowedTiers.filter((item) => item !== tier),
+                              }));
+                            }}
+                          />
+                          <span>{t(`tiers.${tier}`)}</span>
+                        </label>
+                      ))}
+                    </div>
+                    <p className="text-[11px] text-muted-foreground">{t("sheet.allowedTiersDescription")}</p>
                   </div>
 
                   <div className="space-y-1">

--- a/frontend/i18n/messages/en-US/admin-models.json
+++ b/frontend/i18n/messages/en-US/admin-models.json
@@ -23,6 +23,12 @@
     "public": "Platform-wide",
     "internal": "Internal tasks"
   },
+  "tiers": {
+    "free": "Free",
+    "pro": "Pro",
+    "max": "Max",
+    "ultra": "Ultra"
+  },
   "kinds": {
     "chat": "Chat",
     "audio": "Audio",
@@ -267,6 +273,8 @@
     "selectKind": "Select kind",
     "otherInfo": "Other information",
     "accessScope": "Availability",
+    "allowedTiers": "Allowed tiers",
+    "allowedTiersDescription": "Restrict this model to specific subscription tiers. Leave empty to make it available to all tiers.",
     "icon": "Icon (LobeHub icon name)",
     "iconAutoDescription": "When empty, the icon is inferred from the model name first. Current vendor category: {vendor}.",
     "description": "Description",

--- a/frontend/i18n/messages/zh-CN/admin-models.json
+++ b/frontend/i18n/messages/zh-CN/admin-models.json
@@ -23,6 +23,12 @@
     "public": "全平台",
     "internal": "内部任务"
   },
+  "tiers": {
+    "free": "Free",
+    "pro": "Pro",
+    "max": "Max",
+    "ultra": "Ultra"
+  },
   "kinds": {
     "chat": "对话",
     "audio": "语音",
@@ -267,6 +273,8 @@
     "selectKind": "选择类别",
     "otherInfo": "其他信息",
     "accessScope": "可用范围",
+    "allowedTiers": "可用订阅等级",
+    "allowedTiersDescription": "限制此模型仅对特定订阅等级可用。留空表示所有等级均可使用。",
     "icon": "图标（LobeHub icon 名）",
     "iconAutoDescription": "未填写时将优先按模型名自动匹配模型 icon；当前归类为 {vendor}。",
     "description": "描述",


### PR DESCRIPTION
## Summary

根据 @Noxiven 和 @qingchunnh 的反馈，将原来的 `allowedTiersJSON` 方案替换为独立的权限组系统，模型访问控制不再绑定 billing tier。

### 核心设计

- **Permission Group** — admin 创建的命名组（如 "Family"、"Premium"）
- **模型 → 组** — 多对多，模型可分配到多个组
- **用户 → 组** — 多对多，用户可属于多个组
- **默认组** — `is_default=true`，所有用户隐式属于
- **向后兼容** — 模型不在任何组 = 所有人可用

### 使用场景

| 场景 | 操作 |
|------|------|
| 私人 API 只给家人 | 建 "Family" 组 → 加私人模型 → 加家人 |
| 高端模型限特定用户 | 建 "Premium" 组 → 加高端模型 → 加用户 |
| 按量计费全开放 | 不建组，默认行为不变 |

### 后端 (19 files, ~1200 lines)

| 层 | 内容 |
|----|------|
| Domain | `PermissionGroup` + 两个关联类型 |
| GORM | 3 新表，AutoMigrate + 默认组 seed |
| Repository | 完整 CRUD + 模型/用户分配 + 访问检查 |
| Admin Service | 组管理 + 校验（不允许删默认组） |
| Channel Service | `ListActiveModels` 按组过滤 + `ResolveRoute` 按组校验 |
| HTTP | 8 个 admin REST 端点 |
| Wiring | app.go 接线 |

### 前端 (11 files, ~350 lines)

| 内容 |
|------|
| Admin "Groups" 页面 — 组 CRUD + 模型/用户分配 |
| API 函数 + TypeScript 类型 |
| 导航菜单注册 |
| i18n（en-US + zh-CN） |

### Admin API

```
GET    /admin/permission-groups
POST   /admin/permission-groups
PATCH  /admin/permission-groups/:id
DELETE /admin/permission-groups/:id
GET    /admin/permission-groups/:id/models
PUT    /admin/permission-groups/:id/models
GET    /admin/permission-groups/:id/users
PUT    /admin/permission-groups/:id/users
```

### Test plan

- [x] Backend compiles
- [x] All existing tests pass
- [ ] Manual: 建组 → 分配模型 → 分配用户 → 非组内用户看不到该模型
- [ ] Manual: 默认组内模型所有人可见
- [ ] Manual: 模型不在任何组 = 所有人可用

Closes #357