### PR TITLE
feat: Enhance tool call persistence handling and add OpenRouter support

### DIFF
--- a/backend/internal/application/channel/model_catalog.go
+++ b/backend/internal/application/channel/model_catalog.go
@@ -157,6 +157,7 @@ func systemFallbackProtocols(compatible string) map[string]string {
 func isKnownProtocol(raw string) bool {
 	switch strings.TrimSpace(strings.ToLower(raw)) {
 	case llm.AdapterOpenAIResponses,
+		llm.AdapterOpenRouterChat,
 		llm.AdapterOpenRouterResponses,
 		llm.AdapterOpenAIChatCompletions,
 		llm.AdapterAnthropicMessages,
@@ -332,6 +333,7 @@ func isProtocolAllowedForKind(kind string, protocol string) bool {
 	case modelKindChat, modelKindAudio:
 		switch protocol {
 		case llm.AdapterOpenAIResponses,
+			llm.AdapterOpenRouterChat,
 			llm.AdapterOpenRouterResponses,
 			llm.AdapterOpenAIChatCompletions,
 			llm.AdapterAnthropicMessages,

--- a/backend/internal/application/channel/model_catalog_test.go
+++ b/backend/internal/application/channel/model_catalog_test.go
@@ -209,8 +209,14 @@ func TestReasoningContentPassbackRequiredForDeepSeekChatCompletions(t *testing.T
 	if !reasoningContentPassbackRequired(llm.AdapterOpenAIChatCompletions, "deepseek", "deepseek-v4-flash-free") {
 		t.Fatal("expected DeepSeek Chat Completions route to require reasoning_content passback")
 	}
+	if !reasoningContentPassbackRequired(llm.AdapterOpenRouterChat, "openai", "openai/gpt-oss-120b:free") {
+		t.Fatal("expected OpenRouter Chat Completions route to require reasoning passback")
+	}
 	if reasoningContentPassbackRequired(llm.AdapterOpenAIChatCompletions, "openai", "gpt-5.4") {
 		t.Fatal("expected OpenAI Chat Completions route to skip reasoning_content passback")
+	}
+	if reasoningContentPassbackRequired(llm.AdapterOpenRouterResponses, "openai/gpt-oss-120b:free") {
+		t.Fatal("expected OpenRouter Responses route to skip Chat Completions reasoning passback")
 	}
 	if reasoningContentPassbackRequired(llm.AdapterOpenAIResponses, "deepseek", "deepseek-v4-flash-free") {
 		t.Fatal("expected non Chat Completions route to skip reasoning_content passback")

--- a/backend/internal/application/channel/service_probe.go
+++ b/backend/internal/application/channel/service_probe.go
@@ -352,6 +352,7 @@ func selectProbeAPIKey(cfg domainchannel.APIKeysConfig) (string, error) {
 func isLightweightModelProbeProtocol(protocol string) bool {
 	switch llm.NormalizeAdapter(protocol) {
 	case llm.AdapterOpenAIResponses,
+		llm.AdapterOpenRouterChat,
 		llm.AdapterOpenRouterResponses,
 		llm.AdapterOpenAIChatCompletions,
 		llm.AdapterAnthropicMessages,

--- a/backend/internal/application/channel/service_view_normalization.go
+++ b/backend/internal/application/channel/service_view_normalization.go
@@ -403,10 +403,14 @@ func normalizeUpstreamModelVendor(raw string, candidates ...string) string {
 }
 
 func reasoningContentPassbackRequired(protocol string, candidates ...string) bool {
-	if llm.NormalizeAdapter(protocol) != llm.AdapterOpenAIChatCompletions {
+	switch llm.NormalizeAdapter(protocol) {
+	case llm.AdapterOpenRouterChat:
+		return true
+	case llm.AdapterOpenAIChatCompletions:
+		return detectModelVendor(candidates...) == "deepseek"
+	default:
 		return false
 	}
-	return detectModelVendor(candidates...) == "deepseek"
 }
 
 func detectModelVendor(candidates ...string) string {

--- a/backend/internal/application/conversation/context_artifact.go
+++ b/backend/internal/application/conversation/context_artifact.go
@@ -339,7 +339,8 @@ func buildPromptContextArtifacts(input promptContextArtifactInput) []domainconve
 func buildToolContextArtifacts(input toolContextArtifactInput) []domainconversation.ContextArtifact {
 	items := make([]domainconversation.ContextArtifact, 0, len(input.Rows))
 	for _, row := range input.Rows {
-		content := toolArtifactContent(row)
+		rawContent := toolArtifactContent(row)
+		content, truncated := toolArtifactEvidenceContent(rawContent, contextArtifactExcerptChars)
 		if strings.TrimSpace(content) == "" {
 			continue
 		}
@@ -357,8 +358,8 @@ func buildToolContextArtifacts(input toolContextArtifactInput) []domainconversat
 			SourceType:     "tool_call",
 			SourceID:       sourceID,
 			SourceTitle:    strings.TrimSpace(row.ToolName),
-			Content:        contextArtifactExcerpt(content, contextArtifactExcerptChars),
-			ContentHash:    contextArtifactHash(kind, sourceID, content),
+			Content:        content,
+			ContentHash:    contextArtifactHash(kind, sourceID, rawContent),
 			TokenEstimate:  estimateTokens(content),
 			Score:          1,
 			MetadataJSON: contextArtifactMetadata(map[string]interface{}{
@@ -368,6 +369,8 @@ func buildToolContextArtifacts(input toolContextArtifactInput) []domainconversat
 				"status":       strings.TrimSpace(row.Status),
 				"latency_ms":   row.LatencyMS,
 				"input":        strings.TrimSpace(row.InputJSON),
+				"output_chars": len([]rune(rawContent)),
+				"truncated":    truncated,
 			}),
 		})
 	}
@@ -574,6 +577,17 @@ func toolArtifactContent(row domainconversation.ToolCall) string {
 	default:
 		return firstNonEmptyString(row.OutputJSON, row.ErrorJSON)
 	}
+}
+
+func toolArtifactEvidenceContent(raw string, maxChars int) (string, bool) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", false
+	}
+	if maxChars <= 0 || len([]rune(value)) <= maxChars {
+		return value, false
+	}
+	return headTailToolOutput(value, maxChars), true
 }
 
 func toolContextArtifactKind(row domainconversation.ToolCall) domainconversation.ContextArtifactKind {

--- a/backend/internal/application/conversation/context_artifact_test.go
+++ b/backend/internal/application/conversation/context_artifact_test.go
@@ -2,6 +2,7 @@ package conversation
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
@@ -171,6 +172,31 @@ func TestBuildToolContextArtifactsRecordsLocalAndNativeTools(t *testing.T) {
 	}
 	if items[1].Kind != model.ContextArtifactNativeTool || items[1].SourceID != "call_native" {
 		t.Fatalf("expected native tool artifact, got %#v", items[1])
+	}
+}
+
+func TestBuildToolContextArtifactsKeepsHeadAndTailForLargeResults(t *testing.T) {
+	items := buildToolContextArtifacts(toolContextArtifactInput{
+		ConversationID: 7,
+		UserID:         11,
+		MessageID:      13,
+		RunID:          "run_1",
+		Rows: []model.ToolCall{{
+			ToolCallID: "call_large",
+			ToolType:   "function",
+			ToolName:   "fetch_large",
+			Status:     "success",
+			OutputJSON: "HEAD-" + strings.Repeat("x", contextArtifactExcerptChars+256) + "-TAIL",
+		}},
+	})
+	if len(items) != 1 {
+		t.Fatalf("expected one tool artifact, got %#v", items)
+	}
+	if !strings.Contains(items[0].Content, "HEAD-") || !strings.Contains(items[0].Content, "-TAIL") {
+		t.Fatalf("expected large artifact content to preserve head and tail, got %q", items[0].Content)
+	}
+	if !strings.Contains(items[0].MetadataJSON, `"truncated":true`) {
+		t.Fatalf("expected truncated metadata, got %q", items[0].MetadataJSON)
 	}
 }
 

--- a/backend/internal/application/conversation/generation_stream.go
+++ b/backend/internal/application/conversation/generation_stream.go
@@ -20,6 +20,7 @@ const (
 	generationStreamMaxEvents        = 1024
 	generationStreamSubscriberBuffer = 128
 	generationStreamReadBlock        = 5 * time.Second
+	generationStreamMaxPayloadBytes  = 128 * 1024
 )
 
 type generationStreamOptions struct {
@@ -255,13 +256,20 @@ func (r *generationStreamRegistry) publish(ctx context.Context, runID string, pa
 	}
 	r.touchActive(ctx, runID)
 	actual := cloneStreamPayload(payload)
-	payloadJSON, err := marshalStreamPayload(actual)
+	persisted, sanitized := generationStreamPayloadForStore(actual)
+	payloadJSON, err := marshalStreamPayload(persisted)
 	if err != nil {
 		return actual
 	}
 	record, err := r.append(ctx, r.store, runID, payloadJSON)
 	if err == nil && record.Seq > 0 {
 		actual["seq"] = record.Seq
+		if sanitized {
+			persisted["seq"] = record.Seq
+		}
+	}
+	if shouldReturnSanitizedGenerationStreamPayload(actual, sanitized) {
+		return persisted
 	}
 	return actual
 }
@@ -537,6 +545,159 @@ func marshalStreamPayload(payload map[string]interface{}) (string, error) {
 		return "", err
 	}
 	return string(data), nil
+}
+
+func generationStreamPayloadForStore(payload map[string]interface{}) (map[string]interface{}, bool) {
+	if !isTraceUpdateStreamPayload(payload) {
+		return payload, false
+	}
+	payloadJSON, err := marshalStreamPayload(payload)
+	if err != nil || len(payloadJSON) <= generationStreamMaxPayloadBytes {
+		return payload, false
+	}
+	sanitized := sanitizeGenerationStreamPayload(payload)
+	payloadJSON, err = marshalStreamPayload(sanitized)
+	if err != nil || len(payloadJSON) <= generationStreamMaxPayloadBytes {
+		return sanitized, true
+	}
+	return compactOversizedGenerationStreamPayload(sanitized), true
+}
+
+func shouldReturnSanitizedGenerationStreamPayload(actual map[string]interface{}, sanitized bool) bool {
+	return sanitized && isTraceUpdateStreamPayload(actual)
+}
+
+func isTraceUpdateStreamPayload(payload map[string]interface{}) bool {
+	switch strings.TrimSpace(streamString(payload["type"])) {
+	case "process_update", "upstream_think_delta":
+		return true
+	default:
+		return false
+	}
+}
+
+func sanitizeGenerationStreamPayload(payload map[string]interface{}) map[string]interface{} {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		next := cloneStreamPayload(payload)
+		next["payloadTruncated"] = true
+		return next
+	}
+	var normalized interface{}
+	if err := json.Unmarshal(raw, &normalized); err != nil {
+		next := cloneStreamPayload(payload)
+		next["payloadTruncated"] = true
+		return next
+	}
+	sanitized, _ := sanitizeGenerationStreamValue(normalized).(map[string]interface{})
+	if sanitized == nil {
+		sanitized = map[string]interface{}{}
+	}
+	sanitized["payloadTruncated"] = true
+	return sanitized
+}
+
+func sanitizeGenerationStreamValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		next := make(map[string]interface{}, len(typed))
+		for key, item := range typed {
+			if shouldDropStreamTraceField(key) {
+				next[key+"_size"] = len(strings.TrimSpace(streamString(item)))
+				next[key+"_truncated"] = true
+				continue
+			}
+			if isTracePayloadJSONField(key) {
+				if sanitized := sanitizeStreamTracePayloadJSON(streamString(item)); sanitized != "" {
+					next[key] = sanitized
+				}
+				continue
+			}
+			if key == "tool_calls" {
+				next[key] = sanitizeStreamToolCalls(item)
+				continue
+			}
+			next[key] = sanitizeGenerationStreamValue(item)
+		}
+		return next
+	case []interface{}:
+		next := make([]interface{}, 0, len(typed))
+		for _, item := range typed {
+			next = append(next, sanitizeGenerationStreamValue(item))
+		}
+		return next
+	default:
+		return value
+	}
+}
+
+func sanitizeStreamToolCalls(value interface{}) interface{} {
+	items, ok := value.([]interface{})
+	if !ok {
+		return sanitizeGenerationStreamValue(value)
+	}
+	next := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		record, ok := item.(map[string]interface{})
+		if !ok {
+			next = append(next, sanitizeGenerationStreamValue(item))
+			continue
+		}
+		next = append(next, sanitizeGenerationStreamValue(record))
+	}
+	return next
+}
+
+func sanitizeStreamTracePayloadJSON(raw string) string {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return ""
+	}
+	var payload interface{}
+	if err := json.Unmarshal([]byte(value), &payload); err != nil {
+		return ""
+	}
+	sanitized := sanitizeGenerationStreamValue(payload)
+	data, err := json.Marshal(sanitized)
+	if err != nil || string(data) == "{}" {
+		return ""
+	}
+	return string(data)
+}
+
+func compactOversizedGenerationStreamPayload(payload map[string]interface{}) map[string]interface{} {
+	eventType := strings.TrimSpace(streamString(payload["type"]))
+	next := map[string]interface{}{
+		"type":             eventType,
+		"payloadTruncated": true,
+	}
+	for _, key := range []string{"status", "message", "errorCode", "code"} {
+		if value := strings.TrimSpace(streamString(payload[key])); value != "" {
+			next[key] = compactSnippet(value, 512)
+		}
+	}
+	if eventType == "" {
+		next["type"] = "stream_update"
+	}
+	return next
+}
+
+func shouldDropStreamTraceField(key string) bool {
+	switch key {
+	case "input", "input_detail", "output", "output_text", "output_detail":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTracePayloadJSONField(key string) bool {
+	return key == "payloadJSON" || key == "PayloadJSON" || key == "payloadJson"
+}
+
+func streamString(value interface{}) string {
+	text, _ := value.(string)
+	return text
 }
 
 func cloneStreamPayload(payload map[string]interface{}) map[string]interface{} {

--- a/backend/internal/application/conversation/generation_stream_test.go
+++ b/backend/internal/application/conversation/generation_stream_test.go
@@ -2,6 +2,7 @@ package conversation
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -158,6 +159,135 @@ func TestGenerationStreamStoreReturnsLatestWindow(t *testing.T) {
 	}
 	if events[0].Seq != 3 || events[1].Seq != 4 || events[2].Seq != 5 {
 		t.Fatalf("unexpected event window: %+v", events)
+	}
+}
+
+func TestGenerationStreamSanitizesOversizedTracePayload(t *testing.T) {
+	store := newTestGenerationStreamStore()
+	registry := newGenerationStreamRegistry(store, generationStreamOptions{
+		Retention:        time.Minute,
+		ActiveTTL:        time.Minute,
+		MaxEvents:        8,
+		SubscriberBuffer: 4,
+	})
+	ctx := context.Background()
+	runID := EnsureMessageGenerationRunID("")
+	registry.register(ctx, runID, 7, func() {})
+	defer registry.finish(ctx, runID)
+
+	largeOutput := strings.Repeat("x", generationStreamMaxPayloadBytes)
+	tracePayload, err := json.Marshal(map[string]interface{}{
+		"tool_calls": []map[string]interface{}{{
+			"tool_call_id":   "call_1",
+			"name":           "fetch",
+			"status":         "success",
+			"output":         largeOutput,
+			"output_detail":  largeOutput,
+			"output_text":    largeOutput,
+			"output_preview": "short result",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	published := registry.publish(ctx, runID, map[string]interface{}{
+		"type":   "process_update",
+		"status": "streaming",
+		"trace": map[string]interface{}{
+			"tools": map[string]interface{}{
+				"payloadJSON": string(tracePayload),
+			},
+		},
+	})
+	if published["payloadTruncated"] != true {
+		t.Fatalf("expected published payload to be marked truncated, got %#v", published)
+	}
+
+	records, err := store.ListGenerationStreamEvents(ctx, runID, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected one stream record, got %d", len(records))
+	}
+	record := records[0].PayloadJSON
+	if len(record) > generationStreamMaxPayloadBytes {
+		t.Fatalf("expected sanitized stream payload below hard limit, got %d bytes", len(record))
+	}
+	if strings.Contains(record, largeOutput[:1024]) {
+		t.Fatal("sanitized stream payload still contains full tool output")
+	}
+	var parsed struct {
+		Trace struct {
+			Tools struct {
+				PayloadJSON string `json:"payloadJSON"`
+			} `json:"tools"`
+		} `json:"trace"`
+	}
+	if err := json.Unmarshal([]byte(record), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	var parsedTrace struct {
+		ToolCalls []map[string]interface{} `json:"tool_calls"`
+	}
+	if err := json.Unmarshal([]byte(parsed.Trace.Tools.PayloadJSON), &parsedTrace); err != nil {
+		t.Fatal(err)
+	}
+	if len(parsedTrace.ToolCalls) != 1 {
+		t.Fatalf("expected one sanitized tool call, got %#v", parsedTrace.ToolCalls)
+	}
+	call := parsedTrace.ToolCalls[0]
+	if traceInt64(call["output_size"]) != int64(len(largeOutput)) ||
+		traceInt64(call["output_detail_size"]) != int64(len(largeOutput)) ||
+		traceInt64(call["output_text_size"]) != int64(len(largeOutput)) {
+		t.Fatalf("expected output size metadata in sanitized payload, got %#v", call)
+	}
+	if _, ok := call["output_detail"]; ok {
+		t.Fatalf("expected oversized output detail to be removed, got %#v", call)
+	}
+}
+
+func TestGenerationStreamDoesNotCompactOversizedCompletedPayload(t *testing.T) {
+	store := newTestGenerationStreamStore()
+	registry := newGenerationStreamRegistry(store, generationStreamOptions{
+		Retention:        time.Minute,
+		ActiveTTL:        time.Minute,
+		MaxEvents:        8,
+		SubscriberBuffer: 4,
+	})
+	ctx := context.Background()
+	runID := EnsureMessageGenerationRunID("")
+	registry.register(ctx, runID, 7, func() {})
+	defer registry.finish(ctx, runID)
+
+	largeContent := strings.Repeat("a", generationStreamMaxPayloadBytes)
+	published := registry.publish(ctx, runID, map[string]interface{}{
+		"type": "completed",
+		"data": map[string]interface{}{
+			"assistantMessage": map[string]interface{}{
+				"content": largeContent,
+			},
+		},
+	})
+
+	if published["payloadTruncated"] == true {
+		t.Fatalf("completed payload must not be compacted for active clients, got %#v", published)
+	}
+	data, ok := published["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected completed data to be preserved, got %#v", published)
+	}
+	assistant, ok := data["assistantMessage"].(map[string]interface{})
+	if !ok || assistant["content"] != largeContent {
+		t.Fatal("expected completed assistant content to be preserved")
+	}
+	records, err := store.ListGenerationStreamEvents(ctx, runID, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || !strings.Contains(records[0].PayloadJSON, largeContent[:1024]) {
+		t.Fatalf("expected stored terminal event to preserve completed data, got %+v", records)
 	}
 }
 

--- a/backend/internal/application/conversation/model_option_policy.go
+++ b/backend/internal/application/conversation/model_option_policy.go
@@ -550,6 +550,8 @@ func modelOptionPolicyProtocolKey(protocol string) string {
 		return "google_image_generation"
 	case llm.AdapterOpenAIChatCompletions:
 		return "openai_chat_completions"
+	case llm.AdapterOpenRouterChat:
+		return "openrouter_chat_completions"
 	case llm.AdapterOpenRouterResponses:
 		return "openrouter_responses"
 	case llm.AdapterOpenAIImageGenerations:

--- a/backend/internal/application/conversation/model_option_policy_test.go
+++ b/backend/internal/application/conversation/model_option_policy_test.go
@@ -212,6 +212,24 @@ func TestFilterModelOptionsRejectsUnsupportedOpenAIServiceTier(t *testing.T) {
 	}
 }
 
+func TestFilterModelOptionsKeepsOpenRouterChatServiceTierOutOfDefaultAllowlist(t *testing.T) {
+	filtered := filterModelOptions(map[string]interface{}{
+		"service_tier":     "priority",
+		"reasoning_effort": "high",
+	}, llm.AdapterOpenRouterChat, modelOptionPolicyConfig{
+		Mode:             modelOptionPolicyAllowlist,
+		AllowedPathsJSON: config.DefaultModelOptionAllowedPathsJSON(),
+		DeniedPathsJSON:  config.DefaultModelOptionDeniedPathsJSON(),
+	})
+
+	if _, ok := filtered["service_tier"]; ok {
+		t.Fatalf("expected OpenRouter Chat service_tier to stay outside the default allowlist, got %#v", filtered)
+	}
+	if filtered["reasoning_effort"] != "high" {
+		t.Fatalf("expected OpenRouter Chat reasoning_effort to pass, got %#v", filtered)
+	}
+}
+
 func TestFilterModelOptionsDenylistAllowsUnlistedAndRemovesDenied(t *testing.T) {
 	filtered := filterModelOptions(map[string]interface{}{
 		"temperature":          0.2,

--- a/backend/internal/application/conversation/service_message_completion.go
+++ b/backend/internal/application/conversation/service_message_completion.go
@@ -29,24 +29,26 @@ type persistMessageGenerationInput struct {
 	ResponseID                string
 	StatefulPromptFingerprint string
 	ToolCallRows              []model.ToolCall
+	PersistedToolCallKeys     map[string]struct{}
 }
 
 type persistInterruptedMessageGenerationInput struct {
-	SendInput            SendMessageInput
-	UserMessage          *model.Message
-	AssistantMessage     *model.Message
-	AssistantText        string
-	EstimatedInputTokens int64
-	UpstreamCallStarted  bool
-	Usage                llm.Usage
-	AssistantLatency     int64
-	Error                error
-	ToolCallRows         []model.ToolCall
-	TraceRecorder        *messageTraceRecorder
-	Route                *channel.ResolvedRoute
-	EffectiveOptions     map[string]interface{}
-	ServerSideToolUsage  map[string]int64
-	StartedAt            time.Time
+	SendInput             SendMessageInput
+	UserMessage           *model.Message
+	AssistantMessage      *model.Message
+	AssistantText         string
+	EstimatedInputTokens  int64
+	UpstreamCallStarted   bool
+	Usage                 llm.Usage
+	AssistantLatency      int64
+	Error                 error
+	ToolCallRows          []model.ToolCall
+	PersistedToolCallKeys map[string]struct{}
+	TraceRecorder         *messageTraceRecorder
+	Route                 *channel.ResolvedRoute
+	EffectiveOptions      map[string]interface{}
+	ServerSideToolUsage   map[string]int64
+	StartedAt             time.Time
 }
 
 type interruptedMessageGenerationMetrics struct {
@@ -61,11 +63,12 @@ type interruptedMessageGenerationMetrics struct {
 }
 
 type persistMessageToolCallsInput struct {
-	SendInput          SendMessageInput
-	UserMessageID      uint
-	AssistantMessageID uint
-	RunID              string
-	Rows               []model.ToolCall
+	SendInput             SendMessageInput
+	UserMessageID         uint
+	AssistantMessageID    uint
+	RunID                 string
+	Rows                  []model.ToolCall
+	PersistedToolCallKeys map[string]struct{}
 }
 
 func (s *Service) persistSuccessfulMessageGeneration(ctx context.Context, input persistMessageGenerationInput) error {
@@ -166,11 +169,12 @@ func successfulMessageGenerationModelName(input persistMessageGenerationInput) s
 
 func (s *Service) finishSuccessfulMessageGeneration(ctx context.Context, input persistMessageGenerationInput) error {
 	if err := s.persistMessageToolCalls(ctx, persistMessageToolCallsInput{
-		SendInput:          input.SendInput,
-		UserMessageID:      input.UserMessage.ID,
-		AssistantMessageID: input.AssistantMessage.ID,
-		RunID:              input.AssistantMessage.RunID,
-		Rows:               input.ToolCallRows,
+		SendInput:             input.SendInput,
+		UserMessageID:         input.UserMessage.ID,
+		AssistantMessageID:    input.AssistantMessage.ID,
+		RunID:                 input.AssistantMessage.RunID,
+		Rows:                  input.ToolCallRows,
+		PersistedToolCallKeys: input.PersistedToolCallKeys,
 	}); err != nil {
 		return err
 	}
@@ -239,11 +243,12 @@ func (s *Service) persistInterruptedMessageGeneration(ctx context.Context, input
 	applyInterruptedMessageGenerationState(input, metrics)
 
 	if err := s.persistMessageToolCalls(persistCtx, persistMessageToolCallsInput{
-		SendInput:          input.SendInput,
-		UserMessageID:      input.UserMessage.ID,
-		AssistantMessageID: input.AssistantMessage.ID,
-		RunID:              input.AssistantMessage.RunID,
-		Rows:               input.ToolCallRows,
+		SendInput:             input.SendInput,
+		UserMessageID:         input.UserMessage.ID,
+		AssistantMessageID:    input.AssistantMessage.ID,
+		RunID:                 input.AssistantMessage.RunID,
+		Rows:                  input.ToolCallRows,
+		PersistedToolCallKeys: input.PersistedToolCallKeys,
 	}); err != nil {
 		s.logger.Warn("persist_interrupted_tool_calls_failed",
 			zap.String("trace_id", traceid.FromContext(ctx)),
@@ -365,8 +370,16 @@ func (s *Service) persistMessageToolCalls(ctx context.Context, input persistMess
 	if len(rows) == 0 {
 		return nil
 	}
-	if err := s.repo.CreateConversationToolCalls(ctx, rows); err != nil {
-		return err
+	unpersisted := make([]model.ToolCall, 0, len(rows))
+	for _, row := range rows {
+		if _, ok := input.PersistedToolCallKeys[toolCallPersistenceKey(row)]; !ok {
+			unpersisted = append(unpersisted, row)
+		}
+	}
+	if len(unpersisted) > 0 {
+		if err := s.repo.CreateConversationToolCalls(ctx, unpersisted); err != nil {
+			return err
+		}
 	}
 	s.persistToolContextArtifacts(ctx, toolContextArtifactInput{
 		ConversationID: input.SendInput.ConversationID,

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -197,6 +197,7 @@ func (s *Service) sendMessageInternal(
 	var streamedText strings.Builder
 	var streamUsageTotal llm.Usage
 	var toolCallRows []model.ToolCall
+	var persistedToolCallKeys map[string]struct{}
 	var resolvedRoute *channel.ResolvedRoute
 	var filteredOptions map[string]interface{}
 	var totalServerSideToolUsage map[string]int64
@@ -208,21 +209,22 @@ func (s *Service) sendMessageInternal(
 	defer func() {
 		if retErr != nil {
 			if retained := s.persistInterruptedMessageGeneration(ctx, persistInterruptedMessageGenerationInput{
-				SendInput:            input,
-				UserMessage:          userMessage,
-				AssistantMessage:     assistantMessage,
-				AssistantText:        streamedText.String(),
-				EstimatedInputTokens: estimatedInputTokens,
-				UpstreamCallStarted:  upstreamCallStarted,
-				Usage:                streamUsageTotal,
-				AssistantLatency:     time.Since(startedAt).Milliseconds(),
-				Error:                retErr,
-				ToolCallRows:         toolCallRows,
-				TraceRecorder:        traceRecorder,
-				Route:                resolvedRoute,
-				EffectiveOptions:     filteredOptions,
-				ServerSideToolUsage:  totalServerSideToolUsage,
-				StartedAt:            startedAt,
+				SendInput:             input,
+				UserMessage:           userMessage,
+				AssistantMessage:      assistantMessage,
+				AssistantText:         streamedText.String(),
+				EstimatedInputTokens:  estimatedInputTokens,
+				UpstreamCallStarted:   upstreamCallStarted,
+				Usage:                 streamUsageTotal,
+				AssistantLatency:      time.Since(startedAt).Milliseconds(),
+				Error:                 retErr,
+				ToolCallRows:          toolCallRows,
+				PersistedToolCallKeys: persistedToolCallKeys,
+				TraceRecorder:         traceRecorder,
+				Route:                 resolvedRoute,
+				EffectiveOptions:      filteredOptions,
+				ServerSideToolUsage:   totalServerSideToolUsage,
+				StartedAt:             startedAt,
 			}); retained != nil {
 				result = retained
 				applyRetainedGenerationRunUsage(run, retained, len(toolCallRows), startedAt)
@@ -1035,6 +1037,7 @@ func (s *Service) sendMessageInternal(
 		toolResult := s.executeAssistantToolCalls(toolCtx, executeAssistantToolCallsInput{
 			UserID:         input.UserID,
 			ConversationID: input.ConversationID,
+			MessageID:      assistantMessage.ID,
 			RequestID:      input.RequestID,
 			RunID:          runID,
 			ToolCalls:      upstreamOutput.ToolCalls,
@@ -1054,6 +1057,7 @@ func (s *Service) sendMessageInternal(
 		}
 		toolSpan.End()
 		toolCallRows = append(toolCallRows, toolResult.Rows...)
+		mergeToolCallPersistenceKeys(&persistedToolCallKeys, toolResult.PersistedToolCallKeys)
 		remainingToolCalls -= len(toolResult.Rows)
 		if toolResult.FatalErr != nil {
 			retErr = wrapUpstreamRequestError(toolResult.FatalErr)
@@ -1243,6 +1247,7 @@ func (s *Service) sendMessageInternal(
 		ResponseID:                upstreamOutput.ResponseID,
 		StatefulPromptFingerprint: statefulPromptFingerprint,
 		ToolCallRows:              toolCallRows,
+		PersistedToolCallKeys:     persistedToolCallKeys,
 	})
 	platformtracing.RecordError(persistSpan, err)
 	persistSpan.End()

--- a/backend/internal/application/conversation/service_tool_execution.go
+++ b/backend/internal/application/conversation/service_tool_execution.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -12,11 +13,22 @@ import (
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/mcp"
 )
 
-const toolResultModelBudgetChars = 12000
+const (
+	toolResultModelBudgetChars        = 12000
+	toolResultReferenceThresholdChars = 50000
+	toolResultReferencePreviewChars   = 2000
+	toolResultAggregateBudgetChars    = 200000
+)
+
+const (
+	toolResultBudgetRetainedIn = "server-side tool call record"
+	toolResultOpaquePreviewMax = 512
+)
 
 type executeAssistantToolCallsInput struct {
 	UserID         uint
 	ConversationID uint
+	MessageID      uint
 	RequestID      string
 	RunID          string
 	ToolCalls      []llm.ToolCall
@@ -29,10 +41,11 @@ type executeAssistantToolCallsInput struct {
 }
 
 type executeAssistantToolCallsResult struct {
-	Rows              []model.ToolCall
-	ToolResults       []llm.ToolResult
-	ExecutedToolCalls []llm.ToolCall
-	FatalErr          error
+	Rows                  []model.ToolCall
+	ToolResults           []llm.ToolResult
+	ExecutedToolCalls     []llm.ToolCall
+	PersistedToolCallKeys map[string]struct{}
+	FatalErr              error
 }
 
 type toolExecutionRecord struct {
@@ -41,8 +54,9 @@ type toolExecutionRecord struct {
 }
 
 type toolExecutionSlot struct {
-	row    model.ToolCall
-	result llm.ToolResult
+	row       model.ToolCall
+	result    llm.ToolResult
+	persisted bool
 }
 
 type toolExecutionLedger struct {
@@ -73,15 +87,18 @@ func (s *Service) executeAssistantToolCalls(ctx context.Context, input executeAs
 		modelToolName := strings.TrimSpace(item.ToolName)
 		executionToolName := resolveExecutionToolName(modelToolName, input.ToolNameMap)
 		row := model.ToolCall{
-			RunID:      input.RunID,
-			ToolCallID: strings.TrimSpace(item.ToolCallID),
-			ToolType:   normalizeToolType(item.ToolType),
-			ToolName:   executionToolName,
-			Status:     "requested",
-			LatencyMS:  0,
-			InputJSON:  strings.TrimSpace(item.ArgumentsJSON),
-			OutputJSON: "",
-			ErrorJSON:  "",
+			MessageID:      input.MessageID,
+			ConversationID: input.ConversationID,
+			UserID:         input.UserID,
+			RunID:          input.RunID,
+			ToolCallID:     strings.TrimSpace(item.ToolCallID),
+			ToolType:       normalizeToolType(item.ToolType),
+			ToolName:       executionToolName,
+			Status:         "requested",
+			LatencyMS:      0,
+			InputJSON:      strings.TrimSpace(item.ArgumentsJSON),
+			OutputJSON:     "",
+			ErrorJSON:      "",
 		}
 
 		mcpConfig := resolveMCPConfig(modelToolName, input.MCPConfigs)
@@ -90,7 +107,7 @@ func (s *Service) executeAssistantToolCalls(ctx context.Context, input executeAs
 			row.ErrorJSON = toolNotEnabledForRunMessage(modelToolName)
 			slots[i] = toolExecutionSlot{
 				row:    row,
-				result: buildToolResultForModel(row, modelToolName),
+				result: buildToolResultForModel(row, modelToolName, false),
 			}
 			if fatalErr == nil {
 				fatalErr = fmt.Errorf("model requested tool %q, but it is not enabled for this run", modelToolName)
@@ -107,7 +124,7 @@ func (s *Service) executeAssistantToolCalls(ctx context.Context, input executeAs
 			row.ErrorJSON = validationErr.Error()
 			slots[i] = toolExecutionSlot{
 				row:    row,
-				result: buildToolResultForModel(row, modelToolName),
+				result: buildToolResultForModel(row, modelToolName, false),
 			}
 			if input.Ledger != nil {
 				input.Ledger.store(row.ToolName, row.InputJSON, toolExecutionRecord{row: row, result: slots[i].result})
@@ -118,7 +135,11 @@ func (s *Service) executeAssistantToolCalls(ctx context.Context, input executeAs
 
 		if input.Ledger != nil {
 			if previous, ok := input.Ledger.lookup(row.ToolName, row.InputJSON); ok {
-				slots[i] = buildRepeatedToolSlot(row, modelToolName, previous)
+				slot := buildRepeatedToolSlot(row, modelToolName, previous)
+				persisted := s.persistToolCallResult(ctx, &slot.row)
+				slot.result = buildToolResultForModel(slot.row, modelToolName, persisted)
+				slot.persisted = persisted
+				slots[i] = slot
 				continue
 			}
 		}
@@ -146,10 +167,12 @@ func (s *Service) executeAssistantToolCalls(ctx context.Context, input executeAs
 				row.OutputJSON = "{}"
 			}
 		}
-		result := buildToolResultForModel(row, modelToolName)
+		persisted := s.persistToolCallResult(ctx, &row)
+		result := buildToolResultForModel(row, modelToolName, persisted)
 		slots[i] = toolExecutionSlot{
-			row:    row,
-			result: result,
+			row:       row,
+			result:    result,
+			persisted: persisted,
 		}
 		if input.Ledger != nil {
 			input.Ledger.store(row.ToolName, row.InputJSON, toolExecutionRecord{row: row, result: result})
@@ -158,9 +181,14 @@ func (s *Service) executeAssistantToolCalls(ctx context.Context, input executeAs
 
 	rows := make([]model.ToolCall, 0, len(slots))
 	toolResults := make([]llm.ToolResult, 0, len(slots))
+	persistedToolCallKeys := make(map[string]struct{})
+	enforceToolResultAggregateBudget(slots)
 	for _, slot := range slots {
 		rows = append(rows, slot.row)
 		toolResults = append(toolResults, slot.result)
+		if slot.persisted {
+			persistedToolCallKeys[toolCallPersistenceKey(slot.row)] = struct{}{}
+		}
 	}
 	if input.TraceRecorder != nil {
 		summary, markdown, payload := buildToolTrace(rows)
@@ -168,10 +196,11 @@ func (s *Service) executeAssistantToolCalls(ctx context.Context, input executeAs
 		input.TraceRecorder.completeTools()
 	}
 	return executeAssistantToolCallsResult{
-		Rows:              rows,
-		ToolResults:       toolResults,
-		ExecutedToolCalls: executedToolCalls,
-		FatalErr:          fatalErr,
+		Rows:                  rows,
+		ToolResults:           toolResults,
+		ExecutedToolCalls:     executedToolCalls,
+		PersistedToolCallKeys: persistedToolCallKeys,
+		FatalErr:              fatalErr,
 	}
 }
 
@@ -229,13 +258,58 @@ func buildRepeatedToolSlot(row model.ToolCall, modelToolName string, previous to
 	}
 }
 
-func buildToolResultForModel(row model.ToolCall, modelToolName string) llm.ToolResult {
+func (s *Service) persistToolCallResult(ctx context.Context, row *model.ToolCall) bool {
+	if s == nil || s.repo == nil || row == nil {
+		return false
+	}
+	if err := s.repo.CreateConversationToolCall(ctx, row); err != nil {
+		return false
+	}
+	return row.ID > 0
+}
+
+func buildToolResultForModel(row model.ToolCall, modelToolName string, persisted bool) llm.ToolResult {
 	return llm.ToolResult{
 		ToolCallID: row.ToolCallID,
 		ToolName:   modelToolName,
-		OutputJSON: budgetToolOutputForModel(row.OutputJSON, toolResultModelBudgetChars),
+		OutputJSON: budgetToolOutputForModel(row, toolResultModelBudgetChars, persisted),
 		Status:     row.Status,
 		Error:      row.ErrorJSON,
+	}
+}
+
+func enforceToolResultAggregateBudget(slots []toolExecutionSlot) {
+	total := 0
+	for _, slot := range slots {
+		total += len([]rune(strings.TrimSpace(slot.result.OutputJSON)))
+	}
+	if total <= toolResultAggregateBudgetChars {
+		return
+	}
+	candidates := make([]int, 0, len(slots))
+	for index, slot := range slots {
+		if !slot.persisted || strings.TrimSpace(slot.row.OutputJSON) == "" || strings.HasPrefix(strings.TrimSpace(slot.result.OutputJSON), "<persisted-tool-output") {
+			continue
+		}
+		status := strings.TrimSpace(slot.row.Status)
+		if status != "success" && status != "reused" {
+			continue
+		}
+		candidates = append(candidates, index)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		left := len([]rune(strings.TrimSpace(slots[candidates[i]].result.OutputJSON)))
+		right := len([]rune(strings.TrimSpace(slots[candidates[j]].result.OutputJSON)))
+		return left > right
+	})
+	for _, index := range candidates {
+		if total <= toolResultAggregateBudgetChars {
+			break
+		}
+		current := strings.TrimSpace(slots[index].result.OutputJSON)
+		replacement := buildPersistedToolOutputForModel(slots[index].row, toolResultReferencePreviewChars)
+		slots[index].result.OutputJSON = replacement
+		total = total - len([]rune(current)) + len([]rune(replacement))
 	}
 }
 
@@ -247,31 +321,173 @@ func toolNotEnabledForRunMessage(toolName string) string {
 	return fmt.Sprintf("tool %s is not enabled for this run", name)
 }
 
-func budgetToolOutputForModel(raw string, maxChars int) string {
-	value := strings.TrimSpace(raw)
+func budgetToolOutputForModel(row model.ToolCall, maxChars int, persisted bool) string {
+	value := strings.TrimSpace(row.OutputJSON)
 	if value == "" || maxChars <= 0 || len([]rune(value)) <= maxChars {
 		return value
 	}
-	runes := []rune(value)
-	preview := strings.TrimSpace(string(runes[:maxChars]))
-	if preview == "" {
-		preview = string(runes[:maxChars])
+	if persisted && len([]rune(value)) > toolResultReferenceThresholdChars {
+		return buildPersistedToolOutputForModel(row, toolResultReferencePreviewChars)
+	}
+	modelText, metadata := budgetToolOutputText(value, maxChars, persisted)
+	if truncated, _ := metadata["truncated_for_model"].(bool); !truncated {
+		return modelText
+	}
+	note := "\n\n[Tool result truncated for model context.]"
+	if persisted {
+		note = "\n\n[Tool result truncated for model context. The full result is retained in the " + toolResultBudgetRetainedIn + ".]"
 	}
 	payload := map[string]interface{}{
 		"content": []map[string]string{{
 			"type": "text",
-			"text": preview + "\n\n[Tool result truncated for model context. The full result is retained in the run trace.]",
+			"text": modelText + note,
 		}},
-		"structuredContent": map[string]interface{}{
-			"truncated_for_model": true,
-			"original_chars":      len(runes),
-			"preview_chars":       maxChars,
-		},
+		"structuredContent": metadata,
 	}
 	if encoded, err := json.Marshal(payload); err == nil {
 		return string(encoded)
 	}
-	return preview
+	return modelText
+}
+
+func buildPersistedToolOutputForModel(row model.ToolCall, previewChars int) string {
+	output := strings.TrimSpace(row.OutputJSON)
+	preview := firstCharsAtLineBoundary(output, previewChars)
+	size := len([]rune(output))
+	toolCallID := strings.TrimSpace(row.ToolCallID)
+	runID := strings.TrimSpace(row.RunID)
+	toolName := strings.TrimSpace(row.ToolName)
+	var builder strings.Builder
+	builder.WriteString(`<persisted-tool-output`)
+	if toolCallID != "" {
+		builder.WriteString(` id="`)
+		builder.WriteString(xmlEscapeAttr(toolCallID))
+		builder.WriteString(`"`)
+	}
+	if runID != "" {
+		builder.WriteString(` run_id="`)
+		builder.WriteString(xmlEscapeAttr(runID))
+		builder.WriteString(`"`)
+	}
+	if toolName != "" {
+		builder.WriteString(` tool="`)
+		builder.WriteString(xmlEscapeAttr(toolName))
+		builder.WriteString(`"`)
+	}
+	builder.WriteString(">\n")
+	builder.WriteString(fmt.Sprintf("Output too large (%d characters). Full output is stored outside the model context in the conversation tool result store.\n\n", size))
+	builder.WriteString(fmt.Sprintf("Preview (first %d characters):\n", previewChars))
+	builder.WriteString(xmlEscapeText(preview))
+	if len([]rune(output)) > len([]rune(preview)) {
+		builder.WriteString("\n...")
+	}
+	builder.WriteString("\n</persisted-tool-output>")
+	return builder.String()
+}
+
+func firstCharsAtLineBoundary(value string, maxChars int) string {
+	text := strings.TrimSpace(value)
+	if maxChars <= 0 {
+		return ""
+	}
+	runes := []rune(text)
+	if len(runes) <= maxChars {
+		return text
+	}
+	truncated := string(runes[:maxChars])
+	if lastNewline := strings.LastIndex(truncated, "\n"); lastNewline > maxChars/2 {
+		truncated = truncated[:lastNewline]
+	}
+	return strings.TrimSpace(truncated)
+}
+
+func budgetToolOutputText(value string, maxChars int, persisted bool) (string, map[string]interface{}) {
+	normalized := strings.TrimSpace(value)
+	contentType := "text"
+	if jsonText, ok := normalizedToolOutputJSON(normalized); ok {
+		normalized = jsonText
+		contentType = "json"
+	}
+	originalChars := len([]rune(value))
+	normalizedChars := len([]rune(normalized))
+	metadata := map[string]interface{}{
+		"truncated_for_model": true,
+		"original_chars":      originalChars,
+		"model_chars":         maxChars,
+		"content_type":        contentType,
+		"selection":           "head_tail",
+	}
+	if persisted {
+		metadata["retained_in"] = toolResultBudgetRetainedIn
+	}
+	if contentType != "json" && looksLikeOpaqueToolOutput(normalized) {
+		contentType = "opaque"
+		metadata["content_type"] = contentType
+		metadata["selection"] = "metadata_preview"
+		return opaqueToolOutputPreview(normalized, originalChars), metadata
+	}
+	if normalizedChars <= maxChars {
+		metadata["model_chars"] = normalizedChars
+		metadata["selection"] = "normalized"
+		metadata["truncated_for_model"] = false
+		return normalized, metadata
+	}
+	return headTailToolOutput(normalized, maxChars), metadata
+}
+
+func normalizedToolOutputJSON(value string) (string, bool) {
+	var payload interface{}
+	if err := json.Unmarshal([]byte(value), &payload); err != nil {
+		return "", false
+	}
+	formatted, err := json.Marshal(payload)
+	if err != nil {
+		return "", false
+	}
+	text := strings.TrimSpace(string(formatted))
+	return text, text != ""
+}
+
+func looksLikeOpaqueToolOutput(value string) bool {
+	text := strings.TrimSpace(value)
+	runes := []rune(text)
+	if len(runes) < 1024 || strings.ContainsAny(text, " \n\t{}[],:") {
+		return false
+	}
+	base64ish := 0
+	for _, r := range runes {
+		if (r >= 'A' && r <= 'Z') ||
+			(r >= 'a' && r <= 'z') ||
+			(r >= '0' && r <= '9') ||
+			r == '+' || r == '/' || r == '=' || r == '-' || r == '_' {
+			base64ish++
+		}
+	}
+	return float64(base64ish)/float64(len(runes)) > 0.95
+}
+
+func opaqueToolOutputPreview(value string, originalChars int) string {
+	preview := headTailToolOutput(value, toolResultOpaquePreviewMax)
+	return fmt.Sprintf("Large opaque tool result omitted from model context.\nOriginal characters: %d\nPreview:\n%s", originalChars, preview)
+}
+
+func headTailToolOutput(value string, maxChars int) string {
+	runes := []rune(strings.TrimSpace(value))
+	if maxChars <= 0 || len(runes) <= maxChars {
+		return string(runes)
+	}
+	const separatorTemplate = "\n\n[... %d chars omitted ...]\n\n"
+	separator := fmt.Sprintf(separatorTemplate, len(runes)-maxChars)
+	separatorChars := len([]rune(separator))
+	if separatorChars >= maxChars {
+		return strings.TrimSpace(string(runes[:maxChars]))
+	}
+	available := maxChars - separatorChars
+	headChars := available / 2
+	tailChars := available - headChars
+	head := strings.TrimSpace(string(runes[:headChars]))
+	tail := strings.TrimSpace(string(runes[len(runes)-tailChars:]))
+	return head + separator + tail
 }
 
 func (l *toolExecutionLedger) lookup(toolName string, argumentsJSON string) (toolExecutionRecord, bool) {
@@ -291,6 +507,27 @@ func (l *toolExecutionLedger) store(toolName string, argumentsJSON string, recor
 
 func toolExecutionKey(toolName string, argumentsJSON string) string {
 	return strings.ToLower(strings.TrimSpace(toolName)) + "\x00" + canonicalToolArguments(argumentsJSON)
+}
+
+func toolCallPersistenceKey(row model.ToolCall) string {
+	if value := strings.TrimSpace(row.ToolCallID); value != "" {
+		return "id:" + value
+	}
+	return "tool:" + strings.ToLower(strings.TrimSpace(row.ToolName)) + "\x00" + canonicalToolArguments(row.InputJSON)
+}
+
+func mergeToolCallPersistenceKeys(target *map[string]struct{}, source map[string]struct{}) {
+	if target == nil || len(source) == 0 {
+		return
+	}
+	if *target == nil {
+		*target = make(map[string]struct{}, len(source))
+	}
+	for key := range source {
+		if strings.TrimSpace(key) != "" {
+			(*target)[key] = struct{}{}
+		}
+	}
 }
 
 func canonicalToolArguments(raw string) string {

--- a/backend/internal/application/conversation/service_trace.go
+++ b/backend/internal/application/conversation/service_trace.go
@@ -43,6 +43,11 @@ const (
 	processTraceFallbackUnavailable = "unavailable"
 )
 
+const (
+	toolTracePreviewMaxChars = 260
+	toolTraceDetailMaxChars  = 4096
+)
+
 type messageTraceDraft struct {
 	traceType       string
 	eventID         string
@@ -961,8 +966,8 @@ func shouldMergeTraceToolCall(existing map[string]interface{}, incoming map[stri
 	if !sameTraceToolKind(existing, incoming) {
 		return false
 	}
-	existingInput := strings.TrimSpace(getTraceString(existing["input"]))
-	incomingInput := strings.TrimSpace(getTraceString(incoming["input"]))
+	existingInput := traceToolInputKey(existing)
+	incomingInput := traceToolInputKey(incoming)
 	if existingInput == "" || incomingInput == "" {
 		return true
 	}
@@ -997,6 +1002,10 @@ func cloneTraceToolCall(item map[string]interface{}) map[string]interface{} {
 
 func traceToolCallID(item map[string]interface{}) string {
 	return firstTraceString(item, "tool_call_id", "id", "call_id")
+}
+
+func traceToolInputKey(item map[string]interface{}) string {
+	return firstTraceString(item, "input_preview", "input")
 }
 
 func sameTraceToolKind(left map[string]interface{}, right map[string]interface{}) bool {
@@ -1071,8 +1080,8 @@ func toolTraceRowsFromPayload(payload map[string]interface{}) []model.ToolCall {
 			ToolName:   strings.TrimSpace(getTraceString(item["name"])),
 			Status:     strings.TrimSpace(getTraceString(item["status"])),
 			LatencyMS:  traceInt64(item["latency_ms"]),
-			InputJSON:  strings.TrimSpace(getTraceString(item["input"])),
-			OutputJSON: strings.TrimSpace(getTraceString(item["output"])),
+			InputJSON:  firstTraceString(item, "input_preview", "input"),
+			OutputJSON: firstTraceString(item, "output_preview", "output_text", "output"),
 			ErrorJSON:  strings.TrimSpace(getTraceString(item["error"])),
 		})
 	}
@@ -1434,23 +1443,34 @@ func buildToolTrace(rows []model.ToolCall) (string, string, map[string]interface
 		if row.LatencyMS > 0 {
 			parts = append(parts, fmt.Sprintf("%dms", row.LatencyMS))
 		}
+		input := strings.TrimSpace(row.InputJSON)
+		output := strings.TrimSpace(row.OutputJSON)
+		inputDisplay := collapseWhitespace(input)
+		inputPreview := compactSnippet(inputDisplay, toolTracePreviewMaxChars)
+		outputPreview := toolOutputPreview(output)
+		inputDetail, inputTruncated := toolTraceDetail(input, toolTraceDetailMaxChars)
+		outputDetail, outputTruncated := toolTraceDetail(output, toolTraceDetailMaxChars)
 		if strings.TrimSpace(row.ErrorJSON) != "" {
-			parts = append(parts, compactSnippet(collapseWhitespace(strings.TrimSpace(row.ErrorJSON)), 260))
-		} else if preview := toolOutputPreview(row.OutputJSON); preview != "" {
-			parts = append(parts, "结果："+preview)
+			parts = append(parts, compactSnippet(collapseWhitespace(strings.TrimSpace(row.ErrorJSON)), toolTracePreviewMaxChars))
+		} else if outputPreview != "" {
+			parts = append(parts, "结果："+outputPreview)
 		}
 		lines = append(lines, formatTraceStep(toolName, joinTraceParts(parts...)))
 		toolCalls = append(toolCalls, map[string]interface{}{
-			"tool_call_id":   strings.TrimSpace(row.ToolCallID),
-			"name":           toolName,
-			"type":           strings.TrimSpace(row.ToolType),
-			"status":         status,
-			"latency_ms":     row.LatencyMS,
-			"error":          strings.TrimSpace(row.ErrorJSON),
-			"input":          strings.TrimSpace(row.InputJSON),
-			"output":         strings.TrimSpace(row.OutputJSON),
-			"output_text":    toolOutputText(row.OutputJSON),
-			"output_preview": toolOutputPreview(row.OutputJSON),
+			"tool_call_id":     strings.TrimSpace(row.ToolCallID),
+			"name":             toolName,
+			"type":             strings.TrimSpace(row.ToolType),
+			"status":           status,
+			"latency_ms":       row.LatencyMS,
+			"error":            strings.TrimSpace(row.ErrorJSON),
+			"input_preview":    inputPreview,
+			"input_detail":     inputDetail,
+			"input_size":       len(input),
+			"input_truncated":  inputTruncated,
+			"output_preview":   outputPreview,
+			"output_detail":    outputDetail,
+			"output_size":      len(output),
+			"output_truncated": outputTruncated,
 		})
 	}
 	summary := fmt.Sprintf("%d 次工具调用已完成", len(rows))
@@ -1474,57 +1494,31 @@ func toolOutputPreview(raw string) string {
 	var payload interface{}
 	if err := json.Unmarshal([]byte(value), &payload); err == nil {
 		if text := readableMCPToolResultPreview(payload); text != "" {
-			return compactSnippet(collapseWhitespace(text), 260)
+			return compactSnippet(collapseWhitespace(text), toolTracePreviewMaxChars)
 		}
 		if text := readableJSONPreview(payload); text != "" {
-			return compactSnippet(collapseWhitespace(text), 260)
+			return compactSnippet(collapseWhitespace(text), toolTracePreviewMaxChars)
 		}
 		if normalized, marshalErr := json.Marshal(payload); marshalErr == nil {
 			value = string(normalized)
 		}
 	}
-	return compactSnippet(collapseWhitespace(value), 260)
+	return compactSnippet(collapseWhitespace(value), toolTracePreviewMaxChars)
 }
 
-func toolOutputText(raw string) string {
+func toolTraceDetail(raw string, maxChars int) (string, bool) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
-		return ""
+		return "", false
 	}
-	var payload interface{}
-	if err := json.Unmarshal([]byte(value), &payload); err != nil {
-		return value
+	runes := []rune(value)
+	if maxChars <= 0 {
+		maxChars = toolTraceDetailMaxChars
 	}
-	if text := readableMCPToolResultText(payload); text != "" {
-		return text
+	if len(runes) <= maxChars {
+		return value, false
 	}
-	if text := readableJSONPreview(payload); text != "" {
-		return text
-	}
-	if formatted, err := json.MarshalIndent(payload, "", "  "); err == nil {
-		return string(formatted)
-	}
-	return value
-}
-
-func readableMCPToolResultText(value interface{}) string {
-	payload, ok := value.(map[string]interface{})
-	if !ok || !looksLikeMCPToolResult(payload) {
-		return ""
-	}
-	parts := make([]string, 0, 2)
-	if text := readableMCPContentText(payload["content"]); text != "" {
-		parts = append(parts, text)
-	}
-	if structured, ok := payload["structuredContent"]; ok {
-		if formatted, err := json.MarshalIndent(structured, "", "  "); err == nil && strings.TrimSpace(string(formatted)) != "" {
-			parts = append(parts, string(formatted))
-		}
-	}
-	if len(parts) == 0 {
-		return summarizeMCPContent(payload["content"])
-	}
-	return strings.Join(parts, "\n\n")
+	return compactSnippet(collapseWhitespace(value), maxChars), true
 }
 
 func readableMCPToolResultPreview(value interface{}) string {
@@ -1546,24 +1540,6 @@ func readableMCPToolResultPreview(value interface{}) string {
 		}
 	}
 	return strings.Join(parts, "；")
-}
-
-func readableMCPContentText(value interface{}) string {
-	items, ok := value.([]interface{})
-	if !ok || len(items) == 0 {
-		return ""
-	}
-	parts := make([]string, 0, len(items))
-	for _, item := range items {
-		block, ok := item.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if text := stringFromJSONValue(block["text"]); text != "" {
-			parts = append(parts, text)
-		}
-	}
-	return strings.Join(parts, "\n\n")
 }
 
 func looksLikeMCPToolResult(payload map[string]interface{}) bool {

--- a/backend/internal/application/conversation/service_trace_tool_test.go
+++ b/backend/internal/application/conversation/service_trace_tool_test.go
@@ -49,6 +49,49 @@ func TestBuildToolTraceMarksReusedCallsAsCompleted(t *testing.T) {
 	}
 }
 
+func TestBuildToolTraceStoresPreviewMetadataInsteadOfFullOutput(t *testing.T) {
+	largeOutput := `{"content":[{"type":"text","text":"` + strings.Repeat("x", 4096) + `"}]}`
+	_, _, payload := buildToolTrace([]model.ToolCall{{
+		ToolCallID: "call_1",
+		ToolName:   "fetch",
+		Status:     "success",
+		InputJSON:  `{"url":"https://example.com/large"}`,
+		OutputJSON: largeOutput,
+	}})
+
+	items := normalizeTraceToolCalls(payload["tool_calls"])
+	if len(items) != 1 {
+		t.Fatalf("expected one tool call, got %#v", items)
+	}
+	item := items[0]
+	if _, ok := item["output"]; ok {
+		t.Fatalf("tool trace must not store full output: %#v", item)
+	}
+	if _, ok := item["output_text"]; ok {
+		t.Fatalf("tool trace must not store expanded output text: %#v", item)
+	}
+	if _, ok := item["input"]; ok {
+		t.Fatalf("tool trace must not store full input: %#v", item)
+	}
+	if got := traceInt64(item["output_size"]); got != int64(len(largeOutput)) {
+		t.Fatalf("expected output size metadata, got %d", got)
+	}
+	if item["output_truncated"] != true {
+		t.Fatalf("expected truncated output marker, got %#v", item["output_truncated"])
+	}
+	if got := strings.TrimSpace(getTraceString(item["input_detail"])); got != `{"url":"https://example.com/large"}` {
+		t.Fatalf("expected full small input detail, got %q", got)
+	}
+	detail := strings.TrimSpace(getTraceString(item["output_detail"]))
+	if detail == "" || detail == largeOutput || len([]rune(detail)) > toolTraceDetailMaxChars+3 {
+		t.Fatalf("expected bounded output detail, got len=%d", len([]rune(detail)))
+	}
+	preview := strings.TrimSpace(getTraceString(item["output_preview"]))
+	if preview == "" || strings.Contains(preview, strings.Repeat("x", 512)) {
+		t.Fatalf("expected compact output preview, got %q", preview)
+	}
+}
+
 func TestToolTracePayloadMergesStreamingPlaceholderWithFinalCall(t *testing.T) {
 	_, _, streamingPayload := buildToolTrace([]model.ToolCall{{
 		ToolType:  "web_search_call",
@@ -385,20 +428,6 @@ func TestToolOutputPreviewFallsBackForNonMCPJSON(t *testing.T) {
 	}
 }
 
-func TestToolOutputTextUsesReadableSearchResults(t *testing.T) {
-	raw := `[{"url":"https://example.com/a"},{"title":"新闻","url":"https://example.com/b"}]`
-	if got := toolOutputText(raw); got != "https://example.com/a；新闻 https://example.com/b" {
-		t.Fatalf("expected readable search result text, got %q", got)
-	}
-}
-
-func TestCitationsToolOutputJSONBuildsSearchOutput(t *testing.T) {
-	raw := citationsToolOutputJSON([]string{"https://example.com/a", " ", "https://example.com/b"})
-	if got := toolOutputText(raw); got != "https://example.com/a；https://example.com/b" {
-		t.Fatalf("expected citations output text, got %q from raw %q", got, raw)
-	}
-}
-
 func TestServerSideOnlyToolsRenderBeforeFinalThinking(t *testing.T) {
 	output := &llm.GenerateOutput{
 		ServerToolCalls: []llm.ToolCall{{ToolType: "x_search_call", ToolName: "x_search"}},
@@ -440,18 +469,123 @@ func TestToolExecutionLedgerNormalizesArguments(t *testing.T) {
 
 func TestBudgetToolOutputForModelKeepsSmallResults(t *testing.T) {
 	raw := `{"content":[{"type":"text","text":"small result"}]}`
-	if got := budgetToolOutputForModel(raw, 100); got != raw {
+	if got := budgetToolOutputForModel(model.ToolCall{OutputJSON: raw}, 100, false); got != raw {
 		t.Fatalf("expected small tool result to stay unchanged, got %q", got)
 	}
 }
 
+func TestBudgetToolOutputForModelKeepsNormalizedJSONWhenItFits(t *testing.T) {
+	raw := "{\n  \"ok\": true,\n  \"items\": [\n    1,\n    2\n  ]\n}"
+	got := budgetToolOutputForModel(model.ToolCall{OutputJSON: raw}, 32, false)
+	if got != `{"items":[1,2],"ok":true}` {
+		t.Fatalf("expected normalized JSON to fit without truncation envelope, got %q", got)
+	}
+}
+
 func TestBudgetToolOutputForModelWrapsLargeResults(t *testing.T) {
-	raw := `{"content":[{"type":"text","text":"` + strings.Repeat("a", 80) + `"}]}`
-	got := budgetToolOutputForModel(raw, 40)
+	raw := `{"content":[{"type":"text","text":"` + strings.Repeat("a", 80) + `TAIL"}]}`
+	got := budgetToolOutputForModel(model.ToolCall{OutputJSON: raw}, 80, false)
 	if !strings.Contains(got, "truncated_for_model") {
 		t.Fatalf("expected budgeted result marker, got %q", got)
 	}
-	if !strings.Contains(got, "full result is retained") {
-		t.Fatalf("expected retention note, got %q", got)
+	if strings.Contains(got, "server-side tool call record") {
+		t.Fatalf("did not expect retention note without persistence, got %q", got)
+	}
+	if !strings.Contains(got, "TAIL") {
+		t.Fatalf("expected budgeted model result to preserve tail context, got %q", got)
+	}
+	if !strings.Contains(got, "head_tail") {
+		t.Fatalf("expected budget metadata to describe head/tail selection, got %q", got)
+	}
+}
+
+func TestBudgetToolOutputForModelOmitsOpaqueSingleLinePayload(t *testing.T) {
+	raw := strings.Repeat("A", 4096)
+	got := budgetToolOutputForModel(model.ToolCall{OutputJSON: raw}, 800, false)
+	if !strings.Contains(got, "Large opaque tool result omitted") {
+		t.Fatalf("expected opaque payload notice, got %q", got)
+	}
+	if !strings.Contains(got, `"content_type":"opaque"`) {
+		t.Fatalf("expected opaque content type metadata, got %q", got)
+	}
+	if strings.Count(got, strings.Repeat("A", 512)) > 1 {
+		t.Fatalf("expected opaque payload to be bounded, got %d chars", len(got))
+	}
+}
+
+func TestBudgetToolOutputForModelUsesPersistedReferenceForLargeStoredResult(t *testing.T) {
+	raw := "HEAD\n" + strings.Repeat("x", toolResultReferenceThresholdChars) + "\nTAIL"
+	row := model.ToolCall{
+		ToolCallID: "call_large",
+		ToolName:   "fetch_large",
+		RunID:      "run_1",
+		OutputJSON: raw,
+	}
+	got := budgetToolOutputForModel(row, toolResultModelBudgetChars, true)
+	if !strings.HasPrefix(got, "<persisted-tool-output") {
+		t.Fatalf("expected persisted output reference, got %q", got)
+	}
+	if !strings.Contains(got, `id="call_large"`) || !strings.Contains(got, `run_id="run_1"`) {
+		t.Fatalf("expected stable tool identifiers in reference, got %q", got)
+	}
+	if strings.Contains(got, "TAIL") {
+		t.Fatalf("expected reference preview to include only bounded leading content, got %q", got)
+	}
+}
+
+func TestEnforceToolResultAggregateBudgetReplacesLargestPersistedResults(t *testing.T) {
+	large := strings.Repeat("a", toolResultAggregateBudgetChars/2)
+	small := strings.Repeat("b", toolResultAggregateBudgetChars/3)
+	slots := []toolExecutionSlot{
+		{
+			row: model.ToolCall{
+				ToolCallID: "call_a",
+				ToolName:   "tool_a",
+				RunID:      "run_1",
+				Status:     "success",
+				OutputJSON: large,
+			},
+			result:    llm.ToolResult{ToolCallID: "call_a", OutputJSON: large, Status: "success"},
+			persisted: true,
+		},
+		{
+			row: model.ToolCall{
+				ToolCallID: "call_b",
+				ToolName:   "tool_b",
+				RunID:      "run_1",
+				Status:     "success",
+				OutputJSON: large,
+			},
+			result:    llm.ToolResult{ToolCallID: "call_b", OutputJSON: large, Status: "success"},
+			persisted: true,
+		},
+		{
+			row: model.ToolCall{
+				ToolCallID: "call_c",
+				ToolName:   "tool_c",
+				RunID:      "run_1",
+				Status:     "success",
+				OutputJSON: small,
+			},
+			result:    llm.ToolResult{ToolCallID: "call_c", OutputJSON: small, Status: "success"},
+			persisted: true,
+		},
+	}
+
+	enforceToolResultAggregateBudget(slots)
+
+	replaced := 0
+	total := 0
+	for _, slot := range slots {
+		total += len([]rune(slot.result.OutputJSON))
+		if strings.HasPrefix(slot.result.OutputJSON, "<persisted-tool-output") {
+			replaced++
+		}
+	}
+	if replaced == 0 {
+		t.Fatalf("expected at least one aggregate replacement, got %#v", slots)
+	}
+	if total > toolResultAggregateBudgetChars {
+		t.Fatalf("expected aggregate model-visible output under budget, got %d", total)
 	}
 }

--- a/backend/internal/application/settings/model_option_policy.go
+++ b/backend/internal/application/settings/model_option_policy.go
@@ -9,18 +9,19 @@ import (
 )
 
 var validModelOptionProtocolKeys = map[string]struct{}{
-	"default":                  {},
-	"openai_chat_completions":  {},
-	"openai_image_generations": {},
-	"openai_image_edits":       {},
-	"openai_responses":         {},
-	"openrouter_responses":     {},
-	"anthropic_messages":       {},
-	"xai_responses":            {},
-	"xai_image":                {},
-	"xai_image_edits":          {},
-	"gemini_generate_content":  {},
-	"google_image_generation":  {},
+	"default":                     {},
+	"openai_chat_completions":     {},
+	"openrouter_chat_completions": {},
+	"openrouter_responses":        {},
+	"openai_image_generations":    {},
+	"openai_image_edits":          {},
+	"openai_responses":            {},
+	"anthropic_messages":          {},
+	"xai_responses":               {},
+	"xai_image":                   {},
+	"xai_image_edits":             {},
+	"gemini_generate_content":     {},
+	"google_image_generation":     {},
 }
 
 // validateModelOptionPathsJSON 校验模型参数透传路径配置，防止保存不可解析或越界的策略。

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -56,6 +56,16 @@ func DefaultModelOptionAllowedPathsJSON() string {
     "thinking.type",
     "stream_options.include_usage"
   ],
+  "openrouter_chat_completions": [
+    "presence_penalty",
+    "frequency_penalty",
+    "reasoning_effort",
+    "reasoning.effort",
+    "reasoning.summary",
+    "verbosity",
+    "thinking.type",
+    "stream_options.include_usage"
+  ],
   "openai_responses": [
     "service_tier",
     "reasoning.effort",

--- a/backend/internal/infra/llm/adapter.go
+++ b/backend/internal/infra/llm/adapter.go
@@ -9,17 +9,18 @@ import (
 
 // 已支持的协议常量。每个协议固定对应一个 HTTP 端点，任务能力由模型类别和路由规则约束。
 const (
-	AdapterOpenAIResponses        = "openai_responses"         // POST /v1/responses
-	AdapterOpenRouterResponses    = "openrouter_responses"     // POST /v1/responses（OpenRouter Responses Beta）
-	AdapterOpenAIChatCompletions  = "openai_chat_completions"  // POST /v1/chat/completions
-	AdapterOpenAIImageGenerations = "openai_image_generations" // POST /v1/images/generations
-	AdapterOpenAIImageEdits       = "openai_image_edits"       // POST /v1/images/edits
-	AdapterAnthropicMessages      = "anthropic_messages"       // POST /v1/messages
-	AdapterGoogleGenerateContent  = "google_generate_content"  // POST /v1beta/models/{model}:generateContent
-	AdapterGoogleImageGeneration  = "google_image_generation"  // POST /v1beta/models/{model}:generateContent
-	AdapterXAIResponses           = "xai_responses"            // POST /v1/responses（OpenAI 兼容）
-	AdapterXAIImage               = "xai_image"                // POST /v1/images/generations
-	AdapterXAIImageEdits          = "xai_image_edits"          // POST /v1/images/edits
+	AdapterOpenAIResponses        = "openai_responses"            // POST /v1/responses
+	AdapterOpenRouterChat         = "openrouter_chat_completions" // POST /v1/chat/completions（OpenRouter）
+	AdapterOpenRouterResponses    = "openrouter_responses"        // POST /v1/responses（OpenRouter Responses Beta）
+	AdapterOpenAIChatCompletions  = "openai_chat_completions"     // POST /v1/chat/completions
+	AdapterOpenAIImageGenerations = "openai_image_generations"    // POST /v1/images/generations
+	AdapterOpenAIImageEdits       = "openai_image_edits"          // POST /v1/images/edits
+	AdapterAnthropicMessages      = "anthropic_messages"          // POST /v1/messages
+	AdapterGoogleGenerateContent  = "google_generate_content"     // POST /v1beta/models/{model}:generateContent
+	AdapterGoogleImageGeneration  = "google_image_generation"     // POST /v1beta/models/{model}:generateContent
+	AdapterXAIResponses           = "xai_responses"               // POST /v1/responses（OpenAI 兼容）
+	AdapterXAIImage               = "xai_image"                   // POST /v1/images/generations
+	AdapterXAIImageEdits          = "xai_image_edits"             // POST /v1/images/edits
 )
 
 var (
@@ -36,7 +37,7 @@ type transportAdapter interface {
 	ListModels(ctx context.Context, route RouteConfig) ([]ModelItem, error)
 }
 
-// NormalizeAdapter 规范化协议名，未知值默认返回 openai_responses。
+// NormalizeAdapter 规范化协议名；空值按历史默认使用 openai_responses，未知值保留给校验层处理。
 func NormalizeAdapter(raw string) string {
 	value := strings.TrimSpace(strings.ToLower(raw))
 	if value == "" {
@@ -49,6 +50,7 @@ func NormalizeAdapter(raw string) string {
 func IsKnownAdapter(raw string) bool {
 	switch NormalizeAdapter(raw) {
 	case AdapterOpenAIResponses,
+		AdapterOpenRouterChat,
 		AdapterOpenRouterResponses,
 		AdapterOpenAIChatCompletions,
 		AdapterOpenAIImageGenerations,
@@ -68,7 +70,7 @@ func IsKnownAdapter(raw string) bool {
 // IsImplementedAdapter 返回协议是否已有可用的传输层实现。
 func IsImplementedAdapter(raw string) bool {
 	switch NormalizeAdapter(raw) {
-	case AdapterOpenAIResponses, AdapterOpenRouterResponses, AdapterOpenAIChatCompletions, AdapterOpenAIImageGenerations, AdapterOpenAIImageEdits, AdapterXAIResponses,
+	case AdapterOpenAIResponses, AdapterOpenRouterChat, AdapterOpenRouterResponses, AdapterOpenAIChatCompletions, AdapterOpenAIImageGenerations, AdapterOpenAIImageEdits, AdapterXAIResponses,
 		AdapterAnthropicMessages, AdapterGoogleGenerateContent, AdapterGoogleImageGeneration, AdapterXAIImage, AdapterXAIImageEdits:
 		return true
 	default:
@@ -80,6 +82,7 @@ func IsImplementedAdapter(raw string) bool {
 func SupportsStreamingAdapter(raw string) bool {
 	switch NormalizeAdapter(raw) {
 	case AdapterOpenAIResponses,
+		AdapterOpenRouterChat,
 		AdapterOpenRouterResponses,
 		AdapterOpenAIChatCompletions,
 		AdapterOpenAIImageGenerations,
@@ -131,7 +134,7 @@ func IsImageEditAdapter(raw string) bool {
 // DefaultEndpointForAdapter 返回协议对应的固定端点标识。
 func DefaultEndpointForAdapter(adapter string) string {
 	switch NormalizeAdapter(adapter) {
-	case AdapterOpenAIChatCompletions:
+	case AdapterOpenAIChatCompletions, AdapterOpenRouterChat:
 		return EndpointChatCompletions
 	case AdapterOpenAIImageGenerations, AdapterGoogleImageGeneration, AdapterXAIImage:
 		return EndpointImageGenerations

--- a/backend/internal/infra/llm/client.go
+++ b/backend/internal/infra/llm/client.go
@@ -737,6 +737,7 @@ func NewClientWithEnv(env string, ssrfProtectionEnabled bool) *Client {
 	}
 	client.adapters = map[string]transportAdapter{
 		AdapterOpenAIResponses:        &openAIResponsesAdapter{client: client},
+		AdapterOpenRouterChat:         &openRouterChatCompletionsAdapter{client: client},
 		AdapterOpenRouterResponses:    &openRouterResponsesAdapter{client: client},
 		AdapterOpenAIChatCompletions:  &openAIChatCompletionsAdapter{client: client},
 		AdapterOpenAIImageGenerations: &openAIImageGenerationsAdapter{client: client},

--- a/backend/internal/infra/llm/client.go
+++ b/backend/internal/infra/llm/client.go
@@ -595,13 +595,14 @@ func appendRawUsageJSON(items []interface{}, raw string) []interface{} {
 
 // ToolCall 记录上游返回的工具调用请求。
 type ToolCall struct {
-	ToolCallID    string
-	ToolType      string
-	ToolName      string
-	ArgumentsJSON string
-	Status        string
-	OutputJSON    string
-	ErrorJSON     string
+	ToolCallID       string
+	ToolType         string
+	ToolName         string
+	ArgumentsJSON    string
+	ThoughtSignature string
+	Status           string
+	OutputJSON       string
+	ErrorJSON        string
 }
 
 // ToolResult 记录工具执行结果，由各 adapter 序列化为对应 SDK/API 所需格式。
@@ -1282,6 +1283,9 @@ func mergeToolCall(existing ToolCall, incoming ToolCall) ToolCall {
 	}
 	if value := strings.TrimSpace(incoming.ArgumentsJSON); value != "" {
 		merged.ArgumentsJSON = value
+	}
+	if value := strings.TrimSpace(incoming.ThoughtSignature); value != "" {
+		merged.ThoughtSignature = value
 	}
 	if value := strings.TrimSpace(incoming.OutputJSON); value != "" {
 		merged.OutputJSON = value

--- a/backend/internal/infra/llm/client.go
+++ b/backend/internal/infra/llm/client.go
@@ -1354,8 +1354,8 @@ func updateToolCallInput(items *[]ToolCall, itemID string, input string, done bo
 }
 
 func appendUniqueStrings(items []string, values ...string) []string {
-	seen := make(map[string]struct{}, len(items)+len(values))
-	result := make([]string, 0, len(items)+len(values))
+	seen := make(map[string]struct{}, len(items))
+	result := make([]string, 0, len(items))
 	for _, item := range items {
 		value := strings.TrimSpace(item)
 		if value == "" {

--- a/backend/internal/infra/llm/endpoint_url_test.go
+++ b/backend/internal/infra/llm/endpoint_url_test.go
@@ -104,6 +104,18 @@ func TestBuildOpenAIModelsURLRespectsVersionedBasePath(t *testing.T) {
 	}
 }
 
+func TestOpenRouterChatCompletionsAdapterUsesChatEndpoint(t *testing.T) {
+	if got := DefaultEndpointForAdapter(AdapterOpenRouterChat); got != EndpointChatCompletions {
+		t.Fatalf("expected OpenRouter Chat Completions endpoint, got %q", got)
+	}
+	if !SupportsStreamingAdapter(AdapterOpenRouterChat) {
+		t.Fatal("expected OpenRouter Chat Completions to support streaming")
+	}
+	if !IsImplementedAdapter(AdapterOpenRouterChat) {
+		t.Fatal("expected OpenRouter Chat Completions adapter to be implemented")
+	}
+}
+
 func TestBuildAnthropicURLsRespectVersionedBasePath(t *testing.T) {
 	messageCases := map[string]string{
 		"https://api.anthropic.com":              "https://api.anthropic.com/v1/messages",

--- a/backend/internal/infra/llm/gemini.go
+++ b/backend/internal/infra/llm/gemini.go
@@ -153,6 +153,7 @@ func buildGeminiRequestBody(input GenerateInput) (map[string]interface{}, error)
 		webSearchTools = append(webSearchTools, map[string]interface{}{"google_search": map[string]interface{}{}})
 	}
 	appendToolDeclarations(payload, providerTools, webSearchTools, buildGeminiTools(toolDefinitions))
+	applyGeminiToolConfigDefaults(payload, len(providerTools)+len(webSearchTools) > 0, len(toolDefinitions) > 0)
 
 	if len(systemTextParts) > 0 {
 		payload["systemInstruction"] = map[string]interface{}{
@@ -164,6 +165,20 @@ func buildGeminiRequestBody(input GenerateInput) (map[string]interface{}, error)
 
 	applyProviderOptions(payload, input.Options, geminiProtectedProviderOptionKeys()...)
 	return payload, nil
+}
+
+func applyGeminiToolConfigDefaults(payload map[string]interface{}, hasServerSideTools bool, hasFunctionDeclarations bool) {
+	if !hasServerSideTools || !hasFunctionDeclarations {
+		return
+	}
+	toolConfig := asMap(payload["toolConfig"])
+	if len(toolConfig) == 0 {
+		toolConfig = map[string]interface{}{}
+	}
+	if _, ok := toolConfig["includeServerSideToolInvocations"]; !ok {
+		toolConfig["includeServerSideToolInvocations"] = true
+	}
+	payload["toolConfig"] = toolConfig
 }
 
 func geminiProtectedProviderOptionKeys() []string {
@@ -506,13 +521,86 @@ func buildGeminiTools(tools []ToolDefinition) []map[string]interface{} {
 		declarations = append(declarations, map[string]interface{}{
 			"name":        name,
 			"description": strings.TrimSpace(tool.Description),
-			"parameters":  decodeToolSchema(tool.InputSchema),
+			"parameters":  geminiToolParameterSchema(decodeToolSchema(tool.InputSchema)),
 		})
 	}
 	if len(declarations) == 0 {
 		return nil
 	}
 	return []map[string]interface{}{{"functionDeclarations": declarations}}
+}
+
+func geminiToolParameterSchema(schema map[string]interface{}) map[string]interface{} {
+	if len(schema) == 0 {
+		return map[string]interface{}{"type": "object", "properties": map[string]interface{}{}}
+	}
+	normalized := sanitizeGeminiSchema(schema)
+	if strings.TrimSpace(getString(normalized["type"])) == "" {
+		normalized["type"] = "object"
+	}
+	if _, ok := normalized["properties"]; !ok && strings.EqualFold(getString(normalized["type"]), "object") {
+		normalized["properties"] = map[string]interface{}{}
+	}
+	return normalized
+}
+
+func sanitizeGeminiSchema(schema map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{}, len(schema))
+	for key, value := range schema {
+		switch key {
+		case "type", "format", "title", "description", "nullable", "enum", "required", "propertyOrdering":
+			if !isEmptyGeminiPayloadValue(value) {
+				result[key] = value
+			}
+		case "properties":
+			properties := sanitizeGeminiSchemaProperties(asMap(value))
+			if len(properties) > 0 {
+				result[key] = properties
+			}
+		case "items":
+			itemSchema := sanitizeGeminiSchema(asMap(value))
+			if len(itemSchema) > 0 {
+				result[key] = itemSchema
+			}
+		case "anyOf":
+			anyOf := sanitizeGeminiSchemaList(asSlice(value))
+			if len(anyOf) > 0 {
+				result[key] = anyOf
+			}
+		case "minItems", "maxItems":
+			result[key] = value
+		}
+	}
+	return result
+}
+
+func sanitizeGeminiSchemaProperties(properties map[string]interface{}) map[string]interface{} {
+	if len(properties) == 0 {
+		return nil
+	}
+	result := make(map[string]interface{}, len(properties))
+	for name, raw := range properties {
+		property := sanitizeGeminiSchema(asMap(raw))
+		if len(property) == 0 {
+			continue
+		}
+		result[name] = property
+	}
+	return result
+}
+
+func sanitizeGeminiSchemaList(items []interface{}) []interface{} {
+	if len(items) == 0 {
+		return nil
+	}
+	result := make([]interface{}, 0, len(items))
+	for _, raw := range items {
+		item := sanitizeGeminiSchema(asMap(raw))
+		if len(item) > 0 {
+			result = append(result, item)
+		}
+	}
+	return result
 }
 
 func buildGeminiProviderTools(tools []map[string]interface{}) []map[string]interface{} {
@@ -611,6 +699,9 @@ func buildGeminiParts(msg Message) []map[string]interface{} {
 				"args": arguments,
 			},
 		})
+		if signature := strings.TrimSpace(item.ThoughtSignature); signature != "" {
+			parts[len(parts)-1]["thoughtSignature"] = signature
+		}
 	}
 	for _, item := range msg.ToolResults {
 		response := map[string]interface{}{
@@ -739,6 +830,7 @@ func parseGeminiResponse(body []byte) (*GenerateOutput, error) {
 		Reasoning:           extractGeminiReasoning(parsed),
 		Usage:               parseGeminiUsage(parsed),
 		ToolCalls:           parseGeminiFunctionCalls(parsed),
+		ServerToolCalls:     parseGeminiServerToolCalls(parsed),
 		ServerSideToolUsage: parseGeminiServerSideToolUsage(parsed),
 		Citations:           parseGeminiCitations(parsed),
 		RawJSON:             string(body),
@@ -814,16 +906,321 @@ func parseGeminiFunctionCalls(parsed map[string]interface{}) []ToolCall {
 			arguments = "{}"
 		}
 		result = append(result, ToolCall{
-			ToolType:      "function",
-			ToolName:      strings.TrimSpace(getString(fc["name"])),
-			ArgumentsJSON: arguments,
-			Status:        "requested",
+			ToolType:         "function",
+			ToolName:         strings.TrimSpace(getString(fc["name"])),
+			ArgumentsJSON:    arguments,
+			ThoughtSignature: strings.TrimSpace(getString(part["thoughtSignature"])),
+			Status:           "requested",
 		})
 	}
 	if result == nil {
 		return make([]ToolCall, 0)
 	}
 	return result
+}
+
+func parseGeminiServerToolCalls(parsed map[string]interface{}) []ToolCall {
+	if len(parsed) == 0 {
+		return make([]ToolCall, 0)
+	}
+	result := make([]ToolCall, 0)
+	for _, call := range parseGeminiExplicitServerToolCalls(parsed, -1) {
+		appendUniqueToolCall(&result, call)
+	}
+	for candidateIndex, rawCandidate := range asSlice(parsed["candidates"]) {
+		candidate := asMap(rawCandidate)
+		for _, call := range parseGeminiExplicitServerToolCalls(candidate, candidateIndex) {
+			appendUniqueToolCall(&result, call)
+		}
+		if call, ok := parseGeminiGoogleSearchServerToolCall(candidate, candidateIndex); ok {
+			appendUniqueToolCall(&result, call)
+		}
+		if call, ok := parseGeminiURLContextServerToolCall(candidate, candidateIndex); ok {
+			appendUniqueToolCall(&result, call)
+		}
+		for _, call := range parseGeminiCodeExecutionServerToolCalls(candidate, candidateIndex) {
+			appendUniqueToolCall(&result, call)
+		}
+	}
+	return result
+}
+
+func parseGeminiExplicitServerToolCalls(payload map[string]interface{}, candidateIndex int) []ToolCall {
+	if len(payload) == 0 {
+		return nil
+	}
+	result := make([]ToolCall, 0)
+	keys := []string{
+		"serverSideToolInvocations",
+		"server_side_tool_invocations",
+		"toolInvocations",
+		"tool_invocations",
+	}
+	for _, key := range keys {
+		for itemIndex, raw := range asSlice(payload[key]) {
+			if call, ok := parseGeminiExplicitServerToolCall(asMap(raw), candidateIndex, itemIndex); ok {
+				result = append(result, call)
+			}
+		}
+	}
+	content := asMap(payload["content"])
+	for partIndex, raw := range asSlice(content["parts"]) {
+		part := asMap(raw)
+		for _, key := range []string{"serverSideToolInvocation", "server_side_tool_invocation", "toolInvocation", "tool_invocation"} {
+			if call, ok := parseGeminiExplicitServerToolCall(asMap(part[key]), candidateIndex, partIndex); ok {
+				result = append(result, call)
+			}
+		}
+	}
+	return result
+}
+
+func parseGeminiExplicitServerToolCall(item map[string]interface{}, candidateIndex int, itemIndex int) (ToolCall, bool) {
+	if len(item) == 0 {
+		return ToolCall{}, false
+	}
+	name := firstNonEmptyString(
+		getString(item["name"]),
+		getString(item["toolName"]),
+		getString(item["tool_name"]),
+		getString(item["type"]),
+	)
+	name = normalizeGeminiServerToolName(name)
+	if name == "" {
+		return ToolCall{}, false
+	}
+	status := firstNonEmptyString(getString(item["status"]), "in_progress")
+	return ToolCall{
+		ToolCallID: firstNonEmptyString(
+			getString(item["id"]),
+			getString(item["callId"]),
+			getString(item["call_id"]),
+			geminiServerToolCallID(name, candidateIndex, itemIndex),
+		),
+		ToolType:      name,
+		ToolName:      name,
+		ArgumentsJSON: firstNonEmptyString(normalizeJSONString(item["input"]), normalizeJSONString(item["args"]), normalizeJSONString(item["arguments"])),
+		Status:        normalizeGeminiExplicitServerToolStatus(status),
+		OutputJSON:    firstNonEmptyString(normalizeJSONString(item["output"]), normalizeJSONString(item["result"]), normalizeJSONString(item["response"])),
+		ErrorJSON:     normalizeJSONString(item["error"]),
+	}, true
+}
+
+func normalizeGeminiServerToolName(name string) string {
+	value := strings.ToLower(strings.TrimSpace(name))
+	value = strings.TrimSuffix(value, "_call")
+	value = strings.TrimSuffix(value, "_tool")
+	switch value {
+	case "google_search", "search", "web_search":
+		return "google_search"
+	case "url_context", "urlcontext":
+		return "url_context"
+	case "code_execution", "codeexecution":
+		return "code_execution"
+	default:
+		return value
+	}
+}
+
+func normalizeGeminiExplicitServerToolStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "pending", "running", "in_progress", "searching", "requested":
+		return "in_progress"
+	case "success", "succeeded", "completed", "done":
+		return "completed"
+	case "failed", "error":
+		return "error"
+	default:
+		return strings.TrimSpace(status)
+	}
+}
+
+func parseGeminiGoogleSearchServerToolCall(candidate map[string]interface{}, candidateIndex int) (ToolCall, bool) {
+	grounding := asMap(candidate["groundingMetadata"])
+	if !hasGeminiSearchGroundingMetadata(grounding) {
+		return ToolCall{}, false
+	}
+	input := map[string]interface{}{}
+	if queries := asSlice(grounding["webSearchQueries"]); len(queries) > 0 {
+		input["queries"] = queries
+	}
+	output := compactGeminiServerToolPayload(map[string]interface{}{
+		"queries":            grounding["webSearchQueries"],
+		"sources":            geminiGroundingSources(grounding),
+		"support_count":      len(asSlice(grounding["groundingSupports"])),
+		"search_entry_point": grounding["searchEntryPoint"],
+		"retrieval_metadata": grounding["retrievalMetadata"],
+	})
+	return ToolCall{
+		ToolCallID:    geminiServerToolCallID("google_search", candidateIndex, 0),
+		ToolType:      "google_search",
+		ToolName:      "google_search",
+		ArgumentsJSON: normalizeJSONString(input),
+		Status:        "completed",
+		OutputJSON:    normalizeJSONString(output),
+	}, true
+}
+
+func parseGeminiURLContextServerToolCall(candidate map[string]interface{}, candidateIndex int) (ToolCall, bool) {
+	metadata := asMap(candidate["urlContextMetadata"])
+	urlMetadata := asSlice(metadata["urlMetadata"])
+	if len(urlMetadata) == 0 {
+		return ToolCall{}, false
+	}
+	urls := make([]string, 0, len(urlMetadata))
+	for _, raw := range urlMetadata {
+		item := asMap(raw)
+		if uri := firstNonEmptyString(getString(item["retrievedUrl"]), getString(item["url"]), getString(item["uri"])); uri != "" {
+			urls = append(urls, uri)
+		}
+	}
+	input := map[string]interface{}{}
+	if len(urls) > 0 {
+		input["urls"] = urls
+	}
+	output := compactGeminiServerToolPayload(map[string]interface{}{
+		"urls": geminiURLContextItems(urlMetadata),
+	})
+	return ToolCall{
+		ToolCallID:    geminiServerToolCallID("url_context", candidateIndex, 0),
+		ToolType:      "url_context",
+		ToolName:      "url_context",
+		ArgumentsJSON: normalizeJSONString(input),
+		Status:        "completed",
+		OutputJSON:    normalizeJSONString(output),
+	}, true
+}
+
+func parseGeminiCodeExecutionServerToolCalls(candidate map[string]interface{}, candidateIndex int) []ToolCall {
+	content := asMap(candidate["content"])
+	parts := asSlice(content["parts"])
+	result := make([]ToolCall, 0)
+	currentIndex := -1
+	for _, raw := range parts {
+		part := asMap(raw)
+		executableCode := asMap(part["executableCode"])
+		if len(executableCode) > 0 {
+			currentIndex++
+			result = append(result, ToolCall{
+				ToolCallID:    geminiServerToolCallID("code_execution", candidateIndex, currentIndex),
+				ToolType:      "code_execution",
+				ToolName:      "code_execution",
+				ArgumentsJSON: normalizeJSONString(executableCode),
+				Status:        "requested",
+			})
+			continue
+		}
+		executionResult := asMap(part["codeExecutionResult"])
+		if len(executionResult) == 0 {
+			continue
+		}
+		if currentIndex < 0 {
+			currentIndex = 0
+			result = append(result, ToolCall{
+				ToolCallID: geminiServerToolCallID("code_execution", candidateIndex, currentIndex),
+				ToolType:   "code_execution",
+				ToolName:   "code_execution",
+			})
+		}
+		idx := len(result) - 1
+		result[idx].OutputJSON = normalizeJSONString(executionResult)
+		result[idx].Status = geminiCodeExecutionStatus(executionResult)
+		if result[idx].Status == "error" {
+			result[idx].ErrorJSON = normalizeJSONString(executionResult)
+		}
+	}
+	return result
+}
+
+func geminiGroundingSources(grounding map[string]interface{}) []map[string]interface{} {
+	chunks := asSlice(grounding["groundingChunks"])
+	if len(chunks) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(chunks))
+	for _, raw := range chunks {
+		chunk := asMap(raw)
+		for _, key := range []string{"web", "retrievedContext"} {
+			source := asMap(chunk[key])
+			uri := firstNonEmptyString(getString(source["uri"]), getString(source["url"]))
+			if uri == "" {
+				continue
+			}
+			item := map[string]interface{}{"url": uri}
+			if title := strings.TrimSpace(getString(source["title"])); title != "" {
+				item["title"] = title
+			}
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func geminiURLContextItems(items []interface{}) []map[string]interface{} {
+	if len(items) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, raw := range items {
+		item := asMap(raw)
+		url := firstNonEmptyString(getString(item["retrievedUrl"]), getString(item["url"]), getString(item["uri"]))
+		if url == "" {
+			continue
+		}
+		next := map[string]interface{}{"url": url}
+		if status := strings.TrimSpace(getString(item["urlRetrievalStatus"])); status != "" {
+			next["status"] = status
+		}
+		result = append(result, next)
+	}
+	return result
+}
+
+func compactGeminiServerToolPayload(payload map[string]interface{}) map[string]interface{} {
+	if len(payload) == 0 {
+		return nil
+	}
+	result := make(map[string]interface{}, len(payload))
+	for key, value := range payload {
+		if isEmptyGeminiPayloadValue(value) {
+			continue
+		}
+		result[key] = value
+	}
+	return result
+}
+
+func isEmptyGeminiPayloadValue(value interface{}) bool {
+	if value == nil {
+		return true
+	}
+	if len(asSlice(value)) > 0 || len(asMap(value)) > 0 {
+		return false
+	}
+	switch typed := value.(type) {
+	case []interface{}:
+		return len(typed) == 0
+	case map[string]interface{}:
+		return len(typed) == 0
+	case string:
+		return strings.TrimSpace(typed) == ""
+	default:
+		return false
+	}
+}
+
+func geminiCodeExecutionStatus(result map[string]interface{}) string {
+	outcome := strings.ToUpper(strings.TrimSpace(getString(result["outcome"])))
+	switch outcome {
+	case "", "OUTCOME_OK", "OK":
+		return "completed"
+	default:
+		return "error"
+	}
+}
+
+func geminiServerToolCallID(tool string, candidateIndex int, itemIndex int) string {
+	return fmt.Sprintf("gemini_%s_%d_%d", strings.TrimSpace(tool), candidateIndex, itemIndex)
 }
 
 func parseGeminiCitations(parsed map[string]interface{}) []string {
@@ -858,13 +1255,24 @@ func parseGeminiServerSideToolUsage(parsed map[string]interface{}) map[string]in
 	if len(parsed) == 0 {
 		return nil
 	}
+	result := make(map[string]int64)
 	for _, rawCandidate := range asSlice(parsed["candidates"]) {
 		candidate := asMap(rawCandidate)
 		if hasGeminiSearchGroundingMetadata(asMap(candidate["groundingMetadata"])) {
-			return map[string]int64{"google_search": 1}
+			result["google_search"] = 1
+		}
+		if len(asSlice(asMap(candidate["urlContextMetadata"])["urlMetadata"])) > 0 {
+			result["url_context"] = 1
+		}
+		codeExecutionCount := int64(len(parseGeminiCodeExecutionServerToolCalls(candidate, 0)))
+		if codeExecutionCount > 0 {
+			result["code_execution"] += codeExecutionCount
 		}
 	}
-	return nil
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 func hasGeminiSearchGroundingMetadata(grounding map[string]interface{}) bool {
@@ -1005,6 +1413,18 @@ func applyGeminiStreamChunk(
 	}
 	result.Citations = appendUniqueStrings(result.Citations, parseGeminiCitations(parsed)...)
 	result.ServerSideToolUsage = mergeGeminiServerSideToolUsage(result.ServerSideToolUsage, parseGeminiServerSideToolUsage(parsed))
+	for _, call := range parseGeminiServerToolCalls(parsed) {
+		merged := appendGeminiServerToolCall(result, call)
+		if onEvent != nil {
+			if err := onEvent(GenerateStreamEvent{
+				ServerToolCall: &merged,
+				ResponseID:     result.ResponseID,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	applyGeminiStreamServerToolUsage(result)
 
 	// 提取文本增量
 	candidate := firstMapItem(asSlice(parsed["candidates"]))
@@ -1061,10 +1481,11 @@ func applyGeminiStreamChunk(
 			arguments = "{}"
 		}
 		result.ToolCalls = append(result.ToolCalls, ToolCall{
-			ToolType:      "function",
-			ToolName:      strings.TrimSpace(getString(fc["name"])),
-			ArgumentsJSON: arguments,
-			Status:        "requested",
+			ToolType:         "function",
+			ToolName:         strings.TrimSpace(getString(fc["name"])),
+			ArgumentsJSON:    arguments,
+			ThoughtSignature: strings.TrimSpace(getString(part["thoughtSignature"])),
+			Status:           "requested",
 		})
 	}
 
@@ -1080,6 +1501,83 @@ func applyGeminiStreamChunk(
 	}
 
 	return nil
+}
+
+func appendGeminiServerToolCall(result *GenerateOutput, call ToolCall) ToolCall {
+	if result == nil {
+		return call
+	}
+	call = normalizeGeminiStreamServerToolCallID(result.ServerToolCalls, call)
+	appendUniqueToolCall(&result.ServerToolCalls, call)
+	for _, item := range result.ServerToolCalls {
+		if shouldMergeToolCall(item, call) {
+			return item
+		}
+	}
+	return call
+}
+
+func normalizeGeminiStreamServerToolCallID(existing []ToolCall, call ToolCall) ToolCall {
+	if strings.TrimSpace(call.ToolName) != "code_execution" && strings.TrimSpace(call.ToolType) != "code_execution" {
+		return call
+	}
+	hasInput := strings.TrimSpace(call.ArgumentsJSON) != ""
+	hasOutput := strings.TrimSpace(call.OutputJSON) != "" || strings.TrimSpace(call.ErrorJSON) != ""
+	if hasInput && !hasOutput {
+		if item, ok := latestGeminiPendingCodeExecution(existing); ok && strings.TrimSpace(item.OutputJSON) == "" && strings.TrimSpace(item.ErrorJSON) == "" {
+			call.ToolCallID = item.ToolCallID
+			return call
+		}
+		call.ToolCallID = geminiServerToolCallID("code_execution", 0, countGeminiCodeExecutionCalls(existing))
+		return call
+	}
+	if !hasInput && hasOutput {
+		if item, ok := latestGeminiPendingCodeExecution(existing); ok {
+			call.ToolCallID = item.ToolCallID
+			return call
+		}
+		call.ToolCallID = geminiServerToolCallID("code_execution", 0, countGeminiCodeExecutionCalls(existing))
+	}
+	return call
+}
+
+func latestGeminiPendingCodeExecution(items []ToolCall) (ToolCall, bool) {
+	for idx := len(items) - 1; idx >= 0; idx-- {
+		item := items[idx]
+		if strings.TrimSpace(item.ToolName) != "code_execution" && strings.TrimSpace(item.ToolType) != "code_execution" {
+			continue
+		}
+		if strings.TrimSpace(item.OutputJSON) == "" && strings.TrimSpace(item.ErrorJSON) == "" {
+			return item, true
+		}
+	}
+	return ToolCall{}, false
+}
+
+func countGeminiCodeExecutionCalls(items []ToolCall) int {
+	count := 0
+	for _, item := range items {
+		if strings.TrimSpace(item.ToolName) == "code_execution" || strings.TrimSpace(item.ToolType) == "code_execution" {
+			count++
+		}
+	}
+	return count
+}
+
+func applyGeminiStreamServerToolUsage(result *GenerateOutput) {
+	if result == nil {
+		return
+	}
+	codeExecutionCount := int64(countGeminiCodeExecutionCalls(result.ServerToolCalls))
+	if codeExecutionCount <= 0 {
+		return
+	}
+	if result.ServerSideToolUsage == nil {
+		result.ServerSideToolUsage = make(map[string]int64)
+	}
+	if codeExecutionCount > result.ServerSideToolUsage["code_execution"] {
+		result.ServerSideToolUsage["code_execution"] = codeExecutionCount
+	}
 }
 
 func mergeGeminiServerSideToolUsage(current map[string]int64, next map[string]int64) map[string]int64 {

--- a/backend/internal/infra/llm/gemini_test.go
+++ b/backend/internal/infra/llm/gemini_test.go
@@ -88,6 +88,31 @@ func TestApplyGeminiStreamChunkStoresReasoningAndCitations(t *testing.T) {
 	}
 }
 
+func TestParseGeminiResponseCapturesFunctionCallThoughtSignature(t *testing.T) {
+	output, err := parseGeminiResponse([]byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{
+					"functionCall": {
+						"name": "search_web",
+						"args": {"query": "SpaceX stock price"}
+					},
+					"thoughtSignature": "thought-signature-1"
+				}]
+			}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("parse Gemini response: %v", err)
+	}
+	if len(output.ToolCalls) != 1 {
+		t.Fatalf("expected one function call, got %#v", output.ToolCalls)
+	}
+	if output.ToolCalls[0].ThoughtSignature != "thought-signature-1" {
+		t.Fatalf("expected thought signature, got %#v", output.ToolCalls[0])
+	}
+}
+
 func TestBuildGeminiImageGenerationRequestBody(t *testing.T) {
 	payload, err := buildGeminiImageGenerationRequestBody("gemini-3.1-flash-image", GenerateInput{
 		Messages: []Message{
@@ -201,6 +226,186 @@ func TestParseGeminiResponseCapturesGoogleSearchUsage(t *testing.T) {
 	}
 	if output.ServerSideToolUsage["google_search"] != 1 {
 		t.Fatalf("expected google_search server-side usage, got %#v", output.ServerSideToolUsage)
+	}
+	if len(output.ServerToolCalls) != 1 {
+		t.Fatalf("expected google_search server-side tool trace, got %#v", output.ServerToolCalls)
+	}
+	call := output.ServerToolCalls[0]
+	if call.ToolName != "google_search" || call.ToolType != "google_search" || call.Status != "completed" {
+		t.Fatalf("expected completed google_search trace, got %#v", call)
+	}
+	if call.ArgumentsJSON == "" || call.OutputJSON == "" {
+		t.Fatalf("expected google_search input and output details, got %#v", call)
+	}
+	outputPayload := mustDecodeObject(t, call.OutputJSON)
+	if _, ok := outputPayload["groundingChunks"]; ok {
+		t.Fatalf("expected compact Gemini search output, got %#v", outputPayload)
+	}
+	sources := asSlice(outputPayload["sources"])
+	if len(sources) != 1 || asMap(sources[0])["url"] != "https://example.com" {
+		t.Fatalf("expected compact Gemini sources, got %#v", outputPayload)
+	}
+}
+
+func TestParseGeminiResponseCapturesURLContextServerToolTrace(t *testing.T) {
+	output, err := parseGeminiResponse([]byte(`{
+		"candidates": [{
+			"content": {"parts": [{"text": "answer"}]},
+			"urlContextMetadata": {
+				"urlMetadata": [{
+					"retrievedUrl": "https://example.com/page",
+					"urlRetrievalStatus": "URL_RETRIEVAL_STATUS_SUCCESS"
+				}]
+			}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("parse Gemini response: %v", err)
+	}
+	if output.ServerSideToolUsage["url_context"] != 1 {
+		t.Fatalf("expected url_context server-side usage, got %#v", output.ServerSideToolUsage)
+	}
+	if len(output.ServerToolCalls) != 1 {
+		t.Fatalf("expected url_context server-side tool trace, got %#v", output.ServerToolCalls)
+	}
+	call := output.ServerToolCalls[0]
+	if call.ToolName != "url_context" || call.ToolType != "url_context" || call.Status != "completed" {
+		t.Fatalf("expected completed url_context trace, got %#v", call)
+	}
+	if call.ArgumentsJSON == "" || call.OutputJSON == "" {
+		t.Fatalf("expected url_context input and output details, got %#v", call)
+	}
+	outputPayload := mustDecodeObject(t, call.OutputJSON)
+	urls := asSlice(outputPayload["urls"])
+	if len(urls) != 1 || asMap(urls[0])["url"] != "https://example.com/page" {
+		t.Fatalf("expected compact url_context output, got %#v", outputPayload)
+	}
+}
+
+func TestParseGeminiResponseCapturesCodeExecutionServerToolTrace(t *testing.T) {
+	output, err := parseGeminiResponse([]byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{
+						"executableCode": {
+							"language": "PYTHON",
+							"code": "print(1 + 1)"
+						}
+					},
+					{
+						"codeExecutionResult": {
+							"outcome": "OUTCOME_OK",
+							"output": "2\n"
+						}
+					},
+					{"text": "answer"}
+				]
+			}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("parse Gemini response: %v", err)
+	}
+	if output.ServerSideToolUsage["code_execution"] != 1 {
+		t.Fatalf("expected code_execution server-side usage, got %#v", output.ServerSideToolUsage)
+	}
+	if len(output.ServerToolCalls) != 1 {
+		t.Fatalf("expected code_execution server-side tool trace, got %#v", output.ServerToolCalls)
+	}
+	call := output.ServerToolCalls[0]
+	if call.ToolName != "code_execution" || call.ToolType != "code_execution" || call.Status != "completed" {
+		t.Fatalf("expected completed code_execution trace, got %#v", call)
+	}
+	if call.ArgumentsJSON == "" || call.OutputJSON == "" || call.ErrorJSON != "" {
+		t.Fatalf("expected code_execution input and successful output, got %#v", call)
+	}
+}
+
+func TestApplyGeminiStreamChunkEmitsServerToolTrace(t *testing.T) {
+	result := &GenerateOutput{ToolCalls: make([]ToolCall, 0)}
+	events := make([]ToolCall, 0)
+	err := applyGeminiStreamChunk(mustDecodeObject(t, `{
+		"responseId": "gemini-stream-tool-1",
+		"candidates": [{
+			"content": {
+				"parts": [
+					{"executableCode": {"language": "PYTHON", "code": "print(2)"}},
+					{"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "2\n"}}
+				]
+			}
+		}]
+	}`), result, func(event GenerateStreamEvent) error {
+		if event.ServerToolCall != nil {
+			events = append(events, *event.ServerToolCall)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("apply gemini stream chunk: %v", err)
+	}
+	if len(result.ServerToolCalls) != 1 || result.ServerToolCalls[0].ToolName != "code_execution" {
+		t.Fatalf("expected stored code_execution trace, got %#v", result.ServerToolCalls)
+	}
+	if len(events) != 1 || events[0].ToolName != "code_execution" || events[0].OutputJSON == "" {
+		t.Fatalf("expected emitted code_execution trace, got %#v", events)
+	}
+}
+
+func TestApplyGeminiStreamChunkEmitsExplicitServerToolInvocation(t *testing.T) {
+	result := &GenerateOutput{ToolCalls: make([]ToolCall, 0)}
+	events := make([]ToolCall, 0)
+	err := applyGeminiStreamChunk(mustDecodeObject(t, `{
+		"responseId": "gemini-stream-tool-2",
+		"candidates": [{
+			"serverSideToolInvocations": [{
+				"id": "gsi_1",
+				"name": "google_search",
+				"status": "running",
+				"input": {"query": "SpaceX stock price"}
+			}]
+		}]
+	}`), result, func(event GenerateStreamEvent) error {
+		if event.ServerToolCall != nil {
+			events = append(events, *event.ServerToolCall)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("apply gemini stream chunk: %v", err)
+	}
+	if len(result.ServerToolCalls) != 1 || result.ServerToolCalls[0].Status != "in_progress" {
+		t.Fatalf("expected stored in-progress server tool call, got %#v", result.ServerToolCalls)
+	}
+	if len(events) != 1 || events[0].ToolName != "google_search" || events[0].Status != "in_progress" {
+		t.Fatalf("expected emitted google_search invocation, got %#v", events)
+	}
+}
+
+func TestApplyGeminiStreamChunkKeepsMultipleCodeExecutionTraces(t *testing.T) {
+	result := &GenerateOutput{ToolCalls: make([]ToolCall, 0)}
+	chunks := []string{
+		`{"candidates":[{"content":{"parts":[{"executableCode":{"language":"PYTHON","code":"print(1)"}}]}}]}`,
+		`{"candidates":[{"content":{"parts":[{"codeExecutionResult":{"outcome":"OUTCOME_OK","output":"1\n"}}]}}]}`,
+		`{"candidates":[{"content":{"parts":[{"executableCode":{"language":"PYTHON","code":"print(2)"}}]}}]}`,
+		`{"candidates":[{"content":{"parts":[{"codeExecutionResult":{"outcome":"OUTCOME_OK","output":"2\n"}}]}}]}`,
+	}
+	for _, chunk := range chunks {
+		if err := applyGeminiStreamChunk(mustDecodeObject(t, chunk), result, nil); err != nil {
+			t.Fatalf("apply gemini stream chunk: %v", err)
+		}
+	}
+	if len(result.ServerToolCalls) != 2 {
+		t.Fatalf("expected two code_execution traces, got %#v", result.ServerToolCalls)
+	}
+	if result.ServerToolCalls[0].ToolCallID == result.ServerToolCalls[1].ToolCallID {
+		t.Fatalf("expected distinct code_execution trace ids, got %#v", result.ServerToolCalls)
+	}
+	if result.ServerToolCalls[0].OutputJSON == "" || result.ServerToolCalls[1].OutputJSON == "" {
+		t.Fatalf("expected both code_execution outputs, got %#v", result.ServerToolCalls)
+	}
+	if result.ServerSideToolUsage["code_execution"] != 2 {
+		t.Fatalf("expected cumulative code_execution usage, got %#v", result.ServerSideToolUsage)
 	}
 }
 

--- a/backend/internal/infra/llm/openai.go
+++ b/backend/internal/infra/llm/openai.go
@@ -209,7 +209,7 @@ func buildOpenAIRequestBody(protocol string, model string, endpoint string, inpu
 
 	switch endpoint {
 	case EndpointChatCompletions:
-		return buildChatCompletionsRequestBody(model, input, messages, providerTools, toolDefinitions, providerStreamOptions, stream), nil
+		return buildChatCompletionsRequestBody(adapter, model, input, messages, providerTools, toolDefinitions, providerStreamOptions, stream), nil
 	default:
 		return buildResponsesRequestBody(adapter, model, input, messages, providerTools, toolDefinitions, toolsEnabled, providerStreamOptions, stream), nil
 	}

--- a/backend/internal/infra/llm/openai_chat_completions.go
+++ b/backend/internal/infra/llm/openai_chat_completions.go
@@ -35,6 +35,7 @@ func (a *openAIChatCompletionsAdapter) ListModels(ctx context.Context, route Rou
 }
 
 func buildChatCompletionsRequestBody(
+	adapter string,
 	model string,
 	input GenerateInput,
 	messages []Message,
@@ -45,7 +46,7 @@ func buildChatCompletionsRequestBody(
 ) map[string]interface{} {
 	items := make([]map[string]interface{}, 0, len(messages))
 	for _, item := range messages {
-		items = append(items, buildChatCompletionsMessages(item)...)
+		items = append(items, buildChatCompletionsMessages(adapter, item)...)
 	}
 	payload := map[string]interface{}{
 		"model":    strings.TrimSpace(model),
@@ -156,7 +157,7 @@ func normalizedChatCompletionResponseFormat(options map[string]interface{}) (int
 	}, true
 }
 
-func buildChatCompletionsMessages(msg Message) []map[string]interface{} {
+func buildChatCompletionsMessages(adapter string, msg Message) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, 1+len(msg.ToolResults))
 	if len(msg.ToolResults) > 0 {
 		for _, item := range msg.ToolResults {
@@ -174,7 +175,11 @@ func buildChatCompletionsMessages(msg Message) []map[string]interface{} {
 		"content": buildChatCompletionsContent(msg),
 	}
 	if reasoningContent := strings.TrimSpace(msg.ReasoningContent); reasoningContent != "" && normalizeRole(msg.Role) == "assistant" {
-		payload["reasoning_content"] = reasoningContent
+		if NormalizeAdapter(adapter) == AdapterOpenRouterChat {
+			payload["reasoning"] = reasoningContent
+		} else {
+			payload["reasoning_content"] = reasoningContent
+		}
 	}
 	if len(msg.ToolCalls) > 0 {
 		payload["tool_calls"] = buildChatCompletionsToolCalls(msg.ToolCalls)

--- a/backend/internal/infra/llm/openrouter_chat_completions.go
+++ b/backend/internal/infra/llm/openrouter_chat_completions.go
@@ -1,0 +1,41 @@
+package llm
+
+import "context"
+
+// openRouterChatCompletionsAdapter 实现 OpenRouter Chat Completions API。
+type openRouterChatCompletionsAdapter struct {
+	client *Client
+}
+
+func (a *openRouterChatCompletionsAdapter) Name() string { return AdapterOpenRouterChat }
+
+// Generate 调用 OpenRouter Chat Completions 非流式接口。
+func (a *openRouterChatCompletionsAdapter) Generate(ctx context.Context, route RouteConfig, input GenerateInput) (*GenerateOutput, error) {
+	route = normalizeOpenRouterChatCompletionsRoute(route)
+	return a.client.generateOpenAICompatible(ctx, route, input)
+}
+
+// GenerateStream 调用 OpenRouter Chat Completions 流式接口。
+func (a *openRouterChatCompletionsAdapter) GenerateStream(ctx context.Context, route RouteConfig, input GenerateInput, onEvent func(GenerateStreamEvent) error) (*GenerateOutput, error) {
+	route = normalizeOpenRouterChatCompletionsRoute(route)
+	output, err := a.client.generateStreamOpenAICompatible(ctx, route, input, onEvent)
+	if err == nil || !shouldRetryChatCompletionsWithoutAutoStreamUsage(input.Options, err) {
+		return output, err
+	}
+	retryInput := input
+	retryInput.Options = disableChatCompletionsAutoStreamUsage(input.Options)
+	return a.client.generateStreamOpenAICompatible(ctx, route, retryInput, onEvent)
+}
+
+// ListModels 按 OpenRouter OpenAI-compatible 模型列表协议查询模型。
+func (a *openRouterChatCompletionsAdapter) ListModels(ctx context.Context, route RouteConfig) ([]ModelItem, error) {
+	route = normalizeOpenRouterChatCompletionsRoute(route)
+	return a.client.listModelsOpenAICompatible(ctx, route)
+}
+
+// normalizeOpenRouterChatCompletionsRoute 固定 OpenRouter Chat Completions 的协议和端点。
+func normalizeOpenRouterChatCompletionsRoute(route RouteConfig) RouteConfig {
+	route.Protocol = AdapterOpenRouterChat
+	route.Endpoint = EndpointChatCompletions
+	return route
+}

--- a/backend/internal/infra/llm/request_tools_test.go
+++ b/backend/internal/infra/llm/request_tools_test.go
@@ -67,6 +67,31 @@ func TestBuildChatCompletionsToolMessages(t *testing.T) {
 	}
 }
 
+func TestBuildOpenRouterChatCompletionsToolMessagesUsesReasoningField(t *testing.T) {
+	payload := mustBuildRequestBody(t, AdapterOpenRouterChat, "openai/gpt-oss-120b:free", EndpointChatCompletions, GenerateInput{
+		Messages: []Message{
+			{
+				Role:             "assistant",
+				ReasoningContent: "need live news",
+				ToolCalls:        []ToolCall{{ToolCallID: "call_1", ToolType: "function", ToolName: "search_web", ArgumentsJSON: `{"query":"today news China"}`}},
+			},
+			{Role: "tool", ToolResults: []ToolResult{{ToolCallID: "call_1", ToolName: "search_web", OutputJSON: `{"items":[]}`, Status: "success"}}},
+		},
+	}, false)
+
+	messages := payload["messages"].([]map[string]interface{})
+	assistant := messages[0]
+	if assistant["reasoning"] != "need live news" {
+		t.Fatalf("expected OpenRouter reasoning passback, got %#v", assistant)
+	}
+	if _, ok := assistant["reasoning_content"]; ok {
+		t.Fatalf("expected no DeepSeek reasoning_content alias for OpenRouter, got %#v", assistant)
+	}
+	if payload["stream"] != false {
+		t.Fatalf("expected chat completions request body, got %#v", payload)
+	}
+}
+
 func TestParseChatCompletionsOutputSeparatesReasoningContentParts(t *testing.T) {
 	result := &GenerateOutput{}
 	parseChatCompletionsOutput(AdapterOpenAIChatCompletions, map[string]interface{}{

--- a/backend/internal/infra/llm/request_tools_test.go
+++ b/backend/internal/infra/llm/request_tools_test.go
@@ -490,6 +490,90 @@ func TestBuildGeminiToolsMergesProviderAndMCPTools(t *testing.T) {
 	if declarations[0]["name"] != "bing_search" {
 		t.Fatalf("expected MCP tool third, got %#v", tools[2])
 	}
+	toolConfig := payload["toolConfig"].(map[string]interface{})
+	if toolConfig["includeServerSideToolInvocations"] != true {
+		t.Fatalf("expected Gemini server-side tool invocations to be included when mixed with function declarations, got %#v", toolConfig)
+	}
+}
+
+func TestBuildGeminiToolsPreservesExplicitToolConfigWhenMixedTools(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}`)
+	payload := mustBuildGeminiRequestBody(t, GenerateInput{
+		Messages: []Message{{Role: "user", Content: "search"}},
+		Options: map[string]interface{}{
+			"web_search": true,
+			"toolConfig": map[string]interface{}{
+				"functionCallingConfig": map[string]interface{}{"mode": "ANY"},
+			},
+		},
+		Tools: []ToolDefinition{{
+			Name:        "search_web",
+			Description: "Search the web",
+			InputSchema: schema,
+		}},
+	})
+
+	toolConfig := payload["toolConfig"].(map[string]interface{})
+	if toolConfig["includeServerSideToolInvocations"] != true {
+		t.Fatalf("expected mixed tools to enable server-side invocations, got %#v", toolConfig)
+	}
+	if _, ok := toolConfig["functionCallingConfig"].(map[string]interface{}); !ok {
+		t.Fatalf("expected explicit functionCallingConfig to be preserved, got %#v", toolConfig)
+	}
+}
+
+func TestBuildGeminiToolsSanitizesJSONSchemaForFunctionDeclarations(t *testing.T) {
+	schema := json.RawMessage(`{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"additionalProperties": false,
+		"type": "object",
+		"properties": {
+			"query": {
+				"anyOf": [
+					{"type": "string", "default": ""},
+					{"type": "array", "items": {"type": "string", "additionalProperties": false}}
+				],
+				"description": "Search terms"
+			},
+			"num": {
+				"type": "number",
+				"default": 30
+			}
+		},
+		"required": ["query"]
+	}`)
+	payload := mustBuildGeminiRequestBody(t, GenerateInput{
+		Messages: []Message{{Role: "user", Content: "search"}},
+		Tools: []ToolDefinition{{
+			Name:        "search_web",
+			Description: "Search the web",
+			InputSchema: schema,
+		}},
+	})
+
+	tools := payload["tools"].([]map[string]interface{})
+	declarations := tools[0]["functionDeclarations"].([]map[string]interface{})
+	parameters := declarations[0]["parameters"].(map[string]interface{})
+	if _, ok := parameters["$schema"]; ok {
+		t.Fatalf("expected $schema to be removed for Gemini, got %#v", parameters)
+	}
+	if _, ok := parameters["additionalProperties"]; ok {
+		t.Fatalf("expected additionalProperties to be removed for Gemini, got %#v", parameters)
+	}
+	properties := parameters["properties"].(map[string]interface{})
+	query := properties["query"].(map[string]interface{})
+	anyOf := query["anyOf"].([]interface{})
+	if _, ok := anyOf[0].(map[string]interface{})["default"]; ok {
+		t.Fatalf("expected nested default to be removed for Gemini, got %#v", anyOf[0])
+	}
+	arraySchema := anyOf[1].(map[string]interface{})
+	items := arraySchema["items"].(map[string]interface{})
+	if _, ok := items["additionalProperties"]; ok {
+		t.Fatalf("expected nested additionalProperties to be removed for Gemini, got %#v", items)
+	}
+	if parameters["type"] != "object" || len(parameters["required"].([]interface{})) != 1 {
+		t.Fatalf("expected supported schema fields to remain, got %#v", parameters)
+	}
 }
 
 func TestBuildGeminiRequestBodyDisableToolsRemovesProviderAndMCPTools(t *testing.T) {
@@ -1694,5 +1778,20 @@ func TestBuildGeminiToolParts(t *testing.T) {
 	response := parts[0]["functionResponse"].(map[string]interface{})
 	if response["name"] != "memory.list" {
 		t.Fatalf("expected gemini functionResponse name, got %#v", response)
+	}
+}
+
+func TestBuildGeminiToolCallPartsPreserveThoughtSignature(t *testing.T) {
+	parts := buildGeminiParts(Message{
+		Role: "assistant",
+		ToolCalls: []ToolCall{{
+			ToolName:         "search_web",
+			ArgumentsJSON:    `{"query":"SpaceX stock price"}`,
+			ThoughtSignature: "thought-signature-1",
+		}},
+	})
+
+	if parts[0]["thoughtSignature"] != "thought-signature-1" {
+		t.Fatalf("expected thoughtSignature on Gemini functionCall part, got %#v", parts[0])
 	}
 }

--- a/backend/internal/infra/persistence/postgres/conversation/repository.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository.go
@@ -1557,6 +1557,20 @@ func (r *Repo) ListConversationMessageTraceEventsByMessageIDs(ctx context.Contex
 }
 
 // CreateConversationToolCalls 批量写入工具调用日志。
+func (r *Repo) CreateConversationToolCall(ctx context.Context, item *domainconversation.ToolCall) error {
+	if item == nil {
+		return nil
+	}
+	entity := toConversationToolCallModel(item)
+	if err := r.db.WithContext(ctx).Create(&entity).Error; err != nil {
+		return translateError(err)
+	}
+	item.ID = entity.ID
+	item.CreatedAt = entity.CreatedAt
+	item.UpdatedAt = entity.UpdatedAt
+	return nil
+}
+
 func (r *Repo) CreateConversationToolCalls(ctx context.Context, items []domainconversation.ToolCall) error {
 	if len(items) == 0 {
 		return nil
@@ -1565,7 +1579,17 @@ func (r *Repo) CreateConversationToolCalls(ctx context.Context, items []domainco
 	for i := range items {
 		entities = append(entities, toConversationToolCallModel(&items[i]))
 	}
-	return translateError(r.db.WithContext(ctx).Create(&entities).Error)
+	if err := r.db.WithContext(ctx).Create(&entities).Error; err != nil {
+		return translateError(err)
+	}
+	for index := range items {
+		if index < len(entities) {
+			items[index].ID = entities[index].ID
+			items[index].CreatedAt = entities[index].CreatedAt
+			items[index].UpdatedAt = entities[index].UpdatedAt
+		}
+	}
+	return nil
 }
 
 // ListConversationRuns 分页查询会话运行日志。

--- a/backend/internal/repository/conversation_core.go
+++ b/backend/internal/repository/conversation_core.go
@@ -112,6 +112,7 @@ type ConversationTraceRepository interface {
 	ListConversationMessageTracesByMessageIDs(ctx context.Context, messageIDs []uint) ([]domainconversation.MessageTrace, error)
 	UpsertConversationMessageTraceEvent(ctx context.Context, item *domainconversation.MessageTraceEventRow) error
 	ListConversationMessageTraceEventsByMessageIDs(ctx context.Context, messageIDs []uint) ([]domainconversation.MessageTraceEventRow, error)
+	CreateConversationToolCall(ctx context.Context, item *domainconversation.ToolCall) error
 	CreateConversationToolCalls(ctx context.Context, items []domainconversation.ToolCall) error
 	ListConversationRuns(ctx context.Context, userID uint, conversationID uint, offset int, limit int) ([]domainconversation.Run, int64, error)
 	GetLatestConversationRunModel(ctx context.Context, userID uint) (*domainconversation.Run, error)

--- a/frontend/features/admin/api/llm.types.ts
+++ b/frontend/features/admin/api/llm.types.ts
@@ -4,6 +4,7 @@ export type AdminLLMStatus = "active" | "inactive";
 export type AdminLLMModelAccessScope = "public" | "internal";
 export type AdminLLMAdapter =
   | "openai_responses"
+  | "openrouter_chat_completions"
   | "openrouter_responses"
   | "openai_chat_completions"
   | "openai_image_generations"

--- a/frontend/features/admin/components/sections/conversation/admin-conversation.tsx
+++ b/frontend/features/admin/components/sections/conversation/admin-conversation.tsx
@@ -227,10 +227,6 @@ generationConfig.safetySettings.threshold`}
     "reasoning.effort",
     "text.verbosity"
   ],
-  "openrouter_responses": [
-    "reasoning.effort",
-    "reasoning.summary"
-  ],
   "openai_image_generations": [
     "background",
     "moderation",
@@ -277,6 +273,15 @@ generationConfig.safetySettings.threshold`}
     "service_tier",
     "thinking.type"
   ],
+  "openrouter_chat_completions": [
+    "reasoning_effort",
+    "reasoning.effort",
+    "thinking.type"
+  ],
+  "openrouter_responses": [
+    "reasoning.effort",
+    "reasoning.summary"
+  ],
   "anthropic_messages": [
     "speed",
     "thinking.type",
@@ -310,7 +315,7 @@ generationConfig.safetySettings.threshold`}
             <h4 className="text-sm font-medium text-foreground">{t("guide.protocolTitle")}</h4>
             <p className="text-xs">{t("guide.protocolDescription")}</p>
             <div className="flex flex-wrap gap-1.5">
-              {["default", "openai_chat_completions", "openai_responses", "openrouter_responses", "openai_image_generations", "openai_image_edits", "google_image_generation", "xai_image", "xai_image_edits", "anthropic_messages", "xai_responses", "gemini_generate_content"].map((item) => (
+              {["default", "openai_chat_completions", "openrouter_chat_completions", "openai_responses", "openrouter_responses", "openai_image_generations", "openai_image_edits", "google_image_generation", "xai_image", "xai_image_edits", "anthropic_messages", "xai_responses", "gemini_generate_content"].map((item) => (
                 <code key={item} className="rounded-md bg-muted/60 px-2 py-1 text-xs text-foreground">{item}</code>
               ))}
             </div>

--- a/frontend/features/admin/components/sections/upstreams/upstreams-models-dialog.tsx
+++ b/frontend/features/admin/components/sections/upstreams/upstreams-models-dialog.tsx
@@ -760,6 +760,11 @@ function NewBindingDialog({
   const [form, setForm] = React.useState<NewBindingFormState>(DEFAULT_NEW_BINDING);
   const [saving, setSaving] = React.useState(false);
 
+  React.useEffect(() => {
+    if (!open) return;
+    setForm(DEFAULT_NEW_BINDING);
+  }, [open]);
+
   function setField<K extends keyof NewBindingFormState>(
     key: K,
     value: NewBindingFormState[K],
@@ -945,7 +950,7 @@ export function UpstreamModelsDialog({
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [newBindingOpen, setNewBindingOpen] = React.useState(false);
   const [bulkRouteStatus, setBulkRouteStatus] = React.useState<"active" | "inactive">("active");
-  const [bulkProtocols, setBulkProtocols] = React.useState<AdminLLMAdapter[]>(["openai_responses"]);
+  const [bulkProtocols, setBulkProtocols] = React.useState<AdminLLMAdapter[]>([]);
   const [bulkKindsDisplay, setBulkKindsDisplay] = React.useState("chat");
   const [bulkPatchConfirm, setBulkPatchConfirm] = React.useState<BulkPatchConfirm | null>(null);
   const [query, setQuery] = React.useState("");
@@ -957,6 +962,10 @@ export function UpstreamModelsDialog({
   const [probeResults, setProbeResults] = React.useState<AdminLLMModelProbeResult[]>([]);
   const requestSeqRef = React.useRef(0);
   const upstreamID = upstream?.id ?? null;
+
+  React.useEffect(() => {
+    setBulkProtocols([]);
+  }, [upstreamID]);
 
   const loadBindings = React.useCallback(async (params: RouteListParams = listParams) => {
     if (!upstreamID || params.upstreamID !== upstreamID) return;

--- a/frontend/features/admin/components/sections/upstreams/upstreams-sheet.tsx
+++ b/frontend/features/admin/components/sections/upstreams/upstreams-sheet.tsx
@@ -74,6 +74,7 @@ const NO_PROTOCOL_DEFAULT = "__system_default__";
 const PROTOCOL_OPTIONS_BY_KIND: Record<(typeof PROTOCOL_DEFAULT_KINDS)[number], string[]> = {
   chat: [
     "openai_responses",
+    "openrouter_chat_completions",
     "openrouter_responses",
     "openai_chat_completions",
     "anthropic_messages",
@@ -82,6 +83,7 @@ const PROTOCOL_OPTIONS_BY_KIND: Record<(typeof PROTOCOL_DEFAULT_KINDS)[number], 
   ],
   audio: [
     "openai_responses",
+    "openrouter_chat_completions",
     "openrouter_responses",
     "openai_chat_completions",
     "anthropic_messages",
@@ -322,6 +324,14 @@ export function UpstreamSheet({
     setForm((prev) => ({ ...prev, [key]: value }));
   }
 
+  function setCompatible(value: AdminLLMCompatible) {
+    setForm((prev) => ({
+      ...prev,
+      compatible: value,
+      protocolDefaultsJson: "",
+    }));
+  }
+
   function setProtocolDefault(kind: string, protocol: string) {
     setForm((prev) => {
       const defaults = parseProtocolDefaults(prev.protocolDefaultsJson);
@@ -394,9 +404,10 @@ export function UpstreamSheet({
         const existingAPIKeys = maskedAPIKeyItems(target);
         if (nextName !== target.name) payload.name = nextName;
         if (nextBaseURL !== target.baseURL) payload.baseURL = nextBaseURL;
-        if (form.compatible !== target.compatible) payload.compatible = form.compatible;
-        if (form.protocolDefaultsJson !== (target.protocolDefaultsJSON || ""))
-          payload.protocolDefaultsJSON = form.protocolDefaultsJson.trim() || undefined;
+        const compatibleChanged = form.compatible !== target.compatible;
+        if (compatibleChanged) payload.compatible = form.compatible;
+        if (form.protocolDefaultsJson !== (target.protocolDefaultsJSON || "") || compatibleChanged)
+          payload.protocolDefaultsJSON = form.protocolDefaultsJson.trim();
         if (form.status !== target.status) payload.status = form.status;
         if (form.connectTimeoutMs !== String(target.connectTimeoutMS ?? ""))
           payload.connectTimeoutMS = form.connectTimeoutMs
@@ -582,7 +593,7 @@ export function UpstreamSheet({
               <Label className="text-xs font-normal text-muted-foreground">{t("fields.compatibility")} *</Label>
               <Select
                 value={form.compatible}
-                onValueChange={(v) => setField("compatible", v as AdminLLMCompatible)}
+                onValueChange={(v) => setCompatible(v as AdminLLMCompatible)}
               >
                 <SelectTrigger>
                   <SelectValue />

--- a/frontend/features/admin/model/conversation-settings.ts
+++ b/frontend/features/admin/model/conversation-settings.ts
@@ -76,6 +76,16 @@ export const DEFAULT_MODEL_OPTION_ALLOWED_PATHS = `{
     "thinking.type",
     "stream_options.include_usage"
   ],
+  "openrouter_chat_completions": [
+    "presence_penalty",
+    "frequency_penalty",
+    "reasoning_effort",
+    "reasoning.effort",
+    "reasoning.summary",
+    "verbosity",
+    "thinking.type",
+    "stream_options.include_usage"
+  ],
   "openai_responses": [
     "service_tier",
     "store",

--- a/frontend/features/admin/model/upstreams-models.ts
+++ b/frontend/features/admin/model/upstreams-models.ts
@@ -28,7 +28,7 @@ export type NewBindingFormState = {
 export const DEFAULT_NEW_BINDING: NewBindingFormState = {
   upstreamModelName: "",
   platformModelName: "",
-  protocols: ["openai_responses"],
+  protocols: [],
   kindsDisplay: "chat",
   status: "active",
 };

--- a/frontend/features/admin/types/llm.ts
+++ b/frontend/features/admin/types/llm.ts
@@ -24,18 +24,19 @@ export const MODEL_SORT_OPTIONS = [
 export type ModelSortValue = (typeof MODEL_SORT_OPTIONS)[number]["value"];
 
 export const ADAPTER_LABELS: Record<string, string> = {
-  openai_responses:         resolveProtocolLabel("openai_responses"),
-  openrouter_responses:     resolveProtocolLabel("openrouter_responses"),
-  openai_chat_completions:  resolveProtocolLabel("openai_chat_completions"),
+  openai_responses: resolveProtocolLabel("openai_responses"),
+  openrouter_chat_completions: resolveProtocolLabel("openrouter_chat_completions"),
+  openrouter_responses: resolveProtocolLabel("openrouter_responses"),
+  openai_chat_completions: resolveProtocolLabel("openai_chat_completions"),
   openai_image_generations: resolveProtocolLabel("openai_image_generations"),
-  openai_image_edits:       resolveProtocolLabel("openai_image_edits"),
+  openai_image_edits: resolveProtocolLabel("openai_image_edits"),
   openai_video_generations: resolveProtocolLabel("openai_video_generations"),
-  anthropic_messages:       resolveProtocolLabel("anthropic_messages"),
-  google_generate_content:  resolveProtocolLabel("google_generate_content"),
-  google_image_generation:  resolveProtocolLabel("google_image_generation"),
-  xai_responses:            resolveProtocolLabel("xai_responses"),
-  xai_image:                resolveProtocolLabel("xai_image"),
-  xai_image_edits:          resolveProtocolLabel("xai_image_edits"),
+  anthropic_messages: resolveProtocolLabel("anthropic_messages"),
+  google_generate_content: resolveProtocolLabel("google_generate_content"),
+  google_image_generation: resolveProtocolLabel("google_image_generation"),
+  xai_responses: resolveProtocolLabel("xai_responses"),
+  xai_image: resolveProtocolLabel("xai_image"),
+  xai_image_edits: resolveProtocolLabel("xai_image_edits"),
 };
 
 // ---------------------------------------------------------------------------

--- a/frontend/features/admin/utils/llm-display.ts
+++ b/frontend/features/admin/utils/llm-display.ts
@@ -46,6 +46,7 @@ export const PROTOCOL_OPTIONS: ReadonlyArray<ProtocolOption> = [
   { value: "xai_responses", label: "Responses (xAI)", kinds: ["chat"] },
   { value: "xai_image", label: "Images Generations (xAI)", kinds: ["image_gen"] },
   { value: "xai_image_edits", label: "Images Edits (xAI)", kinds: ["image_edit"] },
+  { value: "openrouter_chat_completions", label: "Chat Completions (OpenRouter)", kinds: ["chat"] },
   { value: "openrouter_responses", label: "Responses (OpenRouter)", kinds: ["chat"] },
 ] as const;
 

--- a/frontend/features/chat/components/message/message-bot.tsx
+++ b/frontend/features/chat/components/message/message-bot.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from "next-intl";
 
 import { AssistantMessageMeta } from "@/features/chat/components/message/message-meta";
 import { MessageAttachmentRow } from "@/features/chat/components/message/message-attachment";
-import { MessageProcessTrace, MessageTraceEventBlocks, MessageToolTrace, MessageUpstreamThink } from "@/features/chat/components/message/message-process-trace";
+import { MessageProcessTrace, MessageTraceEventBlocks } from "@/features/chat/components/message/message-process-trace";
 import { GrainientBackground } from "@/components/reactbits/backgrounds/grainient";
 import type { AssistantReaction } from "@/features/chat/components/message/message-meta";
 import type {
@@ -168,8 +168,6 @@ export function ChatMessageBot({
   const toolTrace = item.processTrace?.tools;
   const traceEvents = item.processTrace?.events ?? EMPTY_TRACE_EVENTS;
   const messageStreaming = Boolean(item.isStreaming);
-  const upstreamThinkStreaming = messageStreaming && upstreamThink?.status === "streaming";
-  const toolTraceStreaming = messageStreaming && toolTrace?.status === "streaming";
   const hasStreamdownContent = item.content.trim().length > 0;
   const leadingImagePreview = React.useMemo(() => resolveLeadingImagePreview(item.content), [item.content]);
   const leadingImageAlt = React.useMemo(
@@ -192,6 +190,7 @@ export function ChatMessageBot({
     [traceEvents],
   );
   const hasTraceEvents = postProcessEvents.length > 0;
+  const hasTraceBlocks = hasTraceEvents || Boolean(upstreamThink) || Boolean(toolTrace);
   const isImageGenerationLoading = item.contentType === "image" && item.isStreaming && !hasStreamdownContent;
   const editableImageAttachments = React.useMemo(
     () => (item.attachments ?? []).filter(isEditableImageAttachment),
@@ -221,10 +220,7 @@ export function ChatMessageBot({
     onEditImageAttachment,
     readOnly,
   ]);
-  const activeThinkBlock = hasTraceEvents ? upstreamThink : undefined;
-  const activeToolBlock = hasTraceEvents ? toolTrace : undefined;
-  const processAutoCollapseReady = Boolean(hasTraceEvents || upstreamThink || toolTrace || hasStreamdownContent || item.inlineAlert);
-  const toolAutoCollapseReady = Boolean(upstreamThink || hasStreamdownContent || item.inlineAlert);
+  const processAutoCollapseReady = Boolean(hasTraceBlocks || hasStreamdownContent || item.inlineAlert);
 
   if (!readOnly && isEditing) {
     const nextContent = editingValue.trim();
@@ -264,34 +260,18 @@ export function ChatMessageBot({
 
   return (
     <div className="group/assistant-message flex w-full flex-col items-start">
-      {hasTraceEvents ? (
-        <>
-          <MessageProcessTrace
-            trace={item.processTrace}
-            active={messageStreaming}
-            autoCollapseReady={processAutoCollapseReady}
-          />
-          <MessageTraceEventBlocks
-            events={postProcessEvents}
-            activeToolBlock={activeToolBlock}
-            activeThinkBlock={activeThinkBlock}
-            messageStreaming={messageStreaming}
-            autoCollapseReady={hasStreamdownContent || Boolean(item.inlineAlert)}
-          />
-        </>
-      ) : (
-        <>
-          <MessageProcessTrace
-            trace={item.processTrace}
-            active={messageStreaming}
-            autoCollapseReady={processAutoCollapseReady}
-          />
-
-          <MessageToolTrace block={toolTrace} streaming={toolTraceStreaming} autoCollapseReady={toolAutoCollapseReady} />
-
-          <MessageUpstreamThink block={upstreamThink} streaming={upstreamThinkStreaming} />
-        </>
-      )}
+      <MessageProcessTrace
+        trace={item.processTrace}
+        active={messageStreaming}
+        autoCollapseReady={processAutoCollapseReady}
+      />
+      <MessageTraceEventBlocks
+        events={postProcessEvents}
+        activeToolBlock={toolTrace}
+        activeThinkBlock={upstreamThink}
+        messageStreaming={messageStreaming}
+        autoCollapseReady={hasStreamdownContent || Boolean(item.inlineAlert)}
+      />
 
       <div
         className="w-full min-w-0 max-w-none overflow-hidden text-[15px] leading-8 text-foreground [overflow-wrap:anywhere]"

--- a/frontend/features/chat/components/message/message-process-trace.tsx
+++ b/frontend/features/chat/components/message/message-process-trace.tsx
@@ -31,7 +31,6 @@ import {
 } from "@/features/chat/model/message-process-trace";
 
 export { MessageTraceEventBlocks, MessageUpstreamThink } from "@/features/chat/components/message/message-thinking-trace";
-export { MessageToolTrace } from "@/features/chat/components/message/message-tool-trace";
 
 function buildProcessSummary(trace: ChatMessageProcessTrace): string {
   if (trace.process?.summary) {

--- a/frontend/features/chat/components/message/message-thinking-trace.tsx
+++ b/frontend/features/chat/components/message/message-thinking-trace.tsx
@@ -12,7 +12,10 @@ import {
 import { Marker, MarkerContent } from "@/components/ui/marker";
 import type { ChatTraceBlock, ChatTraceEvent } from "@/features/chat/types/messages";
 import { useProcessTraceLabels } from "@/features/chat/hooks/use-process-trace-labels";
-import { MessageToolChainTrace } from "@/features/chat/components/message/message-tool-trace";
+import {
+  hasActiveToolTraceCalls,
+  MessageToolChainTrace,
+} from "@/features/chat/components/message/message-tool-trace";
 import { StreamdownRender } from "@/shared/components/markdown/streamdown-render";
 import { cn } from "@/lib/utils";
 import { TRACE_ROOT_CLASS } from "@/features/chat/components/shared/message-process-trace-shared";
@@ -116,6 +119,14 @@ function splitTraceDisplayEvents(events: TraceDisplayEvent[], activeThinkBlock?:
   };
 }
 
+function firstTraceSeq(events: TraceDisplayEvent[], kind: TraceDisplayEvent["kind"]): number | undefined {
+  const matched = events.filter((item) => item.kind === kind).map((item) => item.event.seq);
+  if (matched.length === 0) {
+    return undefined;
+  }
+  return Math.min(...matched);
+}
+
 export function MessageTraceEventBlocks({
   events: traceEvents,
   activeToolBlock,
@@ -138,21 +149,44 @@ export function MessageTraceEventBlocks({
     return null;
   }
 
+  const toolSeq = firstTraceSeq(displayEvents, "tool");
+  const thinkSeq = firstTraceSeq(displayEvents, "think");
+  const shouldRenderThinkFirst = Boolean(
+    thinkBlock &&
+      (
+        (toolEvents.length === 0 && !activeToolBlock) ||
+        thinkSeq === undefined ||
+        toolSeq === undefined ||
+        thinkSeq <= toolSeq
+      ),
+  );
+  const toolTrace = (
+    <MessageToolChainTrace
+      events={toolEvents}
+      activeToolBlock={activeToolBlock}
+      streaming={Boolean(
+        messageStreaming &&
+        (
+          activeToolBlock?.status === "streaming" ||
+          hasActiveToolTraceCalls(activeToolBlock?.payloadJson) ||
+          toolEvents.some((item) => item.event.status === "streaming" || hasActiveToolTraceCalls(item.event.payloadJson))
+        ),
+      )}
+      autoCollapseReady={autoCollapseReady || Boolean(thinkBlock)}
+    />
+  );
+  const thinkTrace = thinkBlock ? (
+    <MessageUpstreamThink
+      block={thinkBlock}
+      streaming={Boolean(messageStreaming && thinkBlock.status === "streaming")}
+      autoCollapseReady={autoCollapseReady}
+    />
+  ) : null;
+
   return (
     <>
-      <MessageToolChainTrace
-        events={toolEvents}
-        activeToolBlock={activeToolBlock}
-        streaming={Boolean(messageStreaming && (activeToolBlock?.status === "streaming" || toolEvents.some((item) => item.event.status === "streaming")))}
-        autoCollapseReady={autoCollapseReady || Boolean(thinkBlock)}
-      />
-      {thinkBlock ? (
-        <MessageUpstreamThink
-          block={thinkBlock}
-          streaming={Boolean(messageStreaming && thinkBlock.status === "streaming")}
-          autoCollapseReady={autoCollapseReady}
-        />
-      ) : null}
+      {shouldRenderThinkFirst ? thinkTrace : toolTrace}
+      {shouldRenderThinkFirst ? toolTrace : thinkTrace}
     </>
   );
 }

--- a/frontend/features/chat/components/message/message-tool-trace.tsx
+++ b/frontend/features/chat/components/message/message-tool-trace.tsx
@@ -35,9 +35,12 @@ type ToolTraceCall = {
   latency_ms?: number;
   error?: string;
   input?: string;
+  input_preview?: string;
+  input_detail?: string;
   output?: string;
   output_text?: string;
   output_preview?: string;
+  output_detail?: string;
 };
 
 type NativeToolKind = "web_search" | "code_interpreter" | "image_generation" | "shell" | "generic";
@@ -198,10 +201,10 @@ function toolTraceCallLabel(call: ToolTraceCall, labels: ProcessTraceLabels): st
 function toolTraceCallDetail(call: ToolTraceCall, labels: ProcessTraceLabels): { detail: string; failed: boolean } {
   const status = call.status?.trim();
   const failed = status === "error" || status === "failed";
-  const input = formatToolPayload(call.input);
+  const input = formatToolPayload(call.input_detail) || formatToolPayload(call.input_preview) || formatToolPayload(call.input);
   const output = failed
     ? formatToolPayload(call.error)
-    : formatToolPayload(call.output) || formatToolPayload(call.output_text) || formatToolPayload(call.output_preview);
+    : formatToolPayload(call.output_detail) || formatToolPayload(call.output) || formatToolPayload(call.output_text) || formatToolPayload(call.output_preview);
   const parts = [toolStatusLabel(status, labels)].filter(Boolean);
 
   if (input) {
@@ -416,16 +419,24 @@ function ToolDetailText({
 
 
 function toolInputRecord(call: ToolTraceCall): Record<string, unknown> {
-  const input = parseToolPayload(call.input);
+  const input = toolInputPayload(call);
   return isRecord(input) ? input : {};
 }
 
+function toolInputPayload(call: ToolTraceCall): unknown {
+  return parseToolPayload(call.input_detail) ?? parseToolPayload(call.input_preview) ?? parseToolPayload(call.input);
+}
+
+function toolInputValue(call: ToolTraceCall): string {
+  return call.input_detail?.trim() || call.input_preview?.trim() || call.input?.trim() || "";
+}
+
 function toolOutputPayload(call: ToolTraceCall): unknown {
-  return parseToolPayload(call.output) ?? parseToolPayload(call.output_text) ?? parseToolPayload(call.output_preview);
+  return parseToolPayload(call.output_detail) ?? parseToolPayload(call.output) ?? parseToolPayload(call.output_text) ?? parseToolPayload(call.output_preview);
 }
 
 function toolInputText(call: ToolTraceCall, keys: string[]): string {
-  const input = parseToolPayload(call.input);
+  const input = toolInputPayload(call);
   if (isRecord(input)) {
     return firstStringFromRecord(input, keys);
   }
@@ -468,7 +479,7 @@ function ToolTraceStructuredContent({
     const actionType = firstStringFromRecord(input, ["type", "action"]);
     const urls = collectToolStrings(output, urlKeys);
     const responseText = urls.length === 0
-      ? formatToolPayload(call.output) || formatToolPayload(call.output_text) || formatToolPayload(call.output_preview)
+      ? formatToolPayload(call.output_detail) || formatToolPayload(call.output) || formatToolPayload(call.output_text) || formatToolPayload(call.output_preview)
       : "";
     const hasRequest = Boolean(query || (actionType && actionType !== query));
     const hasResponse = urls.length > 0 || Boolean(responseText);
@@ -551,7 +562,7 @@ function ToolTraceStructuredContent({
   }
 
   if (kind === "shell") {
-    const command = firstStringFromRecord(input, ["cmd", "command", "input"]) || readString(parseToolPayload(call.input));
+    const command = firstStringFromRecord(input, ["cmd", "command", "input"]) || readString(toolInputPayload(call));
     const stdout = toolOutputText(call, ["stdout", "output"]);
     const stderr = toolOutputText(call, ["stderr", "error"]);
     const exitCode = isRecord(output) ? readNumber(output.exit_code) ?? readNumber(output.code) : null;
@@ -765,7 +776,7 @@ function buildToolChainSteps(events: TraceDisplayEvent[], labels: ProcessTraceLa
         toolCallID: toolTraceCallID(call),
         toolType: call.type?.trim(),
         toolName: call.name?.trim(),
-        toolInput: call.input?.trim(),
+        toolInput: toolInputValue(call),
         toolStatus: call.status?.trim(),
         toolCall: call,
       };
@@ -802,7 +813,7 @@ function buildToolChainStepsFromBlock(block: ChatTraceBlock | undefined, labels:
       toolCallID: toolTraceCallID(call),
       toolType: call.type?.trim(),
       toolName: call.name?.trim(),
-      toolInput: call.input?.trim(),
+      toolInput: toolInputValue(call),
       toolStatus: call.status?.trim(),
       toolCall: call,
     };

--- a/frontend/features/chat/components/message/message-tool-trace.tsx
+++ b/frontend/features/chat/components/message/message-tool-trace.tsx
@@ -19,10 +19,7 @@ import {
 } from "@/features/chat/hooks/use-process-trace-labels";
 import { StreamdownRender } from "@/shared/components/markdown/streamdown-render";
 import { cn } from "@/lib/utils";
-import {
-  TRACE_ROOT_CLASS,
-  TraceContent,
-} from "@/features/chat/components/shared/message-process-trace-shared";
+import { TRACE_ROOT_CLASS } from "@/features/chat/components/shared/message-process-trace-shared";
 import type { TraceDisplayEvent } from "@/features/chat/model/message-process-trace";
 
 type ToolTraceCall = {
@@ -56,6 +53,14 @@ function parseToolTraceCalls(payloadJson: string | undefined): ToolTraceCall[] {
   } catch {
     return [];
   }
+}
+
+function isToolTraceStatusActive(status: string | undefined): boolean {
+  return ["requested", "streaming", "queued", "in_progress", "searching"].includes(status?.trim() || "");
+}
+
+export function hasActiveToolTraceCalls(payloadJson: string | undefined): boolean {
+  return parseToolTraceCalls(payloadJson).some((call) => isToolTraceStatusActive(call.status));
 }
 
 function shouldCollapseToolDetail(value: string): boolean {
@@ -96,12 +101,25 @@ function readNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+function readStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => readString(item)).filter(Boolean);
+}
+
 function firstStringFromRecord(record: Record<string, unknown>, keys: string[]): string {
   for (const key of keys) {
     const value = readString(record[key]);
     if (value) return value;
   }
   return "";
+}
+
+function firstStringListFromRecord(record: Record<string, unknown>, keys: string[]): string[] {
+  for (const key of keys) {
+    const values = readStringList(record[key]);
+    if (values.length > 0) return values;
+  }
+  return [];
 }
 
 function collectToolStrings(value: unknown, keys: string[], result: string[] = []): string[] {
@@ -155,7 +173,7 @@ function resolveNativeToolKind(call: ToolTraceCall): NativeToolKind {
   const name = normalizeToolName(call.name);
   const type = normalizeToolName(call.type);
   const value = `${name} ${type}`;
-  if (value.includes("web_search")) return "web_search";
+  if (value.includes("web_search") || value.includes("google_search") || value.includes("url_context")) return "web_search";
   if (value.includes("code_interpreter") || value.includes("code_execution")) return "code_interpreter";
   if (value.includes("image_generation")) return "image_generation";
   if (value.includes("shell")) return "shell";
@@ -233,21 +251,6 @@ function nativeToolStatusText(call: ToolTraceCall, labels: ProcessTraceLabels): 
     default:
       return failed ? labels.tool.nativeStatus.genericFailed : done ? labels.tool.nativeStatus.genericDone : labels.tool.nativeStatus.genericActive;
   }
-}
-
-function localizeToolTraceSummary(block: ChatTraceBlock, calls: ToolTraceCall[], labels: ProcessTraceLabels): string {
-  if (calls.length > 0) {
-    const failed = calls.filter((call) => call.status === "error" || call.status === "failed").length;
-    const active = calls.filter((call) => ["requested", "streaming", "queued", "in_progress", "searching"].includes(call.status?.trim())).length;
-    if (failed > 0) {
-      return labels.tool.trace.summaryFailed(calls.length, failed);
-    }
-    if (active > 0) {
-      return labels.tool.trace.summaryActive(calls.length);
-    }
-    return labels.tool.trace.summaryCount(calls.length);
-  }
-  return block.summary?.trim() || labels.tool.trace.summaryDone;
 }
 
 function ToolDetailExpandButton({
@@ -451,6 +454,25 @@ function toolOutputText(call: ToolTraceCall, keys: string[]): string {
   return readString(output);
 }
 
+function geminiWebSearchQuery(output: unknown): string {
+  if (!isRecord(output)) return "";
+  return firstStringListFromRecord(output, ["queries", "webSearchQueries"]).join(", ");
+}
+
+function geminiWebSearchSummary(output: unknown): string {
+  if (!isRecord(output)) return "";
+  const chunks = Array.isArray(output.groundingChunks) ? output.groundingChunks.length : 0;
+  const supports = Array.isArray(output.groundingSupports) ? output.groundingSupports.length : 0;
+  const supportCount = readNumber(output.support_count);
+  const urls = collectToolStrings(output, ["url", "uri", "retrievedUrl"]);
+  const parts = [];
+  if (chunks > 0) parts.push(`${chunks} sources`);
+  if (supportCount !== null && supportCount > 0) parts.push(`${supportCount} grounding supports`);
+  if (supportCount === null && supports > 0) parts.push(`${supports} grounding supports`);
+  if (urls.length > 0) parts.push(urls.slice(0, 4).map(safeURLHostname).join(", "));
+  return parts.join(" · ");
+}
+
 function ToolTraceStructuredContent({
   call,
   rawDetail,
@@ -475,11 +497,11 @@ function ToolTraceStructuredContent({
   const urlKeys = ["url", "uri", "image_url"];
 
   if (kind === "web_search") {
-    const query = firstStringFromRecord(input, ["query", "q"]) || toolOutputText(call, ["query"]);
+    const query = firstStringFromRecord(input, ["query", "q"]) || firstStringListFromRecord(input, ["queries"]).join(", ") || geminiWebSearchQuery(output) || toolOutputText(call, ["query"]);
     const actionType = firstStringFromRecord(input, ["type", "action"]);
-    const urls = collectToolStrings(output, urlKeys);
+    const urls = collectToolStrings(output, [...urlKeys, "retrievedUrl"]);
     const responseText = urls.length === 0
-      ? formatToolPayload(call.output_detail) || formatToolPayload(call.output) || formatToolPayload(call.output_text) || formatToolPayload(call.output_preview)
+      ? geminiWebSearchSummary(output) || formatToolPayload(call.output_detail) || formatToolPayload(call.output) || formatToolPayload(call.output_text) || formatToolPayload(call.output_preview)
       : "";
     const hasRequest = Boolean(query || (actionType && actionType !== query));
     const hasResponse = urls.length > 0 || Boolean(responseText);
@@ -512,6 +534,7 @@ function ToolTraceStructuredContent({
 
   if (kind === "code_interpreter") {
     const code = toolInputText(call, ["code", "input"]);
+    const language = firstStringFromRecord(input, ["language"]);
     const logs = collectToolStrings(output, ["logs", "stdout", "stderr", "text", "output"]).join("\n\n");
     const artifactURLs = collectToolStrings(output, urlKeys);
     return (
@@ -519,7 +542,7 @@ function ToolTraceStructuredContent({
         <div>{statusText}</div>
         {code ? (
           <div>
-            <ToolMiniLabel>{labels.tool.detail.code}</ToolMiniLabel>
+            <ToolMiniLabel>{language ? `${labels.tool.detail.code} · ${language}` : labels.tool.detail.code}</ToolMiniLabel>
             <ToolPre>{code}</ToolPre>
           </div>
         ) : null}
@@ -605,76 +628,6 @@ function ToolTraceStructuredContent({
     </ToolDetailText>
   );
 }
-
-function ToolTraceRows({ calls, labels }: { calls: ToolTraceCall[]; labels: ProcessTraceLabels }) {
-  const [expanded, setExpanded] = React.useState<Set<number>>(() => new Set());
-
-  if (calls.length === 0) return null;
-
-  return (
-    <ol className="space-y-0.5">
-      {calls.map((call, index) => {
-        const label = toolTraceCallLabel(call, labels);
-        const { detail: rawDetail, failed } = toolTraceCallDetail(call, labels);
-        const open = expanded.has(index);
-        const canExpand = shouldCollapseToolDetail(rawDetail);
-
-        return (
-          <li
-            key={`${label}-${index}-${call.latency_ms ?? 0}`}
-            className={cn(
-              "group/tool-row grid grid-cols-[0.875rem_8rem_minmax(0,1fr)] gap-x-5 gap-y-0.5 text-[12px] leading-5",
-              "max-sm:grid-cols-[0.875rem_minmax(0,1fr)] max-sm:gap-x-2",
-            )}
-          >
-            <div className="relative flex justify-center">
-              {index > 0 ? <span className="absolute -top-0.5 bottom-1/2 w-px bg-border/42" /> : null}
-              {index < calls.length - 1 ? <span className="absolute bottom-[-0.125rem] top-1/2 w-px bg-border/42" /> : null}
-              <span
-                className={cn(
-                  "relative z-10 mt-[0.45rem] size-1.5 rounded-full bg-muted-foreground/38 ring-4 ring-background transition-colors group-hover/tool-row:bg-foreground/58",
-                  failed && "bg-destructive/80",
-                )}
-              />
-            </div>
-            <div className="min-w-0 max-sm:col-start-2">
-              <span
-                className={cn(
-                  "block truncate font-medium text-muted-foreground/76 transition-colors group-hover/tool-row:text-foreground/88",
-                  failed && "text-destructive/85 group-hover/tool-row:text-destructive",
-                )}
-              >
-                {label}
-              </span>
-            </div>
-            <div className="min-w-0 pb-2 max-sm:col-start-2">
-              <ToolTraceStructuredContent
-                call={call}
-                rawDetail={rawDetail}
-                failed={failed}
-                open={open}
-                canExpand={canExpand}
-                labels={labels}
-                onToggle={() =>
-                  setExpanded((current) => {
-                    const next = new Set(current);
-                    if (next.has(index)) {
-                      next.delete(index);
-                    } else {
-                      next.add(index);
-                    }
-                    return next;
-                  })
-                }
-              />
-            </div>
-          </li>
-        );
-      })}
-    </ol>
-  );
-}
-
 
 type ToolChainStep = {
   key: string;
@@ -990,90 +943,6 @@ export function MessageToolChainTrace({
           </AccordionTrigger>
           <AccordionContent className="px-0 pb-0 pt-1.5 duration-[350ms] ease-in-out">
             <ToolChainRows steps={steps} labels={labels} />
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
-    </div>
-  );
-}
-
-
-export function MessageToolTrace({
-  block,
-  streaming,
-  autoCollapseReady,
-  title,
-}: {
-  block?: ChatTraceBlock;
-  streaming?: boolean;
-  autoCollapseReady?: boolean;
-  title?: string;
-}) {
-  const labels = useProcessTraceLabels();
-  const [accordionValue, setAccordionValue] = React.useState(() => (streaming ? "message-tool-trace" : ""));
-
-  React.useEffect(() => {
-    if (streaming) {
-      setAccordionValue("message-tool-trace");
-      return;
-    }
-    if (autoCollapseReady) {
-      setAccordionValue("");
-    }
-  }, [autoCollapseReady, streaming]);
-
-  if (!block) {
-    return null;
-  }
-
-  const open = accordionValue === "message-tool-trace";
-  const resolvedTitle = title ?? (streaming ? labels.tool.trace.titleActive : labels.tool.trace.titleDone);
-  const toolCalls = parseToolTraceCalls(block.payloadJson);
-  const summary = localizeToolTraceSummary(block, toolCalls, labels);
-
-  return (
-    <div className={TRACE_ROOT_CLASS}>
-      <Accordion
-        type="single"
-        collapsible
-        value={accordionValue}
-        onValueChange={(value) => setAccordionValue(value || "")}
-        className="w-full"
-      >
-        <AccordionItem value="message-tool-trace" className="border-b-0">
-          <AccordionTrigger
-            iconPosition="none"
-            className="group/tool min-h-0 justify-between gap-1.5 py-0.5 text-left no-underline hover:no-underline"
-          >
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center">
-                <Marker
-                  render={<span />}
-                  className={cn(
-                    "inline-flex min-h-0 w-auto text-[13px] font-medium transition-colors",
-                    !streaming && "text-muted-foreground group-hover/tool:text-foreground",
-                  )}
-                >
-                  <MarkerContent className={cn("min-w-0", streaming && "shimmer")}>
-                    {resolvedTitle}
-                  </MarkerContent>
-                </Marker>
-              </div>
-              <div className="mt-0.5 truncate text-[11px] font-normal leading-4 text-muted-foreground/62">{summary}</div>
-            </div>
-            <ChevronDown
-              className={cn(
-                "mt-0.5 size-3.5 shrink-0 text-muted-foreground transition-transform duration-200 group-hover/tool:text-foreground",
-                open && "rotate-180",
-              )}
-            />
-          </AccordionTrigger>
-          <AccordionContent className="px-0 pb-0 pt-1.5 duration-[350ms] ease-in-out">
-            {toolCalls.length > 0 ? (
-              <ToolTraceRows calls={toolCalls} labels={labels} />
-            ) : (
-              <TraceContent block={block} streaming={Boolean(streaming)} labels={labels} />
-            )}
           </AccordionContent>
         </AccordionItem>
       </Accordion>

--- a/frontend/features/chat/components/sections/chat-model-config.tsx
+++ b/frontend/features/chat/components/sections/chat-model-config.tsx
@@ -390,6 +390,7 @@ const PROTOCOL_LABELS: Record<string, string> = {
   google_generate_content: "Generate Content",
   google_image_generation: "Image Generation",
   openai_chat_completions: "Chat Completions",
+  openrouter_chat_completions: "OpenRouter Chat Completions",
   openai_image_edits: "Images Edits",
   openai_image_generations: "Images Generations",
   openai_responses: "Responses",

--- a/frontend/features/chat/hooks/use-process-trace-labels.ts
+++ b/frontend/features/chat/hooks/use-process-trace-labels.ts
@@ -99,14 +99,6 @@ export type ProcessTraceLabels = {
       summaryCount: (count: number) => string;
       summaryFallback: string;
     };
-    trace: {
-      titleActive: string;
-      titleDone: string;
-      summaryDone: string;
-      summaryActive: (count: number) => string;
-      summaryCount: (count: number) => string;
-      summaryFailed: (count: number, failed: number) => string;
-    };
   };
   think: {
     titleActive: string;
@@ -259,14 +251,6 @@ export function useProcessTraceLabels(): ProcessTraceLabels {
           summaryCount: (count: number) => t("tool.chain.summaryCount", { count }),
           summaryFallback: t("tool.chain.summaryFallback"),
         },
-        trace: {
-          titleActive: t("tool.trace.titleActive"),
-          titleDone: t("tool.trace.titleDone"),
-          summaryDone: t("tool.trace.summaryDone"),
-          summaryActive: (count: number) => t("tool.trace.summaryActive", { count }),
-          summaryCount: (count: number) => t("tool.trace.summaryCount", { count }),
-          summaryFailed: (count: number, failed: number) => t("tool.trace.summaryFailed", { count, failed }),
-        },
       },
       think: {
         titleActive: t("think.titleActive"),
@@ -321,4 +305,3 @@ export function useProcessTraceLabels(): ProcessTraceLabels {
     [t],
   );
 }
-

--- a/frontend/i18n/messages/en-US/chat.json
+++ b/frontend/i18n/messages/en-US/chat.json
@@ -601,14 +601,6 @@
         "titleDone": "Tool calls",
         "summaryCount": "{count} tool calls",
         "summaryFallback": "Tool calls"
-      },
-      "trace": {
-        "titleActive": "Calling tools",
-        "titleDone": "Tool calls",
-        "summaryDone": "Tool calls completed",
-        "summaryActive": "{count, plural, one {# tool call in progress} other {# tool calls in progress}}",
-        "summaryCount": "{count, plural, one {# tool call completed} other {# tool calls completed}}",
-        "summaryFailed": "{count, plural, one {# tool call} other {# tool calls}}, {failed, plural, one {# failed} other {# failed}}"
       }
     },
     "think": {

--- a/frontend/i18n/messages/zh-CN/chat.json
+++ b/frontend/i18n/messages/zh-CN/chat.json
@@ -601,14 +601,6 @@
         "titleDone": "工具调用",
         "summaryCount": "{count} 次工具调用",
         "summaryFallback": "工具调用"
-      },
-      "trace": {
-        "titleActive": "工具调用中",
-        "titleDone": "工具调用",
-        "summaryDone": "工具调用已完成",
-        "summaryActive": "{count} 次工具调用进行中",
-        "summaryCount": "{count} 次工具调用已完成",
-        "summaryFailed": "{count} 次工具调用，{failed} 次失败"
       }
     },
     "think": {

--- a/frontend/shared/lib/model-option-policy.ts
+++ b/frontend/shared/lib/model-option-policy.ts
@@ -1,6 +1,7 @@
 export const MODEL_OPTION_POLICY_PROTOCOLS = [
   "default",
   "openai_chat_completions",
+  "openrouter_chat_completions",
   "openai_responses",
   "openrouter_responses",
   "openai_image_generations",
@@ -59,6 +60,7 @@ export type ModelNativeToolConfig = {
 export const MODEL_OPTION_POLICY_PROTOCOL_LABELS: Record<ModelOptionPolicyProtocol, string> = {
   default: "Default",
   openai_chat_completions: "OpenAI（Chat Completions）",
+  openrouter_chat_completions: "OpenRouter（Chat Completions）",
   openai_responses: "OpenAI（Responses）",
   openrouter_responses: "OpenRouter（Responses）",
   openai_image_generations: "OpenAI（Images Generations）",
@@ -116,6 +118,8 @@ export function resolveModelOptionPolicyProtocol(protocol: string): ModelOptionP
     case "openai":
     case "openai_responses":
       return "openai_responses";
+    case "openrouter_chat_completions":
+      return "openrouter_chat_completions";
     case "openrouter":
     case "openrouter_responses":
       return "openrouter_responses";


### PR DESCRIPTION
## Summary

This PR improves tool execution reliability and provider protocol handling across three areas:

- Prevents generation stream trace events from repeatedly storing full tool outputs in Redis, while retaining full tool results in persisted tool call records and sending bounded, model-safe previews back into context.
- Improves Gemini tool handling by sanitizing function schemas, preserving `thoughtSignature`, enabling mixed built-in tools + function calling, and surfacing Gemini built-in tool traces during streaming.
- Adds a dedicated OpenRouter Chat Completions protocol, fixes OpenRouter Chat reasoning passback, and removes frontend hardcoded OpenAI protocol defaults so route binding protocol resolution is owned by the backend.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [x] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && ./node_modules/.bin/eslint features/admin/api/llm.types.ts features/admin/components/sections/conversation/admin-conversation.tsx features/admin/components/sections/upstreams/upstreams-models-dialog.tsx features/admin/components/sections/upstreams/upstreams-sheet.tsx features/admin/model/conversation-settings.ts features/admin/model/upstreams-models.ts features/admin/types/llm.ts features/admin/utils/llm-display.ts features/chat/components/sections/chat-model-config.tsx shared/lib/model-option-policy.ts`
- [x] `cd frontend && ./node_modules/.bin/tsc --noEmit --pretty false`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/infra/llm ./internal/application/channel ./internal/application/conversation ./internal/application/settings ./internal/shared/nativetool`
- [x] `git diff --check`

## Screenshots, API examples, or logs

N/A

## Configuration, migration, and compatibility notes

- Adds protocol key: `openrouter_chat_completions`.
- OpenRouter upstream system default remains `openrouter_responses` unless changed through protocol defaults.
- Existing route bindings are not automatically migrated; new or edited bindings can use backend protocol auto-resolution.
- Large tool outputs are no longer repeatedly stored in Redis stream trace payloads; full results remain persisted in tool call records.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.