### PR TITLE
feat: implement user message reuse and enhance message handling logic

### DIFF
--- a/backend/internal/application/conversation/service_billing.go
+++ b/backend/internal/application/conversation/service_billing.go
@@ -172,9 +172,9 @@ func (s *Service) buildSendMessageUsageLedger(ctx context.Context, input SendMes
 		UsageSpeed:          strings.TrimSpace(result.UsageSpeed),
 		RequestServiceTier:  messageRequestServiceTier(result.EffectiveOptions),
 		UsageServiceTier:    strings.TrimSpace(result.UsageServiceTier),
-		InputTokens:         result.UserMessage.InputTokens,
-		CacheReadTokens:     result.UserMessage.CacheReadTokens,
-		CacheWriteTokens:    result.UserMessage.CacheWriteTokens,
+		InputTokens:         sendMessageBillingInputTokens(result),
+		CacheReadTokens:     sendMessageBillingCacheReadTokens(result),
+		CacheWriteTokens:    sendMessageBillingCacheWriteTokens(result),
 		CacheWrite5mTokens:  result.CacheWrite5mTokens,
 		CacheWrite1hTokens:  result.CacheWrite1hTokens,
 		OutputTokens:        result.AssistantMessage.OutputTokens,
@@ -185,6 +185,42 @@ func (s *Service) buildSendMessageUsageLedger(ctx context.Context, input SendMes
 		RawUsageJSON:        result.RawUsageJSON,
 		BillingAt:           result.StartedAt,
 	})
+}
+
+func sendMessageBillingInputTokens(result *SendMessageResult) int64 {
+	if result == nil {
+		return 0
+	}
+	if sendMessageResultUsesAssistantSideInput(result) {
+		return result.AssistantMessage.InputTokens
+	}
+	return result.UserMessage.InputTokens
+}
+
+func sendMessageBillingCacheReadTokens(result *SendMessageResult) int64 {
+	if result == nil {
+		return 0
+	}
+	if sendMessageResultUsesAssistantSideInput(result) {
+		return result.AssistantMessage.CacheReadTokens
+	}
+	return result.UserMessage.CacheReadTokens
+}
+
+func sendMessageBillingCacheWriteTokens(result *SendMessageResult) int64 {
+	if result == nil {
+		return 0
+	}
+	if sendMessageResultUsesAssistantSideInput(result) {
+		return result.AssistantMessage.CacheWriteTokens
+	}
+	return result.UserMessage.CacheWriteTokens
+}
+
+// sendMessageResultUsesAssistantSideInput 判断 prompt-side usage 是否归属 assistant 消息。
+// assistant-only retry 会复用原用户消息，因此本轮 input/cache usage 不能回写到 user。
+func sendMessageResultUsesAssistantSideInput(result *SendMessageResult) bool {
+	return result != nil && result.AssistantMessage.SourceMessageID != nil
 }
 
 func sendMessageBillingPlatformModelName(input SendMessageBillingInput) string {

--- a/backend/internal/application/conversation/service_branch.go
+++ b/backend/internal/application/conversation/service_branch.go
@@ -17,6 +17,7 @@ type messageBranchState struct {
 	ParentPublicID   string
 	SourceMessageID  *uint
 	SourcePublicID   string
+	ReuseUserMessage *model.Message
 }
 
 func (s *Service) resolveMessageBranch(
@@ -49,9 +50,6 @@ func (s *Service) resolveMessageBranch(
 	}
 
 	if sourceMessage != nil {
-		if sourceMessage.Role != "user" {
-			return nil, ErrInvalidMessageBranch
-		}
 		if branchReason != "retry" && branchReason != "edit" {
 			return nil, ErrInvalidMessageBranch
 		}
@@ -67,6 +65,16 @@ func (s *Service) resolveMessageBranch(
 			}
 			parentMessage = cachedParent
 		case expectedParentID != nil && parentMessage != nil && parentMessage.ID != *expectedParentID:
+			return nil, ErrInvalidMessageBranch
+		}
+		switch sourceMessage.Role {
+		case "user":
+			// User retry/edit creates a new user sibling and a fresh assistant child.
+		case "assistant":
+			if branchReason != "retry" || parentMessage == nil || parentMessage.Role != "user" {
+				return nil, ErrInvalidMessageBranch
+			}
+		default:
 			return nil, ErrInvalidMessageBranch
 		}
 	} else if branchReason != "default" {
@@ -120,6 +128,10 @@ func (s *Service) resolveMessageBranch(
 	if sourceMessage != nil {
 		state.SourceMessageID = &sourceMessage.ID
 		state.SourcePublicID = sourceMessage.PublicID
+		if sourceMessage.Role == "assistant" {
+			userMessage := *parentMessage
+			state.ReuseUserMessage = &userMessage
+		}
 	}
 	return state, nil
 }
@@ -190,6 +202,9 @@ func selectLatestDefaultParentCandidate(messages []model.Message) *model.Message
 func buildBranchMessagePath(branch *messageBranchState, userMessage *model.Message) []model.Message {
 	if branch == nil || userMessage == nil {
 		return nil
+	}
+	if branch.ReuseUserMessage != nil {
+		return buildMessagePath(branch.ExistingMessages, branch.ReuseUserMessage.ID)
 	}
 	allMessages := make([]model.Message, 0, len(branch.ExistingMessages)+1)
 	allMessages = append(allMessages, branch.ExistingMessages...)

--- a/backend/internal/application/conversation/service_branch_test.go
+++ b/backend/internal/application/conversation/service_branch_test.go
@@ -111,3 +111,26 @@ func TestSelectLatestDefaultParentCandidateFallsBackToSuccessfulUser(t *testing.
 		t.Fatalf("expected successful user fallback as parent, got %#v", parent)
 	}
 }
+
+func TestBuildBranchMessagePathReusesExistingUserForAssistantRetry(t *testing.T) {
+	rootID := uint(1)
+	userID := uint(2)
+	assistantID := uint(3)
+	branch := &messageBranchState{
+		ExistingMessages: []model.Message{
+			{ID: rootID, PublicID: "msg_root", Role: "assistant", Status: "success"},
+			{ID: userID, PublicID: "msg_user", ParentMessageID: &rootID, Role: "user", Status: "success"},
+		},
+		ReuseUserMessage: &model.Message{ID: userID, PublicID: "msg_user", ParentMessageID: &rootID, Role: "user", Status: "success"},
+	}
+	assistantMessage := &model.Message{ID: assistantID, PublicID: "msg_assistant_retry", ParentMessageID: &userID, Role: "assistant", Status: "pending"}
+
+	path := buildBranchMessagePath(branch, assistantMessage)
+
+	if len(path) != 2 {
+		t.Fatalf("expected reused user path without pending assistant, got %#v", path)
+	}
+	if path[0].ID != rootID || path[1].ID != userID {
+		t.Fatalf("expected root -> reused user path, got %#v", path)
+	}
+}

--- a/backend/internal/application/conversation/service_conversation_export_test.go
+++ b/backend/internal/application/conversation/service_conversation_export_test.go
@@ -24,6 +24,20 @@ func TestExportDefaultMessagePublicIDsUsesLatestVisibleBranch(t *testing.T) {
 	}
 }
 
+func TestExportDefaultMessagePublicIDsUsesLatestAssistantSibling(t *testing.T) {
+	messages := []model.Message{
+		{ID: 1, PublicID: "u1", BranchReason: "default"},
+		{ID: 2, PublicID: "a1-old", ParentPublicID: "u1", BranchReason: "default"},
+		{ID: 3, PublicID: "a1-new", ParentPublicID: "u1", BranchReason: "retry", SourcePublicID: "a1-old"},
+	}
+
+	got := exportDefaultMessagePublicIDs(messages)
+	want := []string{"u1", "a1-new"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected assistant sibling export ids: got %#v want %#v", got, want)
+	}
+}
+
 func TestCollectExportMessageRunIDsTrimsAndDeduplicates(t *testing.T) {
 	messages := []model.Message{
 		{RunID: " run_1 "},

--- a/backend/internal/application/conversation/service_media_generation.go
+++ b/backend/internal/application/conversation/service_media_generation.go
@@ -64,15 +64,6 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 	if input.TaskType != MediaImageTaskGeneration && input.TaskType != MediaImageTaskEdit {
 		return nil, ErrInvalidMediaGenerationTask
 	}
-	if strings.TrimSpace(input.Prompt) == "" {
-		return nil, ErrMediaImagePromptRequired
-	}
-	if input.TaskType == MediaImageTaskGeneration && len(input.FileIDs) > 0 {
-		return nil, ErrMediaImageGenerationRejectsInputs
-	}
-	if input.TaskType == MediaImageTaskEdit && len(input.FileIDs) == 0 {
-		return nil, ErrMediaImageEditInputRequired
-	}
 	if s.routeResolver == nil || s.llmClient == nil {
 		return nil, ErrModelRouteNotConfigured
 	}
@@ -90,14 +81,30 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 	if len(existingRuns) > 0 {
 		return nil, ErrDuplicateMessageGenerationRun
 	}
-	cancelCtx, cancel := context.WithCancel(ctx)
-	ctx = cancelCtx
-	s.generationStreams.register(ctx, runID, input.UserID, cancel)
-
 	startedAt := time.Now()
 	conversation, err := s.repo.GetConversationByUser(ctx, input.ConversationID, input.UserID)
 	if err != nil {
 		return nil, ErrConversationNotFound
+	}
+
+	normalizedBranchReason := normalizeBranchReason(input.BranchReason)
+	branchState, err := s.resolveMessageBranch(ctx, input.ConversationID, input.UserID, input.ParentMessagePublicID, input.SourceMessagePublicID, normalizedBranchReason)
+	if err != nil {
+		return nil, err
+	}
+	reuseUserMessage := branchState.ReuseUserMessage != nil
+	if reuseUserMessage {
+		input.Prompt = branchState.ReuseUserMessage.Content
+		input.FileIDs = parseAttachmentSnapshotFileIDs(branchState.ReuseUserMessage.Attachments)
+	}
+	if strings.TrimSpace(input.Prompt) == "" {
+		return nil, ErrMediaImagePromptRequired
+	}
+	if input.TaskType == MediaImageTaskGeneration && len(input.FileIDs) > 0 {
+		return nil, ErrMediaImageGenerationRejectsInputs
+	}
+	if input.TaskType == MediaImageTaskEdit && len(input.FileIDs) == 0 {
+		return nil, ErrMediaImageEditInputRequired
 	}
 
 	platformModelName := strings.TrimSpace(input.PlatformModelName)
@@ -138,13 +145,6 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 			return nil, err
 		}
 	}
-
-	normalizedBranchReason := normalizeBranchReason(input.BranchReason)
-	branchState, err := s.resolveMessageBranch(ctx, input.ConversationID, input.UserID, input.ParentMessagePublicID, input.SourceMessagePublicID, normalizedBranchReason)
-	if err != nil {
-		return nil, err
-	}
-
 	resolvedAttachments, imageEditParts, err := s.resolveMediaImageEditInputs(ctx, input)
 	if err != nil {
 		return nil, err
@@ -196,43 +196,9 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 			)
 		}
 	}()
-
-	userMessage := &model.Message{
-		ConversationID:  input.ConversationID,
-		UserID:          input.UserID,
-		PublicID:        normalizePublicID(uuid.NewString()),
-		ParentMessageID: branchState.ParentMessageID,
-		RunID:           runID,
-		Role:            "user",
-		ContentType:     mediaImageUserContentType(input.TaskType),
-		Content:         strings.TrimSpace(input.Prompt),
-		BranchReason:    normalizedBranchReason,
-		SourceMessageID: branchState.SourceMessageID,
-		TokenUsage:      estimateTokens(input.Prompt),
-		InputTokens:     estimateTokens(input.Prompt),
-		Status:          "success",
-		Attachments:     attachmentsJSON,
-	}
-	userAttachmentRows := make([]model.Attachment, 0, len(resolvedAttachments))
-	if len(resolvedAttachments) > 0 {
-		now := time.Now()
-		for _, item := range resolvedAttachments {
-			userAttachmentRows = append(userAttachmentRows, model.Attachment{
-				ConversationID: input.ConversationID,
-				UserID:         input.UserID,
-				FileID:         strings.TrimSpace(item.FileID),
-				Kind:           normalizeAttachmentKind(item.Kind, item.MimeType),
-				FileName:       strings.TrimSpace(item.FileName),
-				MimeType:       strings.TrimSpace(item.MimeType),
-				FileSize:       item.FileSize,
-				SHA256:         strings.TrimSpace(item.SHA256),
-				StoragePath:    strings.TrimSpace(item.StoragePath),
-				Status:         "active",
-				MetaJSON:       strings.TrimSpace(item.MetaJSON),
-				UploadedAt:     now,
-			})
-		}
-	}
+	cancelCtx, cancel := context.WithCancel(ctx)
+	ctx = cancelCtx
+	s.generationStreams.register(ctx, runID, input.UserID, cancel)
 
 	assistantMessage := &model.Message{
 		ConversationID: input.ConversationID,
@@ -246,15 +212,66 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 		Status:         "pending",
 		Attachments:    "[]",
 	}
-	// 媒体任务同样产生一个完整消息回合，初始本地写入必须原子提交。
-	if err = s.repo.CreateMessagePairWithUserAttachments(ctx, userMessage, assistantMessage, userAttachmentRows); err != nil {
-		retErr = err
-		return nil, err
+	var userMessage *model.Message
+	if reuseUserMessage {
+		reused := *branchState.ReuseUserMessage
+		userMessage = &reused
+		assistantMessage.ParentMessageID = &userMessage.ID
+		assistantMessage.SourceMessageID = branchState.SourceMessageID
+		if err = s.repo.CreateAssistantBranchMessage(ctx, assistantMessage); err != nil {
+			retErr = err
+			return nil, err
+		}
+		assistantMessage.ParentPublicID = userMessage.PublicID
+		assistantMessage.SourcePublicID = branchState.SourcePublicID
+	} else {
+		userMessage = &model.Message{
+			ConversationID:  input.ConversationID,
+			UserID:          input.UserID,
+			PublicID:        normalizePublicID(uuid.NewString()),
+			ParentMessageID: branchState.ParentMessageID,
+			RunID:           runID,
+			Role:            "user",
+			ContentType:     mediaImageUserContentType(input.TaskType),
+			Content:         strings.TrimSpace(input.Prompt),
+			BranchReason:    normalizedBranchReason,
+			SourceMessageID: branchState.SourceMessageID,
+			TokenUsage:      estimateTokens(input.Prompt),
+			InputTokens:     estimateTokens(input.Prompt),
+			Status:          "success",
+			Attachments:     attachmentsJSON,
+		}
+		userAttachmentRows := make([]model.Attachment, 0, len(resolvedAttachments))
+		if len(resolvedAttachments) > 0 {
+			now := time.Now()
+			for _, item := range resolvedAttachments {
+				userAttachmentRows = append(userAttachmentRows, model.Attachment{
+					ConversationID: input.ConversationID,
+					UserID:         input.UserID,
+					FileID:         strings.TrimSpace(item.FileID),
+					Kind:           normalizeAttachmentKind(item.Kind, item.MimeType),
+					FileName:       strings.TrimSpace(item.FileName),
+					MimeType:       strings.TrimSpace(item.MimeType),
+					FileSize:       item.FileSize,
+					SHA256:         strings.TrimSpace(item.SHA256),
+					StoragePath:    strings.TrimSpace(item.StoragePath),
+					Status:         "active",
+					MetaJSON:       strings.TrimSpace(item.MetaJSON),
+					UploadedAt:     now,
+				})
+			}
+		}
+
+		// 媒体任务同样产生一个完整消息回合，初始本地写入必须原子提交。
+		if err = s.repo.CreateMessagePairWithUserAttachments(ctx, userMessage, assistantMessage, userAttachmentRows); err != nil {
+			retErr = err
+			return nil, err
+		}
+		userMessage.ParentPublicID = branchState.ParentPublicID
+		userMessage.SourcePublicID = branchState.SourcePublicID
+		assistantMessage.ParentPublicID = userMessage.PublicID
+		s.maybeGenerateConversationMetadataAsync(*conversation, *userMessage)
 	}
-	userMessage.ParentPublicID = branchState.ParentPublicID
-	userMessage.SourcePublicID = branchState.SourcePublicID
-	assistantMessage.ParentPublicID = userMessage.PublicID
-	s.maybeGenerateConversationMetadataAsync(*conversation, *userMessage)
 	traceRecorder := newMessageTraceRecorder(s, ctx, assistantMessage, input.OnEvent)
 	defer func() {
 		if retErr != nil && traceRecorder != nil {
@@ -387,39 +404,69 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 		})
 	}
 	usage := output.Usage
-	userMessage.InputTokens = usage.InputTokens
-	userMessage.CacheReadTokens = usage.CacheReadTokens
-	userMessage.CacheWriteTokens = usage.CacheWriteTokens
-	userMessage.TokenUsage = usage.InputTokens + usage.CacheReadTokens + usage.CacheWriteTokens
+	if reuseUserMessage {
+		assistantMessage.InputTokens = usage.InputTokens
+		assistantMessage.CacheReadTokens = usage.CacheReadTokens
+		assistantMessage.CacheWriteTokens = usage.CacheWriteTokens
+	} else {
+		userMessage.InputTokens = usage.InputTokens
+		userMessage.CacheReadTokens = usage.CacheReadTokens
+		userMessage.CacheWriteTokens = usage.CacheWriteTokens
+		userMessage.TokenUsage = usage.InputTokens + usage.CacheReadTokens + usage.CacheWriteTokens
+	}
 
 	content := generatedImageMarkdown(uploaded)
 	latencyMS := time.Since(startedAt).Milliseconds()
 	// 上游与文件上传已完成后，数据库侧的附件、用量和完成态仍需保持原子一致。
-	if err = s.repo.CompleteAssistantMessageWithAttachments(ctx,
-		userMessage.ID,
-		repository.MessageUsageUpdate{
-			InputTokens:      usage.InputTokens,
-			CacheReadTokens:  usage.CacheReadTokens,
-			CacheWriteTokens: usage.CacheWriteTokens,
-		},
-		assistantMessage.ID,
-		repository.AssistantMessageCompletionUpdate{
-			ContentType:     "image",
-			Content:         content,
-			OutputTokens:    usage.OutputTokens,
-			ReasoningTokens: usage.ReasoningTokens,
-			LatencyMS:       latencyMS,
-			Status:          "success",
-		},
-		attachmentRows,
-	); err != nil {
-		retErr = err
-		return nil, err
+	if reuseUserMessage {
+		if err = s.repo.CompleteAssistantMessageWithGeneratedAttachments(ctx,
+			assistantMessage.ID,
+			repository.AssistantMessageCompletionUpdate{
+				ContentType:      "image",
+				Content:          content,
+				InputTokens:      usage.InputTokens,
+				OutputTokens:     usage.OutputTokens,
+				CacheReadTokens:  usage.CacheReadTokens,
+				CacheWriteTokens: usage.CacheWriteTokens,
+				ReasoningTokens:  usage.ReasoningTokens,
+				LatencyMS:        latencyMS,
+				Status:           "success",
+			},
+			attachmentRows,
+		); err != nil {
+			retErr = err
+			return nil, err
+		}
+	} else {
+		if err = s.repo.CompleteAssistantMessageWithAttachments(ctx,
+			userMessage.ID,
+			repository.MessageUsageUpdate{
+				InputTokens:      usage.InputTokens,
+				CacheReadTokens:  usage.CacheReadTokens,
+				CacheWriteTokens: usage.CacheWriteTokens,
+			},
+			assistantMessage.ID,
+			repository.AssistantMessageCompletionUpdate{
+				ContentType:     "image",
+				Content:         content,
+				OutputTokens:    usage.OutputTokens,
+				ReasoningTokens: usage.ReasoningTokens,
+				LatencyMS:       latencyMS,
+				Status:          "success",
+			},
+			attachmentRows,
+		); err != nil {
+			retErr = err
+			return nil, err
+		}
 	}
 	assistantMessage.Content = content
 	assistantMessage.OutputTokens = usage.OutputTokens
 	assistantMessage.ReasoningTokens = usage.ReasoningTokens
 	assistantMessage.TokenUsage = assistantMessage.OutputTokens + assistantMessage.ReasoningTokens
+	if reuseUserMessage {
+		assistantMessage.TokenUsage += usage.InputTokens + usage.CacheReadTokens + usage.CacheWriteTokens
+	}
 	assistantMessage.LatencyMS = latencyMS
 	assistantMessage.Status = "success"
 	assistantMessage.Attachments = string(marshalAttachmentSnapshots(attachmentsFromFiles(uploaded)))

--- a/backend/internal/application/conversation/service_message_completion.go
+++ b/backend/internal/application/conversation/service_message_completion.go
@@ -30,6 +30,7 @@ type persistMessageGenerationInput struct {
 	StatefulPromptFingerprint string
 	ToolCallRows              []model.ToolCall
 	PersistedToolCallKeys     map[string]struct{}
+	ReuseUserMessage          bool
 }
 
 type persistInterruptedMessageGenerationInput struct {
@@ -49,6 +50,7 @@ type persistInterruptedMessageGenerationInput struct {
 	EffectiveOptions      map[string]interface{}
 	ServerSideToolUsage   map[string]int64
 	StartedAt             time.Time
+	ReuseUserMessage      bool
 }
 
 type interruptedMessageGenerationMetrics struct {
@@ -72,10 +74,16 @@ type persistMessageToolCallsInput struct {
 }
 
 func (s *Service) persistSuccessfulMessageGeneration(ctx context.Context, input persistMessageGenerationInput) error {
-	input.UserMessage.InputTokens = input.InputTokens
-	input.UserMessage.CacheReadTokens = input.CacheReadTokens
-	input.UserMessage.CacheWriteTokens = input.CacheWriteTokens
-	input.UserMessage.TokenUsage = input.InputTokens + input.CacheReadTokens + input.CacheWriteTokens
+	if input.ReuseUserMessage {
+		input.AssistantMessage.InputTokens = input.InputTokens
+		input.AssistantMessage.CacheReadTokens = input.CacheReadTokens
+		input.AssistantMessage.CacheWriteTokens = input.CacheWriteTokens
+	} else {
+		input.UserMessage.InputTokens = input.InputTokens
+		input.UserMessage.CacheReadTokens = input.CacheReadTokens
+		input.UserMessage.CacheWriteTokens = input.CacheWriteTokens
+		input.UserMessage.TokenUsage = input.InputTokens + input.CacheReadTokens + input.CacheWriteTokens
+	}
 
 	if completed, err := s.persistAssistantImagePayloadIfPresent(ctx, input); err != nil {
 		return err
@@ -83,22 +91,27 @@ func (s *Service) persistSuccessfulMessageGeneration(ctx context.Context, input 
 		return s.finishSuccessfulMessageGeneration(ctx, input)
 	}
 
-	go func(msgID uint, inputTokens, cacheReadTokens, cacheWriteTokens int64) {
-		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = s.repo.UpdateMessageUsage(bgCtx, msgID, inputTokens, 0, cacheReadTokens, cacheWriteTokens, 0)
-	}(input.UserMessage.ID, input.InputTokens, input.CacheReadTokens, input.CacheWriteTokens)
+	if !input.ReuseUserMessage {
+		go func(msgID uint, inputTokens, cacheReadTokens, cacheWriteTokens int64) {
+			bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = s.repo.UpdateMessageUsage(bgCtx, msgID, inputTokens, 0, cacheReadTokens, cacheWriteTokens, 0)
+		}(input.UserMessage.ID, input.InputTokens, input.CacheReadTokens, input.CacheWriteTokens)
+	}
 
 	if err := s.repo.UpdateAssistantMessageCompletion(
 		ctx,
 		input.AssistantMessage.ID,
-		input.AssistantText,
-		input.OutputTokens,
-		input.ReasoningTokens,
-		input.AssistantLatency,
-		"success",
-		"",
-		"",
+		repository.AssistantMessageCompletionUpdate{
+			Content:          input.AssistantText,
+			InputTokens:      assistantCompletionInputTokens(input),
+			OutputTokens:     input.OutputTokens,
+			CacheReadTokens:  assistantCompletionCacheReadTokens(input),
+			CacheWriteTokens: assistantCompletionCacheWriteTokens(input),
+			ReasoningTokens:  input.ReasoningTokens,
+			LatencyMS:        input.AssistantLatency,
+			Status:           "success",
+		},
 	); err != nil {
 		return err
 	}
@@ -108,8 +121,32 @@ func (s *Service) persistSuccessfulMessageGeneration(ctx context.Context, input 
 	input.AssistantMessage.ReasoningTokens = input.ReasoningTokens
 	input.AssistantMessage.LatencyMS = input.AssistantLatency
 	input.AssistantMessage.Status = "success"
+	if input.ReuseUserMessage {
+		input.AssistantMessage.TokenUsage = input.InputTokens + input.CacheReadTokens + input.CacheWriteTokens + input.OutputTokens + input.ReasoningTokens
+	}
 
 	return s.finishSuccessfulMessageGeneration(ctx, input)
+}
+
+func assistantCompletionInputTokens(input persistMessageGenerationInput) int64 {
+	if input.ReuseUserMessage {
+		return input.InputTokens
+	}
+	return 0
+}
+
+func assistantCompletionCacheReadTokens(input persistMessageGenerationInput) int64 {
+	if input.ReuseUserMessage {
+		return input.CacheReadTokens
+	}
+	return 0
+}
+
+func assistantCompletionCacheWriteTokens(input persistMessageGenerationInput) int64 {
+	if input.ReuseUserMessage {
+		return input.CacheWriteTokens
+	}
+	return 0
 }
 
 func (s *Service) persistAssistantImagePayloadIfPresent(ctx context.Context, input persistMessageGenerationInput) (bool, error) {
@@ -125,31 +162,60 @@ func (s *Service) persistAssistantImagePayloadIfPresent(ctx context.Context, inp
 		return false, err
 	}
 
-	if err := s.repo.CompleteAssistantMessageWithAttachments(
-		ctx,
-		input.UserMessage.ID,
-		repository.MessageUsageUpdate{
-			InputTokens:      input.InputTokens,
-			CacheReadTokens:  input.CacheReadTokens,
-			CacheWriteTokens: input.CacheWriteTokens,
-		},
-		input.AssistantMessage.ID,
-		repository.AssistantMessageCompletionUpdate{
-			ContentType:     "image",
-			Content:         normalized.Content,
-			OutputTokens:    input.OutputTokens,
-			ReasoningTokens: input.ReasoningTokens,
-			LatencyMS:       input.AssistantLatency,
-			Status:          "success",
-		},
-		normalized.AttachmentRows,
-	); err != nil {
-		return false, err
+	if input.ReuseUserMessage {
+		if err := s.repo.CompleteAssistantMessageWithGeneratedAttachments(
+			ctx,
+			input.AssistantMessage.ID,
+			repository.AssistantMessageCompletionUpdate{
+				ContentType:      "image",
+				Content:          normalized.Content,
+				InputTokens:      input.InputTokens,
+				OutputTokens:     input.OutputTokens,
+				CacheReadTokens:  input.CacheReadTokens,
+				CacheWriteTokens: input.CacheWriteTokens,
+				ReasoningTokens:  input.ReasoningTokens,
+				LatencyMS:        input.AssistantLatency,
+				Status:           "success",
+			},
+			normalized.AttachmentRows,
+		); err != nil {
+			return false, err
+		}
+	} else {
+		if err := s.repo.CompleteAssistantMessageWithAttachments(
+			ctx,
+			input.UserMessage.ID,
+			repository.MessageUsageUpdate{
+				InputTokens:      input.InputTokens,
+				CacheReadTokens:  input.CacheReadTokens,
+				CacheWriteTokens: input.CacheWriteTokens,
+			},
+			input.AssistantMessage.ID,
+			repository.AssistantMessageCompletionUpdate{
+				ContentType:     "image",
+				Content:         normalized.Content,
+				OutputTokens:    input.OutputTokens,
+				ReasoningTokens: input.ReasoningTokens,
+				LatencyMS:       input.AssistantLatency,
+				Status:          "success",
+			},
+			normalized.AttachmentRows,
+		); err != nil {
+			return false, err
+		}
 	}
 
 	input.AssistantMessage.ContentType = "image"
 	input.AssistantMessage.Content = normalized.Content
+	if input.ReuseUserMessage {
+		input.AssistantMessage.InputTokens = input.InputTokens
+		input.AssistantMessage.CacheReadTokens = input.CacheReadTokens
+		input.AssistantMessage.CacheWriteTokens = input.CacheWriteTokens
+	}
 	input.AssistantMessage.TokenUsage = input.OutputTokens + input.ReasoningTokens
+	if input.ReuseUserMessage {
+		input.AssistantMessage.TokenUsage += input.InputTokens + input.CacheReadTokens + input.CacheWriteTokens
+	}
 	input.AssistantMessage.OutputTokens = input.OutputTokens
 	input.AssistantMessage.ReasoningTokens = input.ReasoningTokens
 	input.AssistantMessage.LatencyMS = input.AssistantLatency
@@ -180,7 +246,11 @@ func (s *Service) finishSuccessfulMessageGeneration(ctx context.Context, input p
 	}
 
 	s.updateStatefulResponseAsync(input.SendInput.ConversationID, input.ResponseID, input.StatefulPromptFingerprint)
-	s.embedMessagePairAsync(input.SendInput, input.UserMessage, input.AssistantMessage)
+	if input.ReuseUserMessage {
+		s.embedMessagePairAsync(input.SendInput, nil, input.AssistantMessage)
+	} else {
+		s.embedMessagePairAsync(input.SendInput, input.UserMessage, input.AssistantMessage)
+	}
 
 	return nil
 }
@@ -200,38 +270,49 @@ func (s *Service) persistInterruptedMessageGeneration(ctx context.Context, input
 
 	metrics := resolveInterruptedMessageGenerationMetrics(input)
 
-	if err := s.repo.UpdateMessageUsage(
-		persistCtx,
-		input.UserMessage.ID,
-		metrics.InputTokens,
-		0,
-		metrics.CacheReadTokens,
-		metrics.CacheWriteTokens,
-		0,
-	); err != nil {
-		s.logger.Warn("persist_interrupted_user_usage_failed",
-			zap.String("trace_id", traceid.FromContext(ctx)),
-			zap.Uint("message_id", input.UserMessage.ID),
-			zap.Error(err),
-		)
-	}
-	if err := s.repo.UpdateMessageState(persistCtx, input.UserMessage.ID, "success", "", ""); err != nil {
-		s.logger.Warn("persist_interrupted_user_state_failed",
-			zap.String("trace_id", traceid.FromContext(ctx)),
-			zap.Uint("message_id", input.UserMessage.ID),
-			zap.Error(err),
-		)
+	if input.ReuseUserMessage {
+		input.AssistantMessage.InputTokens = metrics.InputTokens
+		input.AssistantMessage.CacheReadTokens = metrics.CacheReadTokens
+		input.AssistantMessage.CacheWriteTokens = metrics.CacheWriteTokens
+	} else {
+		if err := s.repo.UpdateMessageUsage(
+			persistCtx,
+			input.UserMessage.ID,
+			metrics.InputTokens,
+			0,
+			metrics.CacheReadTokens,
+			metrics.CacheWriteTokens,
+			0,
+		); err != nil {
+			s.logger.Warn("persist_interrupted_user_usage_failed",
+				zap.String("trace_id", traceid.FromContext(ctx)),
+				zap.Uint("message_id", input.UserMessage.ID),
+				zap.Error(err),
+			)
+		}
+		if err := s.repo.UpdateMessageState(persistCtx, input.UserMessage.ID, "success", "", ""); err != nil {
+			s.logger.Warn("persist_interrupted_user_state_failed",
+				zap.String("trace_id", traceid.FromContext(ctx)),
+				zap.Uint("message_id", input.UserMessage.ID),
+				zap.Error(err),
+			)
+		}
 	}
 	if err := s.repo.UpdateAssistantMessageCompletion(
 		persistCtx,
 		input.AssistantMessage.ID,
-		input.AssistantText,
-		metrics.OutputTokens,
-		metrics.ReasoningTokens,
-		metrics.LatencyMS,
-		retainedGenerationStatus(input.Error),
-		metrics.ErrorCode,
-		metrics.ErrorMessage,
+		repository.AssistantMessageCompletionUpdate{
+			Content:          input.AssistantText,
+			InputTokens:      interruptedCompletionInputTokens(input, metrics),
+			OutputTokens:     metrics.OutputTokens,
+			CacheReadTokens:  interruptedCompletionCacheReadTokens(input, metrics),
+			CacheWriteTokens: interruptedCompletionCacheWriteTokens(input, metrics),
+			ReasoningTokens:  metrics.ReasoningTokens,
+			LatencyMS:        metrics.LatencyMS,
+			Status:           retainedGenerationStatus(input.Error),
+			ErrorCode:        metrics.ErrorCode,
+			ErrorMessage:     metrics.ErrorMessage,
+		},
 	); err != nil {
 		s.logger.Error("persist_interrupted_assistant_completion_failed",
 			zap.String("trace_id", traceid.FromContext(ctx)),
@@ -310,18 +391,49 @@ func resolveInterruptedMessageGenerationMetrics(input persistInterruptedMessageG
 	}
 }
 
+func interruptedCompletionInputTokens(input persistInterruptedMessageGenerationInput, metrics interruptedMessageGenerationMetrics) int64 {
+	if input.ReuseUserMessage {
+		return metrics.InputTokens
+	}
+	return 0
+}
+
+func interruptedCompletionCacheReadTokens(input persistInterruptedMessageGenerationInput, metrics interruptedMessageGenerationMetrics) int64 {
+	if input.ReuseUserMessage {
+		return metrics.CacheReadTokens
+	}
+	return 0
+}
+
+func interruptedCompletionCacheWriteTokens(input persistInterruptedMessageGenerationInput, metrics interruptedMessageGenerationMetrics) int64 {
+	if input.ReuseUserMessage {
+		return metrics.CacheWriteTokens
+	}
+	return 0
+}
+
 // applyInterruptedMessageGenerationState 同步内存消息对象，保证后续响应、run 记录和持久化状态一致。
 func applyInterruptedMessageGenerationState(input persistInterruptedMessageGenerationInput, metrics interruptedMessageGenerationMetrics) {
-	input.UserMessage.Status = "success"
-	input.UserMessage.ErrorCode = ""
-	input.UserMessage.ErrorMessage = ""
-	input.UserMessage.InputTokens = metrics.InputTokens
-	input.UserMessage.CacheReadTokens = metrics.CacheReadTokens
-	input.UserMessage.CacheWriteTokens = metrics.CacheWriteTokens
-	input.UserMessage.TokenUsage = metrics.InputTokens + metrics.CacheReadTokens + metrics.CacheWriteTokens
+	if !input.ReuseUserMessage {
+		input.UserMessage.Status = "success"
+		input.UserMessage.ErrorCode = ""
+		input.UserMessage.ErrorMessage = ""
+		input.UserMessage.InputTokens = metrics.InputTokens
+		input.UserMessage.CacheReadTokens = metrics.CacheReadTokens
+		input.UserMessage.CacheWriteTokens = metrics.CacheWriteTokens
+		input.UserMessage.TokenUsage = metrics.InputTokens + metrics.CacheReadTokens + metrics.CacheWriteTokens
+	}
 
 	input.AssistantMessage.Content = input.AssistantText
+	if input.ReuseUserMessage {
+		input.AssistantMessage.InputTokens = metrics.InputTokens
+		input.AssistantMessage.CacheReadTokens = metrics.CacheReadTokens
+		input.AssistantMessage.CacheWriteTokens = metrics.CacheWriteTokens
+	}
 	input.AssistantMessage.TokenUsage = metrics.OutputTokens + metrics.ReasoningTokens
+	if input.ReuseUserMessage {
+		input.AssistantMessage.TokenUsage += metrics.InputTokens + metrics.CacheReadTokens + metrics.CacheWriteTokens
+	}
 	input.AssistantMessage.OutputTokens = metrics.OutputTokens
 	input.AssistantMessage.ReasoningTokens = metrics.ReasoningTokens
 	input.AssistantMessage.LatencyMS = metrics.LatencyMS

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -148,9 +148,6 @@ func (s *Service) sendMessageInternal(
 	if maxFiles <= 0 {
 		maxFiles = 10
 	}
-	if len(input.FileIDs) > maxFiles {
-		return nil, ErrTooManyMessageFiles
-	}
 	// application 层保留兜底校验，保证非 HTTP 调用路径也遵守同一 MCP 工具数量策略。
 	if err := s.ValidateSelectedToolIDs(input.SelectedToolIDs); err != nil {
 		return nil, err
@@ -160,11 +157,6 @@ func (s *Service) sendMessageInternal(
 	runID := normalizeRunID(input.ClientRunID)
 	if runID == "" {
 		runID = "run_" + normalizePublicID(uuid.NewString())
-	}
-	if input.Cancelable {
-		cancelCtx, cancel := context.WithCancel(ctx)
-		ctx = cancelCtx
-		s.generationStreams.register(ctx, runID, input.UserID, cancel)
 	}
 
 	conversation, err := s.repo.GetConversationByUser(ctx, input.ConversationID, input.UserID)
@@ -177,6 +169,19 @@ func (s *Service) sendMessageInternal(
 	if err != nil {
 		retErr = err
 		return nil, err
+	}
+	reuseUserMessage := branchState.ReuseUserMessage != nil
+	if reuseUserMessage {
+		input.Content = branchState.ReuseUserMessage.Content
+		input.FileIDs = parseAttachmentSnapshotFileIDs(branchState.ReuseUserMessage.Attachments)
+	}
+	if len(input.FileIDs) > maxFiles {
+		return nil, ErrTooManyMessageFiles
+	}
+	if input.Cancelable {
+		cancelCtx, cancel := context.WithCancel(ctx)
+		ctx = cancelCtx
+		s.generationStreams.register(ctx, runID, input.UserID, cancel)
 	}
 
 	currentPlatformModelName := strings.TrimSpace(conversation.Model)
@@ -205,6 +210,7 @@ func (s *Service) sendMessageInternal(
 	upstreamCallStarted := false
 	runState := newMessageSendRunState(s, input, conversation, startedAt, runID)
 	run := runState.run
+	runState.reuseUserMessage = reuseUserMessage
 	runState.bind(&userMessage, &assistantMessage, &traceRecorder, &result, ctx)
 	defer func() {
 		if retErr != nil {
@@ -225,6 +231,7 @@ func (s *Service) sendMessageInternal(
 				EffectiveOptions:      filteredOptions,
 				ServerSideToolUsage:   totalServerSideToolUsage,
 				StartedAt:             startedAt,
+				ReuseUserMessage:      reuseUserMessage,
 			}); retained != nil {
 				result = retained
 				applyRetainedGenerationRunUsage(run, retained, len(toolCallRows), startedAt)
@@ -260,51 +267,7 @@ func (s *Service) sendMessageInternal(
 		return nil, err
 	}
 
-	attachmentsJSON := []byte(marshalAttachmentSnapshots(resolvedAttachments))
-
 	estimatedInputTokens = estimateTokens(input.Content)
-	userMessage = &model.Message{
-		ConversationID:   input.ConversationID,
-		UserID:           input.UserID,
-		PublicID:         normalizePublicID(uuid.NewString()),
-		ParentMessageID:  branchState.ParentMessageID,
-		RunID:            runID,
-		Role:             "user",
-		ContentType:      fallbackContentType(input.ContentType),
-		Content:          input.Content,
-		BranchReason:     normalizedBranchReason,
-		SourceMessageID:  branchState.SourceMessageID,
-		TokenUsage:       estimatedInputTokens,
-		InputTokens:      estimatedInputTokens,
-		OutputTokens:     0,
-		CacheReadTokens:  0,
-		CacheWriteTokens: 0,
-		ReasoningTokens:  0,
-		LatencyMS:        0,
-		Status:           "pending",
-		ErrorCode:        "",
-		ErrorMessage:     "",
-		Attachments:      string(attachmentsJSON),
-	}
-	attachmentRows := make([]model.Attachment, 0, len(resolvedAttachments))
-	now := time.Now()
-	for _, item := range resolvedAttachments {
-		attachmentRows = append(attachmentRows, model.Attachment{
-			ConversationID: input.ConversationID,
-			UserID:         input.UserID,
-			FileID:         strings.TrimSpace(item.FileID),
-			Kind:           normalizeAttachmentKind(item.Kind, item.MimeType),
-			FileName:       strings.TrimSpace(item.FileName),
-			MimeType:       strings.TrimSpace(item.MimeType),
-			FileSize:       item.FileSize,
-			SHA256:         strings.TrimSpace(item.SHA256),
-			StoragePath:    strings.TrimSpace(item.StoragePath),
-			Status:         "active",
-			MetaJSON:       strings.TrimSpace(item.MetaJSON),
-			UploadedAt:     now,
-		})
-	}
-
 	assistantMessage = &model.Message{
 		ConversationID:   input.ConversationID,
 		UserID:           input.UserID,
@@ -326,14 +289,70 @@ func (s *Service) sendMessageInternal(
 		ErrorMessage:     "",
 		Attachments:      "[]",
 	}
-	// 用户消息、助手占位、用户附件与消息计数必须一起提交，避免失败时留下半个回合。
-	if err = s.repo.CreateMessagePairWithUserAttachments(ctx, userMessage, assistantMessage, attachmentRows); err != nil {
-		retErr = err
-		return nil, err
+	if reuseUserMessage {
+		reused := *branchState.ReuseUserMessage
+		userMessage = &reused
+		assistantMessage.ParentMessageID = &userMessage.ID
+		assistantMessage.SourceMessageID = branchState.SourceMessageID
+		if err = s.repo.CreateAssistantBranchMessage(ctx, assistantMessage); err != nil {
+			retErr = err
+			return nil, err
+		}
+		assistantMessage.ParentPublicID = userMessage.PublicID
+		assistantMessage.SourcePublicID = branchState.SourcePublicID
+	} else {
+		attachmentsJSON := []byte(marshalAttachmentSnapshots(resolvedAttachments))
+		userMessage = &model.Message{
+			ConversationID:   input.ConversationID,
+			UserID:           input.UserID,
+			PublicID:         normalizePublicID(uuid.NewString()),
+			ParentMessageID:  branchState.ParentMessageID,
+			RunID:            runID,
+			Role:             "user",
+			ContentType:      fallbackContentType(input.ContentType),
+			Content:          input.Content,
+			BranchReason:     normalizedBranchReason,
+			SourceMessageID:  branchState.SourceMessageID,
+			TokenUsage:       estimatedInputTokens,
+			InputTokens:      estimatedInputTokens,
+			OutputTokens:     0,
+			CacheReadTokens:  0,
+			CacheWriteTokens: 0,
+			ReasoningTokens:  0,
+			LatencyMS:        0,
+			Status:           "pending",
+			ErrorCode:        "",
+			ErrorMessage:     "",
+			Attachments:      string(attachmentsJSON),
+		}
+		attachmentRows := make([]model.Attachment, 0, len(resolvedAttachments))
+		now := time.Now()
+		for _, item := range resolvedAttachments {
+			attachmentRows = append(attachmentRows, model.Attachment{
+				ConversationID: input.ConversationID,
+				UserID:         input.UserID,
+				FileID:         strings.TrimSpace(item.FileID),
+				Kind:           normalizeAttachmentKind(item.Kind, item.MimeType),
+				FileName:       strings.TrimSpace(item.FileName),
+				MimeType:       strings.TrimSpace(item.MimeType),
+				FileSize:       item.FileSize,
+				SHA256:         strings.TrimSpace(item.SHA256),
+				StoragePath:    strings.TrimSpace(item.StoragePath),
+				Status:         "active",
+				MetaJSON:       strings.TrimSpace(item.MetaJSON),
+				UploadedAt:     now,
+			})
+		}
+
+		// 用户消息、助手占位、用户附件与消息计数必须一起提交，避免失败时留下半个回合。
+		if err = s.repo.CreateMessagePairWithUserAttachments(ctx, userMessage, assistantMessage, attachmentRows); err != nil {
+			retErr = err
+			return nil, err
+		}
+		userMessage.ParentPublicID = branchState.ParentPublicID
+		userMessage.SourcePublicID = branchState.SourcePublicID
+		assistantMessage.ParentPublicID = userMessage.PublicID
 	}
-	userMessage.ParentPublicID = branchState.ParentPublicID
-	userMessage.SourcePublicID = branchState.SourcePublicID
-	assistantMessage.ParentPublicID = userMessage.PublicID
 	traceRecorder = newMessageTraceRecorder(s, ctx, assistantMessage, input.OnEvent)
 
 	if s.routeResolver == nil || s.llmClient == nil {
@@ -370,7 +389,9 @@ func (s *Service) sendMessageInternal(
 			return nil, err
 		}
 	}
-	s.maybeGenerateConversationMetadataAsync(*conversation, *userMessage)
+	if !reuseUserMessage {
+		s.maybeGenerateConversationMetadataAsync(*conversation, *userMessage)
+	}
 	run.Endpoint = llm.DefaultEndpointForAdapter(route.Protocol)
 	run.ProviderProtocol = route.Protocol
 	run.UpstreamID = route.UpstreamID
@@ -1248,6 +1269,7 @@ func (s *Service) sendMessageInternal(
 		StatefulPromptFingerprint: statefulPromptFingerprint,
 		ToolCallRows:              toolCallRows,
 		PersistedToolCallKeys:     persistedToolCallKeys,
+		ReuseUserMessage:          reuseUserMessage,
 	})
 	platformtracing.RecordError(persistSpan, err)
 	persistSpan.End()

--- a/backend/internal/application/conversation/service_run.go
+++ b/backend/internal/application/conversation/service_run.go
@@ -21,6 +21,7 @@ type messageSendRunState struct {
 	traceRecorder    **messageTraceRecorder
 	result           **SendMessageResult
 	traceContext     context.Context
+	reuseUserMessage bool
 }
 
 func newMessageSendRunState(
@@ -123,6 +124,9 @@ func (r *messageSendRunState) finalizeRun(retErr error) {
 }
 
 func (r *messageSendRunState) finalizeUserMessage(ctx context.Context, retErr error) {
+	if r.reuseUserMessage {
+		return
+	}
 	userMessage := r.currentUserMessage()
 	if userMessage == nil {
 		return
@@ -234,9 +238,16 @@ func applyRetainedGenerationRunUsage(run *model.Run, result *SendMessageResult, 
 		return
 	}
 	run.InputTokens = result.UserMessage.InputTokens
+	if sendMessageResultUsesAssistantSideInput(result) {
+		run.InputTokens = result.AssistantMessage.InputTokens
+	}
 	run.OutputTokens = result.AssistantMessage.OutputTokens
 	run.CacheReadTokens = result.UserMessage.CacheReadTokens
 	run.CacheWriteTokens = result.UserMessage.CacheWriteTokens
+	if sendMessageResultUsesAssistantSideInput(result) {
+		run.CacheReadTokens = result.AssistantMessage.CacheReadTokens
+		run.CacheWriteTokens = result.AssistantMessage.CacheWriteTokens
+	}
 	run.ReasoningTokens = result.AssistantMessage.ReasoningTokens
 	run.ToolCallsCount = toolCallsCount
 	run.FirstTokenLatencyMS = result.AssistantMessage.LatencyMS

--- a/backend/internal/infra/persistence/postgres/conversation/repository.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository.go
@@ -824,6 +824,33 @@ func (r *Repo) CreateMessage(ctx context.Context, item *domainconversation.Messa
 	return nil
 }
 
+// CreateAssistantBranchMessage 原子创建 assistant 分支消息并递增会话消息数。
+func (r *Repo) CreateAssistantBranchMessage(ctx context.Context, assistantMessage *domainconversation.Message) error {
+	if assistantMessage == nil || assistantMessage.ParentMessageID == nil {
+		return repository.ErrInvalidInput
+	}
+	attachmentSnapshot := assistantMessage.Attachments
+	return translateError(r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		entity := toMessageModel(assistantMessage)
+		if err := tx.Create(&entity).Error; err != nil {
+			return err
+		}
+		*assistantMessage = toMessageDomain(entity)
+		assistantMessage.Attachments = attachmentSnapshot
+
+		result := tx.Model(&models.Conversation{}).
+			Where("id = ?", assistantMessage.ConversationID).
+			Update("message_count", gorm.Expr("message_count + ?", 1))
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return repository.ErrNotFound
+		}
+		return nil
+	}))
+}
+
 // CreateMessagePairWithUserAttachments 原子创建用户消息、助手占位消息、用户附件并递增会话消息数。
 func (r *Repo) CreateMessagePairWithUserAttachments(
 	ctx context.Context,
@@ -1092,33 +1119,30 @@ func (r *Repo) InterruptPendingAssistantMessageByRunID(
 func (r *Repo) UpdateAssistantMessageCompletion(
 	ctx context.Context,
 	messageID uint,
-	content string,
-	outputTokens int64,
-	reasoningTokens int64,
-	latencyMS int64,
-	status string,
-	errorCode string,
-	errorMessage string,
+	update repository.AssistantMessageCompletionUpdate,
 ) error {
-	tokenUsage := outputTokens + reasoningTokens
+	tokenUsage := update.InputTokens + update.CacheReadTokens + update.CacheWriteTokens + update.OutputTokens + update.ReasoningTokens
 	if tokenUsage < 0 {
 		tokenUsage = 0
 	}
-	if latencyMS < 0 {
-		latencyMS = 0
+	if update.LatencyMS < 0 {
+		update.LatencyMS = 0
 	}
 	return translateError(r.db.WithContext(ctx).
 		Model(&models.Message{}).
 		Where("id = ?", messageID).
 		Updates(map[string]interface{}{
-			"content":          content,
-			"token_usage":      tokenUsage,
-			"output_tokens":    outputTokens,
-			"reasoning_tokens": reasoningTokens,
-			"latency_ms":       latencyMS,
-			"status":           status,
-			"error_code":       errorCode,
-			"error_message":    errorMessage,
+			"content":            update.Content,
+			"token_usage":        tokenUsage,
+			"input_tokens":       update.InputTokens,
+			"output_tokens":      update.OutputTokens,
+			"cache_read_tokens":  update.CacheReadTokens,
+			"cache_write_tokens": update.CacheWriteTokens,
+			"reasoning_tokens":   update.ReasoningTokens,
+			"latency_ms":         update.LatencyMS,
+			"status":             update.Status,
+			"error_code":         update.ErrorCode,
+			"error_message":      update.ErrorMessage,
 		}).
 		Error)
 }
@@ -1165,7 +1189,7 @@ func (r *Repo) CompleteAssistantMessageWithAttachments(
 			return err
 		}
 
-		assistantTokenUsage := assistantCompletion.OutputTokens + assistantCompletion.ReasoningTokens
+		assistantTokenUsage := assistantCompletion.InputTokens + assistantCompletion.CacheReadTokens + assistantCompletion.CacheWriteTokens + assistantCompletion.OutputTokens + assistantCompletion.ReasoningTokens
 		if assistantTokenUsage < 0 {
 			assistantTokenUsage = 0
 		}
@@ -1174,14 +1198,70 @@ func (r *Repo) CompleteAssistantMessageWithAttachments(
 			latencyMS = 0
 		}
 		updates := map[string]interface{}{
-			"content":          assistantCompletion.Content,
-			"token_usage":      assistantTokenUsage,
-			"output_tokens":    assistantCompletion.OutputTokens,
-			"reasoning_tokens": assistantCompletion.ReasoningTokens,
-			"latency_ms":       latencyMS,
-			"status":           assistantCompletion.Status,
-			"error_code":       assistantCompletion.ErrorCode,
-			"error_message":    assistantCompletion.ErrorMessage,
+			"content":            assistantCompletion.Content,
+			"token_usage":        assistantTokenUsage,
+			"input_tokens":       assistantCompletion.InputTokens,
+			"output_tokens":      assistantCompletion.OutputTokens,
+			"cache_read_tokens":  assistantCompletion.CacheReadTokens,
+			"cache_write_tokens": assistantCompletion.CacheWriteTokens,
+			"reasoning_tokens":   assistantCompletion.ReasoningTokens,
+			"latency_ms":         latencyMS,
+			"status":             assistantCompletion.Status,
+			"error_code":         assistantCompletion.ErrorCode,
+			"error_message":      assistantCompletion.ErrorMessage,
+		}
+		if contentType := strings.TrimSpace(assistantCompletion.ContentType); contentType != "" {
+			updates["content_type"] = contentType
+		}
+		return tx.Model(&models.Message{}).
+			Where("id = ?", assistantMessageID).
+			Updates(updates).Error
+	}))
+}
+
+// CompleteAssistantMessageWithGeneratedAttachments 原子写入助手附件并同步助手完成态，不修改父用户消息。
+func (r *Repo) CompleteAssistantMessageWithGeneratedAttachments(
+	ctx context.Context,
+	assistantMessageID uint,
+	assistantCompletion repository.AssistantMessageCompletionUpdate,
+	assistantAttachments []domainconversation.Attachment,
+) error {
+	return translateError(r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if len(assistantAttachments) > 0 {
+			if err := lockActiveFileObjectsForAttachments(tx, 0, assistantAttachments); err != nil {
+				return err
+			}
+			entities := make([]models.Attachment, 0, len(assistantAttachments))
+			for i := range assistantAttachments {
+				item := assistantAttachments[i]
+				item.MessageID = assistantMessageID
+				entities = append(entities, toAttachmentModel(&item))
+			}
+			if err := tx.Create(&entities).Error; err != nil {
+				return err
+			}
+		}
+
+		assistantTokenUsage := assistantCompletion.InputTokens + assistantCompletion.CacheReadTokens + assistantCompletion.CacheWriteTokens + assistantCompletion.OutputTokens + assistantCompletion.ReasoningTokens
+		if assistantTokenUsage < 0 {
+			assistantTokenUsage = 0
+		}
+		latencyMS := assistantCompletion.LatencyMS
+		if latencyMS < 0 {
+			latencyMS = 0
+		}
+		updates := map[string]interface{}{
+			"content":            assistantCompletion.Content,
+			"token_usage":        assistantTokenUsage,
+			"input_tokens":       assistantCompletion.InputTokens,
+			"output_tokens":      assistantCompletion.OutputTokens,
+			"cache_read_tokens":  assistantCompletion.CacheReadTokens,
+			"cache_write_tokens": assistantCompletion.CacheWriteTokens,
+			"reasoning_tokens":   assistantCompletion.ReasoningTokens,
+			"latency_ms":         latencyMS,
+			"status":             assistantCompletion.Status,
+			"error_code":         assistantCompletion.ErrorCode,
+			"error_message":      assistantCompletion.ErrorMessage,
 		}
 		if contentType := strings.TrimSpace(assistantCompletion.ContentType); contentType != "" {
 			updates["content_type"] = contentType

--- a/backend/internal/repository/conversation_core.go
+++ b/backend/internal/repository/conversation_core.go
@@ -19,14 +19,17 @@ type MessageUsageUpdate struct {
 
 // AssistantMessageCompletionUpdate 定义助手消息完成态更新字段。
 type AssistantMessageCompletionUpdate struct {
-	ContentType     string
-	Content         string
-	OutputTokens    int64
-	ReasoningTokens int64
-	LatencyMS       int64
-	Status          string
-	ErrorCode       string
-	ErrorMessage    string
+	ContentType      string
+	Content          string
+	InputTokens      int64
+	OutputTokens     int64
+	CacheReadTokens  int64
+	CacheWriteTokens int64
+	ReasoningTokens  int64
+	LatencyMS        int64
+	Status           string
+	ErrorCode        string
+	ErrorMessage     string
 }
 
 // ConversationMetadataPatch 定义自动生成会话元数据的更新字段。
@@ -73,8 +76,10 @@ type ConversationMetadataRepository interface {
 // MessageRepository 封装消息读写能力。
 type MessageRepository interface {
 	CreateMessage(ctx context.Context, item *domainconversation.Message) error
+	CreateAssistantBranchMessage(ctx context.Context, assistantMessage *domainconversation.Message) error
 	CreateMessagePairWithUserAttachments(ctx context.Context, userMessage *domainconversation.Message, assistantMessage *domainconversation.Message, userAttachments []domainconversation.Attachment) error
 	CompleteAssistantMessageWithAttachments(ctx context.Context, userMessageID uint, userUsage MessageUsageUpdate, assistantMessageID uint, assistantCompletion AssistantMessageCompletionUpdate, assistantAttachments []domainconversation.Attachment) error
+	CompleteAssistantMessageWithGeneratedAttachments(ctx context.Context, assistantMessageID uint, assistantCompletion AssistantMessageCompletionUpdate, assistantAttachments []domainconversation.Attachment) error
 	GetMessageByPublicID(ctx context.Context, conversationID uint, userID uint, publicID string) (*domainconversation.Message, error)
 	GetMessageByPublicIDForUser(ctx context.Context, userID uint, publicID string) (*domainconversation.Message, error)
 	UpdateMessageUsage(ctx context.Context, messageID uint, inputTokens int64, outputTokens int64, cacheReadTokens int64, cacheWriteTokens int64, reasoningTokens int64) error
@@ -82,7 +87,7 @@ type MessageRepository interface {
 	UpdateAssistantMessageContent(ctx context.Context, userID uint, publicID string, content string, editedAt time.Time) (*domainconversation.Message, error)
 	CancelPendingGenerationMessagesByRunID(ctx context.Context, userID uint, runID string, errorCode string, errorMessage string) (bool, error)
 	InterruptPendingAssistantMessageByRunID(ctx context.Context, userID uint, runID string, errorCode string, errorMessage string) (bool, error)
-	UpdateAssistantMessageCompletion(ctx context.Context, messageID uint, content string, outputTokens int64, reasoningTokens int64, latencyMS int64, status string, errorCode string, errorMessage string) error
+	UpdateAssistantMessageCompletion(ctx context.Context, messageID uint, update AssistantMessageCompletionUpdate) error
 	UpdateMessageBilling(ctx context.Context, messageID uint, billedCurrency string, billedNanousd int64, pricingSnapshot string) error
 	SumMessageTokens(ctx context.Context, conversationID uint) (int64, error)
 	ListMessages(ctx context.Context, conversationID uint, offset int, limit int) ([]domainconversation.Message, int64, error)

--- a/frontend/features/chat/hooks/use-chat-branch-state.ts
+++ b/frontend/features/chat/hooks/use-chat-branch-state.ts
@@ -99,7 +99,7 @@ function buildPendingMessages({
       key: `${pendingExchange.key}-assistant`,
       publicID: assistantPublicID,
       parentPublicID: userPublicID,
-      sourcePublicID: null,
+      sourcePublicID: pendingExchange.userPublicID ? pendingExchange.sourcePublicID : null,
       role: "assistant",
       contentType: pendingExchange.assistantContentType,
       content: pendingExchange.assistantText,

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -493,8 +493,13 @@ export function useChatMessageSubmit({
       const resolvedParentPublicID = resolvePersistedPublicID(parentMessagePublicID);
       const resolvedSourcePublicID = resolvePersistedPublicID(sourceMessagePublicID);
       const resolvedBranchReason = branchReason ?? "default";
+      const assistantOnlyBranch =
+        resolvedBranchReason === "retry" &&
+        Boolean(resolvedParentPublicID && resolvedSourcePublicID) &&
+        combinedMessages.some((item) => item.publicID === resolvedSourcePublicID && item.role === "assistant");
       const tempUserPublicID = `${exchangeKey}-user`;
       const tempAssistantPublicID = `${exchangeKey}-assistant`;
+      const pendingUserPublicID = assistantOnlyBranch && resolvedParentPublicID ? resolvedParentPublicID : tempUserPublicID;
       const createdAt = new Date().toISOString();
       let sentSuccessfully = false;
       let shouldKeepConversationLayout = false;
@@ -523,6 +528,7 @@ export function useChatMessageSubmit({
       setPendingExchange({
         key: exchangeKey,
         conversationPublicID: targetConversationID?.trim() || null,
+        userPublicID: assistantOnlyBranch ? pendingUserPublicID : undefined,
         tempUserPublicID,
         tempAssistantPublicID,
         runID: clientRunID,
@@ -544,8 +550,8 @@ export function useChatMessageSubmit({
       });
       setBranchSelections((prev) => ({
         ...prev,
-        [toBranchKey(resolvedParentPublicID)]: tempUserPublicID,
-        [tempUserPublicID]: tempAssistantPublicID,
+        ...(assistantOnlyBranch ? {} : { [toBranchKey(resolvedParentPublicID)]: pendingUserPublicID }),
+        [pendingUserPublicID]: tempAssistantPublicID,
       }));
 
       try {
@@ -845,10 +851,14 @@ export function useChatMessageSubmit({
           applyBranchSelectionPath(
             prev,
             [
-              {
-                parentPublicID: completed.userMessage.parentPublicID || resolvedParentPublicID,
-                publicID: completed.userMessage.publicID,
-              },
+              ...(assistantOnlyBranch
+                ? []
+                : [
+                    {
+                      parentPublicID: completed.userMessage.parentPublicID || resolvedParentPublicID,
+                      publicID: completed.userMessage.publicID,
+                    },
+                  ]),
               {
                 parentPublicID: completed.userMessage.publicID,
                 publicID: completed.assistantMessage.publicID,
@@ -967,6 +977,7 @@ export function useChatMessageSubmit({
       maxFilesPerMessage,
       t,
       visibleMessageCount,
+      combinedMessages,
     ],
   );
 
@@ -1120,8 +1131,9 @@ export function useChatMessageSubmit({
         toast.error(t("retryReplyFailed"), { description: t("retryReplyMissingUser") });
         return;
       }
-      const sourceMessagePublicID = resolvePersistedPublicID(parentUser.publicID);
-      if (!sourceMessagePublicID) {
+      const parentUserPublicID = resolvePersistedPublicID(parentUser.publicID);
+      const assistantSourceMessagePublicID = resolvePersistedPublicID(message.publicID);
+      if (!parentUserPublicID || !assistantSourceMessagePublicID) {
         toast.error(t("retryReplyFailed"), { description: t("continueReplyUnavailable") });
         return;
       }
@@ -1129,8 +1141,8 @@ export function useChatMessageSubmit({
         content: parentUser.content.trim(),
         currentAttachments: toPendingAttachments(parentUser),
         resetComposer: false,
-        parentMessagePublicID: parentUser.parentPublicID,
-        sourceMessagePublicID,
+        parentMessagePublicID: parentUserPublicID,
+        sourceMessagePublicID: assistantSourceMessagePublicID,
         branchReason: "retry",
       });
     },

--- a/frontend/features/chat/model/chat-thread.ts
+++ b/frontend/features/chat/model/chat-thread.ts
@@ -393,8 +393,8 @@ export function buildVisibleMessages(
     visible = buildTailVisibleMessages(messages);
   }
 
-  const withUserNavigators = visible.map((item) => {
-    if (item.role !== "user") {
+  const withBranchNavigators = visible.map((item) => {
+    if (item.role !== "user" && item.role !== "assistant") {
       return item;
     }
     const siblings = children.get(toBranchKey(item.parentPublicID)) ?? [];
@@ -417,11 +417,11 @@ export function buildVisibleMessages(
     };
   });
 
-  return withUserNavigators.map((item, index) => {
+  return withBranchNavigators.map((item, index) => {
     if (item.role !== "assistant") {
       return item;
     }
-    const previous = index > 0 ? withUserNavigators[index - 1] : null;
+    const previous = index > 0 ? withBranchNavigators[index - 1] : null;
     if (!previous || previous.role !== "user") {
       return item;
     }
@@ -430,7 +430,6 @@ export function buildVisibleMessages(
       inputTokens: item.inputTokens && item.inputTokens > 0 ? item.inputTokens : previous.inputTokens,
       cacheReadTokens: item.cacheReadTokens && item.cacheReadTokens > 0 ? item.cacheReadTokens : previous.cacheReadTokens,
       cacheWriteTokens: item.cacheWriteTokens && item.cacheWriteTokens > 0 ? item.cacheWriteTokens : previous.cacheWriteTokens,
-      branchNavigator: previous.branchNavigator ?? item.branchNavigator,
     };
   });
 }


### PR DESCRIPTION
## Summary

Support independent branching for user messages and assistant replies. Retrying an assistant reply now creates a new assistant sibling under the existing user message instead of duplicating the user message, while user retry/edit behavior remains unchanged.

The backend resolves assistant-only retry branches, reuses the persisted user content and attachment snapshots, builds context without the previous assistant reply, and keeps usage, billing, run records, media generation, interrupted generations, exports, and embeddings aligned with the new branch shape. The frontend now submits assistant retries with the assistant message as the source, keeps pending UI attached to the existing user message, and shows user/assistant branch navigation independently.

## Change type

- [x] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [x] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/application/conversation ./internal/infra/persistence/postgres/conversation`
- [x] `cd frontend && ./node_modules/.bin/eslint features/chat/hooks/use-chat-message-submit.ts features/chat/hooks/use-chat-branch-state.ts features/chat/model/chat-thread.ts`
- [x] `git diff --check`

## Screenshots, API examples, or logs

No screenshots. Behavior change is in message branching:

- User retry/edit: creates a new user branch and assistant child.
- Assistant retry: creates only a new assistant branch under the existing user message.

## Configuration, migration, and compatibility notes

No configuration or database migration is required.

No API fields were added or removed. Existing `parentMessagePublicID`, `sourceMessagePublicID`, and `branchReason=retry` are reused; assistant messages can now be used as the retry source when the parent is the original user message.

Existing conversation histories remain compatible.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.