### PR TITLE
refactor: replace custom drag and drop logic with shared sortable list utility for improved consistency across admin components

### DIFF
--- a/frontend/features/admin/components/sections/login/admin-login.tsx
+++ b/frontend/features/admin/components/sections/login/admin-login.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ArrowRight, ChevronDown, GripVertical, Pencil, Plus, Save, Trash2 } from "lucide-react";
+import { ArrowRight, ChevronDown, Pencil, Plus, Save, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
@@ -27,6 +27,12 @@ import { Separator } from "@/components/ui/separator";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { createAdminIdentityProvider, deleteAdminIdentityProvider, listAdminIdentityProviders, listAdminSettings, patchAdminSettings, reorderAdminIdentityProviders, updateAdminIdentityProvider } from "@/features/admin/api";
+import {
+  AdminSortableHandle,
+  AdminSortableItem,
+  AdminSortableList,
+  moveSortableItem,
+} from "@/features/admin/components/sections/shared/admin-sortable-list";
 import type { IdentityProviderPayload } from "@/features/admin/api/auth";
 import { Table, TableBody, TableCell, TableEmptyRow, TableHead, TableHeader, TableLoadingRow, TableRow } from "@/components/ui/table";
 import { ApiError } from "@/shared/api/http-client";
@@ -60,7 +66,6 @@ import {
   normalizeProviderSlugPreview,
   providerToForm,
   PROVIDER_TEMPLATES,
-  reorderProviders,
   toEditorField,
   validateEmailVerificationSettings,
   validatePasswordLoginSettings,
@@ -98,8 +103,6 @@ export function AdminLoginSettingsPage() {
   const [forceDeleteProviderMessage, setForceDeleteProviderMessage] = React.useState("");
   const [providerForm, setProviderForm] = React.useState<IdentityProviderPayload>(DEFAULT_PROVIDER_FORM);
   const [oidcEndpointMode, setOidcEndpointMode] = React.useState<"issuer" | "discovery">("issuer");
-  const [draggedProviderID, setDraggedProviderID] = React.useState<string | null>(null);
-  const [dragOverProviderID, setDragOverProviderID] = React.useState<string | null>(null);
   const [frontendOrigin, setFrontendOrigin] = React.useState("");
   const [loading, setLoading] = React.useState(true);
   const [saving, setSaving] = React.useState(false);
@@ -363,20 +366,20 @@ export function AdminLoginSettingsPage() {
     }
   }, [t]);
 
-  const dropProvider = React.useCallback((targetProvider: IdentityProviderDTO) => {
-    if (!draggedProviderID || draggedProviderID === targetProvider.publicID) {
-      setDraggedProviderID(null);
-      setDragOverProviderID(null);
+  const moveProviderTo = React.useCallback((providerID: string, targetProviderID: string) => {
+    if (providerID === targetProviderID) {
       return;
     }
+    const index = providers.findIndex((provider) => provider.publicID === providerID);
+    const targetIndex = providers.findIndex((provider) => provider.publicID === targetProviderID);
     const previousProviders = providers;
-    const orderedProviders = reorderProviders(providers, draggedProviderID, targetProvider.publicID);
-    setDraggedProviderID(null);
-    setDragOverProviderID(null);
-    if (orderedProviders === providers) return;
+    const orderedProviders = moveSortableItem(providers, index, targetIndex);
+    if (orderedProviders === providers) {
+      return;
+    }
     setProviders(orderedProviders);
     void saveProviderOrder(orderedProviders, previousProviders);
-  }, [draggedProviderID, providers, saveProviderOrder]);
+  }, [providers, saveProviderOrder]);
 
   const oidcEndpointValue = oidcEndpointMode === "discovery" ? (providerForm.discoveryURL ?? "") : (providerForm.issuerURL ?? "");
   const callbackSlug = providerForm.slug?.trim() || normalizeProviderSlugPreview(providerForm.name) || "provider";
@@ -528,119 +531,108 @@ export function AdminLoginSettingsPage() {
                         </div>
                       </div>
 
-                      <Table>
-                        <TableHeader>
-                          <TableRow>
-                            <TableHead className="w-8" />
-                            <TableHead className="w-[220px]">{t("providers.name")}</TableHead>
-                            <TableHead>{t("providers.type")}</TableHead>
-                            <TableHead className="text-center">{t("providers.loginControl")}</TableHead>
-                            <TableHead className="text-center">{t("providers.registrationControl")}</TableHead>
-                            <TableHead>{t("providerDialog.clientID")}</TableHead>
-                            <TableHead className="w-[68px]" stickyEnd />
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {loading && providers.length === 0 ? <TableLoadingRow colSpan={7} /> : null}
-                          {providers.map((provider) => (
-                            <TableRow
-                              key={provider.publicID}
-                              className={dragOverProviderID === provider.publicID && draggedProviderID !== provider.publicID ? "bg-muted/40" : undefined}
-                              onDragOver={(event) => {
-                                if (!draggedProviderID || draggedProviderID === provider.publicID) return;
-                                event.preventDefault();
-                                event.dataTransfer.dropEffect = "move";
-                                setDragOverProviderID(provider.publicID);
-                              }}
-                              onDragLeave={() => {
-                                setDragOverProviderID((current) => (current === provider.publicID ? null : current));
-                              }}
-                              onDrop={(event) => {
-                                event.preventDefault();
-                                dropProvider(provider);
-                              }}
-                            >
-                              <TableCell className="w-8 py-1.5 text-center text-muted-foreground">
-                                <div className="flex h-7 items-center justify-center">
-                                  <button
-                                    type="button"
-                                    draggable={!saving && providers.length > 1}
-                                    className="inline-flex size-4 cursor-grab items-center justify-center text-muted-foreground transition-colors hover:text-foreground active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-50"
-                                    disabled={saving || providers.length < 2}
-                                    aria-label={t("providers.dragToReorder", { name: provider.name })}
-                                    onDragStart={(event) => {
-                                      setDraggedProviderID(provider.publicID);
-                                      event.dataTransfer.effectAllowed = "move";
-                                      event.dataTransfer.setData("text/plain", provider.publicID);
-                                    }}
-                                    onDragEnd={() => {
-                                      setDraggedProviderID(null);
-                                      setDragOverProviderID(null);
-                                    }}
-                                  >
-                                    <GripVertical className="size-3.5" />
-                                  </button>
-                                </div>
-                              </TableCell>
-                              <TableCell className="w-[220px] max-w-[220px] py-1.5">
-                                <div className="flex h-7 max-w-[220px] min-w-0 items-center gap-2">
-                                  <IdentityProviderIcon name={provider.name} slug={provider.slug} logoURL={provider.logoURL} />
-                                  <button
-                                    type="button"
-                                    className="inline-flex min-w-0 max-w-full items-baseline gap-1.5 text-left font-medium hover:underline"
-                                    title={`${provider.name} (${provider.slug})`}
-                                    onClick={() => openEditProvider(provider)}
-                                  >
-                                    <span className="min-w-0 truncate">{provider.name}</span>
-                                    <span className="shrink-0 text-xs font-normal text-muted-foreground">({provider.slug})</span>
-                                  </button>
-                                </div>
-                              </TableCell>
-                              <TableCell className="py-1.5 uppercase">
-                                <span className="flex h-7 items-center">{provider.type}</span>
-                              </TableCell>
-                              <TableCell className="py-1.5 text-center">
-                                <div className="flex h-7 items-center justify-center">
-                                  <Switch
-                                    size="sm"
-                                    checked={provider.loginEnabled}
-                                    disabled={saving}
-                                    aria-label={t("providers.loginControlFor", { name: provider.name })}
-                                    onCheckedChange={(checked) => void updateProviderControl(provider, "loginEnabled", checked)}
-                                  />
-                                </div>
-                              </TableCell>
-                              <TableCell className="py-1.5 text-center">
-                                <div className="flex h-7 items-center justify-center">
-                                  <Switch
-                                    size="sm"
-                                    checked={provider.loginEnabled && provider.registrationEnabled}
-                                    disabled={saving || !provider.loginEnabled}
-                                    aria-label={t("providers.registrationControlFor", { name: provider.name })}
-                                    onCheckedChange={(checked) => void updateProviderControl(provider, "registrationEnabled", checked)}
-                                  />
-                                </div>
-                              </TableCell>
-                              <TableCell className="max-w-52 py-1.5 font-mono text-xs">
-                                <span className="flex h-7 items-center truncate">{provider.clientID || "-"}</span>
-                              </TableCell>
-                              <TableCell className="w-[68px] py-1.5 whitespace-nowrap" stickyEnd onClick={(event) => event.stopPropagation()}>
-                                <div className="flex h-7 items-center justify-start gap-1 md:justify-end">
-                                  <Button type="button" size="icon-xs" variant="ghost" className="text-muted-foreground shadow-none" onClick={() => openEditProvider(provider)} disabled={saving} title={t("providers.edit")} aria-label={t("providers.edit")}>
-                                    <Pencil className="size-3.5 stroke-1" />
-                                  </Button>
-                                  <Button type="button" size="icon-xs" variant="ghost" className="text-muted-foreground shadow-none" onClick={() => setDeleteProviderTarget(provider)} disabled={saving} title={t("providers.delete")} aria-label={t("providers.delete")}>
-                                    <Trash2 className="size-3.5 stroke-1" />
-                                  </Button>
-                                </div>
-                              </TableCell>
+                      <AdminSortableList
+                        items={providers.map((provider) => provider.publicID)}
+                        disabled={saving || providers.length < 2}
+                        onMove={moveProviderTo}
+                      >
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead className="w-8" />
+                              <TableHead className="w-[220px]">{t("providers.name")}</TableHead>
+                              <TableHead>{t("providers.type")}</TableHead>
+                              <TableHead className="text-center">{t("providers.loginControl")}</TableHead>
+                              <TableHead className="text-center">{t("providers.registrationControl")}</TableHead>
+                              <TableHead>{t("providerDialog.clientID")}</TableHead>
+                              <TableHead className="w-[68px]" stickyEnd />
                             </TableRow>
-                          ))}
-                          {!loading && providers.length === 0 ? (
-                            <TableEmptyRow colSpan={7}>{t("providers.empty")}</TableEmptyRow>
-                          ) : null}
-                        </TableBody>
-                      </Table>
+                          </TableHeader>
+                          <TableBody>
+                            {loading && providers.length === 0 ? <TableLoadingRow colSpan={7} /> : null}
+                            {providers.map((provider) => (
+                              <AdminSortableItem
+                                key={provider.publicID}
+                                asChild
+                                id={provider.publicID}
+                                disabled={saving || providers.length < 2}
+                              >
+                                {({ attributes, isDragging, listeners }) => (
+                                  <TableRow className={isDragging ? "opacity-45" : undefined}>
+                                    <TableCell className="w-8 py-1.5 text-center text-muted-foreground">
+                                      <div className="flex h-7 items-center justify-center">
+                                        <AdminSortableHandle
+                                          attributes={attributes}
+                                          className="size-4 bg-transparent p-0 hover:bg-transparent hover:text-foreground"
+                                          disabled={saving}
+                                          hidden={providers.length < 2}
+                                          label={t("providers.dragToReorder", { name: provider.name })}
+                                          listeners={listeners}
+                                        />
+                                      </div>
+                                    </TableCell>
+                                    <TableCell className="w-[220px] max-w-[220px] py-1.5">
+                                      <div className="flex h-7 max-w-[220px] min-w-0 items-center gap-2">
+                                        <IdentityProviderIcon name={provider.name} slug={provider.slug} logoURL={provider.logoURL} />
+                                        <button
+                                          type="button"
+                                          className="inline-flex min-w-0 max-w-full items-baseline gap-1.5 text-left font-medium hover:underline"
+                                          title={`${provider.name} (${provider.slug})`}
+                                          onClick={() => openEditProvider(provider)}
+                                        >
+                                          <span className="min-w-0 truncate">{provider.name}</span>
+                                          <span className="shrink-0 text-xs font-normal text-muted-foreground">({provider.slug})</span>
+                                        </button>
+                                      </div>
+                                    </TableCell>
+                                    <TableCell className="py-1.5 uppercase">
+                                      <span className="flex h-7 items-center">{provider.type}</span>
+                                    </TableCell>
+                                    <TableCell className="py-1.5 text-center">
+                                      <div className="flex h-7 items-center justify-center">
+                                        <Switch
+                                          size="sm"
+                                          checked={provider.loginEnabled}
+                                          disabled={saving}
+                                          aria-label={t("providers.loginControlFor", { name: provider.name })}
+                                          onCheckedChange={(checked) => void updateProviderControl(provider, "loginEnabled", checked)}
+                                        />
+                                      </div>
+                                    </TableCell>
+                                    <TableCell className="py-1.5 text-center">
+                                      <div className="flex h-7 items-center justify-center">
+                                        <Switch
+                                          size="sm"
+                                          checked={provider.loginEnabled && provider.registrationEnabled}
+                                          disabled={saving || !provider.loginEnabled}
+                                          aria-label={t("providers.registrationControlFor", { name: provider.name })}
+                                          onCheckedChange={(checked) => void updateProviderControl(provider, "registrationEnabled", checked)}
+                                        />
+                                      </div>
+                                    </TableCell>
+                                    <TableCell className="max-w-52 py-1.5 font-mono text-xs">
+                                      <span className="flex h-7 items-center truncate">{provider.clientID || "-"}</span>
+                                    </TableCell>
+                                    <TableCell className="w-[68px] py-1.5 whitespace-nowrap" stickyEnd onClick={(event) => event.stopPropagation()}>
+                                      <div className="flex h-7 items-center justify-start gap-1 md:justify-end">
+                                        <Button type="button" size="icon-xs" variant="ghost" className="text-muted-foreground shadow-none" onClick={() => openEditProvider(provider)} disabled={saving} title={t("providers.edit")} aria-label={t("providers.edit")}>
+                                          <Pencil className="size-3.5 stroke-1" />
+                                        </Button>
+                                        <Button type="button" size="icon-xs" variant="ghost" className="text-muted-foreground shadow-none" onClick={() => setDeleteProviderTarget(provider)} disabled={saving} title={t("providers.delete")} aria-label={t("providers.delete")}>
+                                          <Trash2 className="size-3.5 stroke-1" />
+                                        </Button>
+                                      </div>
+                                    </TableCell>
+                                  </TableRow>
+                                )}
+                              </AdminSortableItem>
+                            ))}
+                            {!loading && providers.length === 0 ? (
+                              <TableEmptyRow colSpan={7}>{t("providers.empty")}</TableEmptyRow>
+                            ) : null}
+                          </TableBody>
+                        </Table>
+                      </AdminSortableList>
                     </Field>
                   ) : null}
                 </div>

--- a/frontend/features/admin/components/sections/models/models-order-sheet.tsx
+++ b/frontend/features/admin/components/sections/models/models-order-sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { GripVertical, ListOrdered } from "lucide-react";
+import { ListOrdered } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
@@ -29,6 +29,12 @@ import { LobeHubIcon } from "@/shared/components/lobehub-icon";
 import { resolveLobeHubIconURL, resolveModelIdentity, resolveVendorIdentity } from "@/shared/lib/model-identity";
 import { parseKindsJSON } from "@/shared/model/llm-schema";
 import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
+import {
+  AdminSortableHandle,
+  AdminSortableItem,
+  AdminSortableList,
+  moveSortableItem,
+} from "@/features/admin/components/sections/shared/admin-sortable-list";
 
 type ModelOrderSheetProps = {
   open: boolean;
@@ -66,65 +72,6 @@ function flattenGroups(groups: ModelOrderGroup[]): AdminLLMModelDTO[] {
   return groups.flatMap((group) => group.items);
 }
 
-function moveAt<T>(items: T[], index: number, targetIndex: number): T[] {
-  if (index < 0 || targetIndex < 0 || index >= items.length || targetIndex >= items.length) {
-    return items;
-  }
-  if (index === targetIndex) {
-    return items;
-  }
-  const next = [...items];
-  const [item] = next.splice(index, 1);
-  next.splice(targetIndex, 0, item);
-  return next;
-}
-
-function dragVendorKey(vendorKey: string): string {
-  return `vendor:${vendorKey}`;
-}
-
-function dragModelKey(vendorKey: string, modelID: number): string {
-  return `model:${vendorKey}:${modelID}`;
-}
-
-function parseDraggedModelID(value: string, vendorKey: string): number | null {
-  const prefix = `model:${vendorKey}:`;
-  if (!value.startsWith(prefix)) {
-    return null;
-  }
-  const id = Number(value.slice(prefix.length));
-  return Number.isFinite(id) ? id : null;
-}
-
-function DragHandle({
-  label,
-  disabled,
-  onDragStart,
-  onDragEnd,
-  onKeyDown,
-}: {
-  label: string;
-  disabled?: boolean;
-  onDragStart: (event: React.DragEvent<HTMLButtonElement>) => void;
-  onDragEnd: () => void;
-  onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
-}) {
-  return (
-    <button
-      type="button"
-      draggable={!disabled}
-      disabled={disabled}
-      aria-label={label}
-      className="flex size-5 shrink-0 cursor-grab items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-accent hover:text-accent-foreground active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-50"
-      onDragStart={onDragStart}
-      onDragEnd={onDragEnd}
-      onKeyDown={onKeyDown}
-    >
-      <GripVertical className="size-3 stroke-1" />
-    </button>
-  );
-}
-
 function KindBadges({ kindsJSON }: { kindsJSON: string }) {
   const t = useTranslations("adminModels");
   const kinds = parseKindsJSON(kindsJSON);
@@ -157,8 +104,6 @@ export function ModelOrderSheet({
   const [loading, setLoading] = React.useState(false);
   const [saving, setSaving] = React.useState(false);
   const [dirty, setDirty] = React.useState(false);
-  const [draggingKey, setDraggingKey] = React.useState<string | null>(null);
-  const [dragOverKey, setDragOverKey] = React.useState<string | null>(null);
   const initialOrderRef = React.useRef<string>("");
 
   const groups = React.useMemo(() => buildModelOrderGroups(models), [models]);
@@ -208,15 +153,6 @@ export function ModelOrderSheet({
     setDirty(nextModels.map((item) => item.id).join(",") !== initialOrderRef.current);
   }, []);
 
-  const moveVendor = React.useCallback(
-    (vendorKey: string, direction: "up" | "down") => {
-      const index = groups.findIndex((group) => group.vendorKey === vendorKey);
-      const targetIndex = direction === "up" ? index - 1 : index + 1;
-      commitGroups(moveAt(groups, index, targetIndex));
-    },
-    [commitGroups, groups],
-  );
-
   const moveVendorTo = React.useCallback(
     (vendorKey: string, targetVendorKey: string) => {
       if (vendorKey === targetVendorKey) {
@@ -224,33 +160,9 @@ export function ModelOrderSheet({
       }
       const index = groups.findIndex((group) => group.vendorKey === vendorKey);
       const targetIndex = groups.findIndex((group) => group.vendorKey === targetVendorKey);
-      commitGroups(moveAt(groups, index, targetIndex));
+      commitGroups(moveSortableItem(groups, index, targetIndex));
     },
     [commitGroups, groups],
-  );
-
-  const moveModel = React.useCallback(
-    (modelID: number, direction: "up" | "down") => {
-      if (!selectedGroup) {
-        return;
-      }
-      const groupIndex = groups.findIndex((group) => group.vendorKey === selectedGroup.vendorKey);
-      const itemIndex = selectedGroup.items.findIndex((item) => item.id === modelID);
-      const targetIndex = direction === "up" ? itemIndex - 1 : itemIndex + 1;
-      if (groupIndex < 0) {
-        return;
-      }
-      const nextGroups = groups.map((group, index) =>
-        index === groupIndex
-          ? {
-              ...group,
-              items: moveAt(group.items, itemIndex, targetIndex),
-            }
-          : group,
-      );
-      commitGroups(nextGroups);
-    },
-    [commitGroups, groups, selectedGroup],
   );
 
   const moveModelTo = React.useCallback(
@@ -268,7 +180,7 @@ export function ModelOrderSheet({
         index === groupIndex
           ? {
               ...group,
-              items: moveAt(group.items, itemIndex, targetIndex),
+              items: moveSortableItem(group.items, itemIndex, targetIndex),
             }
           : group,
       );
@@ -276,17 +188,6 @@ export function ModelOrderSheet({
     },
     [commitGroups, groups, selectedGroup],
   );
-
-  const clearDragState = React.useCallback(() => {
-    setDraggingKey(null);
-    setDragOverKey(null);
-  }, []);
-
-  const startDrag = React.useCallback((event: React.DragEvent<HTMLButtonElement>, key: string) => {
-    event.dataTransfer.effectAllowed = "move";
-    event.dataTransfer.setData("text/plain", key);
-    setDraggingKey(key);
-  }, []);
 
   const handleSave = React.useCallback(async () => {
     if (!dirty || saving || models.length === 0) {
@@ -348,67 +249,54 @@ export function ModelOrderSheet({
                   <span className="text-[11px] text-muted-foreground">{t("itemCount", { count: groups.length })}</span>
                 </div>
                 <div className="min-h-0 flex-1 overflow-y-auto p-1">
-                  <div className="space-y-0.5">
-                    {groups.map((group) => {
-                      const selected = group.vendorKey === selectedGroup?.vendorKey;
-                      const iconURL = resolveLobeHubIconURL(group.icon);
-                      const dragKey = dragVendorKey(group.vendorKey);
-                      return (
-                        <div
-                          key={group.vendorKey}
-                          className={cn(
-                            "group flex min-h-8 w-full items-center gap-0.5 rounded-md px-1 py-1 transition-[background-color,box-shadow,opacity]",
-                            selected
-                              ? "bg-accent text-accent-foreground"
-                              : "text-muted-foreground hover:bg-accent/70 hover:text-accent-foreground",
-                            draggingKey === dragKey && "opacity-45",
-                            dragOverKey === dragKey && draggingKey !== dragKey && "ring-1 ring-ring/40",
-                          )}
-                          onDragOver={(event) => {
-                            if (!draggingKey?.startsWith("vendor:")) {
-                              return;
-                            }
-                            event.preventDefault();
-                            event.dataTransfer.dropEffect = "move";
-                            setDragOverKey(dragKey);
-                          }}
-                          onDrop={(event) => {
-                            event.preventDefault();
-                            const raw = event.dataTransfer.getData("text/plain") || draggingKey || "";
-                            if (raw.startsWith("vendor:")) {
-                              moveVendorTo(raw.slice("vendor:".length), group.vendorKey);
-                            }
-                            clearDragState();
-                          }}
-                        >
-                          <DragHandle
-                            label={t("dragVendor", { name: group.label })}
-                            disabled={saving}
-                            onDragStart={(event) => startDrag(event, dragKey)}
-                            onDragEnd={clearDragState}
-                            onKeyDown={(event) => {
-                              if (event.key === "ArrowUp") {
-                                event.preventDefault();
-                                moveVendor(group.vendorKey, "up");
-                              } else if (event.key === "ArrowDown") {
-                                event.preventDefault();
-                                moveVendor(group.vendorKey, "down");
-                              }
-                            }}
-                          />
-                          <button
-                            type="button"
-                            className="flex min-w-0 flex-1 items-center gap-1.5 rounded-sm px-1 text-left"
-                            onClick={() => setSelectedVendorKey(group.vendorKey)}
+                  <AdminSortableList
+                    items={groups.map((group) => group.vendorKey)}
+                    disabled={saving || groups.length < 2}
+                    onMove={moveVendorTo}
+                  >
+                    <div className="space-y-0.5">
+                      {groups.map((group) => {
+                        const selected = group.vendorKey === selectedGroup?.vendorKey;
+                        const iconURL = resolveLobeHubIconURL(group.icon);
+                        return (
+                          <AdminSortableItem
+                            key={group.vendorKey}
+                            id={group.vendorKey}
+                            disabled={saving || groups.length < 2}
                           >
-                            {iconURL ? <LobeHubIcon iconUrl={iconURL} label={group.label} size={14} /> : null}
-                            <span className="min-w-0 flex-1 truncate text-xs font-medium">{group.label}</span>
-                            <span className="shrink-0 text-[11px] text-muted-foreground">{group.items.length}</span>
-                          </button>
-                        </div>
-                      );
-                    })}
-                  </div>
+                            {({ attributes, isDragging, listeners }) => (
+                              <div
+                                className={cn(
+                                  "group flex min-h-8 w-full items-center gap-0.5 rounded-md px-1 py-1 transition-[background-color,box-shadow,opacity]",
+                                  selected
+                                    ? "bg-accent text-accent-foreground"
+                                    : "text-muted-foreground hover:bg-accent/70 hover:text-accent-foreground",
+                                  isDragging && "opacity-45",
+                                )}
+                              >
+                                <AdminSortableHandle
+                                  attributes={attributes}
+                                  disabled={saving}
+                                  hidden={groups.length < 2}
+                                  label={t("dragVendor", { name: group.label })}
+                                  listeners={listeners}
+                                />
+                                <button
+                                  type="button"
+                                  className="flex min-w-0 flex-1 items-center gap-1.5 rounded-sm px-1 text-left"
+                                  onClick={() => setSelectedVendorKey(group.vendorKey)}
+                                >
+                                  {iconURL ? <LobeHubIcon iconUrl={iconURL} label={group.label} size={14} /> : null}
+                                  <span className="min-w-0 flex-1 truncate text-xs font-medium">{group.label}</span>
+                                  <span className="shrink-0 text-[11px] text-muted-foreground">{group.items.length}</span>
+                                </button>
+                              </div>
+                            )}
+                          </AdminSortableItem>
+                        );
+                      })}
+                    </div>
+                  </AdminSortableList>
                 </div>
               </section>
 
@@ -433,67 +321,53 @@ export function ModelOrderSheet({
 
                 <div className="min-h-0 flex-1 overflow-y-auto p-1">
                   {selectedGroup ? (
-                    <div className="space-y-0.5">
-                      {selectedGroup.items.map((model) => {
-                        const identity = resolveModelIdentity({
-                          code: model.platformModelName,
-                          vendor: model.vendor,
-                          icon: model.icon,
-                        });
-                        const iconURL = resolveLobeHubIconURL(identity.modelIcon);
-                        const dragKey = dragModelKey(selectedGroup.vendorKey, model.id);
-                        return (
-                          <div
-                            key={model.id}
-                            className={cn(
-                              "flex min-h-8 items-center gap-1.5 rounded-md px-1.5 py-1 text-left transition-[background-color,box-shadow,opacity] hover:bg-accent/55",
-                              draggingKey === dragKey && "opacity-45",
-                              dragOverKey === dragKey && draggingKey !== dragKey && "ring-1 ring-ring/40",
-                            )}
-                            onDragOver={(event) => {
-                              if (!draggingKey?.startsWith(`model:${selectedGroup.vendorKey}:`)) {
-                                return;
-                              }
-                              event.preventDefault();
-                              event.dataTransfer.dropEffect = "move";
-                              setDragOverKey(dragKey);
-                            }}
-                            onDrop={(event) => {
-                              event.preventDefault();
-                              const raw = event.dataTransfer.getData("text/plain") || draggingKey || "";
-                              const modelID = parseDraggedModelID(raw, selectedGroup.vendorKey);
-                              if (modelID !== null) {
-                                moveModelTo(modelID, model.id);
-                              }
-                              clearDragState();
-                            }}
-                          >
-                            <DragHandle
-                              label={t("dragModel", { name: model.platformModelName })}
-                              disabled={saving}
-                              onDragStart={(event) => startDrag(event, dragKey)}
-                              onDragEnd={clearDragState}
-                              onKeyDown={(event) => {
-                                if (event.key === "ArrowUp") {
-                                  event.preventDefault();
-                                  moveModel(model.id, "up");
-                                } else if (event.key === "ArrowDown") {
-                                  event.preventDefault();
-                                  moveModel(model.id, "down");
-                                }
-                              }}
-                            />
-                            <LobeHubIcon iconUrl={iconURL} label={model.platformModelName} size={14} />
-                            <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
-                              {model.platformModelName}
-                            </span>
-                            <div className="ml-auto flex max-w-[45%] shrink-0 items-center justify-end overflow-hidden">
-                              <KindBadges kindsJSON={model.kindsJSON} />
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
+                    <AdminSortableList
+                      items={selectedGroup.items.map((model) => String(model.id))}
+                      disabled={saving || selectedGroup.items.length < 2}
+                      onMove={(modelID, targetModelID) => moveModelTo(Number(modelID), Number(targetModelID))}
+                    >
+                      <div className="space-y-0.5">
+                        {selectedGroup.items.map((model) => {
+                          const identity = resolveModelIdentity({
+                            code: model.platformModelName,
+                            vendor: model.vendor,
+                            icon: model.icon,
+                          });
+                          const iconURL = resolveLobeHubIconURL(identity.modelIcon);
+                          return (
+                            <AdminSortableItem
+                              key={model.id}
+                              id={String(model.id)}
+                              disabled={saving || selectedGroup.items.length < 2}
+                            >
+                              {({ attributes, isDragging, listeners }) => (
+                                <div
+                                  className={cn(
+                                    "flex min-h-8 items-center gap-1.5 rounded-md px-1.5 py-1 text-left transition-[background-color,box-shadow,opacity] hover:bg-accent/55",
+                                    isDragging && "opacity-45",
+                                  )}
+                                >
+                                  <AdminSortableHandle
+                                    attributes={attributes}
+                                    disabled={saving}
+                                    hidden={selectedGroup.items.length < 2}
+                                    label={t("dragModel", { name: model.platformModelName })}
+                                    listeners={listeners}
+                                  />
+                                  <LobeHubIcon iconUrl={iconURL} label={model.platformModelName} size={14} />
+                                  <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+                                    {model.platformModelName}
+                                  </span>
+                                  <div className="ml-auto flex max-w-[45%] shrink-0 items-center justify-end overflow-hidden">
+                                    <KindBadges kindsJSON={model.kindsJSON} />
+                                  </div>
+                                </div>
+                              )}
+                            </AdminSortableItem>
+                          );
+                        })}
+                      </div>
+                    </AdminSortableList>
                   ) : null}
                 </div>
               </section>

--- a/frontend/features/admin/components/sections/shared/admin-sortable-list.tsx
+++ b/frontend/features/admin/components/sections/shared/admin-sortable-list.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import * as React from "react";
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  type DragEndEvent,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Slot } from "radix-ui";
+
+import { GripVerticalIcon, type GripVerticalIconHandle } from "@/components/ui/grip-vertical";
+import { cn } from "@/lib/utils";
+
+export function moveSortableItem<T>(items: T[], index: number, targetIndex: number): T[] {
+  if (index < 0 || targetIndex < 0 || index >= items.length || targetIndex >= items.length || index === targetIndex) {
+    return items;
+  }
+  const next = [...items];
+  const [item] = next.splice(index, 1);
+  next.splice(targetIndex, 0, item);
+  return next;
+}
+
+export type AdminSortableRenderProps = {
+  attributes: ReturnType<typeof useSortable>["attributes"];
+  listeners: ReturnType<typeof useSortable>["listeners"];
+  isDragging: boolean;
+};
+
+export function AdminSortableList({
+  children,
+  disabled = false,
+  items,
+  onMove,
+}: {
+  children: React.ReactNode;
+  disabled?: boolean;
+  items: string[];
+  onMove: (activeID: string, overID: string) => void;
+}) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 4,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = React.useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (disabled || !over || active.id === over.id) {
+      return;
+    }
+    onMove(String(active.id), String(over.id));
+  }, [disabled, onMove]);
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={items} strategy={verticalListSortingStrategy}>
+        {children}
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+export function AdminSortableItem({
+  asChild = false,
+  children,
+  className,
+  disabled = false,
+  id,
+}: {
+  asChild?: boolean;
+  children: (props: AdminSortableRenderProps) => React.ReactNode;
+  className?: string;
+  disabled?: boolean;
+  id: string;
+}) {
+  const {
+    attributes,
+    isDragging,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({
+    id,
+    disabled,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  } satisfies React.CSSProperties;
+  const Comp = asChild ? Slot.Root : "div";
+
+  return (
+    <Comp ref={setNodeRef} style={style} className={className}>
+      {children({ attributes, isDragging, listeners })}
+    </Comp>
+  );
+}
+
+export function AdminSortableHandle({
+  attributes,
+  className,
+  disabled = false,
+  hidden = false,
+  label,
+  listeners,
+}: {
+  attributes: AdminSortableRenderProps["attributes"];
+  className?: string;
+  disabled?: boolean;
+  hidden?: boolean;
+  label: string;
+  listeners: AdminSortableRenderProps["listeners"];
+}) {
+  const iconRef = React.useRef<GripVerticalIconHandle>(null);
+
+  if (hidden) {
+    return null;
+  }
+
+  return (
+    <button
+      {...attributes}
+      {...listeners}
+      type="button"
+      disabled={disabled}
+      aria-label={label}
+      title={label}
+      className={cn(
+        "flex size-5 shrink-0 cursor-grab items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-accent hover:text-accent-foreground active:cursor-grabbing disabled:cursor-not-allowed disabled:text-muted-foreground/40",
+        className,
+      )}
+      onMouseEnter={() => iconRef.current?.startAnimation()}
+      onMouseLeave={() => iconRef.current?.stopAnimation()}
+    >
+      <GripVerticalIcon ref={iconRef} size={12} className="size-3.5" />
+    </button>
+  );
+}

--- a/frontend/features/admin/components/sections/tools/mcp-order-sheet.tsx
+++ b/frontend/features/admin/components/sections/tools/mcp-order-sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { GripVertical, ListOrdered } from "lucide-react";
+import { ListOrdered } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
@@ -16,6 +16,12 @@ import {
 } from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
+import {
+  AdminSortableHandle,
+  AdminSortableItem,
+  AdminSortableList,
+  moveSortableItem,
+} from "@/features/admin/components/sections/shared/admin-sortable-list";
 import {
   listAdminMCPServerTools,
   reorderAdminMCPServers,
@@ -57,62 +63,6 @@ function flattenGroups(groups: MCPOrderGroup[]): string {
   return groups.map((group) => `${group.server.id}:${group.tools.map((tool) => tool.id).join(".")}`).join(",");
 }
 
-function moveAt<T>(items: T[], index: number, targetIndex: number): T[] {
-  if (index < 0 || targetIndex < 0 || index >= items.length || targetIndex >= items.length || index === targetIndex) {
-    return items;
-  }
-  const next = [...items];
-  const [item] = next.splice(index, 1);
-  next.splice(targetIndex, 0, item);
-  return next;
-}
-
-function dragServerKey(serverID: number): string {
-  return `server:${serverID}`;
-}
-
-function dragToolKey(serverID: number, toolID: number): string {
-  return `tool:${serverID}:${toolID}`;
-}
-
-function parseDraggedToolID(value: string, serverID: number): number | null {
-  const prefix = `tool:${serverID}:`;
-  if (!value.startsWith(prefix)) {
-    return null;
-  }
-  const id = Number(value.slice(prefix.length));
-  return Number.isFinite(id) ? id : null;
-}
-
-function DragHandle({
-  label,
-  disabled,
-  onDragStart,
-  onDragEnd,
-  onKeyDown,
-}: {
-  label: string;
-  disabled?: boolean;
-  onDragStart: (event: React.DragEvent<HTMLButtonElement>) => void;
-  onDragEnd: () => void;
-  onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
-}) {
-  return (
-    <button
-      type="button"
-      draggable={!disabled}
-      disabled={disabled}
-      aria-label={label}
-      className="flex size-5 shrink-0 cursor-grab items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-accent hover:text-accent-foreground active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-50"
-      onDragStart={onDragStart}
-      onDragEnd={onDragEnd}
-      onKeyDown={onKeyDown}
-    >
-      <GripVertical className="size-3 stroke-1" />
-    </button>
-  );
-}
-
 export function MCPOrderSheet({
   open,
   servers,
@@ -127,8 +77,6 @@ export function MCPOrderSheet({
   const [loading, setLoading] = React.useState(false);
   const [saving, setSaving] = React.useState(false);
   const [dirty, setDirty] = React.useState(false);
-  const [draggingKey, setDraggingKey] = React.useState<string | null>(null);
-  const [dragOverKey, setDragOverKey] = React.useState<string | null>(null);
   const initialOrderRef = React.useRef("");
 
   const selectedGroup = groups.find((group) => group.server.id === selectedServerID) ?? groups[0] ?? null;
@@ -174,48 +122,14 @@ export function MCPOrderSheet({
     setDirty(flattenGroups(nextGroups) !== initialOrderRef.current);
   }, []);
 
-  const clearDragState = React.useCallback(() => {
-    setDraggingKey(null);
-    setDragOverKey(null);
-  }, []);
-
-  const startDrag = React.useCallback((event: React.DragEvent<HTMLButtonElement>, key: string) => {
-    event.dataTransfer.effectAllowed = "move";
-    event.dataTransfer.setData("text/plain", key);
-    setDraggingKey(key);
-  }, []);
-
-  const moveServer = React.useCallback((serverID: number, direction: "up" | "down") => {
-    const index = groups.findIndex((group) => group.server.id === serverID);
-    const targetIndex = direction === "up" ? index - 1 : index + 1;
-    commitGroups(moveAt(groups, index, targetIndex));
-  }, [commitGroups, groups]);
-
   const moveServerTo = React.useCallback((serverID: number, targetServerID: number) => {
     if (serverID === targetServerID) {
       return;
     }
     const index = groups.findIndex((group) => group.server.id === serverID);
     const targetIndex = groups.findIndex((group) => group.server.id === targetServerID);
-    commitGroups(moveAt(groups, index, targetIndex));
+    commitGroups(moveSortableItem(groups, index, targetIndex));
   }, [commitGroups, groups]);
-
-  const moveTool = React.useCallback((toolID: number, direction: "up" | "down") => {
-    if (!selectedGroup) {
-      return;
-    }
-    const groupIndex = groups.findIndex((group) => group.server.id === selectedGroup.server.id);
-    const toolIndex = selectedGroup.tools.findIndex((tool) => tool.id === toolID);
-    const targetIndex = direction === "up" ? toolIndex - 1 : toolIndex + 1;
-    if (groupIndex < 0) {
-      return;
-    }
-    commitGroups(groups.map((group, index) =>
-      index === groupIndex
-        ? { ...group, tools: moveAt(group.tools, toolIndex, targetIndex) }
-        : group,
-    ));
-  }, [commitGroups, groups, selectedGroup]);
 
   const moveToolTo = React.useCallback((toolID: number, targetToolID: number) => {
     if (!selectedGroup || toolID === targetToolID) {
@@ -229,7 +143,7 @@ export function MCPOrderSheet({
     }
     commitGroups(groups.map((group, index) =>
       index === groupIndex
-        ? { ...group, tools: moveAt(group.tools, toolIndex, targetIndex) }
+        ? { ...group, tools: moveSortableItem(group.tools, toolIndex, targetIndex) }
         : group,
     ));
   }, [commitGroups, groups, selectedGroup]);
@@ -301,65 +215,52 @@ export function MCPOrderSheet({
                   <span className="text-[11px] text-muted-foreground">{t("itemCount", { count: groups.length })}</span>
                 </div>
                 <div className="min-h-0 flex-1 overflow-y-auto p-1">
-                  <div className="space-y-0.5">
-                    {groups.map((group) => {
-                      const selected = group.server.id === selectedGroup?.server.id;
-                      const dragKey = dragServerKey(group.server.id);
-                      return (
-                        <div
-                          key={group.server.id}
-                          className={cn(
-                            "group flex min-h-8 w-full items-center gap-0.5 rounded-md px-1 py-1 transition-[background-color,box-shadow,opacity]",
-                            selected
-                              ? "bg-accent text-accent-foreground"
-                              : "text-muted-foreground hover:bg-accent/70 hover:text-accent-foreground",
-                            draggingKey === dragKey && "opacity-45",
-                            dragOverKey === dragKey && draggingKey !== dragKey && "ring-1 ring-ring/40",
-                          )}
-                          onDragOver={(event) => {
-                            if (!draggingKey?.startsWith("server:")) {
-                              return;
-                            }
-                            event.preventDefault();
-                            event.dataTransfer.dropEffect = "move";
-                            setDragOverKey(dragKey);
-                          }}
-                          onDrop={(event) => {
-                            event.preventDefault();
-                            const raw = event.dataTransfer.getData("text/plain") || draggingKey || "";
-                            if (raw.startsWith("server:")) {
-                              moveServerTo(Number(raw.slice("server:".length)), group.server.id);
-                            }
-                            clearDragState();
-                          }}
-                        >
-                          <DragHandle
-                            label={t("dragServer", { name: serverLabel(group.server) })}
-                            disabled={saving}
-                            onDragStart={(event) => startDrag(event, dragKey)}
-                            onDragEnd={clearDragState}
-                            onKeyDown={(event) => {
-                              if (event.key === "ArrowUp") {
-                                event.preventDefault();
-                                moveServer(group.server.id, "up");
-                              } else if (event.key === "ArrowDown") {
-                                event.preventDefault();
-                                moveServer(group.server.id, "down");
-                              }
-                            }}
-                          />
-                          <button
-                            type="button"
-                            className="flex min-w-0 flex-1 items-center gap-1.5 rounded-sm px-1 text-left"
-                            onClick={() => setSelectedServerID(group.server.id)}
+                  <AdminSortableList
+                    items={groups.map((group) => String(group.server.id))}
+                    disabled={saving || groups.length < 2}
+                    onMove={(serverID, targetServerID) => moveServerTo(Number(serverID), Number(targetServerID))}
+                  >
+                    <div className="space-y-0.5">
+                      {groups.map((group) => {
+                        const selected = group.server.id === selectedGroup?.server.id;
+                        return (
+                          <AdminSortableItem
+                            key={group.server.id}
+                            id={String(group.server.id)}
+                            disabled={saving || groups.length < 2}
                           >
-                            <span className="min-w-0 flex-1 truncate text-xs font-medium">{serverLabel(group.server)}</span>
-                            <span className="shrink-0 text-[11px] text-muted-foreground">{group.tools.length}</span>
-                          </button>
-                        </div>
-                      );
-                    })}
-                  </div>
+                            {({ attributes, isDragging, listeners }) => (
+                              <div
+                                className={cn(
+                                  "group flex min-h-8 w-full items-center gap-0.5 rounded-md px-1 py-1 transition-[background-color,box-shadow,opacity]",
+                                  selected
+                                    ? "bg-accent text-accent-foreground"
+                                    : "text-muted-foreground hover:bg-accent/70 hover:text-accent-foreground",
+                                  isDragging && "opacity-45",
+                                )}
+                              >
+                                <AdminSortableHandle
+                                  attributes={attributes}
+                                  disabled={saving}
+                                  hidden={groups.length < 2}
+                                  label={t("dragServer", { name: serverLabel(group.server) })}
+                                  listeners={listeners}
+                                />
+                                <button
+                                  type="button"
+                                  className="flex min-w-0 flex-1 items-center gap-1.5 rounded-sm px-1 text-left"
+                                  onClick={() => setSelectedServerID(group.server.id)}
+                                >
+                                  <span className="min-w-0 flex-1 truncate text-xs font-medium">{serverLabel(group.server)}</span>
+                                  <span className="shrink-0 text-[11px] text-muted-foreground">{group.tools.length}</span>
+                                </button>
+                              </div>
+                            )}
+                          </AdminSortableItem>
+                        );
+                      })}
+                    </div>
+                  </AdminSortableList>
                 </div>
               </section>
 
@@ -385,65 +286,49 @@ export function MCPOrderSheet({
                 <div className="min-h-0 flex-1 overflow-y-auto p-1">
                   {selectedGroup ? (
                     selectedGroup.tools.length > 0 ? (
-                      <div className="space-y-0.5">
-                        {selectedGroup.tools.map((tool) => {
-                          const dragKey = dragToolKey(selectedGroup.server.id, tool.id);
-                          return (
-                            <div
+                      <AdminSortableList
+                        items={selectedGroup.tools.map((tool) => String(tool.id))}
+                        disabled={saving || selectedGroup.tools.length < 2}
+                        onMove={(toolID, targetToolID) => moveToolTo(Number(toolID), Number(targetToolID))}
+                      >
+                        <div className="space-y-0.5">
+                          {selectedGroup.tools.map((tool) => (
+                            <AdminSortableItem
                               key={tool.id}
-                              className={cn(
-                                "flex min-h-8 items-center gap-1.5 rounded-md px-1.5 py-1 text-left transition-[background-color,box-shadow,opacity] hover:bg-accent/55",
-                                draggingKey === dragKey && "opacity-45",
-                                dragOverKey === dragKey && draggingKey !== dragKey && "ring-1 ring-ring/40",
-                              )}
-                              onDragOver={(event) => {
-                                if (!draggingKey?.startsWith(`tool:${selectedGroup.server.id}:`)) {
-                                  return;
-                                }
-                                event.preventDefault();
-                                event.dataTransfer.dropEffect = "move";
-                                setDragOverKey(dragKey);
-                              }}
-                              onDrop={(event) => {
-                                event.preventDefault();
-                                const raw = event.dataTransfer.getData("text/plain") || draggingKey || "";
-                                const toolID = parseDraggedToolID(raw, selectedGroup.server.id);
-                                if (toolID !== null) {
-                                  moveToolTo(toolID, tool.id);
-                                }
-                                clearDragState();
-                              }}
+                              id={String(tool.id)}
+                              disabled={saving || selectedGroup.tools.length < 2}
                             >
-                              <DragHandle
-                                label={t("dragTool", { name: toolLabel(tool) })}
-                                disabled={saving}
-                                onDragStart={(event) => startDrag(event, dragKey)}
-                                onDragEnd={clearDragState}
-                                onKeyDown={(event) => {
-                                  if (event.key === "ArrowUp") {
-                                    event.preventDefault();
-                                    moveTool(tool.id, "up");
-                                  } else if (event.key === "ArrowDown") {
-                                    event.preventDefault();
-                                    moveTool(tool.id, "down");
-                                  }
-                                }}
-                              />
-                              <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
-                                {toolLabel(tool)}
-                              </span>
-                              <span className={cn(
-                                "shrink-0 rounded-md px-1.5 py-0.5 text-[10px]",
-                                tool.status === "active"
-                                  ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
-                                  : "bg-muted text-muted-foreground",
-                              )}>
-                                {tool.status === "active" ? t("statusActive") : t("statusInactive")}
-                              </span>
-                            </div>
-                          );
-                        })}
-                      </div>
+                              {({ attributes, isDragging, listeners }) => (
+                                <div
+                                  className={cn(
+                                    "flex min-h-8 items-center gap-1.5 rounded-md px-1.5 py-1 text-left transition-[background-color,box-shadow,opacity] hover:bg-accent/55",
+                                    isDragging && "opacity-45",
+                                  )}
+                                >
+                                  <AdminSortableHandle
+                                    attributes={attributes}
+                                    disabled={saving}
+                                    hidden={selectedGroup.tools.length < 2}
+                                    label={t("dragTool", { name: toolLabel(tool) })}
+                                    listeners={listeners}
+                                  />
+                                  <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+                                    {toolLabel(tool)}
+                                  </span>
+                                  <span className={cn(
+                                    "shrink-0 rounded-md px-1.5 py-0.5 text-[10px]",
+                                    tool.status === "active"
+                                      ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                                      : "bg-muted text-muted-foreground",
+                                  )}>
+                                    {tool.status === "active" ? t("statusActive") : t("statusInactive")}
+                                  </span>
+                                </div>
+                              )}
+                            </AdminSortableItem>
+                          ))}
+                        </div>
+                      </AdminSortableList>
                     ) : (
                       <div className="flex h-full min-h-[12rem] items-center justify-center text-xs text-muted-foreground">
                         {t("emptyTools")}

--- a/frontend/features/admin/model/login-settings.ts
+++ b/frontend/features/admin/model/login-settings.ts
@@ -489,13 +489,3 @@ export function normalizeProviderSlugPreview(value: string): string {
     .replace(/[^a-z0-9_-]+/g, "-")
     .replace(/^[-_]+|[-_]+$/g, "");
 }
-
-export function reorderProviders(items: IdentityProviderDTO[], draggedID: string, targetID: string) {
-  const fromIndex = items.findIndex((item) => item.publicID === draggedID);
-  const toIndex = items.findIndex((item) => item.publicID === targetID);
-  if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex) return items;
-  const next = [...items];
-  const [moved] = next.splice(fromIndex, 1);
-  next.splice(toIndex, 0, moved);
-  return next;
-}


### PR DESCRIPTION
## Summary

Unified frontend drag-and-drop sorting behavior across project and admin sorting surfaces.

- Added a shared admin sortable list/handle abstraction based on `@dnd-kit`.
- Refactored admin model ordering, MCP server/tool ordering, and login provider ordering to use the shared sortable implementation.
- Updated project sidebar sorting details so unsupported sorting does not render or reserve drag-handle space, while temporary saving states keep layout stable.
- Reused the shared `GripVerticalIcon` for drag handles and removed page-local drag animation / HTML5 drag-and-drop code.

## Change type

- [x] Refactor
- [x] Feature

## Affected areas

- [x] Frontend / UI
- [x] Authentication / authorization
- [x] MCP / tools
- [x] Model routing / providers
- [x] Admin console

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm build`

## Screenshots, API examples, or logs

N/A

## Configuration, migration, and compatibility notes

No backend API, database schema, deployment, or configuration changes.

Existing persistence behavior is unchanged:
- Project ordering is still saved through the existing conversation project reorder API.
- Admin model and MCP ordering still use their existing save actions.
- Login provider ordering still saves after reorder.

## Documentation

- [x] Documentation is not needed for this change.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, MCP/tool ordering, and admin APIs where relevant.

## Checklist

- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior and compatibility notes are documented above.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.