### PR TITLE
feat: add support for video generation and enhance Gemini interactions

### DIFF
--- a/backend/internal/application/channel/model_catalog.go
+++ b/backend/internal/application/channel/model_catalog.go
@@ -14,6 +14,8 @@ const (
 	TaskTypeImageGeneration = "image_generation"
 	// TaskTypeImageEdit 表示图片编辑任务。
 	TaskTypeImageEdit = "image_edit"
+	// TaskTypeVideoGeneration 表示视频生成任务。
+	TaskTypeVideoGeneration = "video_generation"
 
 	modelKindChat      = "chat"
 	modelKindAudio     = "audio"
@@ -32,6 +34,7 @@ const (
 	protocolOpenAIImageEdits       = llm.AdapterOpenAIImageEdits
 	protocolOpenAIVideoGenerations = "openai_video_generations"
 	protocolGoogleImageGeneration  = llm.AdapterGoogleImageGeneration
+	protocolGeminiInteractions     = llm.AdapterGeminiInteractions
 	protocolXAIImage               = llm.AdapterXAIImage
 	protocolXAIImageEdits          = llm.AdapterXAIImageEdits
 )
@@ -126,6 +129,7 @@ func systemFallbackProtocols(compatible string) map[string]string {
 			modelKindAudio:     llm.AdapterGoogleGenerateContent,
 			modelKindImageGen:  protocolGoogleImageGeneration,
 			modelKindImageEdit: protocolGoogleImageGeneration,
+			modelKindVideoGen:  protocolGeminiInteractions,
 		}
 	case compatibleXAI:
 		return map[string]string{
@@ -167,6 +171,7 @@ func isKnownProtocol(raw string) bool {
 		protocolOpenAIImageEdits,
 		protocolOpenAIVideoGenerations,
 		protocolGoogleImageGeneration,
+		protocolGeminiInteractions,
 		protocolXAIImage,
 		protocolXAIImageEdits:
 		return true
@@ -189,6 +194,9 @@ func resolveRouteProtocol(explicit string, upCompatible string, defaultsJSON str
 
 	if kind == "" {
 		return "", ErrProtocolRequired
+	}
+	if protocol := unifiedProtocolForMultiKindRoute(upCompatible, defaultsJSON, kindsJSON); protocol != "" {
+		return protocol, nil
 	}
 	if protocol := protocolDefaultForKind(defaultsJSON, kind); protocol != "" {
 		return protocol, nil
@@ -226,6 +234,9 @@ func resolveRouteProtocols(explicit []string, upCompatible string, defaultsJSON 
 	}
 
 	kinds := parseKinds(kindsJSON)
+	if protocol := unifiedProtocolForMultiKindRoute(upCompatible, defaultsJSON, kindsJSON); protocol != "" {
+		return []string{protocol}, nil
+	}
 	if hasModelKind(kinds, modelKindImageGen) && hasModelKind(kinds, modelKindImageEdit) {
 		generationProtocol := defaultRouteProtocolForKind(upCompatible, defaultsJSON, modelKindImageGen)
 		editProtocol := defaultRouteProtocolForKind(upCompatible, defaultsJSON, modelKindImageEdit)
@@ -242,6 +253,27 @@ func resolveRouteProtocols(explicit []string, upCompatible string, defaultsJSON 
 		return nil, err
 	}
 	return []string{protocol}, nil
+}
+
+func unifiedProtocolForMultiKindRoute(upCompatible string, defaultsJSON string, kindsJSON string) string {
+	kinds := parseKinds(kindsJSON)
+	if len(kinds) <= 1 || !hasModelKind(kinds, modelKindVideoGen) {
+		return ""
+	}
+	protocol := defaultRouteProtocolForKind(upCompatible, defaultsJSON, modelKindVideoGen)
+	if protocol == "" || !routeProtocolSupportsAllKinds(protocol, kinds) {
+		return ""
+	}
+	return protocol
+}
+
+func routeProtocolSupportsAllKinds(protocol string, kinds []string) bool {
+	for _, kind := range kinds {
+		if !isProtocolAllowedForKind(kind, protocol) {
+			return false
+		}
+	}
+	return len(kinds) > 0
 }
 
 // uniqueRouteProtocols 保留协议声明顺序，同时避免 Google 图片这类同协议双能力模型创建重复绑定。
@@ -330,7 +362,21 @@ func protocolDefaultForKind(defaultsJSON string, kind string) string {
 
 func isProtocolAllowedForKind(kind string, protocol string) bool {
 	switch kind {
-	case modelKindChat, modelKindAudio:
+	case modelKindChat:
+		switch protocol {
+		case llm.AdapterOpenAIResponses,
+			llm.AdapterOpenRouterChat,
+			llm.AdapterOpenRouterResponses,
+			llm.AdapterOpenAIChatCompletions,
+			llm.AdapterAnthropicMessages,
+			llm.AdapterGoogleGenerateContent,
+			protocolGeminiInteractions,
+			llm.AdapterXAIResponses:
+			return true
+		default:
+			return false
+		}
+	case modelKindAudio:
 		switch protocol {
 		case llm.AdapterOpenAIResponses,
 			llm.AdapterOpenRouterChat,
@@ -347,6 +393,7 @@ func isProtocolAllowedForKind(kind string, protocol string) bool {
 		switch protocol {
 		case protocolOpenAIImageGenerations,
 			protocolGoogleImageGeneration,
+			protocolGeminiInteractions,
 			protocolXAIImage:
 			return true
 		default:
@@ -356,6 +403,7 @@ func isProtocolAllowedForKind(kind string, protocol string) bool {
 		switch protocol {
 		case protocolOpenAIImageEdits,
 			protocolGoogleImageGeneration,
+			protocolGeminiInteractions,
 			protocolXAIImageEdits:
 			return true
 		default:
@@ -363,7 +411,8 @@ func isProtocolAllowedForKind(kind string, protocol string) bool {
 		}
 	case modelKindVideoGen:
 		switch protocol {
-		case protocolOpenAIVideoGenerations:
+		case protocolOpenAIVideoGenerations,
+			protocolGeminiInteractions:
 			return true
 		default:
 			return false
@@ -381,6 +430,8 @@ func NormalizeTaskType(raw string) string {
 		return TaskTypeImageGeneration
 	case TaskTypeImageEdit:
 		return TaskTypeImageEdit
+	case TaskTypeVideoGeneration:
+		return TaskTypeVideoGeneration
 	default:
 		return TaskTypeChat
 	}
@@ -397,6 +448,8 @@ func IsRouteAllowedForTask(taskType string, kindsJSON string, protocol string) b
 			return isProtocolAllowedForKind(modelKindImageGen, protocol)
 		case TaskTypeImageEdit:
 			return isProtocolAllowedForKind(modelKindImageEdit, protocol)
+		case TaskTypeVideoGeneration:
+			return isProtocolAllowedForKind(modelKindVideoGen, protocol)
 		default:
 			return isProtocolAllowedForKind(modelKindChat, protocol) || isProtocolAllowedForKind(modelKindAudio, protocol)
 		}
@@ -406,6 +459,8 @@ func IsRouteAllowedForTask(taskType string, kindsJSON string, protocol string) b
 		return hasModelKind(kinds, modelKindImageGen) && isProtocolAllowedForKind(modelKindImageGen, protocol)
 	case TaskTypeImageEdit:
 		return hasModelKind(kinds, modelKindImageEdit) && isProtocolAllowedForKind(modelKindImageEdit, protocol)
+	case TaskTypeVideoGeneration:
+		return hasModelKind(kinds, modelKindVideoGen) && isProtocolAllowedForKind(modelKindVideoGen, protocol)
 	default:
 		for _, kind := range kinds {
 			if (kind == modelKindChat || kind == modelKindAudio) && isProtocolAllowedForKind(kind, protocol) {
@@ -441,12 +496,15 @@ func primaryKindFromKinds(kindsJSON string) string {
 func inferKindsJSON(platformModelName string) string {
 	code := strings.ToLower(strings.TrimSpace(platformModelName))
 	switch {
+	case isGeminiOmniInteractionsModel(code):
+		return `["chat","image_gen","image_edit","video_gen"]`
 	case strings.HasPrefix(code, "gpt-image-"), code == "chatgpt-image-latest", code == "dall-e-2",
 		isGeminiImageGenerationModel(code), isXAIImageGenerationModel(code):
 		return `["image_gen","image_edit"]`
 	case code == "dall-e-3", strings.HasPrefix(code, "imagen-"):
 		return `["image_gen"]`
-	case code == "sora", code == "veo-2", strings.HasPrefix(code, "kling"):
+	case code == "sora", code == "veo-2", strings.HasPrefix(code, "kling"),
+		strings.HasPrefix(code, "veo-"):
 		return `["video_gen"]`
 	case strings.HasPrefix(code, "gpt-4o-audio"):
 		return `["audio"]`
@@ -458,6 +516,10 @@ func inferKindsJSON(platformModelName string) string {
 	default:
 		return `["chat"]`
 	}
+}
+
+func isGeminiOmniInteractionsModel(code string) bool {
+	return strings.HasPrefix(strings.TrimSpace(strings.ToLower(code)), "gemini-omni-flash")
 }
 
 func isGeminiImageGenerationModel(code string) bool {

--- a/backend/internal/application/channel/model_catalog_test.go
+++ b/backend/internal/application/channel/model_catalog_test.go
@@ -101,6 +101,25 @@ func TestProtocolDefaultsForGoogleUsesGoogleImageGeneration(t *testing.T) {
 	if defaults[modelKindImageEdit] != "google_image_generation" {
 		t.Fatalf("expected Google image edit default, got %q in %s", defaults[modelKindImageEdit], raw)
 	}
+	if defaults[modelKindVideoGen] != "gemini_interactions" {
+		t.Fatalf("expected Google video generation default, got %q in %s", defaults[modelKindVideoGen], raw)
+	}
+}
+
+func TestNormalizeProtocolDefaultsJSONAcceptsGeminiInteractionsForVideo(t *testing.T) {
+	normalized, err := normalizeProtocolDefaultsJSON(`{"chat":"gemini_interactions","image_gen":"gemini_interactions","image_edit":"gemini_interactions","video_gen":"gemini_interactions"}`)
+	if err != nil {
+		t.Fatalf("normalize Gemini Interactions defaults: %v", err)
+	}
+	var defaults map[string]string
+	if err := json.Unmarshal([]byte(normalized), &defaults); err != nil {
+		t.Fatalf("unmarshal normalized defaults: %v", err)
+	}
+	for _, kind := range []string{modelKindChat, modelKindImageGen, modelKindImageEdit, modelKindVideoGen} {
+		if defaults[kind] != "gemini_interactions" {
+			t.Fatalf("expected Gemini Interactions %s default, got %s", kind, normalized)
+		}
+	}
 }
 
 func TestNormalizeCompatibleOnlyAllowsSupportedUpstreamProviders(t *testing.T) {
@@ -323,6 +342,22 @@ func TestInferKindsJSONRecognizesGeminiImageModels(t *testing.T) {
 	}
 }
 
+func TestInferKindsJSONRecognizesGeminiOmniInteractionsModel(t *testing.T) {
+	for _, modelName := range []string{"gemini-omni-flash-preview"} {
+		if got := inferKindsJSON(modelName); got != `["chat","image_gen","image_edit","video_gen"]` {
+			t.Fatalf("expected %s to infer Interactions universal kinds, got %s", modelName, got)
+		}
+	}
+}
+
+func TestInferKindsJSONRecognizesVideoOnlyModels(t *testing.T) {
+	for _, modelName := range []string{"veo-3.1-fast"} {
+		if got := inferKindsJSON(modelName); got != `["video_gen"]` {
+			t.Fatalf("expected %s to infer video generation kind, got %s", modelName, got)
+		}
+	}
+}
+
 func TestInferKindsJSONRecognizesXAIImageModels(t *testing.T) {
 	for _, modelName := range []string{
 		"grok-imagine-image",
@@ -361,6 +396,10 @@ func TestNormalizeProtocolDefaultsJSONRejectsProtocolKindMismatch(t *testing.T) 
 	_, err := normalizeProtocolDefaultsJSON(`{"image_gen":"openai_responses"}`)
 	if !errors.Is(err, ErrInvalidAdapter) {
 		t.Fatalf("expected ErrInvalidAdapter, got %v", err)
+	}
+	_, err = normalizeProtocolDefaultsJSON(`{"audio":"gemini_interactions"}`)
+	if !errors.Is(err, ErrInvalidAdapter) {
+		t.Fatalf("expected ErrInvalidAdapter for audio Gemini Interactions default, got %v", err)
 	}
 }
 
@@ -430,6 +469,26 @@ func TestResolveRouteProtocolsKeepsSingleGoogleProtocolForDualImageKinds(t *test
 	}
 	if len(protocols) != 1 || protocols[0] != "google_image_generation" {
 		t.Fatalf("expected single Google image protocol, got %#v", protocols)
+	}
+}
+
+func TestResolveRouteProtocolsUsesGeminiInteractionsForUniversalOmniKinds(t *testing.T) {
+	kindsJSON := `["chat","image_gen","image_edit","video_gen"]`
+
+	protocol, err := resolveRouteProtocol("", compatibleGoogle, "", kindsJSON)
+	if err != nil {
+		t.Fatalf("resolve route protocol: %v", err)
+	}
+	if protocol != "gemini_interactions" {
+		t.Fatalf("expected Gemini Interactions unified protocol, got %q", protocol)
+	}
+
+	protocols, err := resolveRouteProtocols(nil, compatibleGoogle, "", kindsJSON)
+	if err != nil {
+		t.Fatalf("resolve route protocols: %v", err)
+	}
+	if len(protocols) != 1 || protocols[0] != "gemini_interactions" {
+		t.Fatalf("expected single Gemini Interactions protocol, got %#v", protocols)
 	}
 }
 
@@ -512,6 +571,9 @@ func TestIsRouteAllowedForTaskSeparatesChatAndImageProtocols(t *testing.T) {
 	if !IsRouteAllowedForTask(TaskTypeImageGeneration, `["image_gen"]`, "google_image_generation") {
 		t.Fatalf("expected image generation task to allow Google image generation protocol")
 	}
+	if !IsRouteAllowedForTask(TaskTypeImageGeneration, `["image_gen"]`, "gemini_interactions") {
+		t.Fatalf("expected image generation task to allow Gemini Interactions protocol")
+	}
 	if !IsRouteAllowedForTask(TaskTypeImageGeneration, `["image_gen"]`, "xai_image") {
 		t.Fatalf("expected image generation task to allow xAI image protocol")
 	}
@@ -524,11 +586,32 @@ func TestIsRouteAllowedForTaskSeparatesChatAndImageProtocols(t *testing.T) {
 	if !IsRouteAllowedForTask(TaskTypeImageEdit, `["image_edit"]`, "google_image_generation") {
 		t.Fatalf("expected image edit task to allow Google image protocol")
 	}
+	if !IsRouteAllowedForTask(TaskTypeImageEdit, `["image_edit"]`, "gemini_interactions") {
+		t.Fatalf("expected image edit task to allow Gemini Interactions protocol")
+	}
 	if !IsRouteAllowedForTask(TaskTypeImageEdit, `["image_edit"]`, "xai_image_edits") {
 		t.Fatalf("expected image edit task to allow xAI image edits protocol")
 	}
 	if IsRouteAllowedForTask(TaskTypeImageEdit, `["image_edit"]`, "xai_image") {
 		t.Fatalf("expected image edit task to reject xAI image generation protocol")
+	}
+	if !IsRouteAllowedForTask(TaskTypeVideoGeneration, `["video_gen"]`, "gemini_interactions") {
+		t.Fatalf("expected video generation task to allow Gemini Interactions protocol")
+	}
+	if !IsRouteAllowedForTask(TaskTypeVideoGeneration, `["video_gen"]`, "openai_video_generations") {
+		t.Fatalf("expected video generation task to allow OpenAI video protocol")
+	}
+	if IsRouteAllowedForTask(TaskTypeVideoGeneration, `["chat"]`, "openai_responses") {
+		t.Fatalf("expected video generation task to reject chat protocol")
+	}
+	if IsRouteAllowedForTask(TaskTypeChat, `["video_gen"]`, "gemini_interactions") {
+		t.Fatalf("expected chat task to reject video generation protocol")
+	}
+	if !IsRouteAllowedForTask(TaskTypeChat, `["chat"]`, "gemini_interactions") {
+		t.Fatalf("expected chat task to allow Gemini Interactions protocol")
+	}
+	if IsRouteAllowedForTask(TaskTypeChat, `["audio"]`, "gemini_interactions") {
+		t.Fatalf("expected audio task to reject Gemini Interactions protocol")
 	}
 }
 
@@ -544,6 +627,12 @@ func TestDefaultRouteModelMatchesTaskFiltersByKind(t *testing.T) {
 	}
 	if defaultRouteModelMatchesTask(`["chat"]`, TaskTypeImageGeneration) {
 		t.Fatal("expected image generation default route to reject chat model")
+	}
+	if !defaultRouteModelMatchesTask(`["video_gen"]`, TaskTypeVideoGeneration) {
+		t.Fatal("expected video generation default route to accept video generation model")
+	}
+	if defaultRouteModelMatchesTask(`["chat"]`, TaskTypeVideoGeneration) {
+		t.Fatal("expected video generation default route to reject chat model")
 	}
 }
 

--- a/backend/internal/application/channel/service_default_route.go
+++ b/backend/internal/application/channel/service_default_route.go
@@ -48,6 +48,8 @@ func defaultRouteModelMatchesTask(kindsJSON string, taskType string) bool {
 		return hasModelKind(kinds, modelKindImageGen)
 	case TaskTypeImageEdit:
 		return hasModelKind(kinds, modelKindImageEdit)
+	case TaskTypeVideoGeneration:
+		return hasModelKind(kinds, modelKindVideoGen)
 	default:
 		return hasModelKind(kinds, modelKindChat)
 	}

--- a/backend/internal/application/channel/service_probe.go
+++ b/backend/internal/application/channel/service_probe.go
@@ -357,6 +357,7 @@ func isLightweightModelProbeProtocol(protocol string) bool {
 		llm.AdapterOpenAIChatCompletions,
 		llm.AdapterAnthropicMessages,
 		llm.AdapterGoogleGenerateContent,
+		llm.AdapterGeminiInteractions,
 		llm.AdapterXAIResponses:
 		return true
 	default:

--- a/backend/internal/application/conversation/errs.go
+++ b/backend/internal/application/conversation/errs.go
@@ -89,6 +89,12 @@ var (
 	ErrMediaImageEditTooManyInputs = errors.New("too many image edit input images")
 	// ErrMediaImageEditInputInvalid 图片编辑输入图不合法。
 	ErrMediaImageEditInputInvalid = errors.New("image edit input image is invalid")
+	// ErrMediaVideoPromptRequired 视频任务提示词不能为空。
+	ErrMediaVideoPromptRequired = errors.New("video prompt is required")
+	// ErrMediaVideoInputInvalid 视频生成输入不合法。
+	ErrMediaVideoInputInvalid = errors.New("video generation input is invalid")
+	// ErrMediaVideoTooManyInputs 视频生成输入图数量超限。
+	ErrMediaVideoTooManyInputs = errors.New("too many video generation input images")
 	// ErrMediaRouteProtocolMismatch 图片任务命中的路由协议与任务类型不匹配。
 	ErrMediaRouteProtocolMismatch = errors.New("media route protocol does not match task")
 	// ErrDuplicateMessageGenerationRun 表示客户端重复提交同一个生成 run。

--- a/backend/internal/application/conversation/model_option_policy.go
+++ b/backend/internal/application/conversation/model_option_policy.go
@@ -548,6 +548,8 @@ func modelOptionPolicyProtocolKey(protocol string) string {
 		return "gemini_generate_content"
 	case llm.AdapterGoogleImageGeneration:
 		return "google_image_generation"
+	case llm.AdapterGeminiInteractions:
+		return "gemini_interactions"
 	case llm.AdapterOpenAIChatCompletions:
 		return "openai_chat_completions"
 	case llm.AdapterOpenRouterChat:
@@ -600,11 +602,94 @@ func splitModelOptionPath(value string) []string {
 }
 
 func copyModelOptionPath(dst map[string]interface{}, src map[string]interface{}, path []string) {
-	value, ok := readModelOptionPath(src, path)
+	value, ok := copyModelOptionValueAtPath(src, path)
 	if !ok {
 		return
 	}
-	writeModelOptionPath(dst, path, cloneModelOptionValue(value))
+	mergeModelOptionPathValue(dst, value)
+}
+
+func copyModelOptionValueAtPath(value interface{}, path []string) (interface{}, bool) {
+	if len(path) == 0 {
+		return cloneModelOptionValue(value), true
+	}
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		child, ok := typed[path[0]]
+		if !ok {
+			return nil, false
+		}
+		copied, ok := copyModelOptionValueAtPath(child, path[1:])
+		if !ok {
+			return nil, false
+		}
+		return map[string]interface{}{path[0]: copied}, true
+	case []interface{}:
+		items := make([]interface{}, len(typed))
+		matched := false
+		for index, item := range typed {
+			copied, ok := copyModelOptionValueAtPath(item, path)
+			if ok {
+				items[index] = copied
+				matched = true
+			} else {
+				items[index] = map[string]interface{}{}
+			}
+		}
+		if !matched {
+			return nil, false
+		}
+		return items, true
+	default:
+		return nil, false
+	}
+}
+
+func mergeModelOptionPathValue(dst map[string]interface{}, value interface{}) {
+	payload, ok := value.(map[string]interface{})
+	if !ok {
+		return
+	}
+	mergeModelOptionPathMap(dst, payload)
+}
+
+func mergeModelOptionPathMap(dst map[string]interface{}, src map[string]interface{}) {
+	for key, value := range src {
+		if existingMap, ok := dst[key].(map[string]interface{}); ok {
+			if incomingMap, ok := value.(map[string]interface{}); ok {
+				mergeModelOptionPathMap(existingMap, incomingMap)
+				continue
+			}
+		}
+		if existingItems, ok := dst[key].([]interface{}); ok {
+			if incomingItems, ok := value.([]interface{}); ok {
+				dst[key] = mergeModelOptionPathArray(existingItems, incomingItems)
+				continue
+			}
+		}
+		dst[key] = cloneModelOptionValue(value)
+	}
+}
+
+func mergeModelOptionPathArray(existing []interface{}, incoming []interface{}) []interface{} {
+	result := make([]interface{}, len(existing))
+	for index, item := range existing {
+		result[index] = cloneModelOptionValue(item)
+	}
+	for index, item := range incoming {
+		if index >= len(result) {
+			result = append(result, cloneModelOptionValue(item))
+			continue
+		}
+		existingMap, existingOK := result[index].(map[string]interface{})
+		incomingMap, incomingOK := item.(map[string]interface{})
+		if existingOK && incomingOK {
+			mergeModelOptionPathMap(existingMap, incomingMap)
+			continue
+		}
+		result[index] = cloneModelOptionValue(item)
+	}
+	return result
 }
 
 func readModelOptionPath(src map[string]interface{}, path []string) (interface{}, bool) {

--- a/backend/internal/application/conversation/model_option_policy_test.go
+++ b/backend/internal/application/conversation/model_option_policy_test.go
@@ -68,6 +68,31 @@ func TestFilterModelOptionsAllowlistUsesDefaultAndProtocolPaths(t *testing.T) {
 	}
 }
 
+func TestFilterModelOptionsAllowsGeminiInteractionResponseFormatArray(t *testing.T) {
+	filtered := filterModelOptions(map[string]interface{}{
+		"response_format": []interface{}{
+			map[string]interface{}{"type": "text"},
+			map[string]interface{}{"type": "image", "image_size": "1K", "delivery": "b64_json"},
+		},
+	}, llm.AdapterGeminiInteractions, modelOptionPolicyConfig{
+		Mode:             modelOptionPolicyAllowlist,
+		AllowedPathsJSON: config.DefaultModelOptionAllowedPathsJSON(),
+		DeniedPathsJSON:  config.DefaultModelOptionDeniedPathsJSON(),
+	})
+
+	formats, ok := filtered["response_format"].([]interface{})
+	if !ok || len(formats) != 2 {
+		t.Fatalf("expected Gemini Interactions response_format array to pass, got %#v", filtered)
+	}
+	imageFormat := formats[1].(map[string]interface{})
+	if imageFormat["image_size"] != "1K" {
+		t.Fatalf("expected whitelisted image_size to pass, got %#v", imageFormat)
+	}
+	if _, ok := imageFormat["delivery"]; ok {
+		t.Fatalf("expected non-whitelisted delivery to be filtered, got %#v", imageFormat)
+	}
+}
+
 func TestFilterModelOptionsAppliesCapabilityDefaultOptions(t *testing.T) {
 	filtered := filterModelOptions(map[string]interface{}{
 		"reasoning": map[string]interface{}{
@@ -911,6 +936,77 @@ func TestFilterModelOptionsOpenAIImageEditsAllowsEditParams(t *testing.T) {
 		if _, ok := filtered[key]; ok {
 			t.Fatalf("expected %s to be hard denied, got %#v", key, filtered)
 		}
+	}
+}
+
+func TestFilterModelOptionsGeminiInteractionsAllowsVideoParams(t *testing.T) {
+	filtered := filterModelOptions(map[string]interface{}{
+		"response_format": map[string]interface{}{
+			"aspect_ratio": "16:9",
+			"image_size":   "1K",
+			"mime_type":    "image/png",
+			"delivery":     "b64_json",
+		},
+		"generation_config": map[string]interface{}{
+			"temperature":    0.3,
+			"thinking_level": "low",
+			"video_config": map[string]interface{}{
+				"task": "image_to_video",
+			},
+		},
+		"model": "override",
+		"input": "override",
+	}, llm.AdapterGeminiInteractions, modelOptionPolicyConfig{
+		Mode:             modelOptionPolicyAllowlist,
+		AllowedPathsJSON: config.DefaultModelOptionAllowedPathsJSON(),
+		DeniedPathsJSON:  config.DefaultModelOptionDeniedPathsJSON(),
+	})
+
+	responseFormat, ok := filtered["response_format"].(map[string]interface{})
+	if !ok || responseFormat["aspect_ratio"] != "16:9" || responseFormat["image_size"] != "1K" || responseFormat["mime_type"] != "image/png" {
+		t.Fatalf("expected Gemini response_format aspect ratio to pass, got %#v", filtered)
+	}
+	if _, ok := responseFormat["delivery"]; ok {
+		t.Fatalf("expected delivery override to be filtered, got %#v", responseFormat)
+	}
+	generationConfig, ok := filtered["generation_config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected Gemini generation_config to pass, got %#v", filtered)
+	}
+	videoConfig, ok := generationConfig["video_config"].(map[string]interface{})
+	if generationConfig["temperature"] != 0.3 || generationConfig["thinking_level"] != "low" {
+		t.Fatalf("expected Gemini generation config fields to pass, got %#v", generationConfig)
+	}
+	if !ok || videoConfig["task"] != "image_to_video" {
+		t.Fatalf("expected Gemini video task to pass, got %#v", filtered)
+	}
+	for _, key := range []string{"model", "input"} {
+		if _, ok := filtered[key]; ok {
+			t.Fatalf("expected %s override to be hard denied, got %#v", key, filtered)
+		}
+	}
+}
+
+func TestFilterModelOptionsGeminiInteractionsAllowsCamelCaseVideoConfig(t *testing.T) {
+	filtered := filterModelOptions(map[string]interface{}{
+		"generationConfig": map[string]interface{}{
+			"videoConfig": map[string]interface{}{
+				"task": "text_to_video",
+			},
+		},
+	}, llm.AdapterGeminiInteractions, modelOptionPolicyConfig{
+		Mode:             modelOptionPolicyAllowlist,
+		AllowedPathsJSON: config.DefaultModelOptionAllowedPathsJSON(),
+		DeniedPathsJSON:  config.DefaultModelOptionDeniedPathsJSON(),
+	})
+
+	generationConfig, ok := filtered["generationConfig"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected camelCase Gemini generationConfig to pass, got %#v", filtered)
+	}
+	videoConfig, ok := generationConfig["videoConfig"].(map[string]interface{})
+	if !ok || videoConfig["task"] != "text_to_video" {
+		t.Fatalf("expected camelCase Gemini video task to pass, got %#v", filtered)
 	}
 }
 

--- a/backend/internal/application/conversation/service_file_policy.go
+++ b/backend/internal/application/conversation/service_file_policy.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	fileCategoryImage   = "image"
+	fileCategoryVideo   = "video"
 	fileCategoryPDF     = "pdf"
 	fileCategoryWord    = "word"
 	fileCategoryExcel   = "excel"
@@ -110,6 +111,8 @@ func inferFileCategory(mimeType string, fileName string) string {
 	switch {
 	case strings.HasPrefix(mime, "image/"):
 		return fileCategoryImage
+	case strings.HasPrefix(mime, "video/"):
+		return fileCategoryVideo
 	case mime == "application/pdf" || ext == "pdf":
 		return fileCategoryPDF
 	case strings.Contains(mime, "wordprocessingml") || strings.Contains(mime, "msword") || ext == "docx" || ext == "doc":
@@ -149,6 +152,9 @@ func maxBytesForCategory(category string, cfg config.Config) int64 {
 	if category == fileCategoryImage {
 		return cfg.FileImageMaxBytes
 	}
+	if category == fileCategoryVideo {
+		return 0
+	}
 	return cfg.FileDocMaxBytes
 }
 
@@ -167,7 +173,7 @@ func supportsExtraction(category string) bool {
 
 func supportsRAG(category string) bool {
 	switch category {
-	case fileCategoryPDF, fileCategoryWord, fileCategoryExcel, fileCategoryText:
+	case fileCategoryPDF, fileCategoryWord, fileCategoryExcel, fileCategoryText, fileCategoryImage:
 		return true
 	default:
 		return false

--- a/backend/internal/application/conversation/service_media_generation.go
+++ b/backend/internal/application/conversation/service_media_generation.go
@@ -302,6 +302,11 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 		DeniedPathsJSON:       cfg.ModelOptionDeniedPaths,
 		ModelCapabilitiesJSON: route.ModelCapabilitiesJSON,
 	})
+	if llm.NormalizeAdapter(route.Protocol) == llm.AdapterGeminiInteractions {
+		filteredOptions = withGeminiInteractionResponseType(filteredOptions, "image")
+		routeConfig.Endpoint = llm.EndpointInteractions
+		run.Endpoint = llm.EndpointInteractions
+	}
 
 	emitMediaEvent(input.OnEvent, "running", mediaImageRunningMessage(input.TaskType))
 	generateInput := llm.GenerateInput{
@@ -587,14 +592,18 @@ func (s *Service) readMediaImageEditFile(ctx context.Context, userID uint, fileI
 }
 
 // emitMediaEvent 输出媒体任务状态事件；失败不影响主流程。
-func emitMediaEvent(onEvent func(string, map[string]interface{}) error, status string, message string) {
+func emitMediaEvent(onEvent func(string, map[string]interface{}) error, status string, message string, contentType ...string) {
 	if onEvent == nil {
 		return
 	}
-	_ = onEvent("media_status", map[string]interface{}{
+	payload := map[string]interface{}{
 		"status":  status,
 		"message": message,
-	})
+	}
+	if len(contentType) > 0 && strings.TrimSpace(contentType[0]) != "" {
+		payload["content_type"] = strings.TrimSpace(contentType[0])
+	}
+	_ = onEvent("media_status", payload)
 }
 
 func emitMediaImageDelta(onEvent func(string, map[string]interface{}) error, event llm.GenerateStreamEvent) error {
@@ -615,6 +624,28 @@ func emitMediaImageDelta(onEvent func(string, map[string]interface{}) error, eve
 
 func mediaImageStreamEnabled(protocol string, upstreamModel string, capabilitiesJSON string) bool {
 	return llm.SupportsImageGenerationStream(protocol, upstreamModel) && !mediaImageStreamExplicitlyDisabled(capabilitiesJSON)
+}
+
+func withGeminiInteractionResponseType(options map[string]interface{}, responseType string) map[string]interface{} {
+	next := make(map[string]interface{}, len(options)+1)
+	for key, value := range options {
+		next[key] = value
+	}
+	format := map[string]interface{}{}
+	if raw, ok := next["response_format"].(map[string]interface{}); ok {
+		for key, value := range raw {
+			format[key] = value
+		}
+	}
+	if raw, ok := next["responseFormat"].(map[string]interface{}); ok {
+		for key, value := range raw {
+			format[key] = value
+		}
+		delete(next, "responseFormat")
+	}
+	format["type"] = strings.TrimSpace(responseType)
+	next["response_format"] = format
+	return next
 }
 
 func mediaImageStreamExplicitlyDisabled(capabilitiesJSON string) bool {
@@ -647,6 +678,9 @@ func (s *Service) readGeneratedImage(ctx context.Context, image llm.GeneratedIma
 	if url == "" {
 		return nil, mimeType, ErrUpstreamEmptyResponse
 	}
+	if _, _, ok := geminiGeneratedFileURLs(url); ok {
+		return nil, mimeType, fmt.Errorf("Gemini Files generated image URI is unsupported")
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, mimeType, err
@@ -664,7 +698,7 @@ func (s *Service) readGeneratedImage(ctx context.Context, image llm.GeneratedIma
 	if contentType := strings.TrimSpace(resp.Header.Get("Content-Type")); strings.HasPrefix(strings.ToLower(contentType), "image/") {
 		mimeType = strings.Split(contentType, ";")[0]
 	}
-	limit := s.cfg.Snapshot().MaxUploadFileBytes
+	limit := cfg.MaxUploadFileBytes
 	if limit <= 0 {
 		limit = 20 * 1024 * 1024
 	}

--- a/backend/internal/application/conversation/service_media_generation_test.go
+++ b/backend/internal/application/conversation/service_media_generation_test.go
@@ -117,6 +117,12 @@ func TestMediaImageStreamEnabledUsesModelCapabilitiesOverride(t *testing.T) {
 			want:             true,
 		},
 		{
+			name:          "gemini interactions streams image media",
+			protocol:      llm.AdapterGeminiInteractions,
+			upstreamModel: "gemini-3.5-flash",
+			want:          true,
+		},
+		{
 			name:             "unsupported protocol cannot be enabled by capabilities",
 			protocol:         llm.AdapterXAIImage,
 			upstreamModel:    "grok-2-image",

--- a/backend/internal/application/conversation/service_media_video.go
+++ b/backend/internal/application/conversation/service_media_video.go
@@ -1,0 +1,733 @@
+package conversation
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/channel"
+	appupload "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/upload"
+	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/llm"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/pkg/traceid"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/shared/security"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+const (
+	maxMediaVideoInputImages        = 1
+	geminiGeneratedFilePollAttempts = 12
+	geminiGeneratedFilePollInterval = 5 * time.Second
+)
+
+// MediaVideoInput 定义视频生成任务的应用层入参。
+type MediaVideoInput struct {
+	UserID                uint
+	ConversationID        uint
+	RequestID             string
+	Prompt                string
+	PlatformModelName     string
+	Options               map[string]interface{}
+	ClientRunID           string
+	FileIDs               []string
+	ParentMessagePublicID string
+	SourceMessagePublicID string
+	BranchReason          string
+	OnEvent               func(eventType string, payload map[string]interface{}) error
+}
+
+// StreamMediaVideo 执行视频生成任务并把结果保存为文件对象。
+func (s *Service) StreamMediaVideo(ctx context.Context, input MediaVideoInput) (*SendMessageResult, error) {
+	if s.routeResolver == nil || s.llmClient == nil {
+		return nil, ErrModelRouteNotConfigured
+	}
+	ctx = context.WithoutCancel(ctx)
+
+	runID := normalizeRunID(input.ClientRunID)
+	if runID == "" {
+		runID = "run_" + normalizePublicID(uuid.NewString())
+	}
+	existingRuns, err := s.repo.ListConversationRunsByRunIDs(ctx, input.UserID, input.ConversationID, []string{runID})
+	if err != nil {
+		return nil, err
+	}
+	if len(existingRuns) > 0 {
+		return nil, ErrDuplicateMessageGenerationRun
+	}
+	startedAt := time.Now()
+	conversation, err := s.repo.GetConversationByUser(ctx, input.ConversationID, input.UserID)
+	if err != nil {
+		return nil, ErrConversationNotFound
+	}
+
+	normalizedBranchReason := normalizeBranchReason(input.BranchReason)
+	branchState, err := s.resolveMessageBranch(ctx, input.ConversationID, input.UserID, input.ParentMessagePublicID, input.SourceMessagePublicID, normalizedBranchReason)
+	if err != nil {
+		return nil, err
+	}
+	reuseUserMessage := branchState.ReuseUserMessage != nil
+	if reuseUserMessage {
+		input.Prompt = branchState.ReuseUserMessage.Content
+		input.FileIDs = parseAttachmentSnapshotFileIDs(branchState.ReuseUserMessage.Attachments)
+	}
+	if strings.TrimSpace(input.Prompt) == "" {
+		return nil, ErrMediaVideoPromptRequired
+	}
+
+	platformModelName := strings.TrimSpace(input.PlatformModelName)
+	if platformModelName == "" {
+		platformModelName = strings.TrimSpace(conversation.Model)
+	}
+	if platformModelName == "" {
+		return nil, ErrModelRouteNotConfigured
+	}
+	route, err := s.routeResolver.ResolveRoute(ctx, channel.ResolveRouteInput{
+		PlatformModelName: platformModelName,
+		TaskType:          channel.TaskTypeVideoGeneration,
+		Scope:             channel.RouteScopeUser,
+		UserID:            input.UserID,
+		ConversationID:    input.ConversationID,
+		RequestID:         strings.TrimSpace(input.RequestID),
+	})
+	if err != nil {
+		return nil, ErrModelRouteNotConfigured
+	}
+	if !llm.IsVideoGenerationAdapter(route.Protocol) {
+		return nil, ErrMediaRouteProtocolMismatch
+	}
+	if strings.TrimSpace(conversation.Model) != strings.TrimSpace(route.PlatformModelName) {
+		conversation.Model = strings.TrimSpace(route.PlatformModelName)
+		conversation.Provider = inferProvider(conversation.Model)
+		if err = s.repo.UpdateConversationModel(ctx, input.ConversationID, conversation.Model, conversation.Provider); err != nil {
+			return nil, err
+		}
+	}
+	resolvedAttachments, videoInputParts, err := s.resolveMediaVideoInputs(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	attachmentsJSON := marshalAttachmentSnapshots(resolvedAttachments)
+
+	run := &model.Run{
+		RunID:              runID,
+		RequestID:          strings.TrimSpace(input.RequestID),
+		UserID:             input.UserID,
+		ConversationID:     input.ConversationID,
+		TaskType:           channel.TaskTypeVideoGeneration,
+		Endpoint:           llm.EndpointInteractions,
+		Provider:           strings.TrimSpace(conversation.Provider),
+		ProviderProtocol:   route.Protocol,
+		UpstreamID:         route.UpstreamID,
+		UpstreamModelID:    route.UpstreamModelID,
+		UpstreamName:       route.UpstreamName,
+		RequestedModelName: platformModelName,
+		PlatformModelName:  route.PlatformModelName,
+		RoutedBindingCode:  route.BindingCode,
+		ModelVendor:        route.ModelVendor,
+		ModelIcon:          route.ModelIcon,
+		UpstreamModelName:  route.UpstreamModel,
+		Status:             "error",
+		StartedAt:          startedAt,
+	}
+	var retErr error
+	defer func() {
+		endedAt := time.Now()
+		run.EndedAt = &endedAt
+		run.TotalLatencyMS = endedAt.Sub(startedAt).Milliseconds()
+		if retErr == nil {
+			run.Status = "success"
+		} else {
+			run.Status = "error"
+			run.ErrorCode = classifyRunErrorCode(retErr)
+			run.ErrorMessage = truncateError(messageErrorSummary(retErr), 255)
+		}
+		if err := s.repo.CreateConversationRun(context.WithoutCancel(ctx), run); err != nil && s.logger != nil {
+			s.logger.Error("create_video_conversation_run_failed",
+				zap.String("trace_id", traceid.FromContext(ctx)),
+				zap.String("run_id", run.RunID),
+				zap.Error(err),
+			)
+		}
+	}()
+	cancelCtx, cancel := context.WithCancel(ctx)
+	ctx = cancelCtx
+	s.generationStreams.register(ctx, runID, input.UserID, cancel)
+
+	assistantMessage := &model.Message{
+		ConversationID: input.ConversationID,
+		UserID:         input.UserID,
+		PublicID:       normalizePublicID(uuid.NewString()),
+		RunID:          runID,
+		Role:           "assistant",
+		ContentType:    "video",
+		Content:        "",
+		BranchReason:   normalizedBranchReason,
+		Status:         "pending",
+		Attachments:    "[]",
+	}
+	var userMessage *model.Message
+	if reuseUserMessage {
+		reused := *branchState.ReuseUserMessage
+		userMessage = &reused
+		assistantMessage.ParentMessageID = &userMessage.ID
+		assistantMessage.SourceMessageID = branchState.SourceMessageID
+		if err = s.repo.CreateAssistantBranchMessage(ctx, assistantMessage); err != nil {
+			retErr = err
+			return nil, err
+		}
+		assistantMessage.ParentPublicID = userMessage.PublicID
+		assistantMessage.SourcePublicID = branchState.SourcePublicID
+	} else {
+		userMessage = &model.Message{
+			ConversationID:  input.ConversationID,
+			UserID:          input.UserID,
+			PublicID:        normalizePublicID(uuid.NewString()),
+			ParentMessageID: branchState.ParentMessageID,
+			RunID:           runID,
+			Role:            "user",
+			ContentType:     mediaVideoUserContentType(len(resolvedAttachments) > 0),
+			Content:         strings.TrimSpace(input.Prompt),
+			BranchReason:    normalizedBranchReason,
+			SourceMessageID: branchState.SourceMessageID,
+			TokenUsage:      estimateTokens(input.Prompt),
+			InputTokens:     estimateTokens(input.Prompt),
+			Status:          "success",
+			Attachments:     attachmentsJSON,
+		}
+		userAttachmentRows := mediaInputAttachmentRows(input.ConversationID, input.UserID, resolvedAttachments)
+		if err = s.repo.CreateMessagePairWithUserAttachments(ctx, userMessage, assistantMessage, userAttachmentRows); err != nil {
+			retErr = err
+			return nil, err
+		}
+		userMessage.ParentPublicID = branchState.ParentPublicID
+		userMessage.SourcePublicID = branchState.SourcePublicID
+		assistantMessage.ParentPublicID = userMessage.PublicID
+		s.maybeGenerateConversationMetadataAsync(*conversation, *userMessage)
+	}
+	traceRecorder := newMessageTraceRecorder(s, ctx, assistantMessage, input.OnEvent)
+	defer func() {
+		if retErr != nil && traceRecorder != nil {
+			traceRecorder.fail(retErr)
+			traceRecorder.attachToMessage(assistantMessage)
+		}
+	}()
+	emitMediaEvent(input.OnEvent, "queued", "video task queued", "video")
+
+	cfg := s.cfg.Snapshot()
+	attributionReferer, attributionTitle := s.llmAttribution()
+	routeConfig := llm.RouteConfig{
+		Protocol:            route.Protocol,
+		BaseURL:             route.BaseURL,
+		APIKey:              route.APIKey,
+		HeadersJSON:         route.HeadersJSON,
+		ConnectTimeoutMS:    route.ConnectTimeoutMS,
+		ReadTimeoutMS:       route.ReadTimeoutMS,
+		StreamIdleTimeoutMS: route.StreamIdleTimeoutMS,
+		Endpoint:            llm.EndpointInteractions,
+		UpstreamModel:       route.UpstreamModel,
+		AttributionReferer:  attributionReferer,
+		AttributionTitle:    attributionTitle,
+	}
+	filteredOptions := filterModelOptions(input.Options, route.Protocol, modelOptionPolicyConfig{
+		Mode:                  cfg.ModelOptionPolicyMode,
+		AllowedPathsJSON:      cfg.ModelOptionAllowedPaths,
+		DeniedPathsJSON:       cfg.ModelOptionDeniedPaths,
+		ModelCapabilitiesJSON: route.ModelCapabilitiesJSON,
+	})
+	if llm.NormalizeAdapter(route.Protocol) == llm.AdapterGeminiInteractions {
+		filteredOptions = withGeminiInteractionResponseType(filteredOptions, "video")
+	}
+
+	emitMediaEvent(input.OnEvent, "running", "generating video", "video")
+	generateInput := llm.GenerateInput{
+		RequestID:      strings.TrimSpace(input.RequestID),
+		ConversationID: input.ConversationID,
+		Messages: []llm.Message{{
+			Role:    "user",
+			Content: strings.TrimSpace(input.Prompt),
+		}},
+		Options: filteredOptions,
+	}
+	if len(videoInputParts) > 0 {
+		parts := make([]llm.ContentPart, 0, 1+len(videoInputParts))
+		parts = append(parts, llm.ContentPart{Kind: llm.ContentPartText, Text: strings.TrimSpace(input.Prompt)})
+		parts = append(parts, videoInputParts...)
+		generateInput.Messages = []llm.Message{{Role: "user", Parts: parts}}
+	}
+
+	output, err := s.llmClient.Generate(ctx, routeConfig, generateInput)
+	if err != nil {
+		s.routeResolver.MarkRouteFailure(ctx, route, err)
+		retErr = wrapUpstreamRequestError(err)
+		_ = s.repo.UpdateMessageState(ctx, assistantMessage.ID, "error", classifyRunErrorCode(retErr), truncateError(messageErrorSummary(retErr), 255))
+		return nil, retErr
+	}
+	s.routeResolver.MarkRouteSuccess(ctx, route)
+	if output == nil || len(output.GeneratedVideos) == 0 {
+		retErr = ErrUpstreamEmptyResponse
+		_ = s.repo.UpdateMessageState(ctx, assistantMessage.ID, "error", classifyRunErrorCode(retErr), truncateError(messageErrorSummary(retErr), 255))
+		return nil, retErr
+	}
+
+	emitMediaEvent(input.OnEvent, "saving_artifact", "saving video", "video")
+	uploaded := make([]model.FileObject, 0, len(output.GeneratedVideos))
+	attachmentRows := make([]model.Attachment, 0, len(output.GeneratedVideos))
+	now := time.Now()
+	for i, video := range output.GeneratedVideos {
+		data, mimeType, readErr := s.readGeneratedVideo(ctx, video, route.APIKey)
+		if readErr != nil {
+			retErr = readErr
+			_ = s.repo.UpdateMessageState(ctx, assistantMessage.ID, "error", classifyRunErrorCode(retErr), truncateError(messageErrorSummary(retErr), 255))
+			return nil, readErr
+		}
+		fileName := generatedVideoFileName(route.PlatformModelName, now, i, len(output.GeneratedVideos), mimeType)
+		uploadResult, uploadErr := s.UploadFile(ctx, appupload.UploadFileInput{
+			UserID:       input.UserID,
+			Purpose:      "generated_video",
+			FileName:     fileName,
+			MimeType:     mimeType,
+			DeclaredSize: int64(len(data)),
+			Reader:       bytes.NewReader(data),
+		})
+		if uploadErr != nil {
+			retErr = uploadErr
+			_ = s.repo.UpdateMessageState(ctx, assistantMessage.ID, "error", classifyRunErrorCode(retErr), truncateError(messageErrorSummary(retErr), 255))
+			return nil, uploadErr
+		}
+		file := uploadResult.File
+		uploaded = append(uploaded, file)
+		attachmentRows = append(attachmentRows, model.Attachment{
+			ConversationID: input.ConversationID,
+			MessageID:      assistantMessage.ID,
+			UserID:         input.UserID,
+			FileID:         file.FileID,
+			Kind:           "file",
+			FileName:       file.FileName,
+			MimeType:       file.DetectedMIME,
+			FileSize:       file.SizeBytes,
+			SHA256:         file.SHA256,
+			StoragePath:    file.StoragePath,
+			Status:         "active",
+			UploadedAt:     now,
+		})
+	}
+
+	usage := output.Usage
+	if reuseUserMessage {
+		assistantMessage.InputTokens = usage.InputTokens
+		assistantMessage.CacheReadTokens = usage.CacheReadTokens
+		assistantMessage.CacheWriteTokens = usage.CacheWriteTokens
+	} else {
+		userMessage.InputTokens = usage.InputTokens
+		userMessage.CacheReadTokens = usage.CacheReadTokens
+		userMessage.CacheWriteTokens = usage.CacheWriteTokens
+		userMessage.TokenUsage = usage.InputTokens + usage.CacheReadTokens + usage.CacheWriteTokens
+	}
+
+	content := generatedVideoMarkdown(uploaded)
+	latencyMS := time.Since(startedAt).Milliseconds()
+	if reuseUserMessage {
+		err = s.repo.CompleteAssistantMessageWithGeneratedAttachments(ctx,
+			assistantMessage.ID,
+			repository.AssistantMessageCompletionUpdate{
+				ContentType:      "video",
+				Content:          content,
+				InputTokens:      usage.InputTokens,
+				OutputTokens:     usage.OutputTokens,
+				CacheReadTokens:  usage.CacheReadTokens,
+				CacheWriteTokens: usage.CacheWriteTokens,
+				ReasoningTokens:  usage.ReasoningTokens,
+				LatencyMS:        latencyMS,
+				Status:           "success",
+			},
+			attachmentRows,
+		)
+	} else {
+		err = s.repo.CompleteAssistantMessageWithAttachments(ctx,
+			userMessage.ID,
+			repository.MessageUsageUpdate{
+				InputTokens:      usage.InputTokens,
+				CacheReadTokens:  usage.CacheReadTokens,
+				CacheWriteTokens: usage.CacheWriteTokens,
+			},
+			assistantMessage.ID,
+			repository.AssistantMessageCompletionUpdate{
+				ContentType:     "video",
+				Content:         content,
+				OutputTokens:    usage.OutputTokens,
+				ReasoningTokens: usage.ReasoningTokens,
+				LatencyMS:       latencyMS,
+				Status:          "success",
+			},
+			attachmentRows,
+		)
+	}
+	if err != nil {
+		retErr = err
+		return nil, err
+	}
+
+	assistantMessage.Content = content
+	assistantMessage.OutputTokens = usage.OutputTokens
+	assistantMessage.ReasoningTokens = usage.ReasoningTokens
+	assistantMessage.TokenUsage = usage.OutputTokens + usage.ReasoningTokens
+	if reuseUserMessage {
+		assistantMessage.TokenUsage += usage.InputTokens + usage.CacheReadTokens + usage.CacheWriteTokens
+	}
+	assistantMessage.LatencyMS = latencyMS
+	assistantMessage.Status = "success"
+	assistantMessage.Attachments = string(marshalAttachmentSnapshots(videoAttachmentsFromFiles(uploaded)))
+	run.InputTokens = usage.InputTokens
+	run.OutputTokens = usage.OutputTokens
+	run.CacheReadTokens = usage.CacheReadTokens
+	run.CacheWriteTokens = usage.CacheWriteTokens
+	run.ReasoningTokens = usage.ReasoningTokens
+
+	return &SendMessageResult{
+		UserMessage:         *userMessage,
+		AssistantMessage:    *assistantMessage,
+		MetadataRefreshHint: conversationMetadataRefreshHint(*conversation, *userMessage),
+		UpstreamID:          route.UpstreamID,
+		UpstreamName:        route.UpstreamName,
+		PlatformModelName:   route.PlatformModelName,
+		RoutedBindingCode:   route.BindingCode,
+		UpstreamModelName:   route.UpstreamModel,
+		UpstreamProtocol:    route.Protocol,
+		EffectiveOptions:    filteredOptions,
+		UsageSpeed:          usage.Speed,
+		UsageServiceTier:    usage.ServiceTier,
+		RawUsageJSON:        usage.RawUsageJSON,
+		CacheWrite5mTokens:  usage.CacheWrite5mTokens,
+		CacheWrite1hTokens:  usage.CacheWrite1hTokens,
+		StartedAt:           startedAt,
+		LatencyMS:           latencyMS,
+	}, nil
+}
+
+func mediaVideoUserContentType(hasInputs bool) string {
+	if hasInputs {
+		return "mixed"
+	}
+	return "text"
+}
+
+func (s *Service) resolveMediaVideoInputs(ctx context.Context, input MediaVideoInput) ([]AttachmentInput, []llm.ContentPart, error) {
+	if len(input.FileIDs) == 0 {
+		return nil, nil, nil
+	}
+	attachments, err := s.resolveAttachments(ctx, input.UserID, input.FileIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(attachments) > maxMediaVideoInputImages {
+		return nil, nil, ErrMediaVideoTooManyInputs
+	}
+	parts := make([]llm.ContentPart, 0, len(attachments))
+	for _, attachment := range attachments {
+		if normalizeAttachmentKind(attachment.Kind, attachment.MimeType) != "image" {
+			return nil, nil, ErrMediaVideoInputInvalid
+		}
+		part, readErr := s.readMediaImageEditFile(ctx, input.UserID, attachment.FileID)
+		if readErr != nil {
+			return nil, nil, readErr
+		}
+		part.FileName = mediaImageEditInputFileName(attachment.FileName, part.MimeType)
+		parts = append(parts, part)
+	}
+	return attachments, parts, nil
+}
+
+func mediaInputAttachmentRows(conversationID uint, userID uint, attachments []AttachmentInput) []model.Attachment {
+	rows := make([]model.Attachment, 0, len(attachments))
+	now := time.Now()
+	for _, item := range attachments {
+		rows = append(rows, model.Attachment{
+			ConversationID: conversationID,
+			UserID:         userID,
+			FileID:         strings.TrimSpace(item.FileID),
+			Kind:           normalizeAttachmentKind(item.Kind, item.MimeType),
+			FileName:       strings.TrimSpace(item.FileName),
+			MimeType:       strings.TrimSpace(item.MimeType),
+			FileSize:       item.FileSize,
+			SHA256:         strings.TrimSpace(item.SHA256),
+			StoragePath:    strings.TrimSpace(item.StoragePath),
+			Status:         "active",
+			MetaJSON:       strings.TrimSpace(item.MetaJSON),
+			UploadedAt:     now,
+		})
+	}
+	return rows
+}
+
+func (s *Service) readGeneratedVideo(ctx context.Context, video llm.GeneratedVideo, apiKey string) ([]byte, string, error) {
+	mimeType := strings.TrimSpace(video.MIMEType)
+	if mimeType == "" {
+		mimeType = "video/mp4"
+	}
+	if b64 := strings.TrimSpace(video.B64JSON); b64 != "" {
+		data, err := base64.StdEncoding.DecodeString(stripBase64DataURLPrefix(b64))
+		if err != nil {
+			return nil, mimeType, err
+		}
+		return validateGeneratedVideoBytes(data, mimeType)
+	}
+	url := strings.TrimSpace(video.URL)
+	if url == "" {
+		return nil, mimeType, ErrUpstreamEmptyResponse
+	}
+	metadataURL, downloadURL, geminiFileDownload := geminiGeneratedFileURLs(url)
+	if geminiFileDownload {
+		resolvedMIME, resolveErr := s.waitGeminiGeneratedVideoFileReady(ctx, metadataURL, apiKey)
+		if resolveErr != nil {
+			return nil, mimeType, resolveErr
+		}
+		url = downloadURL
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(resolvedMIME)), "video/") {
+			mimeType = strings.TrimSpace(resolvedMIME)
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, mimeType, err
+	}
+	if geminiFileDownload {
+		req.Header.Set("x-goog-api-key", strings.TrimSpace(apiKey))
+	}
+	cfg := s.cfg.Snapshot()
+	client := security.NewOutboundHTTPClient(cfg.Env, cfg.SSRFProtectionEnabled, 120*time.Second)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, mimeType, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, mimeType, fmt.Errorf("download generated video failed: HTTP %d", resp.StatusCode)
+	}
+	if contentType := strings.TrimSpace(resp.Header.Get("Content-Type")); strings.HasPrefix(strings.ToLower(contentType), "video/") {
+		mimeType = strings.Split(contentType, ";")[0]
+	}
+	limit := cfg.MaxUploadFileBytes
+	if limit <= 0 {
+		limit = 20 * 1024 * 1024
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, mimeType, err
+	}
+	if int64(len(data)) > limit {
+		return nil, mimeType, ErrFileTooLarge
+	}
+	return validateGeneratedVideoBytes(data, mimeType)
+}
+
+func (s *Service) waitGeminiGeneratedVideoFileReady(ctx context.Context, metadataURL string, apiKey string) (string, error) {
+	if strings.TrimSpace(apiKey) == "" {
+		return "", fmt.Errorf("Gemini Files generated video URI requires an API key")
+	}
+	cfg := s.cfg.Snapshot()
+	client := security.NewOutboundHTTPClient(cfg.Env, cfg.SSRFProtectionEnabled, 30*time.Second)
+	mimeType, err := pollGeminiGeneratedFileReady(ctx, client, metadataURL, apiKey)
+	if err != nil {
+		return "", err
+	}
+	return mimeType, nil
+}
+
+func geminiGeneratedFileURLs(rawURL string) (string, string, bool) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || !isGeminiFilesHost(parsed.Hostname()) {
+		return "", "", false
+	}
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	for index, segment := range segments {
+		if !strings.EqualFold(segment, "files") || index+1 >= len(segments) {
+			continue
+		}
+		fileID := strings.TrimSpace(segments[index+1])
+		if colon := strings.Index(fileID, ":"); colon >= 0 {
+			fileID = fileID[:colon]
+		}
+		if fileID == "" {
+			return "", "", false
+		}
+		fileSegments := append([]string(nil), segments[:index+2]...)
+		fileSegments[index+1] = fileID
+
+		metadata := *parsed
+		metadata.Path = "/" + strings.Join(fileSegments, "/")
+		metadata.RawPath = ""
+		metadata.RawQuery = ""
+		metadata.Fragment = ""
+
+		download := metadata
+		download.Path = metadata.Path + ":download"
+		download.RawQuery = "alt=media"
+		return metadata.String(), download.String(), true
+	}
+	return "", "", false
+}
+
+func isGeminiFilesHost(host string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(host))
+	return normalized == "generativelanguage.googleapis.com"
+}
+
+func pollGeminiGeneratedFileReady(ctx context.Context, client *http.Client, metadataURL string, apiKey string) (string, error) {
+	lastState := ""
+	for attempt := 0; attempt < geminiGeneratedFilePollAttempts; attempt++ {
+		state, mimeType, err := fetchGeminiGeneratedFileState(ctx, client, metadataURL, apiKey)
+		if err != nil {
+			return "", err
+		}
+		if geminiGeneratedFileReady(state) {
+			return mimeType, nil
+		}
+		lastState = state
+		if geminiGeneratedFileFailed(state) {
+			return "", fmt.Errorf("generated video file failed: %s", state)
+		}
+		if attempt == geminiGeneratedFilePollAttempts-1 {
+			break
+		}
+		timer := time.NewTimer(geminiGeneratedFilePollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return "", ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return "", fmt.Errorf("generated video file is not ready: %s", strings.TrimSpace(lastState))
+}
+
+func fetchGeminiGeneratedFileState(ctx context.Context, client *http.Client, metadataURL string, apiKey string) (string, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("x-goog-api-key", strings.TrimSpace(apiKey))
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return "", "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", "", fmt.Errorf("poll generated video file failed: HTTP %d: %s", resp.StatusCode, truncateError(string(body), 512))
+	}
+	payload := map[string]interface{}{}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", "", err
+	}
+	file := mapFromAny(payload["file"])
+	state := firstNonEmptyString(
+		getStringFromAny(payload["state"]),
+		getStringFromAny(file["state"]),
+	)
+	mimeType := firstNonEmptyString(
+		getStringFromAny(payload["mimeType"]),
+		getStringFromAny(payload["mime_type"]),
+		getStringFromAny(file["mimeType"]),
+		getStringFromAny(file["mime_type"]),
+	)
+	return state, mimeType, nil
+}
+
+func mapFromAny(raw interface{}) map[string]interface{} {
+	if payload, ok := raw.(map[string]interface{}); ok {
+		return payload
+	}
+	return map[string]interface{}{}
+}
+
+func geminiGeneratedFileReady(state string) bool {
+	return strings.ToUpper(strings.TrimSpace(state)) == "ACTIVE"
+}
+
+func geminiGeneratedFileFailed(state string) bool {
+	return strings.ToUpper(strings.TrimSpace(state)) == "FAILED"
+}
+
+func validateGeneratedVideoBytes(data []byte, declaredMIME string) ([]byte, string, error) {
+	detected := detectGeneratedVideoMIME(data)
+	if detected == "" {
+		return nil, strings.TrimSpace(declaredMIME), ErrMediaVideoInputInvalid
+	}
+	return data, detected, nil
+}
+
+func detectGeneratedVideoMIME(data []byte) string {
+	if len(data) >= 12 && bytes.Equal(data[4:8], []byte("ftyp")) {
+		return "video/mp4"
+	}
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte{0x1a, 0x45, 0xdf, 0xa3}) {
+		return "video/webm"
+	}
+	return ""
+}
+
+func generatedVideoFileName(modelName string, capturedAt time.Time, index int, total int, mimeType string) string {
+	base := sanitizeGeneratedImageFileBase(modelName)
+	if base == "image" {
+		base = "video"
+	}
+	timestamp := fmt.Sprintf("%s-%03d", capturedAt.Format("20060102-150405"), capturedAt.Nanosecond()/int(time.Millisecond))
+	if total > 1 {
+		return fmt.Sprintf("%s-%s-%02d%s", base, timestamp, index+1, videoFileExtension(mimeType))
+	}
+	return fmt.Sprintf("%s-%s%s", base, timestamp, videoFileExtension(mimeType))
+}
+
+func videoFileExtension(mimeType string) string {
+	switch strings.ToLower(strings.TrimSpace(mimeType)) {
+	case "video/webm":
+		return ".webm"
+	default:
+		return ".mp4"
+	}
+}
+
+func generatedVideoMarkdown(files []model.FileObject) string {
+	blocks := make([]string, 0, len(files))
+	for i, file := range files {
+		label := "Generated video"
+		if len(files) > 1 {
+			label = fmt.Sprintf("Generated video %d", i+1)
+		}
+		blocks = append(blocks, fmt.Sprintf("[%s](/api/v1/files/%s/content)", label, file.FileID))
+	}
+	return strings.Join(blocks, "\n\n")
+}
+
+func videoAttachmentsFromFiles(files []model.FileObject) []AttachmentInput {
+	items := make([]AttachmentInput, 0, len(files))
+	for _, file := range files {
+		items = append(items, AttachmentInput{
+			FileObjID:        file.ID,
+			FileID:           file.FileID,
+			Kind:             "file",
+			FileName:         file.FileName,
+			MimeType:         file.MimeType,
+			DetectedMIME:     file.DetectedMIME,
+			FileCategory:     file.FileCategory,
+			FileSize:         file.SizeBytes,
+			SHA256:           file.SHA256,
+			StoragePath:      file.StoragePath,
+			ProcessingStatus: file.ProcessingStatus,
+			ProcessingReady:  file.ProcessingReady,
+		})
+	}
+	return items
+}

--- a/backend/internal/application/conversation/service_media_video_test.go
+++ b/backend/internal/application/conversation/service_media_video_test.go
@@ -1,0 +1,65 @@
+package conversation
+
+import "testing"
+
+func TestGeminiGeneratedFileURLsBuildsMetadataAndDownloadURLs(t *testing.T) {
+	metadataURL, downloadURL, ok := geminiGeneratedFileURLs("https://generativelanguage.googleapis.com/v1beta/files/video_123?alt=media&key=secret")
+	if !ok {
+		t.Fatal("expected Gemini Files URL to be recognized")
+	}
+	if metadataURL != "https://generativelanguage.googleapis.com/v1beta/files/video_123" {
+		t.Fatalf("unexpected metadata URL: %s", metadataURL)
+	}
+	if downloadURL != "https://generativelanguage.googleapis.com/v1beta/files/video_123:download?alt=media" {
+		t.Fatalf("unexpected download URL: %s", downloadURL)
+	}
+}
+
+func TestGeminiGeneratedFileURLsNormalizesDownloadURL(t *testing.T) {
+	metadataURL, downloadURL, ok := geminiGeneratedFileURLs("https://generativelanguage.googleapis.com/v1beta/files/video_123:download?alt=media")
+	if !ok {
+		t.Fatal("expected Gemini download URL to be recognized")
+	}
+	if metadataURL != "https://generativelanguage.googleapis.com/v1beta/files/video_123" {
+		t.Fatalf("unexpected metadata URL: %s", metadataURL)
+	}
+	if downloadURL != "https://generativelanguage.googleapis.com/v1beta/files/video_123:download?alt=media" {
+		t.Fatalf("unexpected download URL: %s", downloadURL)
+	}
+}
+
+func TestGeminiGeneratedFileURLsRejectsNonFileURLs(t *testing.T) {
+	if _, _, ok := geminiGeneratedFileURLs("https://generativelanguage.googleapis.com/v1beta/files/video_123"); !ok {
+		t.Fatal("expected Gemini Files URL to be recognized")
+	}
+	if _, _, ok := geminiGeneratedFileURLs("https://example.com/v1beta/files/video_123"); ok {
+		t.Fatal("expected non-Gemini host to be ignored")
+	}
+	if _, _, ok := geminiGeneratedFileURLs("https://generativelanguage.googleapis.com/v1beta/models/gemini"); ok {
+		t.Fatal("expected non-Files Gemini URL to be ignored")
+	}
+}
+
+func TestGeminiGeneratedFileStateHelpers(t *testing.T) {
+	if !geminiGeneratedFileReady("ACTIVE") {
+		t.Fatal("expected ACTIVE to be accepted")
+	}
+	if geminiGeneratedFileReady("READY") || geminiGeneratedFileReady("PROCESSED") {
+		t.Fatal("expected non-Files ready aliases to stay pending")
+	}
+	if !geminiGeneratedFileFailed("FAILED") {
+		t.Fatal("expected FAILED to be rejected")
+	}
+	if geminiGeneratedFileFailed("ERROR") || geminiGeneratedFileFailed("CANCELLED") {
+		t.Fatal("expected non-Files failure aliases to stay pending")
+	}
+	if geminiGeneratedFileReady("PROCESSING") || geminiGeneratedFileFailed("PROCESSING") {
+		t.Fatal("expected processing to stay pending")
+	}
+}
+
+func TestValidateGeneratedVideoBytesRejectsUndetectedContent(t *testing.T) {
+	if _, _, err := validateGeneratedVideoBytes([]byte("not a video"), "video/mp4"); err == nil {
+		t.Fatal("expected declared video MIME to be insufficient without a supported video header")
+	}
+}

--- a/backend/internal/application/conversation/service_message_context.go
+++ b/backend/internal/application/conversation/service_message_context.go
@@ -192,6 +192,12 @@ func classifyRunErrorCode(err error) string {
 		return "media_image_edit_too_many_inputs"
 	case errors.Is(err, ErrMediaImageEditInputInvalid):
 		return "media_image_edit_input_invalid"
+	case errors.Is(err, ErrMediaVideoPromptRequired):
+		return "media_video_prompt_required"
+	case errors.Is(err, ErrMediaVideoInputInvalid):
+		return "media_video_input_invalid"
+	case errors.Is(err, ErrMediaVideoTooManyInputs):
+		return "media_video_too_many_inputs"
 	case errors.Is(err, ErrMediaRouteProtocolMismatch):
 		return "media_route_protocol_mismatch"
 	case errors.Is(err, ErrUpstreamRequestFailed):

--- a/backend/internal/application/embedding/service.go
+++ b/backend/internal/application/embedding/service.go
@@ -103,12 +103,7 @@ func (s *Service) ShouldTrigger(fileObj domainconversation.FileObject) bool {
 	if strings.TrimSpace(fileObj.StoragePath) == "" || strings.ToLower(strings.TrimSpace(fileObj.Status)) != "active" {
 		return false
 	}
-	if strings.EqualFold(strings.TrimSpace(fileObj.FileCategory), "image") {
-		return cfg.ExtractImageOCREnabled
-	}
-	mime := strings.ToLower(strings.TrimSpace(fileObj.MimeType))
-	name := strings.TrimSpace(fileObj.FileName)
-	return isTextMIMEForEmbed(mime, name) || isPDFMIME(mime, name) || isDocxMIME(mime, name) || isExcelMIME(mime, name)
+	return supportsEmbeddingSource(fileObj, cfg)
 }
 
 // MaybeTrigger 在满足条件时异步触发 embedding。
@@ -143,6 +138,9 @@ func (s *Service) ProcessFile(ctx context.Context, fileObj domainconversation.Fi
 		return nil
 	}
 	if s.repo == nil {
+		return nil
+	}
+	if !supportsEmbeddingSource(fileObj, cfg) {
 		return nil
 	}
 
@@ -399,6 +397,9 @@ func (s *Service) ReindexStaleFiles(ctx context.Context) (int, error) {
 			break
 		}
 		for _, f := range files {
+			if !supportsEmbeddingSource(f, cfg) {
+				continue
+			}
 			s.Trigger(f)
 			submitted++
 		}
@@ -408,6 +409,18 @@ func (s *Service) ReindexStaleFiles(ctx context.Context) (int, error) {
 		offset += pageSize
 	}
 	return submitted, nil
+}
+
+func supportsEmbeddingSource(fileObj domainconversation.FileObject, cfg config.Config) bool {
+	switch strings.ToLower(strings.TrimSpace(fileObj.FileCategory)) {
+	case "video":
+		return false
+	case "image":
+		return cfg.ExtractImageOCREnabled
+	}
+	mime := strings.ToLower(strings.TrimSpace(fileObj.MimeType))
+	name := strings.TrimSpace(fileObj.FileName)
+	return isTextMIMEForEmbed(mime, name) || isPDFMIME(mime, name) || isDocxMIME(mime, name) || isExcelMIME(mime, name)
 }
 
 // postProcessEmbeddings 对批量向量做两步后处理：

--- a/backend/internal/application/embedding/service_test.go
+++ b/backend/internal/application/embedding/service_test.go
@@ -55,6 +55,28 @@ func TestShouldTriggerSkipsImagesWhenOCRDisabled(t *testing.T) {
 	}
 }
 
+func TestShouldTriggerSkipsVideos(t *testing.T) {
+	service := NewService(config.Config{
+		RAGEnabled:           true,
+		EmbeddingEnabled:     true,
+		EmbedTriggerOnUpload: true,
+		RAGModel:             "text-embedding-test",
+		EmbeddingHost:        "http://127.0.0.1:8081",
+	}, nil, nil, nil, nil)
+
+	fileObj := domainconversation.FileObject{
+		FileID:       "file_video",
+		FileName:     "clip.mp4",
+		MimeType:     "video/mp4",
+		FileCategory: "video",
+		StoragePath:  "uploads/clip.mp4",
+		Status:       "active",
+	}
+	if service.ShouldTrigger(fileObj) {
+		t.Fatal("expected videos to skip embedding")
+	}
+}
+
 func TestShouldTriggerDoesNotRequireRAGEnabled(t *testing.T) {
 	service := NewService(config.Config{
 		RAGEnabled:           false,
@@ -133,6 +155,57 @@ func TestProcessFileDoesNotRequireRAGEnabled(t *testing.T) {
 
 	if repo.updateStatusCalls == 0 {
 		t.Fatal("expected ProcessFile to start embedding even when chat RAG is disabled")
+	}
+}
+
+func TestProcessFileIncludesOCRImages(t *testing.T) {
+	repo := &reindexRepo{vectorAvailable: true}
+	service := NewService(config.Config{
+		RAGEnabled:             true,
+		EmbeddingEnabled:       true,
+		RAGModel:               "text-embedding-test",
+		EmbeddingHost:          "http://127.0.0.1:8081",
+		ExtractImageOCREnabled: true,
+	}, repo, nil, infraembedding.New(), nil)
+
+	_ = service.ProcessFile(context.Background(), domainconversation.FileObject{
+		ID:           1,
+		UserID:       1,
+		FileID:       "file_image",
+		FileName:     "photo.png",
+		MimeType:     "image/png",
+		FileCategory: "image",
+		StoragePath:  "uploads/photo.png",
+		Status:       "active",
+	})
+
+	if repo.updateStatusCalls == 0 {
+		t.Fatal("expected ProcessFile to allow OCR image embedding")
+	}
+}
+
+func TestProcessFileSkipsVideos(t *testing.T) {
+	repo := &reindexRepo{vectorAvailable: true}
+	service := NewService(config.Config{
+		RAGEnabled:       true,
+		EmbeddingEnabled: true,
+		RAGModel:         "text-embedding-test",
+		EmbeddingHost:    "http://127.0.0.1:8081",
+	}, repo, nil, infraembedding.New(), nil)
+
+	_ = service.ProcessFile(context.Background(), domainconversation.FileObject{
+		ID:           1,
+		UserID:       1,
+		FileID:       "file_video",
+		FileName:     "clip.mp4",
+		MimeType:     "video/mp4",
+		FileCategory: "video",
+		StoragePath:  "uploads/clip.mp4",
+		Status:       "active",
+	})
+
+	if repo.updateStatusCalls != 0 {
+		t.Fatal("expected ProcessFile to skip video embedding")
 	}
 }
 

--- a/backend/internal/application/processing/service.go
+++ b/backend/internal/application/processing/service.go
@@ -128,10 +128,14 @@ func (s *Service) InitializeUploadedFile(ctx context.Context, fileObj *domaincon
 		return nil
 	}
 	now := time.Now()
-	if fileObj.FileCategory == "image" && !s.snapshot().ExtractImageOCREnabled {
+	if fileObj.FileCategory == "video" || (fileObj.FileCategory == "image" && !s.snapshot().ExtractImageOCREnabled) {
 		fileObj.ProcessingStatus = "ready"
 		fileObj.ProcessingReady = true
 		fileObj.ExtractStatus = "none"
+		ragReason := "image_not_applicable"
+		if fileObj.FileCategory == "video" {
+			ragReason = "video_not_applicable"
+		}
 		processingStatus := "ready"
 		processingReady := true
 		processingErrorCode := ""
@@ -154,7 +158,7 @@ func (s *Service) InitializeUploadedFile(ctx context.Context, fileObj *domaincon
 			ProcessingStatus: "ready",
 			ExtractStatus:    "none",
 			RAGReady:         false,
-			RAGReason:        "image_not_applicable",
+			RAGReason:        ragReason,
 			ExtractorVersion: s.version(),
 			StartedAt:        &now,
 			CompletedAt:      &now,

--- a/backend/internal/application/settings/model_option_policy.go
+++ b/backend/internal/application/settings/model_option_policy.go
@@ -22,6 +22,7 @@ var validModelOptionProtocolKeys = map[string]struct{}{
 	"xai_image_edits":             {},
 	"gemini_generate_content":     {},
 	"google_image_generation":     {},
+	"gemini_interactions":         {},
 }
 
 // validateModelOptionPathsJSON 校验模型参数透传路径配置，防止保存不可解析或越界的策略。

--- a/backend/internal/application/settings/seed.go
+++ b/backend/internal/application/settings/seed.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	defaultAllowedMIMETypes = "image/jpeg,image/png,image/webp,image/gif,text/plain,text/markdown,text/csv,text/yaml,application/json,application/yaml,application/x-yaml,application/toml,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
-	defaultRAGModel         = "sentence-transformers/all-MiniLM-L6-v2"
-	defaultLoginPageTitle   = "Sign in to DEEIX Chat"
+	legacyDefaultAllowedMIMETypes = "image/jpeg,image/png,image/webp,image/gif,text/plain,text/markdown,text/csv,text/yaml,application/json,application/yaml,application/x-yaml,application/toml,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
+	defaultAllowedMIMETypes       = "image/jpeg,image/png,image/webp,image/gif,video/mp4,video/webm,text/plain,text/markdown,text/csv,text/yaml,application/json,application/yaml,application/x-yaml,application/toml,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
+	defaultRAGModel               = "sentence-transformers/all-MiniLM-L6-v2"
+	defaultLoginPageTitle         = "Sign in to DEEIX Chat"
 )
 
 // defaultSettings 返回所有动态配置的默认种子数据。

--- a/backend/internal/application/settings/service.go
+++ b/backend/internal/application/settings/service.go
@@ -92,7 +92,10 @@ func (s *Service) Seed(ctx context.Context, cfg config.Config) error {
 	if err != nil {
 		return err
 	}
-	return s.repo.UpsertWithDescription(ctx, items)
+	if err := s.repo.UpsertWithDescription(ctx, items); err != nil {
+		return err
+	}
+	return s.migrateDefaultAllowedMIMETypes(ctx)
 }
 
 // ListAll 查询全部配置，按 namespace 分组。
@@ -132,6 +135,61 @@ func (s *Service) RuntimeValuesByNamespace(ctx context.Context, namespace string
 		result[item.Key] = strings.TrimSpace(value)
 	}
 	return result, nil
+}
+
+func (s *Service) migrateDefaultAllowedMIMETypes(ctx context.Context) error {
+	items, err := s.repo.ListByNamespace(ctx, "file")
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		if item.Key != "allowed_mime_types" {
+			continue
+		}
+		value := strings.TrimSpace(item.Value)
+		if value == "" || !sameCSVSet(value, legacyDefaultAllowedMIMETypes) {
+			return nil
+		}
+		updates, encryptErr := s.encryptSettingsForStorage([]domainsettings.SystemSetting{{
+			Namespace:   "file",
+			Key:         "allowed_mime_types",
+			Value:       defaultAllowedMIMETypes,
+			ValueType:   "string",
+			Description: "白名单MIME类型(逗号分隔)",
+		}})
+		if encryptErr != nil {
+			return encryptErr
+		}
+		return s.repo.Upsert(ctx, updates)
+	}
+	return nil
+}
+
+func sameCSVSet(left string, right string) bool {
+	leftSet := csvSet(left)
+	rightSet := csvSet(right)
+	if len(leftSet) != len(rightSet) {
+		return false
+	}
+	for item := range leftSet {
+		if _, ok := rightSet[item]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func csvSet(raw string) map[string]struct{} {
+	parts := strings.Split(raw, ",")
+	result := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		value := strings.ToLower(strings.TrimSpace(part))
+		if value == "" {
+			continue
+		}
+		result[value] = struct{}{}
+	}
+	return result
 }
 
 // validNamespaces 合法的 namespace 集合。

--- a/backend/internal/application/settings/service_seed_test.go
+++ b/backend/internal/application/settings/service_seed_test.go
@@ -1,0 +1,98 @@
+package settings
+
+import (
+	"context"
+	"testing"
+
+	domainsettings "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/settings"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
+)
+
+type settingsSeedRepo struct {
+	items map[string]domainsettings.SystemSetting
+}
+
+func newSettingsSeedRepo(items ...domainsettings.SystemSetting) *settingsSeedRepo {
+	repo := &settingsSeedRepo{items: map[string]domainsettings.SystemSetting{}}
+	for _, item := range items {
+		repo.items[item.Namespace+":"+item.Key] = item
+	}
+	return repo
+}
+
+func (r *settingsSeedRepo) ListAll(context.Context) ([]domainsettings.SystemSetting, error) {
+	items := make([]domainsettings.SystemSetting, 0, len(r.items))
+	for _, item := range r.items {
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+func (r *settingsSeedRepo) ListByNamespace(_ context.Context, namespace string) ([]domainsettings.SystemSetting, error) {
+	items := make([]domainsettings.SystemSetting, 0)
+	for _, item := range r.items {
+		if item.Namespace == namespace {
+			items = append(items, item)
+		}
+	}
+	return items, nil
+}
+
+func (r *settingsSeedRepo) Upsert(_ context.Context, items []domainsettings.SystemSetting) error {
+	for _, item := range items {
+		r.items[item.Namespace+":"+item.Key] = item
+	}
+	return nil
+}
+
+func (r *settingsSeedRepo) UpsertWithDescription(_ context.Context, items []domainsettings.SystemSetting) error {
+	for _, item := range items {
+		key := item.Namespace + ":" + item.Key
+		if _, ok := r.items[key]; !ok {
+			r.items[key] = item
+		}
+	}
+	return nil
+}
+
+func (r *settingsSeedRepo) Delete(_ context.Context, namespace string, key string) error {
+	delete(r.items, namespace+":"+key)
+	return nil
+}
+
+func TestSeedMigratesLegacyDefaultAllowedMIMETypes(t *testing.T) {
+	repo := newSettingsSeedRepo(domainsettings.SystemSetting{
+		Namespace: "file",
+		Key:       "allowed_mime_types",
+		Value:     legacyDefaultAllowedMIMETypes,
+		ValueType: "string",
+	})
+	service := NewService(repo, "")
+
+	if err := service.Seed(context.Background(), config.Config{}); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+	got := repo.items["file:allowed_mime_types"].Value
+	if got != defaultAllowedMIMETypes {
+		t.Fatalf("expected legacy MIME defaults to migrate, got %q", got)
+	}
+}
+
+func TestSeedKeepsCustomAllowedMIMETypes(t *testing.T) {
+	custom := "image/png,text/plain"
+	repo := newSettingsSeedRepo(domainsettings.SystemSetting{
+		Namespace: "file",
+		Key:       "allowed_mime_types",
+		Value:     custom,
+		ValueType: "string",
+	})
+	service := NewService(repo, "")
+
+	if err := service.Seed(context.Background(), config.Config{}); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+	got := repo.items["file:allowed_mime_types"].Value
+	if got != custom {
+		t.Fatalf("expected custom MIME defaults to stay unchanged, got %q", got)
+	}
+}

--- a/backend/internal/application/upload/service.go
+++ b/backend/internal/application/upload/service.go
@@ -289,7 +289,7 @@ func (s *Service) UploadFile(ctx context.Context, input UploadFileInput) (*Uploa
 		StoragePath:      relativePath,
 		Status:           "active",
 		ProcessingStatus: "uploaded",
-		ProcessingReady:  category == fileCategoryImage && !cfg.ExtractImageOCREnabled,
+		ProcessingReady:  category == fileCategoryVideo || (category == fileCategoryImage && !cfg.ExtractImageOCREnabled),
 		ExtractStatus:    "none",
 		EmbedStatus:      "none",
 		ExtractorVersion: s.resolveExtractorVersion(),
@@ -325,7 +325,7 @@ func (s *Service) UploadFile(ctx context.Context, input UploadFileInput) (*Uploa
 				zap.Error(initErr),
 			)
 		}
-	} else if category != fileCategoryImage {
+	} else if fileCategoryRequiresProcessing(category) {
 		fileItem.ProcessingStatus = "queued"
 		fileItem.ProcessingReady = false
 		fileItem.ProcessingErrorCode = ""
@@ -579,6 +579,7 @@ func (s *Service) OpenFileContent(ctx context.Context, userID uint, fileID strin
 
 const (
 	fileCategoryImage   = "image"
+	fileCategoryVideo   = "video"
 	fileCategoryPDF     = "pdf"
 	fileCategoryWord    = "word"
 	fileCategoryExcel   = "excel"
@@ -717,6 +718,10 @@ func normalizeDetectedMIME(detected string, fileName string) string {
 		return "text/yaml"
 	case "toml":
 		return "application/toml"
+	case "mp4":
+		return "video/mp4"
+	case "webm":
+		return "video/webm"
 	}
 	if ext != "" && isTextMIMEForEmbed("", "sample."+ext) {
 		return "text/plain"
@@ -781,6 +786,8 @@ func inferFileCategory(mimeType string, fileName string) string {
 	switch {
 	case strings.HasPrefix(mimeType, "image/"):
 		return fileCategoryImage
+	case strings.HasPrefix(mimeType, "video/"):
+		return fileCategoryVideo
 	case mimeType == "application/pdf" || ext == "pdf":
 		return fileCategoryPDF
 	case strings.Contains(mimeType, "wordprocessingml") || strings.Contains(mimeType, "msword") || ext == "docx" || ext == "doc":
@@ -815,12 +822,24 @@ func maxBytesForCategory(category string, cfg config.Config) int64 {
 	if category == fileCategoryImage {
 		return cfg.FileImageMaxBytes
 	}
+	if category == fileCategoryVideo {
+		return 0
+	}
 	return cfg.FileDocMaxBytes
+}
+
+func fileCategoryRequiresProcessing(category string) bool {
+	switch category {
+	case fileCategoryPDF, fileCategoryWord, fileCategoryExcel, fileCategoryText:
+		return true
+	default:
+		return false
+	}
 }
 
 func supportsRAG(category string) bool {
 	switch category {
-	case fileCategoryPDF, fileCategoryWord, fileCategoryExcel, fileCategoryText:
+	case fileCategoryPDF, fileCategoryWord, fileCategoryExcel, fileCategoryText, fileCategoryImage:
 		return true
 	default:
 		return false

--- a/backend/internal/application/upload/service_test.go
+++ b/backend/internal/application/upload/service_test.go
@@ -261,6 +261,64 @@ func TestNormalizeDetectedMIMEDowngradesActiveContent(t *testing.T) {
 	}
 }
 
+func TestNormalizeDetectedMIMERecognizesVideoExtensions(t *testing.T) {
+	tests := []struct {
+		detected string
+		fileName string
+		want     string
+	}{
+		{detected: "application/octet-stream", fileName: "clip.mp4", want: "video/mp4"},
+		{detected: "application/octet-stream", fileName: "clip.webm", want: "video/webm"},
+	}
+	for _, tt := range tests {
+		if got := normalizeDetectedMIME(tt.detected, tt.fileName); got != tt.want {
+			t.Fatalf("normalizeDetectedMIME(%q, %q) = %q, want %q", tt.detected, tt.fileName, got, tt.want)
+		}
+	}
+}
+
+func TestUploadFileAllowsMP4WhenVideoMP4IsAllowed(t *testing.T) {
+	ctx := context.Background()
+	repo := newUploadTestRepo()
+	store := newUploadTestStore()
+	cfg := config.Config{
+		MaxUploadFileBytes:    1024 * 1024,
+		UserStorageQuotaBytes: 10 * 1024 * 1024,
+		FileAllowedMIMETypes:  "video/mp4",
+	}
+	service := NewServiceWithRuntime(config.NewRuntime(cfg), repo, nil, Hooks{}, ErrorSet{
+		InvalidFileReference: repository.ErrInvalidInput,
+		InvalidFileName:      repository.ErrInvalidInput,
+		StorageQuotaExceeded: repository.ErrConflict,
+		FileTooLarge:         repository.ErrInvalidInput,
+		MIMEBlocked:          repository.ErrInvalidInput,
+		DangerousMIMEType:    repository.ErrInvalidInput,
+	}, "test")
+	service.SetObjectStoreProvider(uploadTestStoreProvider{store: store})
+
+	content := []byte("not a real mp4 but uploaded with a .mp4 extension")
+	result, err := service.UploadFile(ctx, UploadFileInput{
+		UserID:       1,
+		Purpose:      "chat",
+		FileName:     "clip.mp4",
+		MimeType:     "video/mp4",
+		DeclaredSize: int64(len(content)),
+		Reader:       bytes.NewReader(content),
+	})
+	if err != nil {
+		t.Fatalf("mp4 upload should be allowed: %v", err)
+	}
+	if result.File.DetectedMIME != "video/mp4" {
+		t.Fatalf("DetectedMIME = %q, want video/mp4", result.File.DetectedMIME)
+	}
+	if result.File.FileCategory != fileCategoryVideo {
+		t.Fatalf("FileCategory = %q, want %q", result.File.FileCategory, fileCategoryVideo)
+	}
+	if result.File.ProcessingStatus != "uploaded" || !result.File.ProcessingReady {
+		t.Fatalf("video processing state = %q ready=%v, want uploaded ready=true", result.File.ProcessingStatus, result.File.ProcessingReady)
+	}
+}
+
 func TestValidateImageFile(t *testing.T) {
 	repo := newUploadTestRepo()
 	store := newUploadTestStore()

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -106,6 +106,22 @@ func DefaultModelOptionAllowedPathsJSON() string {
     "generationConfig.imageConfig.aspectRatio",
     "generationConfig.imageConfig.imageSize"
   ],
+  "gemini_interactions": [
+    "generation_config.temperature",
+    "generation_config.top_p",
+    "generation_config.max_output_tokens",
+    "generation_config.thinking_level",
+    "response_format.type",
+    "response_format.aspect_ratio",
+    "response_format.image_size",
+    "response_format.mime_type",
+    "responseFormat.type",
+    "responseFormat.aspectRatio",
+    "responseFormat.imageSize",
+    "responseFormat.mimeType",
+    "generationConfig.videoConfig.task",
+    "generation_config.video_config.task"
+  ],
   "anthropic_messages": [
     "speed",
     "top_k",
@@ -590,7 +606,7 @@ func Load() Config {
 		FileImageMaxBytes:                 0,
 		FileDocMaxBytes:                   0,
 		FileFullContextPDFMaxPages:        20,
-		FileAllowedMIMETypes:              "image/jpeg,image/png,image/webp,image/gif,text/plain,text/markdown,text/csv,text/yaml,application/json,application/yaml,application/x-yaml,application/toml,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel",
+		FileAllowedMIMETypes:              "image/jpeg,image/png,image/webp,image/gif,video/mp4,video/webm,text/plain,text/markdown,text/csv,text/yaml,application/json,application/yaml,application/x-yaml,application/toml,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel",
 		ExtractEngine:                     "builtin",
 		ExtractOCREngine:                  "rapidocr",
 		ExtractImageOCREnabled:            false,

--- a/backend/internal/infra/llm/adapter.go
+++ b/backend/internal/infra/llm/adapter.go
@@ -18,6 +18,7 @@ const (
 	AdapterAnthropicMessages      = "anthropic_messages"          // POST /v1/messages
 	AdapterGoogleGenerateContent  = "google_generate_content"     // POST /v1beta/models/{model}:generateContent
 	AdapterGoogleImageGeneration  = "google_image_generation"     // POST /v1beta/models/{model}:generateContent
+	AdapterGeminiInteractions     = "gemini_interactions"         // POST /v1beta/interactions
 	AdapterXAIResponses           = "xai_responses"               // POST /v1/responses（OpenAI 兼容）
 	AdapterXAIImage               = "xai_image"                   // POST /v1/images/generations
 	AdapterXAIImageEdits          = "xai_image_edits"             // POST /v1/images/edits
@@ -58,6 +59,7 @@ func IsKnownAdapter(raw string) bool {
 		AdapterAnthropicMessages,
 		AdapterGoogleGenerateContent,
 		AdapterGoogleImageGeneration,
+		AdapterGeminiInteractions,
 		AdapterXAIResponses,
 		AdapterXAIImage,
 		AdapterXAIImageEdits:
@@ -71,7 +73,7 @@ func IsKnownAdapter(raw string) bool {
 func IsImplementedAdapter(raw string) bool {
 	switch NormalizeAdapter(raw) {
 	case AdapterOpenAIResponses, AdapterOpenRouterChat, AdapterOpenRouterResponses, AdapterOpenAIChatCompletions, AdapterOpenAIImageGenerations, AdapterOpenAIImageEdits, AdapterXAIResponses,
-		AdapterAnthropicMessages, AdapterGoogleGenerateContent, AdapterGoogleImageGeneration, AdapterXAIImage, AdapterXAIImageEdits:
+		AdapterAnthropicMessages, AdapterGoogleGenerateContent, AdapterGoogleImageGeneration, AdapterGeminiInteractions, AdapterXAIImage, AdapterXAIImageEdits:
 		return true
 	default:
 		return false
@@ -90,6 +92,7 @@ func SupportsStreamingAdapter(raw string) bool {
 		AdapterAnthropicMessages,
 		AdapterGoogleGenerateContent,
 		AdapterGoogleImageGeneration,
+		AdapterGeminiInteractions,
 		AdapterXAIResponses:
 		return true
 	default:
@@ -104,6 +107,8 @@ func SupportsImageGenerationStream(protocol string, model string) bool {
 		return openAIImageGenerationModelSupportsStream(model)
 	case AdapterGoogleImageGeneration:
 		return true
+	case AdapterGeminiInteractions:
+		return true
 	case AdapterOpenAIImageEdits:
 		return openAIImageEditModelSupportsStream(model)
 	default:
@@ -114,7 +119,7 @@ func SupportsImageGenerationStream(protocol string, model string) bool {
 // IsImageGenerationAdapter 返回协议是否属于独立图片生成链路。
 func IsImageGenerationAdapter(raw string) bool {
 	switch NormalizeAdapter(raw) {
-	case AdapterOpenAIImageGenerations, AdapterGoogleImageGeneration, AdapterXAIImage:
+	case AdapterOpenAIImageGenerations, AdapterGoogleImageGeneration, AdapterGeminiInteractions, AdapterXAIImage:
 		return true
 	default:
 		return false
@@ -124,11 +129,16 @@ func IsImageGenerationAdapter(raw string) bool {
 // IsImageEditAdapter 返回协议是否属于独立图片编辑链路。
 func IsImageEditAdapter(raw string) bool {
 	switch NormalizeAdapter(raw) {
-	case AdapterOpenAIImageEdits, AdapterGoogleImageGeneration, AdapterXAIImageEdits:
+	case AdapterOpenAIImageEdits, AdapterGoogleImageGeneration, AdapterGeminiInteractions, AdapterXAIImageEdits:
 		return true
 	default:
 		return false
 	}
+}
+
+// IsVideoGenerationAdapter 返回协议是否属于独立视频生成链路。
+func IsVideoGenerationAdapter(raw string) bool {
+	return NormalizeAdapter(raw) == AdapterGeminiInteractions
 }
 
 // DefaultEndpointForAdapter 返回协议对应的固定端点标识。
@@ -140,6 +150,8 @@ func DefaultEndpointForAdapter(adapter string) string {
 		return EndpointImageGenerations
 	case AdapterOpenAIImageEdits, AdapterXAIImageEdits:
 		return EndpointImageEdits
+	case AdapterGeminiInteractions:
+		return EndpointInteractions
 	default:
 		// openai_responses、openrouter_responses、xai_responses 及所有未知值均使用 Responses 端点。
 		return EndpointResponses

--- a/backend/internal/infra/llm/adapter_test.go
+++ b/backend/internal/infra/llm/adapter_test.go
@@ -29,6 +29,9 @@ func TestSupportsImageGenerationStream(t *testing.T) {
 	if !SupportsImageGenerationStream(AdapterGoogleImageGeneration, "gemini-3-pro-image") {
 		t.Fatalf("expected google image generation adapter to support image generation streaming")
 	}
+	if !SupportsImageGenerationStream(AdapterGeminiInteractions, "gemini-3.5-flash") {
+		t.Fatalf("expected Gemini Interactions adapter to support image generation streaming")
+	}
 	if SupportsStreamingAdapter(AdapterXAIImage) {
 		t.Fatalf("expected xAI image adapter to use non-streaming media flow")
 	}

--- a/backend/internal/infra/llm/client.go
+++ b/backend/internal/infra/llm/client.go
@@ -27,6 +27,8 @@ const (
 	EndpointImageGenerations = "image_generations"
 	// EndpointImageEdits 表示 OpenAI Images API 编辑端点。
 	EndpointImageEdits = "image_edits"
+	// EndpointInteractions 表示 Gemini Interactions API 端点。
+	EndpointInteractions = "interactions"
 )
 
 // 超时默认值。
@@ -635,6 +637,7 @@ type GenerateOutput struct {
 	ServerSideToolUsage map[string]int64
 	Citations           []string
 	GeneratedImages     []GeneratedImage
+	GeneratedVideos     []GeneratedVideo
 	RawJSON             string
 	Debug               *UpstreamDebugSnapshot `json:"-"`
 
@@ -647,6 +650,14 @@ type GeneratedImage struct {
 	B64JSON       string
 	MIMEType      string
 	RevisedPrompt string
+}
+
+// GeneratedVideo 表示视频生成接口返回的一个视频结果。
+type GeneratedVideo struct {
+	URL      string
+	B64JSON  string
+	MIMEType string
+	FileName string
 }
 
 // ReasoningDelta 定义流式 reasoning 增量。
@@ -748,6 +759,7 @@ func NewClientWithEnv(env string, ssrfProtectionEnabled bool) *Client {
 		AdapterAnthropicMessages:      &anthropicMessagesAdapter{client: client},
 		AdapterGoogleGenerateContent:  &geminiGenerateContentAdapter{client: client},
 		AdapterGoogleImageGeneration:  &geminiImageGenerationAdapter{client: client},
+		AdapterGeminiInteractions:     &geminiInteractionsAdapter{client: client},
 	}
 	return client
 }
@@ -1491,6 +1503,8 @@ func normalizeEndpoint(raw string) string {
 		return EndpointImageGenerations
 	case EndpointImageEdits:
 		return EndpointImageEdits
+	case EndpointInteractions:
+		return EndpointInteractions
 	default:
 		return EndpointResponses
 	}

--- a/backend/internal/infra/llm/gemini.go
+++ b/backend/internal/infra/llm/gemini.go
@@ -726,11 +726,11 @@ func buildGeminiParts(msg Message) []map[string]interface{} {
 
 func (c *Client) newGeminiRequest(
 	ctx context.Context,
-	method, url string,
+	method, requestURL string,
 	body io.Reader,
 	route RouteConfig,
 ) (*http.Request, error) {
-	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, body)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/infra/llm/gemini_interactions.go
+++ b/backend/internal/infra/llm/gemini_interactions.go
@@ -1,0 +1,1257 @@
+package llm
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// geminiInteractionsAdapter 实现 Google Gemini Interactions API。
+type geminiInteractionsAdapter struct {
+	client *Client
+}
+
+func (a *geminiInteractionsAdapter) Name() string { return AdapterGeminiInteractions }
+
+func (a *geminiInteractionsAdapter) Generate(ctx context.Context, route RouteConfig, input GenerateInput) (*GenerateOutput, error) {
+	return a.client.generateGeminiInteraction(ctx, route, input)
+}
+
+func (a *geminiInteractionsAdapter) GenerateStream(
+	ctx context.Context,
+	route RouteConfig,
+	input GenerateInput,
+	onEvent func(GenerateStreamEvent) error,
+) (*GenerateOutput, error) {
+	return a.client.generateGeminiInteractionStream(ctx, route, input, onEvent)
+}
+
+func (a *geminiInteractionsAdapter) ListModels(ctx context.Context, route RouteConfig) ([]ModelItem, error) {
+	return a.client.listModelsGemini(ctx, route)
+}
+
+func (c *Client) generateGeminiInteraction(ctx context.Context, route RouteConfig, input GenerateInput) (*GenerateOutput, error) {
+	base := geminiBaseURL(route)
+	requestURL := buildGeminiInteractionsURL(base)
+	requestBody, err := buildGeminiInteractionRequestBody(route, input)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, resolveReadTimeout(route.ReadTimeoutMS))
+	defer cancel()
+
+	req, err := c.newGeminiRequest(requestCtx, http.MethodPost, requestURL, bytes.NewReader(payload), route)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClientForRoute(route).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, err := readUpstreamBody(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, parseGeminiError(resp.StatusCode, body, upstreamDebugSnapshot(req, payload, resp, body))
+	}
+	return parseGeminiInteractionOutput(body)
+}
+
+func (c *Client) generateGeminiInteractionStream(
+	ctx context.Context,
+	route RouteConfig,
+	input GenerateInput,
+	onEvent func(GenerateStreamEvent) error,
+) (*GenerateOutput, error) {
+	base := geminiBaseURL(route)
+	requestURL := buildGeminiInteractionsURL(base)
+	requestBody, err := buildGeminiInteractionRequestBody(route, input)
+	if err != nil {
+		return nil, err
+	}
+	requestBody["stream"] = true
+	payload, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	firstByteCtx, firstByteCancel := context.WithCancel(ctx)
+	defer firstByteCancel()
+
+	firstByteTimer := time.AfterFunc(resolveReadTimeout(route.ReadTimeoutMS), firstByteCancel)
+	defer firstByteTimer.Stop()
+
+	req, err := c.newGeminiRequest(firstByteCtx, http.MethodPost, requestURL, bytes.NewReader(payload), route)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.httpClientForRoute(route).Do(req)
+	firstByteTimer.Stop()
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := readUpstreamBody(resp.Body)
+		return nil, parseGeminiError(resp.StatusCode, body, upstreamDebugSnapshot(req, payload, resp, body))
+	}
+
+	result := &GenerateOutput{
+		ToolCalls: make([]ToolCall, 0),
+	}
+	idleReader := newIdleTimeoutReader(resp.Body, resolveStreamIdleTimeout(route.StreamIdleTimeoutMS))
+	streamBody := newUpstreamBodyRecorder(idleReader)
+	if err = consumeGeminiInteractionStream(streamBody, result, onEvent); err != nil {
+		return nil, attachUpstreamDebug(err, upstreamDebugSnapshot(req, payload, resp, streamErrorBody(streamBody, err)))
+	}
+	return result, nil
+}
+
+func buildGeminiInteractionsURL(base string) string {
+	return buildGeminiEndpointURL(base, "/interactions")
+}
+
+func buildGeminiInteractionRequestBody(route RouteConfig, input GenerateInput) (map[string]interface{}, error) {
+	model := strings.TrimSpace(route.UpstreamModel)
+	if model == "" {
+		return nil, fmt.Errorf("interaction model required")
+	}
+	interactionInput := buildGeminiInteractionInput(input.Messages)
+	if geminiInteractionInputEmpty(interactionInput) {
+		return nil, fmt.Errorf("interaction input required")
+	}
+	payload := map[string]interface{}{
+		"model": model,
+		"input": interactionInput,
+	}
+	if format := buildGeminiInteractionResponseFormat(route, input.Options); !geminiInteractionInputEmpty(format) {
+		payload["response_format"] = format
+	}
+	if config := buildGeminiInteractionGenerationConfig(input.Options); len(config) > 0 {
+		payload["generation_config"] = config
+	}
+	if instructions := strings.TrimSpace(input.Instructions); instructions != "" {
+		payload["system_instruction"] = instructions
+	}
+	if previousID := strings.TrimSpace(input.PreviousResponseID); previousID != "" {
+		payload["previous_interaction_id"] = previousID
+	}
+	if tools := buildGeminiInteractionTools(input.Tools); len(tools) > 0 && !input.DisableTools {
+		payload["tools"] = tools
+	}
+	applyProviderOptions(payload, input.Options, geminiInteractionsProtectedProviderOptionKeys()...)
+	return payload, nil
+}
+
+func buildGeminiInteractionInput(messages []Message) interface{} {
+	steps := make([]map[string]interface{}, 0, len(messages))
+	for _, message := range messages {
+		stepType := geminiInteractionStepType(message.Role)
+		contentMessage := message
+		contentMessage.ToolCalls = nil
+		contentMessage.ToolResults = nil
+		if stepType != "" {
+			content := buildGeminiInteractionContent(contentMessage)
+			if !geminiInteractionInputEmpty(content) {
+				steps = append(steps, map[string]interface{}{
+					"type":    stepType,
+					"content": content,
+				})
+			}
+		}
+		for _, call := range message.ToolCalls {
+			if functionCall := buildGeminiInteractionFunctionCall(call); len(functionCall) > 0 {
+				steps = append(steps, functionCall)
+			}
+		}
+		for _, result := range message.ToolResults {
+			if functionResult := buildGeminiInteractionFunctionResult(result); len(functionResult) > 0 {
+				steps = append(steps, functionResult)
+			}
+		}
+	}
+	if len(steps) == 1 && steps[0]["type"] == "user_input" {
+		return steps[0]["content"]
+	}
+	return steps
+}
+
+func geminiInteractionStepType(role string) string {
+	switch strings.TrimSpace(strings.ToLower(role)) {
+	case "assistant", "model":
+		return "model_output"
+	case "user", "tool":
+		return "user_input"
+	default:
+		return ""
+	}
+}
+
+func buildGeminiInteractionContent(message Message) interface{} {
+	if len(message.Parts) == 0 {
+		return strings.TrimSpace(message.Content)
+	}
+	items := make([]map[string]interface{}, 0, len(message.Parts)+1)
+	if text := strings.TrimSpace(message.Content); text != "" {
+		items = append(items, map[string]interface{}{"type": "text", "text": text})
+	}
+	for _, part := range message.Parts {
+		switch part.Kind {
+		case ContentPartText, ContentPartFile:
+			text := strings.TrimSpace(part.Text)
+			if text == "" {
+				continue
+			}
+			items = append(items, map[string]interface{}{"type": "text", "text": text})
+		case ContentPartImage:
+			if len(part.Data) == 0 {
+				continue
+			}
+			mimeType := strings.TrimSpace(part.MimeType)
+			if mimeType == "" {
+				mimeType = "image/png"
+			}
+			items = append(items, map[string]interface{}{
+				"type":      "image",
+				"mime_type": mimeType,
+				"data":      base64.StdEncoding.EncodeToString(part.Data),
+			})
+		}
+	}
+	if len(items) == 1 && items[0]["type"] == "text" {
+		return strings.TrimSpace(getString(items[0]["text"]))
+	}
+	return items
+}
+
+func buildGeminiInteractionFunctionCall(call ToolCall) map[string]interface{} {
+	name := strings.TrimSpace(call.ToolName)
+	if name == "" {
+		return nil
+	}
+	args := strings.TrimSpace(call.ArgumentsJSON)
+	if args == "" {
+		args = "{}"
+	}
+	arguments := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(args), &arguments); err != nil {
+		arguments = map[string]interface{}{"arguments": args}
+	}
+	item := map[string]interface{}{
+		"type":      "function_call",
+		"name":      name,
+		"arguments": arguments,
+	}
+	if id := strings.TrimSpace(call.ToolCallID); id != "" {
+		item["id"] = id
+	}
+	return item
+}
+
+func buildGeminiInteractionFunctionResult(result ToolResult) map[string]interface{} {
+	name := strings.TrimSpace(result.ToolName)
+	if name == "" {
+		return nil
+	}
+	item := map[string]interface{}{
+		"type":   "function_result",
+		"name":   name,
+		"result": geminiInteractionFunctionResultContent(result),
+	}
+	if id := strings.TrimSpace(result.ToolCallID); id != "" {
+		item["call_id"] = id
+	}
+	return item
+}
+
+func geminiInteractionFunctionResultContent(result ToolResult) []map[string]interface{} {
+	output := map[string]interface{}{}
+	raw := strings.TrimSpace(result.OutputJSON)
+	if raw != "" {
+		var decoded interface{}
+		if err := json.Unmarshal([]byte(raw), &decoded); err == nil {
+			if payload, ok := decoded.(map[string]interface{}); ok {
+				output = payload
+			} else {
+				output["content"] = decoded
+			}
+		} else {
+			output["content"] = raw
+		}
+	}
+	if errText := strings.TrimSpace(result.Error); errText != "" {
+		output["error"] = errText
+	}
+	if len(output) == 0 {
+		output["content"] = ""
+	}
+	text, err := json.Marshal(output)
+	if err != nil {
+		text = []byte(`{"content":""}`)
+	}
+	return []map[string]interface{}{{
+		"type": "text",
+		"text": string(text),
+	}}
+}
+
+func geminiInteractionInputEmpty(value interface{}) bool {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed) == ""
+	case map[string]interface{}:
+		return len(typed) == 0
+	case []map[string]interface{}:
+		return len(typed) == 0
+	case []interface{}:
+		return len(typed) == 0
+	default:
+		return value == nil
+	}
+}
+
+func buildGeminiInteractionResponseFormat(route RouteConfig, options map[string]interface{}) interface{} {
+	if rawFormats, ok := firstGeminiInteractionResponseFormatList(options); ok {
+		items := make([]interface{}, 0, len(rawFormats))
+		for _, rawFormat := range rawFormats {
+			if format := normalizeGeminiInteractionResponseFormat(route, rawFormat); len(format) > 0 {
+				items = append(items, format)
+			}
+		}
+		if len(items) > 0 {
+			return items
+		}
+	}
+	raw := modelParamMap(options, "response_format")
+	if len(raw) == 0 {
+		raw = modelParamMap(options, "responseFormat")
+	}
+	return normalizeGeminiInteractionResponseFormat(route, raw)
+}
+
+func normalizeGeminiInteractionResponseFormat(route RouteConfig, raw map[string]interface{}) map[string]interface{} {
+	responseType := geminiInteractionResponseType(getString(raw["type"]))
+	if responseType == "" {
+		switch normalizeEndpoint(route.Endpoint) {
+		case EndpointImageGenerations, EndpointImageEdits:
+			responseType = "image"
+		}
+	}
+	if responseType == "" {
+		return nil
+	}
+	format := map[string]interface{}{
+		"type": responseType,
+	}
+	if responseType == "video" {
+		format["delivery"] = "uri"
+	}
+	if aspectRatio := geminiInteractionAspectRatio(getString(raw["aspect_ratio"]), responseType); aspectRatio != "" {
+		format["aspect_ratio"] = aspectRatio
+	}
+	if aspectRatio := geminiInteractionAspectRatio(getString(raw["aspectRatio"]), responseType); aspectRatio != "" {
+		format["aspect_ratio"] = aspectRatio
+	}
+	if imageSize := geminiInteractionImageSize(getString(raw["image_size"])); imageSize != "" {
+		format["image_size"] = imageSize
+	}
+	if imageSize := geminiInteractionImageSize(getString(raw["imageSize"])); imageSize != "" {
+		format["image_size"] = imageSize
+	}
+	if mimeType := geminiInteractionMIMEType(getString(raw["mime_type"]), responseType); mimeType != "" {
+		format["mime_type"] = mimeType
+	}
+	if mimeType := geminiInteractionMIMEType(getString(raw["mimeType"]), responseType); mimeType != "" {
+		format["mime_type"] = mimeType
+	}
+	return format
+}
+
+func firstGeminiInteractionResponseFormatList(options map[string]interface{}) ([]map[string]interface{}, bool) {
+	for _, key := range []string{"response_format", "responseFormat"} {
+		value, ok := options[key]
+		if !ok {
+			continue
+		}
+		switch typed := value.(type) {
+		case []map[string]interface{}:
+			items := make([]map[string]interface{}, 0, len(typed))
+			for _, item := range typed {
+				if len(item) > 0 {
+					items = append(items, item)
+				}
+			}
+			return items, len(items) > 0
+		case []interface{}:
+			items := make([]map[string]interface{}, 0, len(typed))
+			for _, raw := range typed {
+				item := asMap(raw)
+				if len(item) > 0 {
+					items = append(items, item)
+				}
+			}
+			return items, len(items) > 0
+		default:
+			return nil, false
+		}
+	}
+	return nil, false
+}
+
+func geminiInteractionResponseType(value string) string {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "image":
+		return "image"
+	case "video":
+		return "video"
+	case "text":
+		return "text"
+	default:
+		return ""
+	}
+}
+
+func buildGeminiInteractionGenerationConfig(options map[string]interface{}) map[string]interface{} {
+	config := map[string]interface{}{}
+	raw := modelParamMap(options, "generation_config")
+	if len(raw) == 0 {
+		raw = modelParamMap(options, "generationConfig")
+	}
+	for key, value := range raw {
+		if strings.TrimSpace(key) != "" {
+			config[camelToSnakeGeminiInteractionKey(key)] = value
+		}
+	}
+	if maxTokens, ok := firstGeminiIntOption(options, "max_output_tokens", "max_completion_tokens", "maxOutputTokens"); ok && maxTokens > 0 {
+		config["max_output_tokens"] = maxTokens
+	}
+	if value, ok := modelParamFloat(options, "temperature"); ok {
+		config["temperature"] = value
+	}
+	if value, ok := firstGeminiFloatOption(options, "top_p", "topP"); ok {
+		config["top_p"] = value
+	}
+	if topK, ok := firstGeminiIntOption(options, "top_k", "topK"); ok && topK > 0 {
+		config["top_k"] = topK
+	}
+	if stops := firstGeminiStringListOption(options, "stop", "stop_sequences", "stopSequences"); len(stops) > 0 {
+		config["stop_sequences"] = stops
+	}
+	if level := firstGeminiStringOption(options, "thinking_level", "thinkingLevel"); level != "" {
+		config["thinking_level"] = level
+	}
+	if videoConfig := buildGeminiInteractionVideoConfig(modelParamMap(raw, "video_config")); len(videoConfig) > 0 {
+		config["video_config"] = videoConfig
+	} else if videoConfig := buildGeminiInteractionVideoConfig(modelParamMap(raw, "videoConfig")); len(videoConfig) > 0 {
+		config["video_config"] = videoConfig
+	}
+	return config
+}
+
+func buildGeminiInteractionVideoConfig(raw map[string]interface{}) map[string]interface{} {
+	config := map[string]interface{}{}
+	if task := geminiInteractionVideoTask(getString(raw["task"])); task != "" {
+		config["task"] = task
+	}
+	return config
+}
+
+func geminiInteractionAspectRatio(value string, responseType string) string {
+	normalized := strings.TrimSpace(value)
+	switch responseType {
+	case "video":
+		switch normalized {
+		case "9:16", "16:9":
+			return normalized
+		default:
+			return ""
+		}
+	default:
+		switch normalized {
+		case "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9", "1:4", "4:1", "1:8", "8:1":
+			return normalized
+		default:
+			return ""
+		}
+	}
+}
+
+func geminiInteractionVideoTask(value string) string {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "text_to_video":
+		return "text_to_video"
+	case "image_to_video":
+		return "image_to_video"
+	case "reference_to_video":
+		return "reference_to_video"
+	case "edit":
+		return "edit"
+	default:
+		return ""
+	}
+}
+
+func geminiInteractionImageSize(value string) string {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case "512", "1K", "2K", "4K":
+		return strings.ToUpper(strings.TrimSpace(value))
+	default:
+		return ""
+	}
+}
+
+func geminiInteractionMIMEType(value string, responseType string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "" {
+		return ""
+	}
+	switch responseType {
+	case "image":
+		switch normalized {
+		case "image/png", "image/jpeg", "image/webp":
+			return normalized
+		}
+	case "video":
+		if strings.HasPrefix(normalized, "video/") {
+			return normalized
+		}
+	}
+	return ""
+}
+
+func camelToSnakeGeminiInteractionKey(value string) string {
+	switch strings.TrimSpace(value) {
+	case "maxOutputTokens":
+		return "max_output_tokens"
+	case "topP":
+		return "top_p"
+	case "topK":
+		return "top_k"
+	case "stopSequences":
+		return "stop_sequences"
+	case "videoConfig":
+		return "video_config"
+	case "thinkingLevel":
+		return "thinking_level"
+	default:
+		return value
+	}
+}
+
+func buildGeminiInteractionTools(tools []ToolDefinition) []map[string]interface{} {
+	if len(tools) == 0 {
+		return nil
+	}
+	items := make([]map[string]interface{}, 0, len(tools))
+	for _, tool := range tools {
+		name := strings.TrimSpace(tool.Name)
+		if name == "" {
+			continue
+		}
+		items = append(items, map[string]interface{}{
+			"type":        "function",
+			"name":        name,
+			"description": strings.TrimSpace(tool.Description),
+			"parameters":  geminiToolParameterSchema(decodeToolSchema(tool.InputSchema)),
+		})
+	}
+	return items
+}
+
+func geminiInteractionsProtectedProviderOptionKeys() []string {
+	return []string{
+		"input",
+		"model",
+		"response_format",
+		"responseFormat",
+		"thinking_level",
+		"thinkingLevel",
+		"generation_config",
+		"generationConfig",
+		"max_completion_tokens",
+		"max_output_tokens",
+		"maxOutputTokens",
+		"previous_interaction_id",
+		"previousInteractionId",
+		"stop",
+		"stopSequences",
+		"stream",
+		"system_instruction",
+		"systemInstruction",
+		"temperature",
+		"tools",
+		"top_k",
+		"top_p",
+		"topK",
+		"topP",
+	}
+}
+
+func firstString(payload map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(getString(payload[key])); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func consumeGeminiInteractionStream(
+	reader io.Reader,
+	result *GenerateOutput,
+	onEvent func(GenerateStreamEvent) error,
+) error {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxUpstreamBodyBytes)
+
+	var dataLines []string
+	flush := func() error {
+		data := strings.TrimSpace(strings.Join(dataLines, "\n"))
+		dataLines = dataLines[:0]
+		if data == "" || data == "[DONE]" {
+			return nil
+		}
+		parsed := make(map[string]interface{})
+		if err := json.Unmarshal([]byte(data), &parsed); err != nil {
+			return nil
+		}
+		if err := parseStreamUpstreamError(parsed, data); err != nil {
+			return err
+		}
+		return applyGeminiInteractionStreamEvent(parsed, result, onEvent)
+	}
+
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), "\r")
+		if line == "" {
+			if err := flush(); err != nil {
+				return err
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			dataLines = append(dataLines, strings.TrimPrefix(line[len("data:"):], " "))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return flush()
+}
+
+func applyGeminiInteractionStreamEvent(
+	parsed map[string]interface{},
+	result *GenerateOutput,
+	onEvent func(GenerateStreamEvent) error,
+) error {
+	if result == nil {
+		return nil
+	}
+	eventType := strings.TrimSpace(getString(parsed["type"]))
+	if responseID := geminiInteractionStreamResponseID(parsed, eventType); responseID != "" {
+		result.ResponseID = responseID
+	}
+	if finalPayload := geminiInteractionStreamFinalPayload(parsed, eventType); len(finalPayload) > 0 {
+		return mergeGeminiInteractionStreamFinal(result, finalPayload, onEvent)
+	}
+	if delta := geminiInteractionStreamTextDelta(parsed); delta != "" {
+		result.Text += delta
+		if onEvent != nil {
+			if err := onEvent(GenerateStreamEvent{
+				Delta:      delta,
+				ResponseID: result.ResponseID,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	for _, call := range parseGeminiInteractionFunctionCalls(parsed) {
+		result.ToolCalls = append(result.ToolCalls, call)
+	}
+	result.ToolCalls = dedupeGeminiInteractionToolCalls(result.ToolCalls)
+	result.GeneratedImages = dedupeGeminiInteractionImages(append(result.GeneratedImages, extractGeminiInteractionGeneratedImages(parsed)...))
+	result.GeneratedVideos = dedupeGeminiInteractionVideos(append(result.GeneratedVideos, extractGeminiInteractionGeneratedVideos(parsed)...))
+	if usage := parseGeminiInteractionUsage(parsed); usage != (Usage{}) {
+		result.Usage = usage
+		if onEvent != nil {
+			return onEvent(GenerateStreamEvent{
+				Usage:      usage,
+				ResponseID: result.ResponseID,
+			})
+		}
+	}
+	return nil
+}
+
+func geminiInteractionStreamResponseID(parsed map[string]interface{}, eventType string) string {
+	if interaction := asMap(parsed["interaction"]); len(interaction) > 0 {
+		return firstString(interaction, "id", "name")
+	}
+	if strings.HasPrefix(strings.ToLower(eventType), "interaction.") {
+		return firstString(parsed, "id", "name", "interaction_id", "interactionId")
+	}
+	return firstString(parsed, "interaction_id", "interactionId")
+}
+
+func geminiInteractionStreamFinalPayload(parsed map[string]interface{}, eventType string) map[string]interface{} {
+	eventType = strings.ToLower(strings.TrimSpace(eventType))
+	if eventType != "interaction.completed" && eventType != "completed" {
+		return nil
+	}
+	return parsed
+}
+
+func mergeGeminiInteractionStreamFinal(
+	result *GenerateOutput,
+	payload map[string]interface{},
+	onEvent func(GenerateStreamEvent) error,
+) error {
+	finalOutput := parseGeminiInteractionPayload(payload)
+	if finalOutput.ResponseID != "" {
+		result.ResponseID = finalOutput.ResponseID
+	}
+	if finalOutput.Text != "" {
+		delta := ""
+		if result.Text == "" {
+			delta = finalOutput.Text
+		} else if strings.HasPrefix(finalOutput.Text, result.Text) && len(finalOutput.Text) > len(result.Text) {
+			delta = finalOutput.Text[len(result.Text):]
+		}
+		result.Text = finalOutput.Text
+		if delta != "" && onEvent != nil {
+			if err := onEvent(GenerateStreamEvent{
+				Delta:      delta,
+				ResponseID: result.ResponseID,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	if finalOutput.Usage != (Usage{}) {
+		result.Usage = finalOutput.Usage
+		if onEvent != nil {
+			if err := onEvent(GenerateStreamEvent{
+				Usage:      finalOutput.Usage,
+				ResponseID: result.ResponseID,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	result.ToolCalls = dedupeGeminiInteractionToolCalls(append(result.ToolCalls, finalOutput.ToolCalls...))
+	result.GeneratedImages = dedupeGeminiInteractionImages(append(result.GeneratedImages, finalOutput.GeneratedImages...))
+	result.GeneratedVideos = dedupeGeminiInteractionVideos(append(result.GeneratedVideos, finalOutput.GeneratedVideos...))
+	return nil
+}
+
+func geminiInteractionStreamTextDelta(parsed map[string]interface{}) string {
+	eventType := strings.ToLower(strings.TrimSpace(getString(parsed["type"])))
+	if strings.Contains(eventType, "text") || strings.Contains(eventType, "output") {
+		for _, key := range []string{"delta", "text", "output_text"} {
+			if text := geminiInteractionTextDeltaFromValue(parsed[key]); text != "" {
+				return text
+			}
+		}
+	}
+	return geminiInteractionTextDeltaFromValue(parsed["delta"])
+}
+
+func geminiInteractionTextDeltaFromValue(raw interface{}) string {
+	switch typed := raw.(type) {
+	case string:
+		return typed
+	case []interface{}:
+		parts := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if text := geminiInteractionTextDeltaFromValue(item); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, "")
+	case map[string]interface{}:
+		itemType := strings.ToLower(strings.TrimSpace(getString(typed["type"])))
+		switch itemType {
+		case "text", "output_text", "model_output":
+			if text := getString(typed["text"]); text != "" {
+				return text
+			}
+			return geminiInteractionTextDeltaFromValue(typed["content"])
+		case "thinking", "thought", "reasoning", "function_call", "function_result", "image", "video":
+			return ""
+		}
+		if text := getString(typed["text"]); text != "" {
+			return text
+		}
+		return geminiInteractionTextDeltaFromValue(typed["content"])
+	default:
+		return ""
+	}
+}
+
+func parseGeminiInteractionOutput(body []byte) (*GenerateOutput, error) {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, err
+	}
+	output := parseGeminiInteractionPayload(parsed)
+	output.RawJSON = string(body)
+	return output, nil
+}
+
+func parseGeminiInteractionPayload(parsed map[string]interface{}) *GenerateOutput {
+	payload := parsed
+	hasInteractionWrapper := false
+	if interaction := asMap(parsed["interaction"]); len(interaction) > 0 {
+		payload = interaction
+		hasInteractionWrapper = true
+	}
+	usage := parseGeminiInteractionUsage(parsed)
+	if usage == (Usage{}) && hasInteractionWrapper {
+		usage = parseGeminiInteractionUsage(payload)
+	}
+	output := &GenerateOutput{
+		ResponseID:      firstString(payload, "id", "name"),
+		Text:            strings.TrimSpace(firstString(payload, "text", "output_text")),
+		Usage:           usage,
+		ToolCalls:       parseGeminiInteractionFunctionCalls(payload),
+		GeneratedImages: extractGeminiInteractionGeneratedImages(payload),
+		GeneratedVideos: extractGeminiInteractionGeneratedVideos(payload),
+	}
+	if output.Text == "" {
+		output.Text = geminiInteractionTextFromOutput(payload["output"])
+	}
+	if output.Text == "" {
+		output.Text = geminiInteractionTextFromSteps(payload["steps"])
+	}
+	for i := range output.GeneratedImages {
+		if output.GeneratedImages[i].RevisedPrompt == "" {
+			output.GeneratedImages[i].RevisedPrompt = output.Text
+		}
+	}
+	return output
+}
+
+func parseGeminiInteractionUsage(parsed map[string]interface{}) Usage {
+	if usage := parseGeminiUsage(parsed); usage != (Usage{}) {
+		return usage
+	}
+	if metadata := asMap(parsed["usage_metadata"]); len(metadata) > 0 {
+		totalInputTokens := firstGeminiInteractionInt64(metadata, "promptTokenCount", "prompt_token_count", "inputTokens", "input_tokens", "prompt_tokens")
+		cacheReadTokens := firstGeminiInteractionInt64(metadata, "cachedContentTokenCount", "cached_content_token_count", "cacheReadTokens", "cache_read_tokens")
+		return Usage{
+			InputTokens:     nonCachedInputTokens(totalInputTokens, cacheReadTokens),
+			OutputTokens:    firstGeminiInteractionInt64(metadata, "candidatesTokenCount", "candidates_token_count", "outputTokens", "output_tokens", "completion_tokens"),
+			CacheReadTokens: cacheReadTokens,
+			ReasoningTokens: firstGeminiInteractionInt64(metadata, "thoughtsTokenCount", "thoughts_token_count", "reasoningTokens", "reasoning_tokens"),
+			RawUsageJSON:    rawJSONFromValue(metadata),
+		}
+	}
+	if usage := asMap(parsed["usage"]); len(usage) > 0 {
+		totalInputTokens := firstGeminiInteractionInt64(usage, "inputTokens", "input_tokens", "prompt_tokens", "promptTokenCount", "prompt_token_count")
+		cacheReadTokens := firstGeminiInteractionInt64(usage, "cacheReadTokens", "cache_read_tokens", "cachedContentTokenCount", "cached_content_token_count")
+		return Usage{
+			InputTokens:     nonCachedInputTokens(totalInputTokens, cacheReadTokens),
+			OutputTokens:    firstGeminiInteractionInt64(usage, "outputTokens", "output_tokens", "completion_tokens", "candidatesTokenCount", "candidates_token_count"),
+			CacheReadTokens: cacheReadTokens,
+			ReasoningTokens: firstGeminiInteractionInt64(usage, "reasoningTokens", "reasoning_tokens", "thoughtsTokenCount", "thoughts_token_count"),
+			RawUsageJSON:    rawJSONFromValue(usage),
+		}
+	}
+	return Usage{}
+}
+
+func firstGeminiInteractionInt64(payload map[string]interface{}, keys ...string) int64 {
+	for _, key := range keys {
+		if value := toInt64(payload[key]); value > 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func rawJSONFromValue(value interface{}) string {
+	if value == nil {
+		return ""
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
+func parseGeminiInteractionFunctionCalls(parsed map[string]interface{}) []ToolCall {
+	calls := make([]ToolCall, 0)
+	walkGeminiInteractionFunctionCalls(parsed["steps"], &calls)
+	walkGeminiInteractionFunctionCalls(parsed["output"], &calls)
+	return dedupeGeminiInteractionToolCalls(calls)
+}
+
+func walkGeminiInteractionFunctionCalls(value interface{}, calls *[]ToolCall) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		if call, ok := geminiInteractionToolCallFromMap(typed); ok {
+			*calls = append(*calls, call)
+		}
+		for _, child := range typed {
+			walkGeminiInteractionFunctionCalls(child, calls)
+		}
+	case []interface{}:
+		for _, child := range typed {
+			walkGeminiInteractionFunctionCalls(child, calls)
+		}
+	}
+}
+
+func geminiInteractionToolCallFromMap(item map[string]interface{}) (ToolCall, bool) {
+	if strings.TrimSpace(strings.ToLower(getString(item["type"]))) != "function_call" {
+		return ToolCall{}, false
+	}
+	name := strings.TrimSpace(getString(item["name"]))
+	if name == "" {
+		return ToolCall{}, false
+	}
+	arguments := normalizeJSONString(item["arguments"])
+	if arguments == "" {
+		arguments = normalizeJSONString(item["args"])
+	}
+	if arguments == "" {
+		arguments = "{}"
+	}
+	return ToolCall{
+		ToolCallID:    firstString(item, "id", "call_id", "tool_call_id"),
+		ToolType:      "function",
+		ToolName:      name,
+		ArgumentsJSON: arguments,
+		Status:        "requested",
+	}, true
+}
+
+func dedupeGeminiInteractionToolCalls(calls []ToolCall) []ToolCall {
+	if len(calls) <= 1 {
+		return calls
+	}
+	result := make([]ToolCall, 0, len(calls))
+	seen := make(map[string]struct{}, len(calls))
+	for _, call := range calls {
+		key := strings.TrimSpace(call.ToolCallID)
+		if key == "" {
+			key = call.ToolName + "\x00" + call.ArgumentsJSON
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, call)
+	}
+	return result
+}
+
+func extractGeminiInteractionGeneratedImages(parsed map[string]interface{}) []GeneratedImage {
+	images := make([]GeneratedImage, 0)
+	walkGeminiInteractionImages(parsed["output"], &images)
+	walkGeminiInteractionModelOutputContent(parsed["steps"], func(content interface{}) {
+		walkGeminiInteractionImages(content, &images)
+	})
+	return dedupeGeminiInteractionImages(images)
+}
+
+func dedupeGeminiInteractionImages(images []GeneratedImage) []GeneratedImage {
+	if len(images) <= 1 {
+		return images
+	}
+	deduped := make([]GeneratedImage, 0, len(images))
+	seen := make(map[string]struct{}, len(images))
+	for _, image := range images {
+		key := strings.TrimSpace(image.URL)
+		if key == "" {
+			key = strings.TrimSpace(image.B64JSON)
+		}
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		deduped = append(deduped, image)
+	}
+	return deduped
+}
+
+func walkGeminiInteractionModelOutputContent(raw interface{}, walk func(interface{})) {
+	if walk == nil {
+		return
+	}
+	for _, rawStep := range asSlice(raw) {
+		step := asMap(rawStep)
+		if stepType := strings.TrimSpace(strings.ToLower(getString(step["type"]))); stepType != "" && stepType != "model_output" {
+			continue
+		}
+		if content, ok := step["content"]; ok {
+			walk(content)
+			continue
+		}
+		walk(step)
+	}
+}
+
+func walkGeminiInteractionImages(value interface{}, images *[]GeneratedImage) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		if image, ok := geminiImageFromInteractionMap(typed); ok {
+			*images = append(*images, image)
+		}
+		for _, child := range typed {
+			walkGeminiInteractionImages(child, images)
+		}
+	case []interface{}:
+		for _, child := range typed {
+			walkGeminiInteractionImages(child, images)
+		}
+	}
+}
+
+func geminiImageFromInteractionMap(item map[string]interface{}) (GeneratedImage, bool) {
+	mimeType := strings.TrimSpace(firstString(item, "mime_type", "mimeType"))
+	if mimeType == "" {
+		if inlineData := asMap(item["inlineData"]); len(inlineData) > 0 {
+			mimeType = strings.TrimSpace(firstString(inlineData, "mimeType", "mime_type"))
+		}
+	}
+	if mimeType != "" && !strings.HasPrefix(strings.ToLower(mimeType), "image/") {
+		return GeneratedImage{}, false
+	}
+
+	url := strings.TrimSpace(firstString(item, "uri", "url", "file_uri", "fileUri"))
+	b64 := strings.TrimSpace(firstString(item, "b64_json", "b64Json", "data"))
+	if fileData := asMap(item["fileData"]); len(fileData) > 0 {
+		if url == "" {
+			url = strings.TrimSpace(firstString(fileData, "fileUri", "file_uri", "uri", "url"))
+		}
+		if mimeType == "" {
+			mimeType = strings.TrimSpace(firstString(fileData, "mimeType", "mime_type"))
+		}
+	}
+	if fileData := asMap(item["file_data"]); len(fileData) > 0 {
+		if url == "" {
+			url = strings.TrimSpace(firstString(fileData, "fileUri", "file_uri", "uri", "url"))
+		}
+		if mimeType == "" {
+			mimeType = strings.TrimSpace(firstString(fileData, "mimeType", "mime_type"))
+		}
+	}
+	if inlineData := asMap(item["inlineData"]); len(inlineData) > 0 {
+		if b64 == "" {
+			b64 = strings.TrimSpace(firstString(inlineData, "data", "b64_json", "b64Json"))
+		}
+		if mimeType == "" {
+			mimeType = strings.TrimSpace(firstString(inlineData, "mimeType", "mime_type"))
+		}
+	}
+	if inlineData := asMap(item["inline_data"]); len(inlineData) > 0 {
+		if b64 == "" {
+			b64 = strings.TrimSpace(firstString(inlineData, "data", "b64_json", "b64Json"))
+		}
+		if mimeType == "" {
+			mimeType = strings.TrimSpace(firstString(inlineData, "mimeType", "mime_type"))
+		}
+	}
+	if nested := asMap(item["image"]); len(nested) > 0 {
+		image, ok := geminiImageFromInteractionMap(nested)
+		if ok {
+			return image, true
+		}
+	}
+	itemType := strings.TrimSpace(strings.ToLower(firstString(item, "type")))
+	if mimeType == "" && itemType == "image" {
+		mimeType = "image/png"
+	}
+	if !strings.HasPrefix(strings.ToLower(mimeType), "image/") || (url == "" && b64 == "") {
+		return GeneratedImage{}, false
+	}
+	return GeneratedImage{
+		URL:      url,
+		B64JSON:  b64,
+		MIMEType: mimeType,
+	}, true
+}
+
+func extractGeminiInteractionGeneratedVideos(parsed map[string]interface{}) []GeneratedVideo {
+	videos := make([]GeneratedVideo, 0)
+	walkGeminiInteractionVideos(parsed["output"], &videos)
+	walkGeminiInteractionModelOutputContent(parsed["steps"], func(content interface{}) {
+		walkGeminiInteractionVideos(content, &videos)
+	})
+	return dedupeGeminiInteractionVideos(videos)
+}
+
+func dedupeGeminiInteractionVideos(videos []GeneratedVideo) []GeneratedVideo {
+	if len(videos) <= 1 {
+		return videos
+	}
+	deduped := make([]GeneratedVideo, 0, len(videos))
+	seen := make(map[string]struct{}, len(videos))
+	for _, video := range videos {
+		key := strings.TrimSpace(video.URL)
+		if key == "" {
+			key = strings.TrimSpace(video.B64JSON)
+		}
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		deduped = append(deduped, video)
+	}
+	return deduped
+}
+
+func walkGeminiInteractionVideos(value interface{}, videos *[]GeneratedVideo) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		if video, ok := geminiVideoFromMap(typed); ok {
+			*videos = append(*videos, video)
+		}
+		for _, child := range typed {
+			walkGeminiInteractionVideos(child, videos)
+		}
+	case []interface{}:
+		for _, child := range typed {
+			walkGeminiInteractionVideos(child, videos)
+		}
+	}
+}
+
+func geminiVideoFromMap(item map[string]interface{}) (GeneratedVideo, bool) {
+	mimeType := strings.TrimSpace(firstString(item, "mime_type", "mimeType"))
+	if mimeType == "" {
+		if inlineData := asMap(item["inlineData"]); len(inlineData) > 0 {
+			mimeType = strings.TrimSpace(firstString(inlineData, "mimeType", "mime_type"))
+		}
+	}
+	if mimeType != "" && !strings.HasPrefix(strings.ToLower(mimeType), "video/") {
+		return GeneratedVideo{}, false
+	}
+
+	url := strings.TrimSpace(firstString(item, "uri", "url", "file_uri", "fileUri"))
+	b64 := strings.TrimSpace(firstString(item, "b64_json", "b64Json", "data"))
+	if fileData := asMap(item["fileData"]); len(fileData) > 0 {
+		if url == "" {
+			url = strings.TrimSpace(firstString(fileData, "fileUri", "file_uri", "uri", "url"))
+		}
+		if mimeType == "" {
+			mimeType = strings.TrimSpace(firstString(fileData, "mimeType", "mime_type"))
+		}
+	}
+	if fileData := asMap(item["file_data"]); len(fileData) > 0 {
+		if url == "" {
+			url = strings.TrimSpace(firstString(fileData, "fileUri", "file_uri", "uri", "url"))
+		}
+		if mimeType == "" {
+			mimeType = strings.TrimSpace(firstString(fileData, "mimeType", "mime_type"))
+		}
+	}
+	if inlineData := asMap(item["inlineData"]); len(inlineData) > 0 {
+		if b64 == "" {
+			b64 = strings.TrimSpace(firstString(inlineData, "data", "b64_json", "b64Json"))
+		}
+		if mimeType == "" {
+			mimeType = strings.TrimSpace(firstString(inlineData, "mimeType", "mime_type"))
+		}
+	}
+	if inlineData := asMap(item["inline_data"]); len(inlineData) > 0 {
+		if b64 == "" {
+			b64 = strings.TrimSpace(firstString(inlineData, "data", "b64_json", "b64Json"))
+		}
+		if mimeType == "" {
+			mimeType = strings.TrimSpace(firstString(inlineData, "mimeType", "mime_type"))
+		}
+	}
+	if mimeType == "" {
+		mimeType = "video/mp4"
+	}
+	if !strings.HasPrefix(strings.ToLower(mimeType), "video/") || (url == "" && b64 == "") {
+		return GeneratedVideo{}, false
+	}
+	return GeneratedVideo{
+		URL:      url,
+		B64JSON:  b64,
+		MIMEType: mimeType,
+		FileName: strings.TrimSpace(firstString(item, "file_name", "fileName", "name")),
+	}, true
+}
+
+func geminiInteractionTextFromOutput(raw interface{}) string {
+	items, ok := raw.([]interface{})
+	if !ok {
+		return ""
+	}
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		if text := strings.TrimSpace(getString(asMap(item)["text"])); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func geminiInteractionTextFromSteps(raw interface{}) string {
+	steps, ok := raw.([]interface{})
+	if !ok {
+		return ""
+	}
+	parts := make([]string, 0, len(steps))
+	for _, rawStep := range steps {
+		step := asMap(rawStep)
+		if stepType := strings.TrimSpace(strings.ToLower(getString(step["type"]))); stepType != "" && stepType != "model_output" {
+			continue
+		}
+		parts = appendGeminiInteractionTextParts(parts, step["content"])
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func appendGeminiInteractionTextParts(parts []string, raw interface{}) []string {
+	switch typed := raw.(type) {
+	case string:
+		if text := strings.TrimSpace(typed); text != "" {
+			return append(parts, text)
+		}
+	case map[string]interface{}:
+		if itemType := strings.TrimSpace(strings.ToLower(getString(typed["type"]))); itemType != "" && itemType != "text" {
+			return parts
+		}
+		if text := strings.TrimSpace(getString(typed["text"])); text != "" {
+			return append(parts, text)
+		}
+		if content, ok := typed["content"]; ok {
+			parts = appendGeminiInteractionTextParts(parts, content)
+		}
+	case []interface{}:
+		for _, child := range typed {
+			parts = appendGeminiInteractionTextParts(parts, child)
+		}
+	}
+	return parts
+}

--- a/backend/internal/infra/llm/gemini_interactions_test.go
+++ b/backend/internal/infra/llm/gemini_interactions_test.go
@@ -1,0 +1,497 @@
+package llm
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGeminiInteractionsAdapterDefaults(t *testing.T) {
+	if got := DefaultEndpointForAdapter(AdapterGeminiInteractions); got != EndpointInteractions {
+		t.Fatalf("expected interactions endpoint, got %q", got)
+	}
+	if !IsVideoGenerationAdapter(AdapterGeminiInteractions) {
+		t.Fatal("expected Gemini Interactions to be a video generation adapter")
+	}
+	if !SupportsStreamingAdapter(AdapterGeminiInteractions) {
+		t.Fatal("Gemini Interactions should support official streaming")
+	}
+	if !IsImageGenerationAdapter(AdapterGeminiInteractions) {
+		t.Fatal("Gemini Interactions should support image generation")
+	}
+	if !IsImageEditAdapter(AdapterGeminiInteractions) {
+		t.Fatal("Gemini Interactions should support image editing")
+	}
+}
+
+func TestBuildGeminiInteractionRequestBody(t *testing.T) {
+	payload, err := buildGeminiInteractionRequestBody(RouteConfig{
+		Endpoint:      EndpointInteractions,
+		UpstreamModel: "gemini-omni-flash-preview",
+	}, GenerateInput{
+		Messages: []Message{{
+			Role: "user",
+			Parts: []ContentPart{
+				{Kind: ContentPartText, Text: "A short cinematic product video"},
+				{Kind: ContentPartImage, MimeType: "image/png", Data: []byte("image-bytes")},
+			},
+		}},
+		Options: map[string]interface{}{
+			"response_format": map[string]interface{}{"type": "video", "aspect_ratio": "16:9", "delivery": "b64_json"},
+			"generation_config": map[string]interface{}{
+				"video_config": map[string]interface{}{"task": "IMAGE_TO_VIDEO"},
+			},
+			"input": "override",
+		},
+	})
+	if err != nil {
+		t.Fatalf("build Gemini interaction request body: %v", err)
+	}
+	if payload["model"] != "gemini-omni-flash-preview" {
+		t.Fatalf("unexpected model: %#v", payload)
+	}
+	responseFormat, ok := payload["response_format"].(map[string]interface{})
+	if !ok || responseFormat["type"] != "video" {
+		t.Fatalf("expected video response format, got %#v", payload["response_format"])
+	}
+	if responseFormat["delivery"] != "uri" {
+		t.Fatalf("expected video delivery to use URI downloads, got %#v", payload["response_format"])
+	}
+	if responseFormat["aspect_ratio"] != "16:9" {
+		t.Fatalf("expected response_format aspect ratio, got %#v", payload["response_format"])
+	}
+	config, ok := payload["generation_config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected generation config, got %#v", payload["generation_config"])
+	}
+	videoConfig, ok := config["video_config"].(map[string]interface{})
+	if !ok || videoConfig["task"] != "image_to_video" {
+		t.Fatalf("expected video config task, got %#v", payload["generation_config"])
+	}
+	input, ok := payload["input"].([]map[string]interface{})
+	if !ok || len(input) != 2 {
+		t.Fatalf("expected text and image input parts, got %#v", payload["input"])
+	}
+	if input[0]["type"] != "text" || input[0]["text"] != "A short cinematic product video" {
+		t.Fatalf("unexpected text part: %#v", input[0])
+	}
+	if input[1]["type"] != "image" || input[1]["mime_type"] != "image/png" || input[1]["data"] == "" {
+		t.Fatalf("unexpected image part: %#v", input[1])
+	}
+}
+
+func TestBuildGeminiInteractionRequestBodyRequiresModel(t *testing.T) {
+	_, err := buildGeminiInteractionRequestBody(RouteConfig{
+		Endpoint: EndpointInteractions,
+	}, GenerateInput{
+		Messages: []Message{{Role: "user", Content: "Hello"}},
+	})
+	if err == nil {
+		t.Fatal("expected empty Interactions model to be rejected")
+	}
+}
+
+func TestBuildGeminiInteractionRequestBodySupportsUniversalOptionsAndTools(t *testing.T) {
+	payload, err := buildGeminiInteractionRequestBody(RouteConfig{
+		Endpoint:      EndpointInteractions,
+		UpstreamModel: "gemini-3-flash-preview",
+	}, GenerateInput{
+		Messages: []Message{
+			{Role: "user", Content: "Create a short answer and an image."},
+			{
+				Role:    "assistant",
+				Content: "I need the weather first.",
+				ToolCalls: []ToolCall{{
+					ToolCallID:    "call_weather",
+					ToolName:      "get_weather",
+					ArgumentsJSON: `{"location":"Paris"}`,
+				}},
+			},
+			{
+				Role: "tool",
+				ToolResults: []ToolResult{{
+					ToolCallID: "call_weather",
+					ToolName:   "get_weather",
+					OutputJSON: `{"temperature":"20C"}`,
+				}},
+			},
+			{Role: "user", Content: "Use that result."},
+		},
+		Tools: []ToolDefinition{{
+			Name:        "get_weather",
+			Description: "Gets weather for a location.",
+			InputSchema: json.RawMessage(`{
+				"type":"object",
+				"properties":{"location":{"type":"string"}},
+				"required":["location"]
+			}`),
+		}},
+		Options: map[string]interface{}{
+			"response_format": []interface{}{
+				map[string]interface{}{"type": "text"},
+				map[string]interface{}{
+					"type":         "image",
+					"aspect_ratio": "1:1",
+					"image_size":   "1K",
+					"mime_type":    "image/png",
+				},
+			},
+			"temperature":       0.4,
+			"top_p":             0.9,
+			"max_output_tokens": 512,
+			"thinking_level":    "low",
+			"generation_config": map[string]interface{}{
+				"thinkingLevel": "high",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build Gemini interaction universal body: %v", err)
+	}
+	formats, ok := payload["response_format"].([]interface{})
+	if !ok || len(formats) != 2 {
+		t.Fatalf("expected response_format array, got %#v", payload["response_format"])
+	}
+	if _, leaked := asMap(payload["response_format"])["_list"]; leaked {
+		t.Fatalf("response_format must not use private _list wrapper: %#v", payload["response_format"])
+	}
+	imageFormat := asMap(formats[1])
+	if imageFormat["type"] != "image" || imageFormat["aspect_ratio"] != "1:1" || imageFormat["image_size"] != "1K" || imageFormat["mime_type"] != "image/png" {
+		t.Fatalf("unexpected image response_format: %#v", imageFormat)
+	}
+	config, ok := payload["generation_config"].(map[string]interface{})
+	if !ok || config["temperature"] != 0.4 || config["top_p"] != 0.9 || config["max_output_tokens"] != 512 || config["thinking_level"] != "low" {
+		t.Fatalf("unexpected generation_config: %#v", payload["generation_config"])
+	}
+	tools, ok := payload["tools"].([]map[string]interface{})
+	if !ok || len(tools) != 1 {
+		t.Fatalf("expected Interactions tool declaration, got %#v", payload["tools"])
+	}
+	if tools[0]["type"] != "function" || tools[0]["name"] != "get_weather" {
+		t.Fatalf("unexpected tool declaration: %#v", tools[0])
+	}
+	steps, ok := payload["input"].([]map[string]interface{})
+	if !ok || len(steps) != 5 {
+		t.Fatalf("expected conversation steps with tool call/result, got %#v", payload["input"])
+	}
+	if steps[0]["type"] != "user_input" || steps[1]["type"] != "model_output" || steps[2]["type"] != "function_call" || steps[3]["type"] != "function_result" || steps[4]["type"] != "user_input" {
+		t.Fatalf("unexpected Interactions step order: %#v", steps)
+	}
+	if steps[2]["name"] != "get_weather" || steps[3]["name"] != "get_weather" {
+		t.Fatalf("expected function call/result steps, got %#v", steps)
+	}
+	if steps[3]["call_id"] != "call_weather" {
+		t.Fatalf("expected function result call_id, got %#v", steps[3])
+	}
+	resultContent, ok := steps[3]["result"].([]map[string]interface{})
+	if !ok || len(resultContent) != 1 || resultContent[0]["type"] != "text" || resultContent[0]["text"] != `{"temperature":"20C"}` {
+		t.Fatalf("expected function result content blocks, got %#v", steps[3]["result"])
+	}
+}
+
+func TestBuildGeminiInteractionRequestBodyAcceptsTypedResponseFormatList(t *testing.T) {
+	payload, err := buildGeminiInteractionRequestBody(RouteConfig{
+		Endpoint:      EndpointInteractions,
+		UpstreamModel: "gemini-3-flash-preview",
+	}, GenerateInput{
+		Messages: []Message{{Role: "user", Content: "Return text and image."}},
+		Options: map[string]interface{}{
+			"response_format": []map[string]interface{}{
+				{"type": "text"},
+				{"type": "image", "image_size": "2K"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build Gemini interaction typed response format body: %v", err)
+	}
+	formats, ok := payload["response_format"].([]interface{})
+	if !ok || len(formats) != 2 {
+		t.Fatalf("expected response_format array, got %#v", payload["response_format"])
+	}
+	imageFormat := asMap(formats[1])
+	if imageFormat["type"] != "image" || imageFormat["image_size"] != "2K" {
+		t.Fatalf("unexpected typed response_format image entry: %#v", imageFormat)
+	}
+}
+
+func TestBuildGeminiInteractionRequestBodyNormalizesVideoOptions(t *testing.T) {
+	payload, err := buildGeminiInteractionRequestBody(RouteConfig{
+		Endpoint:      EndpointInteractions,
+		UpstreamModel: "gemini-omni-flash-preview",
+	}, GenerateInput{
+		Messages: []Message{{Role: "user", Content: "Edit this video."}},
+		Options: map[string]interface{}{
+			"response_format": map[string]interface{}{"type": "video", "aspect_ratio": "1:1"},
+			"generation_config": map[string]interface{}{
+				"video_config": map[string]interface{}{"task": "edit"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build Gemini interaction video body: %v", err)
+	}
+	responseFormat := asMap(payload["response_format"])
+	if _, ok := responseFormat["aspect_ratio"]; ok {
+		t.Fatalf("unsupported video aspect ratio should be dropped, got %#v", responseFormat)
+	}
+	videoConfig := asMap(asMap(payload["generation_config"])["video_config"])
+	if videoConfig["task"] != "edit" {
+		t.Fatalf("expected video edit task to normalize to edit, got %#v", videoConfig)
+	}
+}
+
+func TestBuildGeminiInteractionRequestBodyUsesConversationSteps(t *testing.T) {
+	payload, err := buildGeminiInteractionRequestBody(RouteConfig{
+		Endpoint:      EndpointInteractions,
+		UpstreamModel: "gemini-3.5-flash",
+	}, GenerateInput{
+		Instructions: "Be concise.",
+		Messages: []Message{
+			{Role: "user", Content: "Hello"},
+			{Role: "assistant", Content: "Hi"},
+			{Role: "user", Content: "Reply with OK."},
+		},
+		PreviousResponseID: "interaction-prev",
+	})
+	if err != nil {
+		t.Fatalf("build Gemini interaction chat body: %v", err)
+	}
+	if _, ok := payload["response_format"]; ok {
+		t.Fatalf("chat interaction should not force media response_format, got %#v", payload["response_format"])
+	}
+	if payload["system_instruction"] != "Be concise." || payload["previous_interaction_id"] != "interaction-prev" {
+		t.Fatalf("expected instruction and previous interaction id, got %#v", payload)
+	}
+	steps, ok := payload["input"].([]map[string]interface{})
+	if !ok || len(steps) != 3 {
+		t.Fatalf("expected conversation steps, got %#v", payload["input"])
+	}
+	if steps[0]["type"] != "user_input" || steps[1]["type"] != "model_output" || steps[2]["content"] != "Reply with OK." {
+		t.Fatalf("unexpected steps: %#v", steps)
+	}
+}
+
+func TestParseGeminiInteractionOutputExtractsVideoURIAndInlineData(t *testing.T) {
+	inline := base64.StdEncoding.EncodeToString([]byte("video"))
+	body := []byte(`{
+		"id": "interaction-1",
+		"output": [
+			{"type": "video", "fileData": {"fileUri": "https://example.com/video.mp4", "mimeType": "video/mp4"}},
+			{"type": "video", "file_data": {"file_uri": "https://example.com/video.mp4", "mime_type": "video/mp4"}},
+			{"type": "video", "inlineData": {"data": "` + inline + `", "mimeType": "video/webm"}}
+		],
+		"usageMetadata": {"promptTokenCount": 3, "candidatesTokenCount": 5}
+	}`)
+	output, err := parseGeminiInteractionOutput(body)
+	if err != nil {
+		t.Fatalf("parse Gemini interaction output: %v", err)
+	}
+	if output.ResponseID != "interaction-1" {
+		t.Fatalf("unexpected response id: %q", output.ResponseID)
+	}
+	if got := len(output.GeneratedVideos); got != 2 {
+		t.Fatalf("expected duplicate URI to be deduped, got %d videos: %#v", got, output.GeneratedVideos)
+	}
+	if output.GeneratedVideos[0].URL != "https://example.com/video.mp4" || output.GeneratedVideos[0].MIMEType != "video/mp4" {
+		t.Fatalf("unexpected URI video: %#v", output.GeneratedVideos[0])
+	}
+	if output.GeneratedVideos[1].B64JSON != inline || output.GeneratedVideos[1].MIMEType != "video/webm" {
+		t.Fatalf("unexpected inline video: %#v", output.GeneratedVideos[1])
+	}
+	if output.Usage.InputTokens != 3 || output.Usage.OutputTokens != 5 {
+		t.Fatalf("unexpected usage: %#v", output.Usage)
+	}
+}
+
+func TestParseGeminiInteractionOutputExtractsTextAndImages(t *testing.T) {
+	inline := base64.StdEncoding.EncodeToString([]byte("png"))
+	inputInline := base64.StdEncoding.EncodeToString([]byte("source"))
+	body := []byte(`{
+		"id": "interaction-2",
+		"steps": [
+			{"type": "user_input", "content": [
+				{"type": "image", "inlineData": {"data": "` + inputInline + `", "mimeType": "image/png"}}
+			]},
+			{"type": "model_output", "content": [
+				{"type": "text", "text": "A revised prompt"},
+				{"type": "image", "inlineData": {"data": "` + inline + `", "mimeType": "image/png"}},
+				{"type": "image", "fileData": {"fileUri": "https://example.com/image.png", "mimeType": "image/png"}}
+			]}
+		]
+	}`)
+	output, err := parseGeminiInteractionOutput(body)
+	if err != nil {
+		t.Fatalf("parse Gemini interaction output: %v", err)
+	}
+	if output.Text != "A revised prompt" {
+		t.Fatalf("expected text from steps, got %q", output.Text)
+	}
+	if len(output.GeneratedImages) != 2 {
+		t.Fatalf("expected generated images, got %#v", output.GeneratedImages)
+	}
+	if output.GeneratedImages[0].B64JSON != inline || output.GeneratedImages[0].RevisedPrompt != "A revised prompt" {
+		t.Fatalf("unexpected inline image: %#v", output.GeneratedImages[0])
+	}
+	if output.GeneratedImages[0].B64JSON == inputInline {
+		t.Fatalf("user input image must not be treated as generated output: %#v", output.GeneratedImages)
+	}
+	if output.GeneratedImages[1].URL != "https://example.com/image.png" {
+		t.Fatalf("unexpected URI image: %#v", output.GeneratedImages[1])
+	}
+}
+
+func TestParseGeminiInteractionOutputExtractsFunctionCalls(t *testing.T) {
+	body := []byte(`{
+		"id": "interaction-tools",
+		"steps": [
+			{"type": "model_output", "content": "Let me check."},
+			{"type": "function_call", "id": "call_weather", "name": "get_weather", "arguments": {"location": "Paris"}},
+			{"type": "model_output", "content": [
+				{"type": "function_call", "id": "call_weather", "name": "get_weather", "arguments": {"location": "Paris"}}
+			]}
+		]
+	}`)
+	output, err := parseGeminiInteractionOutput(body)
+	if err != nil {
+		t.Fatalf("parse Gemini interaction output: %v", err)
+	}
+	if output.Text != "Let me check." {
+		t.Fatalf("expected text from model_output only, got %q", output.Text)
+	}
+	if len(output.ToolCalls) != 1 {
+		t.Fatalf("expected deduped function call, got %#v", output.ToolCalls)
+	}
+	call := output.ToolCalls[0]
+	if call.ToolCallID != "call_weather" || call.ToolType != "function" || call.ToolName != "get_weather" || call.Status != "requested" {
+		t.Fatalf("unexpected function call: %#v", call)
+	}
+	if call.ArgumentsJSON != `{"location":"Paris"}` {
+		t.Fatalf("unexpected arguments: %s", call.ArgumentsJSON)
+	}
+}
+
+func TestGenerateGeminiInteractionPostsInteractionsRequest(t *testing.T) {
+	var capturedPath string
+	var capturedPayload map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		if !strings.HasSuffix(capturedPath, "/v1beta/interactions") {
+			t.Fatalf("unexpected request path: %s", capturedPath)
+		}
+		if got := r.Header.Get("X-goog-api-key"); got != "test-key" {
+			t.Fatalf("expected Gemini API key header, got %q", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("expected Gemini interactions request to avoid bearer auth, got %q", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&capturedPayload); err != nil {
+			t.Fatalf("decode request payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"interaction-1","output":[{"fileData":{"fileUri":"https://example.com/video.mp4","mimeType":"video/mp4"}}]}`))
+	}))
+	defer server.Close()
+
+	output, err := NewClient().generateGeminiInteraction(context.Background(), RouteConfig{
+		BaseURL:       server.URL,
+		APIKey:        "test-key",
+		UpstreamModel: "gemini-omni-flash-preview",
+	}, GenerateInput{
+		Messages: []Message{{Role: "user", Content: "Make a short video"}},
+		Options:  map[string]interface{}{"response_format": map[string]interface{}{"type": "video"}},
+	})
+	if err != nil {
+		t.Fatalf("generate Gemini interaction: %v", err)
+	}
+	if capturedPayload["model"] != "gemini-omni-flash-preview" || capturedPayload["input"] != "Make a short video" {
+		t.Fatalf("unexpected request payload: %#v", capturedPayload)
+	}
+	if len(output.GeneratedVideos) != 1 || output.GeneratedVideos[0].URL != "https://example.com/video.mp4" {
+		t.Fatalf("unexpected generated videos: %#v", output.GeneratedVideos)
+	}
+}
+
+func TestGenerateGeminiInteractionStreamPostsStreamRequest(t *testing.T) {
+	var capturedPayload map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/v1beta/interactions") {
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-goog-api-key"); got != "test-key" {
+			t.Fatalf("expected Gemini API key header, got %q", got)
+		}
+		if got := r.Header.Get("Accept"); got != "text/event-stream" {
+			t.Fatalf("expected event-stream accept header, got %q", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&capturedPayload); err != nil {
+			t.Fatalf("decode request payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"interaction.created","interaction":{"id":"interaction-stream-1"}}
+
+data: {"type":"step.delta","interaction_id":"interaction-stream-1","delta":{"type":"text","text":"Hello"}}
+
+data: {"type":"step.delta","interaction_id":"interaction-stream-1","delta":{"type":"text","text":" world"}}
+
+data: {"type":"interaction.completed","usage_metadata":{"prompt_token_count":4,"candidates_token_count":2},"interaction":{"id":"interaction-stream-1","output":[{"type":"text","text":"Hello world"}]}}
+
+data: {"type":"done"}
+
+`))
+	}))
+	defer server.Close()
+
+	var deltas []string
+	var usageEvents []Usage
+	output, err := NewClient().GenerateStream(context.Background(), RouteConfig{
+		Protocol:      AdapterGeminiInteractions,
+		BaseURL:       server.URL,
+		APIKey:        "test-key",
+		UpstreamModel: "gemini-3.5-flash",
+	}, GenerateInput{
+		Messages: []Message{{Role: "user", Content: "How does AI work?"}},
+	}, func(event GenerateStreamEvent) error {
+		if event.Delta != "" {
+			deltas = append(deltas, event.Delta)
+		}
+		if event.Usage != (Usage{}) {
+			usageEvents = append(usageEvents, event.Usage)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("generate Gemini interaction stream: %v", err)
+	}
+	if capturedPayload["model"] != "gemini-3.5-flash" || capturedPayload["input"] != "How does AI work?" || capturedPayload["stream"] != true {
+		t.Fatalf("unexpected stream request payload: %#v", capturedPayload)
+	}
+	if output.ResponseID != "interaction-stream-1" || output.Text != "Hello world" {
+		t.Fatalf("unexpected stream output: %#v", output)
+	}
+	if strings.Join(deltas, "") != "Hello world" {
+		t.Fatalf("unexpected stream deltas: %#v", deltas)
+	}
+	if len(usageEvents) != 1 || output.Usage.InputTokens != 4 || output.Usage.OutputTokens != 2 {
+		t.Fatalf("unexpected stream usage events=%#v output=%#v", usageEvents, output.Usage)
+	}
+}
+
+func TestNewGeminiRequestUsesOnlyGoogleAPIKeyForOfficialHost(t *testing.T) {
+	req, err := NewClient().newGeminiRequest(context.Background(), http.MethodPost, "https://generativelanguage.googleapis.com/v1beta/interactions", nil, RouteConfig{
+		APIKey: "test-key",
+	})
+	if err != nil {
+		t.Fatalf("build Gemini request: %v", err)
+	}
+	if got := req.Header.Get("X-goog-api-key"); got != "test-key" {
+		t.Fatalf("expected Google API key header, got %q", got)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("expected official Gemini host to avoid bearer fallback, got %q", got)
+	}
+}

--- a/backend/internal/shared/response/error_code.go
+++ b/backend/internal/shared/response/error_code.go
@@ -161,6 +161,9 @@ var exactErrorSpecs = map[string]errorSpec{
 	"image edit requires at least one input image":            {Code: "media.image_edit_input_required", Message: "image edit requires at least one input image"},
 	"too many image edit input images":                        {Code: "media.image_edit_too_many_inputs", Message: "too many image edit input images"},
 	"image edit input image is invalid":                       {Code: "media.image_edit_input_invalid", Message: "image edit input image is invalid"},
+	"video prompt is required":                                {Code: "media.video_prompt_required", Message: "video prompt is required"},
+	"video generation input is invalid":                       {Code: "media.video_input_invalid", Message: "video generation input is invalid"},
+	"too many video generation input images":                  {Code: "media.video_too_many_inputs", Message: "too many video generation input images"},
 	"media route protocol does not match task":                {Code: "media.route_protocol_mismatch", Message: "media route protocol does not match task"},
 	"invalid media generation task":                           {Code: "media.invalid_task", Message: "invalid media generation task"},
 

--- a/backend/internal/transport/http/channel/dto_request.go
+++ b/backend/internal/transport/http/channel/dto_request.go
@@ -146,5 +146,5 @@ type ImportUpstreamModelItemRequest struct {
 
 // ModelProbeRequest 后台模型连通性测试请求。
 type ModelProbeRequest struct {
-	TaskType string `json:"taskType" binding:"omitempty,oneof=chat image_generation image_edit"`
+	TaskType string `json:"taskType" binding:"omitempty,oneof=chat image_generation image_edit video_generation"`
 }

--- a/backend/internal/transport/http/conversation/dto_request.go
+++ b/backend/internal/transport/http/conversation/dto_request.go
@@ -108,6 +108,18 @@ type MediaImageRequest struct {
 	BranchReason          string                 `json:"branchReason" binding:"omitempty,oneof=default retry edit"`
 }
 
+// MediaVideoRequest 视频生成请求。
+type MediaVideoRequest struct {
+	Prompt                string                 `json:"prompt" binding:"required"`
+	Model                 string                 `json:"model" binding:"omitempty,max=128"`
+	Options               map[string]interface{} `json:"options"`
+	ClientRunID           string                 `json:"clientRunID" binding:"omitempty,max=64"`
+	FileIDs               []string               `json:"fileIDs" binding:"max=1"`
+	ParentMessagePublicID string                 `json:"parentMessagePublicID" binding:"omitempty,max=32"`
+	SourceMessagePublicID string                 `json:"sourceMessagePublicID" binding:"omitempty,max=32"`
+	BranchReason          string                 `json:"branchReason" binding:"omitempty,oneof=default retry edit"`
+}
+
 // SetMessageFeedbackRequest 设置消息反馈请求。
 type SetMessageFeedbackRequest struct {
 	Feedback string `json:"feedback" binding:"omitempty,oneof=up down"`

--- a/backend/internal/transport/http/conversation/handler.go
+++ b/backend/internal/transport/http/conversation/handler.go
@@ -171,6 +171,15 @@ func mapStreamError(err error) streamError {
 	case errors.Is(err, appconversation.ErrMediaImageEditInputInvalid):
 		status = http.StatusBadRequest
 		message = "image edit input image is invalid"
+	case errors.Is(err, appconversation.ErrMediaVideoPromptRequired):
+		status = http.StatusBadRequest
+		message = "video prompt is required"
+	case errors.Is(err, appconversation.ErrMediaVideoInputInvalid):
+		status = http.StatusBadRequest
+		message = "video generation input is invalid"
+	case errors.Is(err, appconversation.ErrMediaVideoTooManyInputs):
+		status = http.StatusBadRequest
+		message = "too many video generation input images"
 	case errors.Is(err, appconversation.ErrMediaRouteProtocolMismatch):
 		status = http.StatusServiceUnavailable
 		message = "media route protocol does not match task"

--- a/backend/internal/transport/http/conversation/handler_media.go
+++ b/backend/internal/transport/http/conversation/handler_media.go
@@ -28,6 +28,65 @@ func (h *Handler) StreamImageEdit(c *gin.Context) {
 	h.streamMediaImage(c, appconversation.MediaImageTaskEdit)
 }
 
+// StreamVideoGeneration 处理会话内视频生成流式状态接口。
+func (h *Handler) StreamVideoGeneration(c *gin.Context) {
+	userID := middleware.MustUserID(c)
+	publicID, err := stringParam(c, "id")
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid conversation id")
+		return
+	}
+	conversation, err := h.service.GetConversationByPublicID(c.Request.Context(), userID, publicID)
+	if err != nil {
+		if errors.Is(err, appconversation.ErrConversationNotFound) {
+			response.Error(c, http.StatusNotFound, "conversation not found")
+			return
+		}
+		response.Error(c, http.StatusInternalServerError, "load conversation failed")
+		return
+	}
+	var req MediaVideoRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.Error(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	req.ClientRunID = appconversation.EnsureMessageGenerationRunID(req.ClientRunID)
+	req.Options = sanitizeMessageOptions(req.Options)
+	if err = h.ensureMediaVideoBillingModelAccess(c, conversation, &req); err != nil {
+		return
+	}
+	reservation, err := h.reserveMediaVideoUsageBalance(c, conversation, &req)
+	if err != nil {
+		return
+	}
+
+	h.streamMediaTask(
+		c,
+		req.ClientRunID,
+		reservation,
+		"视频生成失败退回预扣",
+		func(onEvent func(string, map[string]interface{}) error) (*appconversation.SendMessageResult, error) {
+			return h.service.StreamMediaVideo(c.Request.Context(), appconversation.MediaVideoInput{
+				UserID:                userID,
+				ConversationID:        conversation.ID,
+				RequestID:             middleware.MustRequestID(c),
+				Prompt:                req.Prompt,
+				PlatformModelName:     req.Model,
+				Options:               req.Options,
+				ClientRunID:           req.ClientRunID,
+				FileIDs:               req.FileIDs,
+				ParentMessagePublicID: req.ParentMessagePublicID,
+				SourceMessagePublicID: req.SourceMessagePublicID,
+				BranchReason:          req.BranchReason,
+				OnEvent:               onEvent,
+			})
+		},
+		func(result *appconversation.SendMessageResult) appconversation.SendMessageBillingInput {
+			return mediaVideoBillingInput(userID, conversation, &req, result)
+		},
+	)
+}
+
 // streamMediaImage 只负责 HTTP 绑定、计费预扣和 NDJSON 事件转发，图片业务由 application 执行。
 func (h *Handler) streamMediaImage(c *gin.Context, taskType appconversation.MediaImageTaskType) {
 	userID := middleware.MustUserID(c)
@@ -60,6 +119,43 @@ func (h *Handler) streamMediaImage(c *gin.Context, taskType appconversation.Medi
 		return
 	}
 
+	h.streamMediaTask(
+		c,
+		req.ClientRunID,
+		reservation,
+		"图片生成失败退回预扣",
+		func(onEvent func(string, map[string]interface{}) error) (*appconversation.SendMessageResult, error) {
+			return h.service.StreamMediaImage(c.Request.Context(), appconversation.MediaImageInput{
+				UserID:                userID,
+				ConversationID:        conversation.ID,
+				RequestID:             middleware.MustRequestID(c),
+				TaskType:              taskType,
+				Prompt:                req.Prompt,
+				PlatformModelName:     req.Model,
+				Options:               req.Options,
+				ClientRunID:           req.ClientRunID,
+				FileIDs:               req.FileIDs,
+				MaskFileID:            req.MaskFileID,
+				ParentMessagePublicID: req.ParentMessagePublicID,
+				SourceMessagePublicID: req.SourceMessagePublicID,
+				BranchReason:          req.BranchReason,
+				OnEvent:               onEvent,
+			})
+		},
+		func(result *appconversation.SendMessageResult) appconversation.SendMessageBillingInput {
+			return mediaImageBillingInput(userID, conversation, &req, result)
+		},
+	)
+}
+
+func (h *Handler) streamMediaTask(
+	c *gin.Context,
+	clientRunID string,
+	reservation *domainbilling.UsageBalanceReservation,
+	failureReleaseReason string,
+	run func(onEvent func(string, map[string]interface{}) error) (*appconversation.SendMessageResult, error),
+	billingInput func(result *appconversation.SendMessageResult) appconversation.SendMessageBillingInput,
+) {
 	c.Header("Content-Type", "application/x-ndjson; charset=utf-8")
 	c.Header("Cache-Control", "no-cache, no-transform")
 	c.Header("Connection", "keep-alive")
@@ -68,7 +164,7 @@ func (h *Handler) streamMediaImage(c *gin.Context, taskType appconversation.Medi
 
 	var clientDisconnected atomic.Bool
 	flushStreamEvent := func(payload map[string]interface{}) error {
-		payload = h.service.PublishMessageGenerationEvent(req.ClientRunID, payload)
+		payload = h.service.PublishMessageGenerationEvent(clientRunID, payload)
 		if clientDisconnected.Load() {
 			return nil
 		}
@@ -84,40 +180,25 @@ func (h *Handler) streamMediaImage(c *gin.Context, taskType appconversation.Medi
 		return nil
 	}
 
-	result, err := h.service.StreamMediaImage(c.Request.Context(), appconversation.MediaImageInput{
-		UserID:                userID,
-		ConversationID:        conversation.ID,
-		RequestID:             middleware.MustRequestID(c),
-		TaskType:              taskType,
-		Prompt:                req.Prompt,
-		PlatformModelName:     req.Model,
-		Options:               req.Options,
-		ClientRunID:           req.ClientRunID,
-		FileIDs:               req.FileIDs,
-		MaskFileID:            req.MaskFileID,
-		ParentMessagePublicID: req.ParentMessagePublicID,
-		SourceMessagePublicID: req.SourceMessagePublicID,
-		BranchReason:          req.BranchReason,
-		OnEvent: func(eventType string, payload map[string]interface{}) error {
-			_ = flushStreamEvent(normalizeStreamEventPayload(eventType, payload))
-			return nil
-		},
+	result, err := run(func(eventType string, payload map[string]interface{}) error {
+		_ = flushStreamEvent(normalizeStreamEventPayload(eventType, payload))
+		return nil
 	})
 	if err != nil {
-		if releaseErr := h.releaseSendMessageUsageReservation(reservation, "图片生成失败退回预扣"); releaseErr != nil {
+		if releaseErr := h.releaseSendMessageUsageReservation(reservation, failureReleaseReason); releaseErr != nil {
 			_ = flushStreamEvent(billingStreamErrorPayload(releaseErr))
-			h.service.FinishMessageGeneration(req.ClientRunID)
+			h.service.FinishMessageGeneration(clientRunID)
 			return
 		}
 		_ = flushStreamEvent(streamErrorPayload(err))
-		h.service.FinishMessageGeneration(req.ClientRunID)
+		h.service.FinishMessageGeneration(clientRunID)
 		return
 	}
 
 	billingCtx, billingCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	usageLedger, billingErr := h.service.RecordSendMessageBilling(
 		billingCtx,
-		mediaImageBillingInput(userID, conversation, &req, result),
+		billingInput(result),
 		reservation,
 	)
 	billingCancel()
@@ -126,7 +207,7 @@ func (h *Handler) streamMediaImage(c *gin.Context, taskType appconversation.Medi
 			_ = h.releaseSendMessageUsageReservation(reservation, "计费失败退回预扣")
 		}
 		_ = flushStreamEvent(billingStreamErrorPayload(billingErr))
-		h.service.FinishMessageGeneration(req.ClientRunID)
+		h.service.FinishMessageGeneration(clientRunID)
 		return
 	}
 	appconversation.ApplyUsageBilling(&result.AssistantMessage, usageLedger)
@@ -135,7 +216,7 @@ func (h *Handler) streamMediaImage(c *gin.Context, taskType appconversation.Medi
 		"type": "completed",
 		"data": toSendMessageResponse(result),
 	})
-	h.service.FinishMessageGeneration(req.ClientRunID)
+	h.service.FinishMessageGeneration(clientRunID)
 }
 
 // mediaImageBillingInput 构造媒体任务复用消息计费链路所需的上下文。
@@ -143,6 +224,26 @@ func mediaImageBillingInput(
 	userID uint,
 	conversation *model.Conversation,
 	req *MediaImageRequest,
+	result *appconversation.SendMessageResult,
+) appconversation.SendMessageBillingInput {
+	input := appconversation.SendMessageBillingInput{
+		UserID:            userID,
+		PlatformModelName: strings.TrimSpace(req.Model),
+		ClientRunID:       strings.TrimSpace(req.ClientRunID),
+		Result:            result,
+	}
+	if conversation != nil {
+		input.ConversationID = conversation.ID
+		input.ConversationModel = conversation.Model
+	}
+	return input
+}
+
+// mediaVideoBillingInput 构造视频任务复用消息计费链路所需的上下文。
+func mediaVideoBillingInput(
+	userID uint,
+	conversation *model.Conversation,
+	req *MediaVideoRequest,
 	result *appconversation.SendMessageResult,
 ) appconversation.SendMessageBillingInput {
 	input := appconversation.SendMessageBillingInput{
@@ -182,11 +283,56 @@ func (h *Handler) ensureMediaImageBillingModelAccess(c *gin.Context, conversatio
 	return nil
 }
 
+// ensureMediaVideoBillingModelAccess 在进入流式响应前校验模型是否可计费使用。
+func (h *Handler) ensureMediaVideoBillingModelAccess(c *gin.Context, conversation *model.Conversation, req *MediaVideoRequest) error {
+	if err := h.service.EnsureSendMessageBillingAccess(
+		c.Request.Context(),
+		mediaVideoBillingInput(middleware.MustUserID(c), conversation, req, nil),
+	); err != nil {
+		if errors.Is(err, billing.ErrPeriodCreditExceeded) {
+			response.Error(c, http.StatusPaymentRequired, "period usage credit exceeded")
+			return err
+		}
+		if errors.Is(err, billing.ErrModelPricingRequired) {
+			response.Error(c, http.StatusPaymentRequired, "model pricing is required")
+			return err
+		}
+		if errors.Is(err, billing.ErrUsageBalanceInsufficient) {
+			response.Error(c, http.StatusPaymentRequired, "usage balance is insufficient")
+			return err
+		}
+		response.Error(c, http.StatusInternalServerError, "billing access check failed")
+		return err
+	}
+	return nil
+}
+
 // reserveMediaImageUsageBalance 在上游调用前预扣余额，失败直接返回 HTTP 错误。
 func (h *Handler) reserveMediaImageUsageBalance(c *gin.Context, conversation *model.Conversation, req *MediaImageRequest) (*domainbilling.UsageBalanceReservation, error) {
 	reservation, err := h.service.ReserveSendMessageUsageBalance(
 		c.Request.Context(),
 		mediaImageBillingInput(middleware.MustUserID(c), conversation, req, nil),
+	)
+	if err != nil {
+		if errors.Is(err, billing.ErrUsageBalanceInsufficient) {
+			response.Error(c, http.StatusPaymentRequired, "usage balance is insufficient")
+			return nil, err
+		}
+		if errors.Is(err, billing.ErrModelPricingRequired) {
+			response.Error(c, http.StatusPaymentRequired, "model pricing is required")
+			return nil, err
+		}
+		response.Error(c, http.StatusInternalServerError, "usage balance reservation failed")
+		return nil, err
+	}
+	return reservation, nil
+}
+
+// reserveMediaVideoUsageBalance 在上游调用前预扣余额，失败直接返回 HTTP 错误。
+func (h *Handler) reserveMediaVideoUsageBalance(c *gin.Context, conversation *model.Conversation, req *MediaVideoRequest) (*domainbilling.UsageBalanceReservation, error) {
+	reservation, err := h.service.ReserveSendMessageUsageBalance(
+		c.Request.Context(),
+		mediaVideoBillingInput(middleware.MustUserID(c), conversation, req, nil),
 	)
 	if err != nil {
 		if errors.Is(err, billing.ErrUsageBalanceInsufficient) {

--- a/backend/internal/transport/http/conversation/router.go
+++ b/backend/internal/transport/http/conversation/router.go
@@ -33,6 +33,7 @@ func (m *Module) RegisterRoutes(authRequired *gin.RouterGroup) {
 	authRequired.POST("/conversations/:id/messages/stream", m.Handler.StreamMessage)
 	authRequired.POST("/conversations/:id/media/images/generations/stream", m.Handler.StreamImageGeneration)
 	authRequired.POST("/conversations/:id/media/images/edits/stream", m.Handler.StreamImageEdit)
+	authRequired.POST("/conversations/:id/media/videos/generations/stream", m.Handler.StreamVideoGeneration)
 	authRequired.GET("/context-artifacts/:id", m.Handler.GetContextArtifact)
 	authRequired.GET("/conversation-runs/:run_id/stream", m.Handler.ResumeMessageGenerationStream)
 	authRequired.POST("/conversation-runs/:run_id/cancel", m.Handler.CancelMessageGeneration)

--- a/backend/internal/transport/http/middleware/ratelimit.go
+++ b/backend/internal/transport/http/middleware/ratelimit.go
@@ -193,7 +193,8 @@ func isMessageGenerationRoute(method string, route string) bool {
 }
 
 func isMediaGenerationRoute(method string, route string) bool {
-	return method == http.MethodPost && strings.Contains(route, "/media/images/")
+	return method == http.MethodPost && (strings.Contains(route, "/media/images/") ||
+		strings.Contains(route, "/media/videos/"))
 }
 
 func isFileUploadRoute(method string, route string) bool {

--- a/frontend/app/(project)/preview/video-generation/page.tsx
+++ b/frontend/app/(project)/preview/video-generation/page.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+import * as React from "react";
+
+import { ChatArea } from "@/features/chat/components/sections/chat-area";
+import { ChatEmptyState } from "@/features/chat/components/sections/chat-empty";
+import { ChatInput } from "@/features/chat/components/sections/chat-input";
+import type { ChatAreaMessage, MessageAttachment } from "@/features/chat/types/messages";
+import type { ChatModelOption, PendingAttachment, UploadingAttachment } from "@/features/chat/types/chat-runtime";
+import type { ConversationOptions } from "@/shared/api/conversation.types";
+import type { FileContentResult } from "@/shared/api/file";
+import type { MCPToolDTO } from "@/shared/api/mcp.types";
+import type { SkillSummaryDTO } from "@/shared/api/skills.types";
+import type { PreviewDialogFile } from "@/shared/components/file-preview/file-preview-dialog";
+import { cn } from "@/lib/utils";
+
+const GENERATION_MS = 10_000;
+const VIDEO_MS = 5_000;
+const CONTENT_WIDTH_CLASS_NAME = "max-w-[1080px]";
+const DEFAULT_PROMPT =
+  "Create a 5 second cinematic video of an orange concept car driving through a coastal road at sunset.";
+const MODEL_NAME = "gemini-omni-flash-preview";
+const MOCK_VIDEO_FILE_ID = "file_mock_gemini_omni_video";
+const MOCK_VIDEO_MIME = "video/webm";
+const VIDEO_OPTIONS: ConversationOptions = {
+  response_format: { type: "video" },
+};
+
+type Phase = "queued" | "running" | "saving" | "complete";
+
+const EMPTY_ATTACHMENTS: PendingAttachment[] = [];
+const EMPTY_UPLOADS: UploadingAttachment[] = [];
+const MODEL_OPTIONS: ChatModelOption[] = [
+  {
+    platformModelName: MODEL_NAME,
+    icon: "gemini",
+    vendor: "Google",
+    kinds: ["chat", "image_gen", "image_edit", "video_gen"],
+    protocols: ["gemini_interactions"],
+    defaultOptions: VIDEO_OPTIONS,
+    optionControls: [],
+    lockedOptionPaths: [],
+    nativeToolKeys: [],
+    nativeTools: [],
+    pricing: null,
+  },
+];
+const EMPTY_TOOLS: MCPToolDTO[] = [];
+const EMPTY_SKILLS: SkillSummaryDTO[] = [];
+const DEFAULT_VIDEO_ATTACHMENT: MessageAttachment = {
+  fileID: MOCK_VIDEO_FILE_ID,
+  fileName: "gemini-omni-preview-5s.webm",
+  mimeType: MOCK_VIDEO_MIME,
+  detectedMime: MOCK_VIDEO_MIME,
+  fileCategory: "video",
+  sizeBytes: 1_250_000,
+  kind: "file",
+  processingStatus: "ready",
+  processingReady: true,
+};
+
+function phaseForElapsed(elapsed: number): Phase {
+  if (elapsed >= GENERATION_MS) return "complete";
+  if (elapsed >= 8_000) return "saving";
+  if (elapsed >= 2_000) return "running";
+  return "queued";
+}
+
+function activityLabelForPhase(phase: Phase): string {
+  if (phase === "queued") return "Video task queued";
+  if (phase === "running") return "Generating video";
+  if (phase === "saving") return "Saving video";
+  return "Video ready";
+}
+
+function buildMessages(prompt: string, phase: Phase, elapsed: number, createdAt: string): ChatAreaMessage[] {
+  const isComplete = phase === "complete";
+  const updatedAt = new Date(new Date(createdAt).getTime() + Math.min(elapsed, GENERATION_MS)).toISOString();
+  const userMessage: ChatAreaMessage = {
+    key: "preview-user",
+    publicID: "msg_preview_user",
+    parentPublicID: null,
+    sourcePublicID: null,
+    role: "user",
+    content: prompt,
+    contentType: "text",
+    branchReason: "default",
+    status: "success",
+    platformModelName: MODEL_NAME,
+    createdAt,
+    updatedAt: createdAt,
+  };
+  const assistantMessage: ChatAreaMessage = {
+    key: "preview-assistant",
+    publicID: "msg_preview_assistant",
+    parentPublicID: userMessage.publicID,
+    sourcePublicID: null,
+    role: "assistant",
+    contentType: "video",
+    content: isComplete ? "Generated 5-second video is ready." : "",
+    branchReason: "default",
+    status: isComplete ? "success" : "pending",
+    runID: "run_preview_gemini_omni_video",
+    platformModelName: MODEL_NAME,
+    createdAt,
+    updatedAt,
+    isPending: !isComplete,
+    isStreaming: !isComplete,
+    isFileProc: !isComplete,
+    activityLabel: activityLabelForPhase(phase),
+    attachments: isComplete ? [DEFAULT_VIDEO_ATTACHMENT] : [],
+    inputTokens: isComplete ? 32 : undefined,
+    outputTokens: isComplete ? 0 : undefined,
+    latencyMS: isComplete ? GENERATION_MS : undefined,
+  };
+
+  return [userMessage, assistantMessage];
+}
+
+function drawMockVideoFrame(ctx: CanvasRenderingContext2D, progress: number) {
+  const { width, height } = ctx.canvas;
+  const carX = -width * 0.22 + progress * width * 1.35;
+  const sunX = width * (0.18 + progress * 0.18);
+
+  const sky = ctx.createLinearGradient(0, 0, width, height);
+  sky.addColorStop(0, "#f59e0b");
+  sky.addColorStop(0.45, "#38bdf8");
+  sky.addColorStop(1, "#1e293b");
+  ctx.fillStyle = sky;
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.fillStyle = "rgba(254, 240, 138, 0.9)";
+  ctx.beginPath();
+  ctx.arc(sunX, height * 0.24, 34, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = "#315a66";
+  ctx.beginPath();
+  ctx.moveTo(0, height * 0.58);
+  ctx.bezierCurveTo(width * 0.2, height * 0.42, width * 0.32, height * 0.54, width * 0.48, height * 0.4);
+  ctx.bezierCurveTo(width * 0.62, height * 0.26, width * 0.78, height * 0.5, width, height * 0.34);
+  ctx.lineTo(width, height);
+  ctx.lineTo(0, height);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = "#1f2937";
+  ctx.fillRect(0, height * 0.72, width, height * 0.28);
+  ctx.strokeStyle = "rgba(248, 250, 252, 0.72)";
+  ctx.lineWidth = 5;
+  ctx.setLineDash([70, 48]);
+  ctx.beginPath();
+  ctx.moveTo(0, height * 0.84);
+  ctx.lineTo(width, height * 0.84);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  ctx.save();
+  ctx.translate(carX, height * 0.68);
+  ctx.fillStyle = "#f97316";
+  roundRect(ctx, 86, 30, 170, 54, 16);
+  ctx.fill();
+  ctx.fillStyle = "#fb923c";
+  ctx.beginPath();
+  ctx.moveTo(118, 30);
+  ctx.lineTo(155, -8);
+  ctx.lineTo(210, -8);
+  ctx.lineTo(246, 30);
+  ctx.closePath();
+  ctx.fill();
+  ctx.fillStyle = "#dbeafe";
+  roundRect(ctx, 158, 4, 44, 23, 5);
+  ctx.fill();
+  ctx.fillStyle = "#111827";
+  ctx.beginPath();
+  ctx.arc(126, 88, 19, 0, Math.PI * 2);
+  ctx.arc(220, 88, 19, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = "#cbd5e1";
+  ctx.beginPath();
+  ctx.arc(126, 88, 7, 0, Math.PI * 2);
+  ctx.arc(220, 88, 7, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+function roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, width: number, height: number, radius: number) {
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.arcTo(x + width, y, x + width, y + height, radius);
+  ctx.arcTo(x + width, y + height, x, y + height, radius);
+  ctx.arcTo(x, y + height, x, y, radius);
+  ctx.arcTo(x, y, x + width, y, radius);
+  ctx.closePath();
+}
+
+function createMockVideoBlob(): Promise<Blob> {
+  if (typeof MediaRecorder === "undefined") {
+    return Promise.reject(new Error("MediaRecorder is not available in this browser."));
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = 960;
+  canvas.height = 540;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return Promise.reject(new Error("Canvas is not available in this browser."));
+  }
+
+  const stream = canvas.captureStream(30);
+  const mimeType = ["video/webm;codecs=vp9", "video/webm;codecs=vp8", MOCK_VIDEO_MIME].find((item) =>
+    MediaRecorder.isTypeSupported(item),
+  );
+  const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+  const chunks: BlobPart[] = [];
+
+  return new Promise((resolve, reject) => {
+    let frameID = 0;
+    const stopTracks = () => stream.getTracks().forEach((track) => track.stop());
+
+    recorder.ondataavailable = (event) => {
+      if (event.data.size > 0) {
+        chunks.push(event.data);
+      }
+    };
+    recorder.onerror = () => {
+      cancelAnimationFrame(frameID);
+      stopTracks();
+      reject(new Error("Failed to render mock video."));
+    };
+    recorder.onstop = () => {
+      stopTracks();
+      resolve(new Blob(chunks, { type: recorder.mimeType || mimeType || MOCK_VIDEO_MIME }));
+    };
+
+    recorder.start();
+    const startedAt = performance.now();
+    const render = (now: number) => {
+      const progress = Math.min(1, (now - startedAt) / VIDEO_MS);
+      drawMockVideoFrame(ctx, progress);
+      if (progress < 1) {
+        frameID = requestAnimationFrame(render);
+        return;
+      }
+      recorder.stop();
+    };
+    frameID = requestAnimationFrame(render);
+  });
+}
+
+export default function Page() {
+  const [draft, setDraft] = React.useState(DEFAULT_PROMPT);
+  const [submittedPrompt, setSubmittedPrompt] = React.useState("");
+  const [submittedAt, setSubmittedAt] = React.useState("");
+  const [startedAt, setStartedAt] = React.useState<number | null>(null);
+  const [elapsed, setElapsed] = React.useState(0);
+  const [selectedPlatformModelName, setSelectedPlatformModelName] = React.useState(MODEL_NAME);
+  const [options, setOptions] = React.useState<ConversationOptions>(VIDEO_OPTIONS);
+  const messageContentRef = React.useRef<HTMLDivElement | null>(null);
+  const mockVideoBlobRef = React.useRef<Promise<Blob> | null>(null);
+
+  React.useEffect(() => {
+    if (startedAt === null) {
+      return undefined;
+    }
+    const timer = window.setInterval(() => {
+      const nextElapsed = Math.min(GENERATION_MS, performance.now() - startedAt);
+      setElapsed(nextElapsed);
+      if (nextElapsed >= GENERATION_MS) {
+        window.clearInterval(timer);
+      }
+    }, 120);
+    return () => window.clearInterval(timer);
+  }, [startedAt]);
+
+  const phase = startedAt === null ? null : phaseForElapsed(elapsed);
+  const messages = React.useMemo(
+    () => (phase && submittedAt ? buildMessages(submittedPrompt, phase, elapsed, submittedAt) : []),
+    [elapsed, phase, submittedAt, submittedPrompt],
+  );
+  const busy = Boolean(phase && phase !== "complete");
+
+  const onSendMessage = React.useCallback(() => {
+    const nextPrompt = draft.trim();
+    if (!nextPrompt) {
+      return;
+    }
+    mockVideoBlobRef.current = createMockVideoBlob();
+    setSubmittedPrompt(nextPrompt);
+    setSubmittedAt(new Date().toISOString());
+    setDraft("");
+    setElapsed(0);
+    setStartedAt(performance.now());
+  }, [draft]);
+
+  const loadMockVideoContent = React.useCallback(async (file: PreviewDialogFile): Promise<FileContentResult> => {
+    if (file.fileID !== MOCK_VIDEO_FILE_ID) {
+      throw new Error("Unknown preview file.");
+    }
+    if (!mockVideoBlobRef.current) {
+      mockVideoBlobRef.current = createMockVideoBlob();
+    }
+    const blob = await mockVideoBlobRef.current;
+    return {
+      blob,
+      contentType: blob.type || MOCK_VIDEO_MIME,
+      disposition: `attachment; filename="${file.fileName}"`,
+      contentLength: blob.size,
+    };
+  }, []);
+
+  const chatInput = (
+    <ChatInput
+      draft={draft}
+      loading={false}
+      sending={busy}
+      uploading={false}
+      isConversationMode={messages.length > 0}
+      maxFilesPerMessage={1}
+      fileMode="auto"
+      inputHeight="standard"
+      attachments={EMPTY_ATTACHMENTS}
+      uploadingAttachments={EMPTY_UPLOADS}
+      modelOptions={MODEL_OPTIONS}
+      billingDisplayCurrency="USD"
+      billingDisplayUsdToCnyRate={null}
+      selectedPlatformModelName={selectedPlatformModelName}
+      availableTools={EMPTY_TOOLS}
+      selectedToolIDs={[]}
+      selectedSkills={EMPTY_SKILLS}
+      defaultToolIDs={[]}
+      queuedMessages={[]}
+      htmlVisualPromptEnabled={false}
+      maxSelectedTools={0}
+      maxSelectedSkills={0}
+      toolsLoading={false}
+      options={options}
+      defaultOptions={VIDEO_OPTIONS}
+      modelOptionPolicy={null}
+      modelLoading={false}
+      modelDisabled={false}
+      onDraftChange={setDraft}
+      onModelChange={setSelectedPlatformModelName}
+      onSelectedToolsChange={() => undefined}
+      onSelectedSkillsChange={() => undefined}
+      onDefaultToolsChange={() => undefined}
+      onHTMLVisualPromptChange={() => undefined}
+      onOptionsChange={setOptions}
+      onOptionsReset={(defaults) => setOptions(defaults ?? VIDEO_OPTIONS)}
+      onOptionsDefaultRestore={() => Promise.resolve(VIDEO_OPTIONS)}
+      onAttachExistingFile={() => undefined}
+      onUploadFiles={() => undefined}
+      onCaptureScreenshot={() => undefined}
+      onRemoveAttachment={() => undefined}
+      onSendMessage={onSendMessage}
+      onStopMessage={() => setElapsed(GENERATION_MS)}
+      onDeleteQueuedMessage={() => undefined}
+      onEditQueuedMessage={() => undefined}
+      onGuideQueuedMessage={() => undefined}
+    />
+  );
+
+  return (
+    <main className="flex h-full min-h-0 w-full bg-background text-foreground">
+      <div className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden md:overflow-visible">
+        {messages.length === 0 ? (
+          <ChatEmptyState
+            greetingTitle="Gemini video generation preview"
+            badgeLabel="Preview"
+            contentWidthClassName={CONTENT_WIDTH_CLASS_NAME}
+          >
+            {chatInput}
+          </ChatEmptyState>
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <ChatArea
+              title="Gemini video generation preview"
+              starred={false}
+              canOperateConversation={false}
+              messages={messages}
+              busy={busy}
+              messageContentRef={messageContentRef}
+              onScroll={() => undefined}
+              onRetryUserMessage={() => undefined}
+              onRetryAssistantMessage={() => undefined}
+              onEditAssistantMessage={() => false}
+              onEditUserMessage={() => false}
+              modelOptions={MODEL_OPTIONS}
+              selectedPlatformModelName={selectedPlatformModelName}
+              onModelChange={setSelectedPlatformModelName}
+              attachmentContentLoader={loadMockVideoContent}
+              onCycleMessageBranch={() => undefined}
+              markdownRender
+              showModelInfo
+              showLatency
+              showTokenUsage={false}
+              contentWidthClassName={CONTENT_WIDTH_CLASS_NAME}
+            />
+            <div className="relative z-10 shrink-0 px-3 pb-3 md:px-6">
+              <div className={cn("mx-auto w-full", CONTENT_WIDTH_CLASS_NAME)}>{chatInput}</div>
+            </div>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/features/admin/api/llm.types.ts
+++ b/frontend/features/admin/api/llm.types.ts
@@ -13,6 +13,7 @@ export type AdminLLMAdapter =
   | "anthropic_messages"
   | "google_generate_content"
   | "google_image_generation"
+  | "gemini_interactions"
   | "xai_responses"
   | "xai_image"
   | "xai_image_edits";

--- a/frontend/features/admin/components/sections/conversation/admin-conversation.tsx
+++ b/frontend/features/admin/components/sections/conversation/admin-conversation.tsx
@@ -257,6 +257,22 @@ generationConfig.safetySettings.threshold`}
     "generationConfig.imageConfig.aspectRatio",
     "generationConfig.imageConfig.imageSize"
   ],
+  "gemini_interactions": [
+    "generation_config.temperature",
+    "generation_config.top_p",
+    "generation_config.max_output_tokens",
+    "generation_config.thinking_level",
+    "response_format.type",
+    "response_format.aspect_ratio",
+    "response_format.image_size",
+    "response_format.mime_type",
+    "responseFormat.type",
+    "responseFormat.aspectRatio",
+    "responseFormat.imageSize",
+    "responseFormat.mimeType",
+    "generationConfig.videoConfig.task",
+    "generation_config.video_config.task"
+  ],
   "xai_image": [
     "aspect_ratio",
     "n",
@@ -315,7 +331,7 @@ generationConfig.safetySettings.threshold`}
             <h4 className="text-sm font-medium text-foreground">{t("guide.protocolTitle")}</h4>
             <p className="text-xs">{t("guide.protocolDescription")}</p>
             <div className="flex flex-wrap gap-1.5">
-              {["default", "openai_chat_completions", "openrouter_chat_completions", "openai_responses", "openrouter_responses", "openai_image_generations", "openai_image_edits", "google_image_generation", "xai_image", "xai_image_edits", "anthropic_messages", "xai_responses", "gemini_generate_content"].map((item) => (
+              {["default", "openai_chat_completions", "openrouter_chat_completions", "openai_responses", "openrouter_responses", "openai_image_generations", "openai_image_edits", "google_image_generation", "gemini_interactions", "xai_image", "xai_image_edits", "anthropic_messages", "xai_responses", "gemini_generate_content"].map((item) => (
                 <code key={item} className="rounded-md bg-muted/60 px-2 py-1 text-xs text-foreground">{item}</code>
               ))}
             </div>

--- a/frontend/features/admin/components/sections/upstreams/upstreams-sheet.tsx
+++ b/frontend/features/admin/components/sections/upstreams/upstreams-sheet.tsx
@@ -79,6 +79,7 @@ const PROTOCOL_OPTIONS_BY_KIND: Record<(typeof PROTOCOL_DEFAULT_KINDS)[number], 
     "openai_chat_completions",
     "anthropic_messages",
     "google_generate_content",
+    "gemini_interactions",
     "xai_responses",
   ],
   audio: [
@@ -93,15 +94,18 @@ const PROTOCOL_OPTIONS_BY_KIND: Record<(typeof PROTOCOL_DEFAULT_KINDS)[number], 
   image_gen: [
     "openai_image_generations",
     "google_image_generation",
+    "gemini_interactions",
     "xai_image",
   ],
   image_edit: [
     "openai_image_edits",
     "google_image_generation",
+    "gemini_interactions",
     "xai_image_edits",
   ],
   video_gen: [
     "openai_video_generations",
+    "gemini_interactions",
   ],
 };
 

--- a/frontend/features/admin/model/conversation-settings.ts
+++ b/frontend/features/admin/model/conversation-settings.ts
@@ -123,6 +123,22 @@ export const DEFAULT_MODEL_OPTION_ALLOWED_PATHS = `{
     "generationConfig.imageConfig.aspectRatio",
     "generationConfig.imageConfig.imageSize"
   ],
+  "gemini_interactions": [
+    "generation_config.temperature",
+    "generation_config.top_p",
+    "generation_config.max_output_tokens",
+    "generation_config.thinking_level",
+    "response_format.type",
+    "response_format.aspect_ratio",
+    "response_format.image_size",
+    "response_format.mime_type",
+    "responseFormat.type",
+    "responseFormat.aspectRatio",
+    "responseFormat.imageSize",
+    "responseFormat.mimeType",
+    "generationConfig.videoConfig.task",
+    "generation_config.video_config.task"
+  ],
   "anthropic_messages": [
     "speed",
     "top_k",

--- a/frontend/features/admin/utils/llm-display.ts
+++ b/frontend/features/admin/utils/llm-display.ts
@@ -43,6 +43,7 @@ export const PROTOCOL_OPTIONS: ReadonlyArray<ProtocolOption> = [
   { value: "anthropic_messages", label: "Messages (Anthropic)", kinds: ["chat"] },
   { value: "google_generate_content", label: "Generate Content (Google)", kinds: ["chat"] },
   { value: "google_image_generation", label: "Image Generation (Google)", kinds: ["image_gen", "image_edit"] },
+  { value: "gemini_interactions", label: "Interactions (Google)", kinds: ["chat", "image_gen", "image_edit", "video_gen"] },
   { value: "xai_responses", label: "Responses (xAI)", kinds: ["chat"] },
   { value: "xai_image", label: "Images Generations (xAI)", kinds: ["image_gen"] },
   { value: "xai_image_edits", label: "Images Edits (xAI)", kinds: ["image_edit"] },

--- a/frontend/features/chat/components/message/message-bot.tsx
+++ b/frontend/features/chat/components/message/message-bot.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ChevronDown, CircleAlert } from "lucide-react";
+import { ChevronDown, CircleAlert, Film } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { AssistantMessageMeta } from "@/features/chat/components/message/message-meta";
@@ -16,6 +16,7 @@ import type {
 } from "@/features/chat/types/messages";
 import { MarkdownImage, type MarkdownArtifactActions } from "@/shared/components/markdown/streamdown-components";
 import { StreamdownRender } from "@/shared/components/markdown/streamdown-render";
+import { PreviewMedia } from "@/shared/components/file-preview/preview-media";
 import {
   Accordion,
   AccordionContent,
@@ -31,8 +32,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { isUpstreamStreamingDebugBody, summarizeUpstreamError } from "@/features/chat/utils/chat-runtime";
-import type { FileContentResult } from "@/shared/api/file";
+import { fetchFileContent, type FileContentResult } from "@/shared/api/file";
 import type { PreviewDialogFile } from "@/shared/components/file-preview/file-preview-dialog";
+import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
+import { useLocalizedErrorMessage } from "@/i18n/use-localized-error";
 import { resolveLeadingImagePreview } from "@/features/chat/model/media-image-preview";
 import {
   clearLiveUpstreamThinkTrace,
@@ -54,6 +57,16 @@ function isEditableImageAttachment(attachment: MessageAttachment): boolean {
   );
 }
 
+function isVideoAttachment(attachment: MessageAttachment): boolean {
+  const mimeType = attachment.mimeType.toLowerCase();
+  const detectedMime = attachment.detectedMime?.toLowerCase() || "";
+  return (
+    attachment.fileCategory === "video" ||
+    mimeType.startsWith("video/") ||
+    detectedMime.startsWith("video/")
+  );
+}
+
 function resolveFileIDFromImageSrc(src: string): string | null {
   if (typeof window === "undefined") {
     return null;
@@ -65,6 +78,27 @@ function resolveFileIDFromImageSrc(src: string): string | null {
   } catch {
     return null;
   }
+}
+
+function isGeneratedVideoMarkdownContent(content: string, attachments: MessageAttachment[]): boolean {
+  const blocks = content
+    .trim()
+    .split(/\n{2,}/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+  if (blocks.length === 0) {
+    return false;
+  }
+
+  const videoFileIDs = new Set(attachments.filter(isVideoAttachment).map((attachment) => attachment.fileID));
+  if (videoFileIDs.size === 0) {
+    return false;
+  }
+
+  return blocks.every((block) => {
+    const match = block.match(/^\[Generated video(?: \d+)?\]\(\/api\/v1\/files\/([^/)]+)\/content\)$/);
+    return Boolean(match?.[1] && videoFileIDs.has(match[1]));
+  });
 }
 
 function resolveEditableImageAttachment(
@@ -183,15 +217,33 @@ export function ChatMessageBot({
   const toolTrace = processTrace?.tools;
   const traceEvents = processTrace?.events ?? EMPTY_TRACE_EVENTS;
   const messageStreaming = Boolean(item.isStreaming);
-  const hasStreamdownContent = item.content.trim().length > 0;
-  const leadingImagePreview = React.useMemo(() => resolveLeadingImagePreview(item.content), [item.content]);
+  const inlineVideoAttachment = React.useMemo(
+    () =>
+      !item.isStreaming && item.contentType === "video"
+        ? (item.attachments ?? []).find(isVideoAttachment) ?? null
+        : null,
+    [item.attachments, item.contentType, item.isStreaming],
+  );
+  const visibleAttachments = React.useMemo(
+    () =>
+      inlineVideoAttachment
+        ? (item.attachments ?? []).filter((attachment) => attachment.fileID !== inlineVideoAttachment.fileID)
+        : item.attachments ?? [],
+    [inlineVideoAttachment, item.attachments],
+  );
+  const hideGeneratedVideoMarkdown = inlineVideoAttachment
+    ? isGeneratedVideoMarkdownContent(item.content, item.attachments ?? [])
+    : false;
+  const renderableContent = hideGeneratedVideoMarkdown ? "" : item.content;
+  const hasStreamdownContent = renderableContent.trim().length > 0;
+  const leadingImagePreview = React.useMemo(() => resolveLeadingImagePreview(renderableContent), [renderableContent]);
   const leadingImageAlt = React.useMemo(
     () => leadingImagePreview?.alt || submitT("imagePreviewAlt"),
     [leadingImagePreview?.alt, submitT],
   );
   const leadingImageReady = Boolean(leadingImagePreview?.complete);
   const leadingImagePending = Boolean(leadingImagePreview && item.isStreaming && !leadingImagePreview.complete);
-  const streamdownContent = leadingImagePreview?.rest ?? item.content;
+  const streamdownContent = leadingImagePreview?.rest ?? renderableContent;
   const hasInlineContent = streamdownContent.trim().length > 0;
   const postProcessEvents = React.useMemo(
     () =>
@@ -207,6 +259,7 @@ export function ChatMessageBot({
   const hasTraceEvents = postProcessEvents.length > 0;
   const hasTraceBlocks = hasTraceEvents || Boolean(upstreamThink) || Boolean(toolTrace);
   const isImageGenerationLoading = item.contentType === "image" && item.isStreaming && !hasStreamdownContent;
+  const isVideoGenerationLoading = item.contentType === "video" && item.isStreaming && !hasStreamdownContent;
   const editableImageAttachments = React.useMemo(
     () => (item.attachments ?? []).filter(isEditableImageAttachment),
     [item.attachments],
@@ -294,6 +347,8 @@ export function ChatMessageBot({
       >
         {isImageGenerationLoading && !item.inlineAlert ? (
           <AssistantImageGenerationSkeleton label={item.activityLabel} aspectRatio={item.imageAspectRatio} />
+        ) : isVideoGenerationLoading && !item.inlineAlert ? (
+          <AssistantVideoGenerationSkeleton label={item.activityLabel} />
         ) : item.isStreaming && !hasStreamdownContent && !item.inlineAlert ? (
           <AssistantMessageSkeleton fileProc={item.isFileProc} label={item.activityLabel} />
         ) : leadingImagePending ? (
@@ -324,14 +379,18 @@ export function ChatMessageBot({
         ) : null}
       </div>
 
+      {inlineVideoAttachment ? (
+        <MessageInlineVideoPreview attachment={inlineVideoAttachment} loadContent={attachmentContentLoader} />
+      ) : null}
+
       {item.inlineAlert ? (
         <ChatInlineAlertCard alert={item.inlineAlert} className={hasStreamdownContent ? "my-4" : "mb-4"} />
       ) : null}
 
-      {item.attachments && item.attachments.length > 0 ? (
+      {visibleAttachments.length > 0 ? (
         <div className="mt-2 flex w-full justify-start">
           <MessageAttachmentRow
-            attachments={item.attachments}
+            attachments={visibleAttachments}
             loadContent={attachmentContentLoader}
             allowDownload={!readOnly}
             align="start"
@@ -569,6 +628,169 @@ export function AssistantImageGenerationSkeleton({
           </span>
         </div>
       </div>
+    </div>
+  );
+}
+
+export function AssistantVideoGenerationSkeleton({ label }: { label?: string }) {
+  const t = useTranslations("chat.messages");
+  return (
+    <div className="my-4 w-full max-w-[32rem] space-y-2.5">
+      <div className="flex items-center gap-2 pt-1 text-[13px] text-muted-foreground">
+        <span className="inline-block size-3.5 animate-spin rounded-full border-2 border-muted border-t-foreground/50" />
+        {label?.trim() || t("processing")}
+      </div>
+      <div className="relative aspect-video w-full overflow-hidden rounded-xl bg-muted/20 text-primary">
+        <GrainientBackground
+          className="absolute inset-0 text-primary/75"
+          color1="#FDE68A"
+          color2="#FDA4AF"
+          color3="#FB7185"
+          contrast={1.48}
+          saturation={1.0}
+          timeSpeed={2.6}
+          warpAmplitude={72}
+          warpSpeed={2.1}
+        />
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-5 text-white/30 mix-blend-overlay drop-shadow-sm">
+            <Film className="size-14" strokeWidth={1.4} />
+            <span className="select-none text-[clamp(1.75rem,7vw,4rem)] font-semibold tracking-[0.18em]">
+              DEEIX
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type InlineVideoPreviewState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; source: string; contentType: string };
+
+function MessageInlineVideoPreview({
+  attachment,
+  loadContent,
+}: {
+  attachment: MessageAttachment;
+  loadContent?: (file: PreviewDialogFile) => Promise<FileContentResult>;
+}) {
+  const tPreview = useTranslations("files.previewDialog");
+  const tMessages = useTranslations("chat.messages");
+  const resolveErrorMessage = useLocalizedErrorMessage();
+  const objectURLRef = React.useRef<string | null>(null);
+  const [state, setState] = React.useState<InlineVideoPreviewState>({ status: "loading" });
+  const fileID = attachment.fileID;
+  const fileName = attachment.fileName;
+  const mimeType = attachment.mimeType;
+  const detectedMime = attachment.detectedMime;
+  const previewURL = attachment.previewURL;
+  const sizeBytes = attachment.sizeBytes;
+
+  const revokeObjectURL = React.useCallback(() => {
+    if (!objectURLRef.current) {
+      return;
+    }
+    URL.revokeObjectURL(objectURLRef.current);
+    objectURLRef.current = null;
+  }, []);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    revokeObjectURL();
+
+    if (previewURL) {
+      setState({
+        status: "ready",
+        source: previewURL,
+        contentType: detectedMime || mimeType,
+      });
+      return undefined;
+    }
+
+    setState({ status: "loading" });
+    void (async () => {
+      try {
+        const file = {
+          fileID,
+          fileName,
+          mimeType,
+          sizeBytes,
+        };
+        const result = loadContent
+          ? await loadContent(file)
+          : await (async () => {
+              const token = await resolveAccessToken();
+              if (!token) {
+                throw new Error(tPreview("sessionExpired"));
+              }
+              return fetchFileContent(token, fileID);
+            })();
+        const objectURL = URL.createObjectURL(result.blob);
+        objectURLRef.current = objectURL;
+
+        if (cancelled) {
+          URL.revokeObjectURL(objectURL);
+          if (objectURLRef.current === objectURL) {
+            objectURLRef.current = null;
+          }
+          return;
+        }
+
+        setState({
+          status: "ready",
+          source: objectURL,
+          contentType: result.contentType || detectedMime || mimeType,
+        });
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        setState({ status: "error", message: resolveErrorMessage(error, tPreview("loadFailed")) });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      revokeObjectURL();
+    };
+  }, [
+    detectedMime,
+    fileID,
+    fileName,
+    loadContent,
+    mimeType,
+    previewURL,
+    resolveErrorMessage,
+    revokeObjectURL,
+    sizeBytes,
+    tPreview,
+  ]);
+
+  if (state.status === "loading") {
+    return <AssistantVideoGenerationSkeleton label={tMessages("processing")} />;
+  }
+
+  if (state.status === "error") {
+    return (
+      <Alert className="my-4 max-w-[36rem]" variant="destructive">
+        <CircleAlert className="size-4" />
+        <AlertDescription>{state.message}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="my-4 w-full max-w-[40rem]">
+      <PreviewMedia
+        kind="video"
+        source={state.source}
+        alt={attachment.fileName}
+        contentType={state.contentType}
+        inline
+      />
     </div>
   );
 }

--- a/frontend/features/chat/components/sections/chat-area.tsx
+++ b/frontend/features/chat/components/sections/chat-area.tsx
@@ -24,6 +24,8 @@ import { ChatScreenshotSelectionBar } from "@/features/chat/components/sections/
 import { useCopyAction } from "@/shared/components/copy-action";
 import type { ChatModelOption } from "@/features/chat/types/chat-runtime";
 import type { BillingDisplayCurrency } from "@/shared/lib/billing-display";
+import type { FileContentResult } from "@/shared/api/file";
+import type { PreviewDialogFile } from "@/shared/components/file-preview/file-preview-dialog";
 import {
   MessageScroller,
   MessageScrollerButton,
@@ -80,6 +82,7 @@ type ChatAreaProps = {
   selectedPlatformModelName: string;
   onModelChange: (platformModelName: string) => void;
   onModelCatalogRefresh?: () => void | Promise<void>;
+  attachmentContentLoader?: (file: PreviewDialogFile) => Promise<FileContentResult>;
   onEditImageAttachment?: (attachment: MessageAttachment, sourceModelName?: string) => void;
   onOpenCodeArtifact?: (message: ChatAreaMessage, artifact: OpenCodeArtifactInput) => void;
   onCycleMessageBranch: (parentPublicID: string | null, direction: "previous" | "next") => void;
@@ -224,6 +227,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
   selectedPlatformModelName,
   onModelChange,
   onModelCatalogRefresh,
+  attachmentContentLoader,
   onEditImageAttachment,
   onCycleMessageBranch,
   onReactAssistantMessage,
@@ -252,6 +256,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
   selectedPlatformModelName: string;
   onModelChange: (platformModelName: string) => void;
   onModelCatalogRefresh?: () => void | Promise<void>;
+  attachmentContentLoader?: (file: PreviewDialogFile) => Promise<FileContentResult>;
   onEditImageAttachment?: (attachment: MessageAttachment, sourceModelName?: string) => void;
   onCycleMessageBranch: (parentPublicID: string | null, direction: "previous" | "next") => void;
   onReactAssistantMessage: (publicID: string, reaction: AssistantReaction) => void;
@@ -315,6 +320,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
         onCycleMessageBranch={onCycleMessageBranch}
         onCopy={() => void onCopy()}
         copySucceeded={isCopied(copyKey)}
+        attachmentContentLoader={attachmentContentLoader}
         screenshotMeta={screenshotMeta}
       />
     );
@@ -333,6 +339,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
         onReactAssistantMessage={onReactAssistantMessage}
         onCopy={() => void onCopy()}
         copySucceeded={isCopied(copyKey)}
+        attachmentContentLoader={attachmentContentLoader}
         onEditImageAttachment={onEditImageAttachment}
         artifactActions={artifactActions}
         markdownRender={markdownRender}
@@ -379,6 +386,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
   previous.selectedPlatformModelName === next.selectedPlatformModelName &&
   previous.onModelChange === next.onModelChange &&
   previous.onModelCatalogRefresh === next.onModelCatalogRefresh &&
+  previous.attachmentContentLoader === next.attachmentContentLoader &&
   previous.onEditImageAttachment === next.onEditImageAttachment &&
   previous.onOpenCodeArtifact === next.onOpenCodeArtifact &&
   areChatAreaMessagesRenderEqual(previous.item, next.item)
@@ -401,6 +409,7 @@ export function ChatArea({
   selectedPlatformModelName,
   onModelChange,
   onModelCatalogRefresh,
+  attachmentContentLoader,
   onEditImageAttachment,
   onOpenCodeArtifact,
   onCycleMessageBranch,
@@ -579,6 +588,7 @@ export function ChatArea({
                       selectedPlatformModelName={selectedPlatformModelName}
                       onModelChange={stableOnModelChange}
                       onModelCatalogRefresh={onModelCatalogRefresh ? stableOnModelCatalogRefresh : undefined}
+                      attachmentContentLoader={attachmentContentLoader}
                       onEditImageAttachment={editImageAttachmentHandler}
                       onCycleMessageBranch={stableOnCycleMessageBranch}
                       onReactAssistantMessage={stableOnReactAssistantMessage}

--- a/frontend/features/chat/components/sections/chat-input.tsx
+++ b/frontend/features/chat/components/sections/chat-input.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import dynamic from "next/dynamic";
-import { Box, CornerDownRight, Image, ImageOff, ImagePlus, LoaderCircle, PencilLine, Trash2 } from "lucide-react";
+import { Box, CornerDownRight, Film, Image, ImageOff, ImagePlus, LoaderCircle, PencilLine, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
@@ -141,7 +141,10 @@ function resolveComposerModeIndicator(
   decision: ChatSubmitDecision,
   t: (key: string) => string,
 ): ComposerModeIndicator | null {
-  if (decision.blockedReason === "image_task_rejects_non_image_attachments") {
+  if (
+    decision.blockedReason === "image_task_rejects_non_image_attachments" ||
+    decision.blockedReason === "video_task_rejects_non_image_attachments"
+  ) {
     return {
       label: t("mediaMode.invalidFile"),
       intro: t("mediaMode.invalidFileIntro"),
@@ -169,6 +172,17 @@ function resolveComposerModeIndicator(
         ? t(`mediaMode.blockedDescriptions.${decision.blockedReason}`)
         : t("mediaMode.imageEditDescription"),
       icon: ImagePlus,
+      tone: "default",
+    };
+  }
+  if (decision.task === "video_generation") {
+    return {
+      label: t("mediaMode.videoGeneration"),
+      intro: t("mediaMode.videoGenerationIntro"),
+      description: decision.blockedReason
+        ? t(`mediaMode.blockedDescriptions.${decision.blockedReason}`)
+        : t("mediaMode.videoGenerationDescription"),
+      icon: Film,
       tone: "default",
     };
   }
@@ -342,7 +356,7 @@ function ChatInputComponent({
   );
   const selectedProtocol = selectedModel?.protocols[0]?.trim() ?? "";
   const selectedModelName = selectedModel?.platformModelName || selectedPlatformModelName;
-  const submitDecision = resolveChatSubmitDecision(selectedModel, attachments);
+  const submitDecision = resolveChatSubmitDecision(selectedModel, attachments, options);
   const submitTask = submitDecision.task;
   const isMediaMode = isMediaSubmitTask(submitTask);
   const composerModeIndicator = resolveComposerModeIndicator(submitDecision, tComposer);

--- a/frontend/features/chat/components/sections/chat-model-config.tsx
+++ b/frontend/features/chat/components/sections/chat-model-config.tsx
@@ -389,6 +389,7 @@ const PROTOCOL_LABELS: Record<string, string> = {
   fal_queue: "Queue",
   google_generate_content: "Generate Content",
   google_image_generation: "Image Generation",
+  gemini_interactions: "Interactions",
   openai_chat_completions: "Chat Completions",
   openrouter_chat_completions: "OpenRouter Chat Completions",
   openai_image_edits: "Images Edits",

--- a/frontend/features/chat/hooks/use-chat-branch-state.ts
+++ b/frontend/features/chat/hooks/use-chat-branch-state.ts
@@ -95,6 +95,10 @@ function buildPendingMessages({
     pendingExchange.assistantText.length > 0 ||
     !serverMessagePublicIDs.has(assistantPublicID)
   ) {
+    const assistantAttachments =
+      pendingExchange.assistantAttachments && pendingExchange.assistantAttachments.length > 0
+        ? pendingExchange.assistantAttachments
+        : undefined;
     nextMessages.push({
       key: `${pendingExchange.key}-assistant`,
       publicID: assistantPublicID,
@@ -124,6 +128,7 @@ function buildPendingMessages({
       reasoningTokens: pendingExchange.assistantReasoningTokens,
       latencyMS: pendingExchange.assistantLatencyMS,
       compactDone: pendingExchange.compactDone,
+      attachments: assistantAttachments,
     });
   }
 
@@ -171,6 +176,10 @@ function mergePendingAssistantState(messages: ChatAreaMessage[], pendingExchange
       latencyMS: pendingExchange.assistantLatencyMS ?? item.latencyMS,
       compactDone: pendingExchange.compactDone ?? item.compactDone,
       platformModelName: pendingExchange.platformModelName ?? item.platformModelName,
+      attachments:
+        pendingExchange.assistantAttachments && pendingExchange.assistantAttachments.length > 0
+          ? pendingExchange.assistantAttachments
+          : item.attachments,
       status: pendingExchange.assistantPending
         ? "pending"
         : serverHasTerminalState

--- a/frontend/features/chat/hooks/use-chat-data.ts
+++ b/frontend/features/chat/hooks/use-chat-data.ts
@@ -352,19 +352,20 @@ export function useChatData(
           },
           onMediaStatus: (event) => {
             const status = event.status.trim();
+            const contentType = event.content_type === "video" ? "video" : "image";
             const activityLabel =
               status === "queued"
-                ? tSubmit("mediaStatus.queued")
+                ? tSubmit(contentType === "video" ? "mediaStatus.videoQueued" : "mediaStatus.queued")
                 : status === "running"
-                  ? tSubmit("mediaStatus.running")
+                  ? tSubmit(contentType === "video" ? "mediaStatus.videoRunning" : "mediaStatus.running")
                   : status === "saving_artifact"
-                    ? tSubmit("mediaStatus.savingArtifact")
+                    ? tSubmit(contentType === "video" ? "mediaStatus.videoSavingArtifact" : "mediaStatus.savingArtifact")
                     : event.message.trim() || status;
             setState((prev) => ({
               ...prev,
               messages: prev.messages.map((message) =>
                 message.runID === pendingRunID && message.role === "assistant" && message.status === "pending"
-                  ? { ...message, activityLabel, contentType: "image" }
+                  ? { ...message, activityLabel, contentType }
                   : message,
               ),
             }));

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -28,6 +28,7 @@ import {
 import {
   applyBranchSelectionPath,
   buildChildrenIndex,
+  parseAttachments,
   resolveBranchSelectionPath,
   toBranchKey,
 } from "@/features/chat/model/chat-thread";
@@ -41,6 +42,7 @@ import {
   streamImageEdit,
   streamImageGeneration,
   streamMessage as streamConversationMessage,
+  streamVideoGeneration,
   updateMessage,
   type ConversationStreamOptions,
 } from "@/shared/api/conversation";
@@ -48,6 +50,7 @@ import type {
   ConversationDTO,
   ConversationOptions,
   MediaImageRequest,
+  MediaVideoRequest,
   MessageDTO,
   SendMessageRequest,
   SendMessageResult,
@@ -107,14 +110,24 @@ function resolveInputSideUsageValue(...values: Array<number | null | undefined>)
 function resolveMediaStatusLabel(
   status: string,
   fallbackMessage: string,
+  contentType: string | undefined,
   t: ReturnType<typeof useTranslations>,
 ): string {
   switch (status.trim()) {
     case "queued":
+      if (contentType === "video") {
+        return t("mediaStatus.videoQueued");
+      }
       return t("mediaStatus.queued");
     case "running":
+      if (contentType === "video") {
+        return t("mediaStatus.videoRunning");
+      }
       return t("mediaStatus.running");
     case "saving_artifact":
+      if (contentType === "video") {
+        return t("mediaStatus.videoSavingArtifact");
+      }
       return t("mediaStatus.savingArtifact");
     default:
       return fallbackMessage.trim() || status.trim();
@@ -480,7 +493,8 @@ export function useChatMessageSubmit({
           description: t("attachmentsTruncatedDescription", { count: maxFilesPerMessage }),
         });
       }
-      const submitDecision = resolveChatSubmitDecision(selectedModel, effectiveAttachments);
+      const sanitizedOptions = sanitizeConversationOptions(requestOptions);
+      const submitDecision = resolveChatSubmitDecision(selectedModel, effectiveAttachments, sanitizedOptions);
       if (submitDecision.blockedReason) {
         toast.error(t("mediaInputUnsupported"), {
           description: resolveSubmitBlockDescription(submitDecision.blockedReason, t),
@@ -510,9 +524,12 @@ export function useChatMessageSubmit({
       let shouldKeepConversationLayout = false;
       const streamAbortController = new AbortController();
       const clientRunID = createClientRunID();
-      const sanitizedOptions = sanitizeConversationOptions(requestOptions);
       const assistantImageAspectRatio =
-        submitTask === "chat" ? undefined : resolveImageLoadingAspectRatio(sanitizedOptions);
+        submitTask === "image_generation" || submitTask === "image_edit"
+          ? resolveImageLoadingAspectRatio(sanitizedOptions)
+          : undefined;
+      const assistantContentType =
+        submitTask === "chat" ? "markdown" : submitTask === "video_generation" ? "video" : "image";
       let targetConversationID = conversationIDRef.current;
       let targetConversation = activeConversationRef.current;
       let metadataRefreshInFlight = false;
@@ -547,7 +564,7 @@ export function useChatMessageSubmit({
         assistantText: "",
         assistantPending: true,
         assistantStreaming: true,
-        assistantContentType: submitTask === "chat" ? "markdown" : "image",
+        assistantContentType,
         assistantImageAspectRatio,
         assistantInlineAlert: undefined,
         assistantCreatedAt: createdAt,
@@ -670,7 +687,7 @@ export function useChatMessageSubmit({
             );
           },
           onMediaStatus: (event) => {
-            const activityLabel = resolveMediaStatusLabel(event.status, event.message, t);
+            const activityLabel = resolveMediaStatusLabel(event.status, event.message, event.content_type, t);
             setPendingExchange((prev) =>
               prev && prev.key === exchangeKey
                 ? { ...prev, assistantFileProc: true, assistantActivityLabel: activityLabel }
@@ -756,6 +773,12 @@ export function useChatMessageSubmit({
             htmlVisualColorMode: requestHTMLVisualPromptEnabled ? requestHTMLVisualColorMode : undefined,
           };
           completed = await streamConversationMessage(token, targetConversationID, chatPayload, streamOptions);
+        } else if (submitTask === "video_generation") {
+          const mediaPayload: MediaVideoRequest = {
+            ...commonStreamPayload,
+            prompt: payloadContent,
+          };
+          completed = await streamVideoGeneration(token, targetConversationID, mediaPayload, streamOptions);
         } else {
           const mediaPayload: MediaImageRequest = {
             ...commonStreamPayload,
@@ -810,6 +833,7 @@ export function useChatMessageSubmit({
             assistantCreatedAt: completed.assistantMessage.createdAt,
             assistantUpdatedAt: completed.assistantMessage.updatedAt,
             assistantContentType: completed.assistantMessage.contentType || prev.assistantContentType,
+            assistantAttachments: parseAttachments(completed.assistantMessage.attachments),
             assistantInputTokens: resolveInputSideUsageValue(
               completed.assistantMessage.inputTokens,
               completed.userMessage.inputTokens,

--- a/frontend/features/chat/model/chat-task.ts
+++ b/frontend/features/chat/model/chat-task.ts
@@ -1,11 +1,14 @@
 import type { ChatModelOption, PendingAttachment } from "@/features/chat/types/chat-runtime";
+import type { ConversationOptions } from "@/shared/api/conversation.types";
 
-export type ChatSubmitTask = "chat" | "image_generation" | "image_edit";
+export type ChatSubmitTask = "chat" | "image_generation" | "image_edit" | "video_generation";
 export type ChatSubmitBlockReason =
   | "image_edit_input_required"
   | "image_edit_unsupported"
   | "image_generation_rejects_attachments"
   | "image_task_rejects_non_image_attachments"
+  | "video_generation_too_many_images"
+  | "video_task_rejects_non_image_attachments"
   | "model_task_unsupported";
 
 export type ChatSubmitDecision = {
@@ -17,6 +20,7 @@ export type ChatSubmitDecision = {
   supportsChat: boolean;
   supportsImageGeneration: boolean;
   supportsImageEdit: boolean;
+  supportsVideoGeneration: boolean;
 };
 
 function isImageAttachment(item: PendingAttachment): boolean {
@@ -35,9 +39,38 @@ function buildDecision(
   };
 }
 
+function optionObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function responseFormatType(value: unknown): "image" | "video" | "text" | "" {
+  if (Array.isArray(value)) {
+    if (value.some((item) => responseFormatType(item) === "video")) return "video";
+    if (value.some((item) => responseFormatType(item) === "image")) return "image";
+    if (value.some((item) => responseFormatType(item) === "text")) return "text";
+    return "";
+  }
+  const format = optionObject(value);
+  const type = typeof format?.type === "string" ? format.type.trim().toLowerCase() : "";
+  if (type === "image" || type === "video" || type === "text") {
+    return type;
+  }
+  return "";
+}
+
+function requestedResponseType(options?: ConversationOptions): "image" | "video" | "text" | "" {
+  if (!options) {
+    return "";
+  }
+  return responseFormatType(options.response_format ?? options.responseFormat);
+}
+
 export function resolveChatSubmitDecision(
   model: ChatModelOption | null,
   attachments: PendingAttachment[],
+  options?: ConversationOptions,
 ): ChatSubmitDecision {
   const kinds = new Set(model?.kinds ?? []);
   const attachmentCount = attachments.length;
@@ -46,6 +79,7 @@ export function resolveChatSubmitDecision(
   const supportsChat = kinds.size === 0 || kinds.has("chat") || kinds.has("audio");
   const supportsImageGeneration = kinds.has("image_gen");
   const supportsImageEdit = kinds.has("image_edit");
+  const supportsVideoGeneration = kinds.has("video_gen");
   const baseDecision = {
     attachmentCount,
     imageAttachmentCount,
@@ -53,15 +87,20 @@ export function resolveChatSubmitDecision(
     supportsChat,
     supportsImageGeneration,
     supportsImageEdit,
+    supportsVideoGeneration,
   };
+  const requestedType = requestedResponseType(options);
 
   if (
     nonImageAttachmentCount > 0 &&
-    (supportsImageGeneration || supportsImageEdit) &&
+    (supportsImageGeneration || supportsImageEdit || supportsVideoGeneration) &&
     (imageAttachmentCount > 0 || !supportsChat)
   ) {
     if (imageAttachmentCount > 0 && supportsImageEdit) {
       return buildDecision("image_edit", "image_task_rejects_non_image_attachments", baseDecision);
+    }
+    if (supportsVideoGeneration) {
+      return buildDecision("video_generation", "video_task_rejects_non_image_attachments", baseDecision);
     }
     if (supportsImageGeneration) {
       return buildDecision("image_generation", "image_task_rejects_non_image_attachments", baseDecision);
@@ -70,8 +109,20 @@ export function resolveChatSubmitDecision(
   }
 
   if (imageAttachmentCount > 0) {
+    if (requestedType === "video" && supportsVideoGeneration) {
+      if (imageAttachmentCount > 1) {
+        return buildDecision("video_generation", "video_generation_too_many_images", baseDecision);
+      }
+      return buildDecision("video_generation", null, baseDecision);
+    }
     if (supportsImageEdit) {
       return buildDecision("image_edit", null, baseDecision);
+    }
+    if (supportsVideoGeneration) {
+      if (imageAttachmentCount > 1) {
+        return buildDecision("video_generation", "video_generation_too_many_images", baseDecision);
+      }
+      return buildDecision("video_generation", null, baseDecision);
     }
     if (supportsChat) {
       return buildDecision("chat", null, baseDecision);
@@ -86,11 +137,26 @@ export function resolveChatSubmitDecision(
     if (supportsImageGeneration) {
       return buildDecision("image_generation", "image_generation_rejects_attachments", baseDecision);
     }
+    if (supportsVideoGeneration) {
+      return buildDecision("video_generation", "video_task_rejects_non_image_attachments", baseDecision);
+    }
     return buildDecision("chat", "model_task_unsupported", baseDecision);
   }
 
+  if (requestedType === "video" && supportsVideoGeneration) {
+    return buildDecision("video_generation", null, baseDecision);
+  }
+  if (requestedType === "image" && supportsImageGeneration) {
+    return buildDecision("image_generation", null, baseDecision);
+  }
+  if (supportsChat) {
+    return buildDecision("chat", null, baseDecision);
+  }
   if (supportsImageGeneration) {
     return buildDecision("image_generation", null, baseDecision);
+  }
+  if (supportsVideoGeneration) {
+    return buildDecision("video_generation", null, baseDecision);
   }
   if (supportsImageEdit && !supportsChat) {
     return buildDecision("image_edit", "image_edit_input_required", baseDecision);
@@ -103,5 +169,5 @@ export function resolveChatSubmitDecision(
 }
 
 export function isMediaSubmitTask(task: ChatSubmitTask): boolean {
-  return task === "image_generation" || task === "image_edit";
+  return task === "image_generation" || task === "image_edit" || task === "video_generation";
 }

--- a/frontend/features/chat/model/chat-thread.ts
+++ b/frontend/features/chat/model/chat-thread.ts
@@ -1,7 +1,7 @@
 import type { ChatAreaMessage, MessageAttachment } from "@/features/chat/types/messages";
 import type { MessageDTO, UpstreamDebugInfo } from "@/shared/api/conversation.types";
 
-function parseAttachments(raw: string): MessageAttachment[] {
+export function parseAttachments(raw: string): MessageAttachment[] {
   if (!raw) return [];
   try {
     const parsed: unknown = JSON.parse(raw);

--- a/frontend/features/chat/types/chat-runtime.ts
+++ b/frontend/features/chat/types/chat-runtime.ts
@@ -1,6 +1,7 @@
 import type {
   ChatInlineAlert,
   ImageLoadingAspectRatio,
+  MessageAttachment,
   ChatMessageProcessTrace,
 } from "@/features/chat/types/messages";
 import type { ConversationOptions } from "@/shared/api/conversation.types";
@@ -95,6 +96,7 @@ export type PendingExchange = {
   assistantCreatedAt: string;
   assistantUpdatedAt?: string;
   assistantContentType?: string;
+  assistantAttachments?: MessageAttachment[];
   assistantInputTokens?: number;
   assistantOutputTokens?: number;
   assistantCacheReadTokens?: number;

--- a/frontend/i18n/messages/en-US/chat.json
+++ b/frontend/i18n/messages/en-US/chat.json
@@ -267,12 +267,17 @@
       "image_edit_unsupported": "This model does not support image editing. Remove the image or select an editing-capable model.",
       "image_generation_rejects_attachments": "Image generation accepts text prompts only. Remove attachments or select a model that handles them.",
       "image_task_rejects_non_image_attachments": "Image tasks only support image attachments. Remove non-image files.",
+      "video_generation_too_many_images": "Video generation supports one input image at most. Keep one image and try again.",
+      "video_task_rejects_non_image_attachments": "Video generation only supports text prompts and image attachments. Remove non-image files.",
       "model_task_unsupported": "This model cannot process the current input. Select another model and try again."
     },
     "mediaStatus": {
       "queued": "Image task queued",
       "running": "Generating image",
-      "savingArtifact": "Saving image"
+      "savingArtifact": "Saving image",
+      "videoQueued": "Video task queued",
+      "videoRunning": "Generating video",
+      "videoSavingArtifact": "Saving video"
     },
     "generationInterrupted": "Generation interrupted",
     "sendFailed": "Send failed",
@@ -437,13 +442,18 @@
       "imageEdit": "Image editing",
       "imageEditIntro": "Image editing mode is active.",
       "imageEditDescription": "Edits the uploaded image using the text prompt.",
+      "videoGeneration": "Video generation",
+      "videoGenerationIntro": "Video generation mode is active.",
+      "videoGenerationDescription": "Creates a video from the text prompt. Upload one image to use it as a reference input.",
       "invalidFile": "Invalid file detected",
-      "invalidFileIntro": "This file cannot be used for an image task.",
+      "invalidFileIntro": "This file cannot be used for a media task.",
       "blockedDescriptions": {
         "image_edit_input_required": "Upload an image to edit first.",
         "image_edit_unsupported": "The selected model does not support image editing. Remove the image or switch models.",
         "image_generation_rejects_attachments": "Image generation only accepts text prompts. Remove attachments.",
         "image_task_rejects_non_image_attachments": "Image tasks only support image attachments. Remove non-image files.",
+        "video_generation_too_many_images": "Video generation supports one input image at most.",
+        "video_task_rejects_non_image_attachments": "Video generation only supports text prompts and image attachments. Remove non-image files.",
         "model_task_unsupported": "The selected model cannot process this input. Switch models and try again."
       }
     },

--- a/frontend/i18n/messages/zh-CN/chat.json
+++ b/frontend/i18n/messages/zh-CN/chat.json
@@ -267,12 +267,17 @@
       "image_edit_unsupported": "该模型不支持图像编辑，请移除图片或切换到支持编辑的模型。",
       "image_generation_rejects_attachments": "图像生成仅接受文字提示词，请移除附件或切换到可处理附件的模型。",
       "image_task_rejects_non_image_attachments": "图像任务仅支持图片附件，请移除非图片文件。",
+      "video_generation_too_many_images": "视频生成最多支持一张输入图片，请保留一张图片后重试。",
+      "video_task_rejects_non_image_attachments": "视频生成仅支持文字提示和图片附件，请移除非图片文件。",
       "model_task_unsupported": "该模型无法处理当前输入，请切换模型后重试。"
     },
     "mediaStatus": {
       "queued": "图片任务已排队",
       "running": "正在生成图片",
-      "savingArtifact": "正在保存图片"
+      "savingArtifact": "正在保存图片",
+      "videoQueued": "视频任务已排队",
+      "videoRunning": "正在生成视频",
+      "videoSavingArtifact": "正在保存视频"
     },
     "generationInterrupted": "生成中断",
     "sendFailed": "发送失败",
@@ -437,13 +442,18 @@
       "imageEdit": "图像编辑",
       "imageEditIntro": "当前为图像编辑模式。",
       "imageEditDescription": "将基于已上传图片和文字提示进行编辑。",
+      "videoGeneration": "视频生成",
+      "videoGenerationIntro": "当前为视频生成模式。",
+      "videoGenerationDescription": "将根据文字提示生成视频；上传一张图片后会作为视频参考输入。",
       "invalidFile": "监测到无效文件",
-      "invalidFileIntro": "当前文件无法用于图像任务。",
+      "invalidFileIntro": "当前文件无法用于媒体任务。",
       "blockedDescriptions": {
         "image_edit_input_required": "请先上传需要编辑的图片。",
         "image_edit_unsupported": "当前模型不支持图像编辑，请移除图片或切换模型。",
         "image_generation_rejects_attachments": "图像生成仅接收文字提示，请移除附件。",
         "image_task_rejects_non_image_attachments": "图像任务仅支持图片附件，请移除非图片文件。",
+        "video_generation_too_many_images": "视频生成最多支持一张输入图片。",
+        "video_task_rejects_non_image_attachments": "视频生成仅支持文字提示和图片附件，请移除非图片文件。",
         "model_task_unsupported": "当前模型不支持此输入，请切换模型后重试。"
       }
     },

--- a/frontend/shared/api/conversation.ts
+++ b/frontend/shared/api/conversation.ts
@@ -30,6 +30,7 @@ import type {
   ReorderConversationProjectsRequest,
   SendMessageRequest,
   MediaImageRequest,
+  MediaVideoRequest,
   SendMessageResult,
   SetConversationArchiveRequest,
   SetConversationProjectRequest,
@@ -1030,6 +1031,21 @@ export async function streamImageEdit(
     accessToken,
     conversationPublicID,
     "/media/images/edits/stream",
+    payload,
+    options,
+  );
+}
+
+export async function streamVideoGeneration(
+  accessToken: string,
+  conversationPublicID: string,
+  payload: MediaVideoRequest,
+  options: ConversationStreamOptions = {},
+): Promise<SendMessageResult> {
+  return postConversationStream(
+    accessToken,
+    conversationPublicID,
+    "/media/videos/generations/stream",
     payload,
     options,
   );

--- a/frontend/shared/api/conversation.types.ts
+++ b/frontend/shared/api/conversation.types.ts
@@ -424,6 +424,17 @@ export type MediaImageRequest = {
   branchReason?: "default" | "retry" | "edit";
 };
 
+export type MediaVideoRequest = {
+  prompt: string;
+  model?: string;
+  options?: ConversationOptions;
+  clientRunID?: string;
+  fileIDs?: string[];
+  parentMessagePublicID?: string;
+  sourceMessagePublicID?: string;
+  branchReason?: "default" | "retry" | "edit";
+};
+
 export type SendMessageResult = {
   userMessage: MessageDTO;
   assistantMessage: MessageDTO;
@@ -483,6 +494,7 @@ export type StreamMessageEvent =
       seq?: number;
       status: string;
       message: string;
+      content_type?: string;
     }
   | {
       type: "media_image_delta";

--- a/frontend/shared/components/file-preview/preview-media.tsx
+++ b/frontend/shared/components/file-preview/preview-media.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { createPortal } from "react-dom";
-import { FastForward, FileAudio2, Maximize2, Minimize2, Minus, Pause, Play, Plus, Rewind, Volume2, VolumeX } from "lucide-react";
+import { FileAudio2, Maximize2, Minimize2, Minus, Pause, Play, Plus } from "lucide-react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 
@@ -15,6 +15,7 @@ type PreviewMediaProps = {
   alt?: string;
   contentType?: string;
   toolbarContainer?: HTMLElement | null;
+  inline?: boolean;
 };
 
 const IMAGE_MIN_ZOOM = 0.5;
@@ -68,15 +69,17 @@ function resolveAudioLabel(contentType?: string, name?: string): string {
   return "audio";
 }
 
-export function PreviewMedia({ kind, source, alt, contentType, toolbarContainer }: PreviewMediaProps) {
+export function PreviewMedia({ kind, source, alt, contentType, toolbarContainer, inline = false }: PreviewMediaProps) {
   const t = useTranslations("files.previewErrors");
   const mediaRef = React.useRef<HTMLAudioElement | HTMLVideoElement | null>(null);
   const imagePreviewRef = React.useRef<HTMLDivElement | null>(null);
   const imageScrollRegionRef = React.useRef<HTMLDivElement | null>(null);
   const videoPreviewRef = React.useRef<HTMLDivElement | null>(null);
-  const previousVolumeRef = React.useRef(1);
+  const videoPointerInsideRef = React.useRef(false);
+  const videoFocusInsideRef = React.useRef(false);
+  const videoControlsHideTimerRef = React.useRef<number | null>(null);
   const [playing, setPlaying] = React.useState(false);
-  const [volume, setVolume] = React.useState(1);
+  const [videoControlsVisible, setVideoControlsVisible] = React.useState(true);
   const [duration, setDuration] = React.useState(0);
   const [currentTime, setCurrentTime] = React.useState(0);
   const [imageZoom, setImageZoom] = React.useState(IMAGE_DEFAULT_ZOOM);
@@ -88,8 +91,6 @@ export function PreviewMedia({ kind, source, alt, contentType, toolbarContainer 
   const progress = duration > 0 ? Math.min(currentTime / duration, 1) : 0;
   const audioTitle = React.useMemo(() => resolveMediaTitle(alt, t("untitledAudio")), [alt, t]);
   const audioLabel = React.useMemo(() => resolveAudioLabel(contentType, alt), [alt, contentType]);
-  const videoTitle = React.useMemo(() => resolveMediaTitle(alt, t("untitledAudio")), [alt, t]);
-  const videoLabel = React.useMemo(() => resolveAudioLabel(contentType, alt), [alt, contentType]);
 
   React.useEffect(() => {
     if (kind !== "image") {
@@ -193,15 +194,98 @@ export function PreviewMedia({ kind, source, alt, contentType, toolbarContainer 
     setCurrentTime(0);
   }, [kind, source]);
 
+  const clearVideoControlsHideTimer = React.useCallback(() => {
+    if (videoControlsHideTimerRef.current === null) {
+      return;
+    }
+    window.clearTimeout(videoControlsHideTimerRef.current);
+    videoControlsHideTimerRef.current = null;
+  }, []);
+
+  const revealVideoControls = React.useCallback(() => {
+    clearVideoControlsHideTimer();
+    setVideoControlsVisible(true);
+  }, [clearVideoControlsHideTimer]);
+
+  const scheduleVideoControlsHide = React.useCallback(() => {
+    clearVideoControlsHideTimer();
+    if (!playing || videoPointerInsideRef.current || videoFocusInsideRef.current) {
+      setVideoControlsVisible(true);
+      return;
+    }
+    videoControlsHideTimerRef.current = window.setTimeout(() => {
+      setVideoControlsVisible(false);
+      videoControlsHideTimerRef.current = null;
+    }, 2000);
+  }, [clearVideoControlsHideTimer, playing]);
+
+  React.useEffect(() => {
+    if (!playing) {
+      clearVideoControlsHideTimer();
+      setVideoControlsVisible(true);
+      return;
+    }
+
+    scheduleVideoControlsHide();
+  }, [clearVideoControlsHideTimer, playing, scheduleVideoControlsHide]);
+
+  React.useEffect(() => clearVideoControlsHideTimer, [clearVideoControlsHideTimer]);
+
+  const handleVideoPointerEnter = React.useCallback(() => {
+    videoPointerInsideRef.current = true;
+    revealVideoControls();
+  }, [revealVideoControls]);
+
+  const handleVideoPointerMove = React.useCallback(() => {
+    videoPointerInsideRef.current = true;
+    revealVideoControls();
+  }, [revealVideoControls]);
+
+  const handleVideoPointerLeave = React.useCallback(() => {
+    videoPointerInsideRef.current = false;
+    scheduleVideoControlsHide();
+  }, [scheduleVideoControlsHide]);
+
+  const handleVideoFocus = React.useCallback(() => {
+    videoFocusInsideRef.current = true;
+    revealVideoControls();
+  }, [revealVideoControls]);
+
+  const handleVideoBlur = React.useCallback(
+    (event: React.FocusEvent<HTMLDivElement>) => {
+      const nextFocusedElement = event.relatedTarget;
+      if (nextFocusedElement instanceof Node && event.currentTarget.contains(nextFocusedElement)) {
+        return;
+      }
+
+      videoFocusInsideRef.current = false;
+      scheduleVideoControlsHide();
+    },
+    [scheduleVideoControlsHide],
+  );
+
+  React.useEffect(() => {
+    if (kind === "image" || !playing) {
+      return undefined;
+    }
+
+    let frameID = 0;
+    const syncPlaybackTime = () => {
+      const media = mediaRef.current;
+      if (!media) {
+        return;
+      }
+      setCurrentTime(media.currentTime || 0);
+      frameID = window.requestAnimationFrame(syncPlaybackTime);
+    };
+
+    frameID = window.requestAnimationFrame(syncPlaybackTime);
+    return () => window.cancelAnimationFrame(frameID);
+  }, [kind, playing]);
+
   const syncMediaMetrics = React.useCallback((media: HTMLAudioElement | HTMLVideoElement) => {
     setDuration(media.duration || 0);
     setCurrentTime(media.currentTime || 0);
-    const nextVolume = media.muted ? 0 : media.volume || 0;
-    setVolume(nextVolume);
-
-    if (nextVolume > 0.001) {
-      previousVolumeRef.current = nextVolume;
-    }
   }, []);
 
   const handleMediaLoadedMetadata = React.useCallback((event: React.SyntheticEvent<HTMLAudioElement | HTMLVideoElement>) => {
@@ -223,16 +307,6 @@ export function PreviewMedia({ kind, source, alt, contentType, toolbarContainer 
   const handleMediaEnded = React.useCallback((event: React.SyntheticEvent<HTMLAudioElement | HTMLVideoElement>) => {
     setPlaying(false);
     setCurrentTime(event.currentTarget.duration || 0);
-  }, []);
-
-  const handleMediaVolumeChange = React.useCallback((event: React.SyntheticEvent<HTMLAudioElement | HTMLVideoElement>) => {
-    const media = event.currentTarget;
-    const nextVolume = media.muted ? 0 : media.volume || 0;
-    setVolume(nextVolume);
-
-    if (nextVolume > 0.001) {
-      previousVolumeRef.current = nextVolume;
-    }
   }, []);
 
   const togglePlay = React.useCallback(async () => {
@@ -260,57 +334,6 @@ export function PreviewMedia({ kind, source, alt, contentType, toolbarContainer 
     }
     media.currentTime = nextTime;
     setCurrentTime(nextTime);
-  }, []);
-
-  const seekBy = React.useCallback((deltaSeconds: number) => {
-    const media = mediaRef.current;
-    if (!media) {
-      return;
-    }
-
-    const nextTime = Math.min(Math.max(media.currentTime + deltaSeconds, 0), media.duration || 0);
-    media.currentTime = nextTime;
-    setCurrentTime(nextTime);
-  }, []);
-
-  const handleVolumeInput = React.useCallback((value: string) => {
-    const media = mediaRef.current;
-    if (!media) {
-      return;
-    }
-
-    const nextVolume = Number.parseFloat(value);
-    if (!Number.isFinite(nextVolume)) {
-      return;
-    }
-
-    media.volume = nextVolume;
-    media.muted = nextVolume <= 0.001;
-    setVolume(nextVolume);
-
-    if (nextVolume > 0.001) {
-      previousVolumeRef.current = nextVolume;
-    }
-  }, []);
-
-  const toggleMute = React.useCallback(() => {
-    const media = mediaRef.current;
-    if (!media) {
-      return;
-    }
-
-    if (media.muted || media.volume <= 0.001) {
-      const nextVolume = previousVolumeRef.current > 0.001 ? previousVolumeRef.current : 1;
-      media.muted = false;
-      media.volume = nextVolume;
-      setVolume(nextVolume);
-      return;
-    }
-
-    previousVolumeRef.current = media.volume;
-    media.muted = true;
-    media.volume = 0;
-    setVolume(0);
   }, []);
 
   const imageFitScale = React.useMemo(() => {
@@ -418,48 +441,36 @@ export function PreviewMedia({ kind, source, alt, contentType, toolbarContainer 
           )}
 
           <div ref={imageScrollRegionRef} className="min-h-0 flex-1 overflow-auto">
+            <div
+              className="flex min-h-full min-w-full w-max items-center justify-center box-border px-4 py-6"
+              style={{ minHeight: imageViewport.height > 0 ? `${imageViewport.height}px` : undefined }}
+            >
               <div
-                className="flex min-h-full min-w-full w-max items-center justify-center box-border px-4 py-6"
-                style={{ minHeight: imageViewport.height > 0 ? `${imageViewport.height}px` : undefined }}
+                className="relative shrink-0"
+                style={{
+                  width: `${scaledImageWidth}px`,
+                  height: `${scaledImageHeight}px`,
+                }}
               >
                 <div
-                  className="relative shrink-0"
                   style={{
-                    width: `${scaledImageWidth}px`,
-                    height: `${scaledImageHeight}px`,
+                    transform: `scale(${imageEffectiveScale})`,
+                    transformOrigin: "top left",
+                    width: `${imageSize.width}px`,
+                    height: `${imageSize.height}px`,
                   }}
                 >
-                  <div
-                    style={{
-                      transform: `scale(${imageEffectiveScale})`,
-                      transformOrigin: "top left",
-                      width: `${imageSize.width}px`,
-                      height: `${imageSize.height}px`,
-                    }}
-                  >
-                    {isSVG ? (
-                      <object
-                        data={source}
-                        type="image/svg+xml"
-                        aria-label={alt || "SVG preview"}
-                        className="block rounded-lg"
-                        style={{ width: `${imageSize.width}px`, height: `${imageSize.height}px` }}
-                      >
-                        <Image
-                          src={source}
-                          alt={alt || "SVG preview"}
-                          className="block rounded-lg object-contain"
-                          width={imageSize.width}
-                          height={imageSize.height}
-                          sizes="100vw"
-                          unoptimized
-                          style={{ width: `${imageSize.width}px`, height: `${imageSize.height}px` }}
-                        />
-                      </object>
-                    ) : (
+                  {isSVG ? (
+                    <object
+                      data={source}
+                      type="image/svg+xml"
+                      aria-label={alt || "SVG preview"}
+                      className="block rounded-lg"
+                      style={{ width: `${imageSize.width}px`, height: `${imageSize.height}px` }}
+                    >
                       <Image
                         src={source}
-                        alt={alt || "Image preview"}
+                        alt={alt || "SVG preview"}
                         className="block rounded-lg object-contain"
                         width={imageSize.width}
                         height={imageSize.height}
@@ -467,27 +478,50 @@ export function PreviewMedia({ kind, source, alt, contentType, toolbarContainer 
                         unoptimized
                         style={{ width: `${imageSize.width}px`, height: `${imageSize.height}px` }}
                       />
-                    )}
-                  </div>
+                    </object>
+                  ) : (
+                    <Image
+                      src={source}
+                      alt={alt || "Image preview"}
+                      className="block rounded-lg object-contain"
+                      width={imageSize.width}
+                      height={imageSize.height}
+                      sizes="100vw"
+                      unoptimized
+                      style={{ width: `${imageSize.width}px`, height: `${imageSize.height}px` }}
+                    />
+                  )}
                 </div>
               </div>
+            </div>
           </div>
         </div>
       ) : kind === "video" ? (
-        <div className="flex min-h-full flex-1 items-center justify-center px-4 py-6">
-          <div className="w-full max-w-[min(100%,980px)]">
+        <div
+          className={cn(
+            "flex flex-1",
+            inline ? "min-h-0 items-start justify-start p-0" : "min-h-full items-center justify-center px-4 py-6",
+          )}
+        >
+          <div className={cn("w-full", inline ? "max-w-full" : "max-w-[min(100%,980px)]")}>
             <div
               ref={videoPreviewRef}
               className={cn(
-                "relative mx-auto max-w-full",
+                "relative max-w-full",
+                !inline && "mx-auto",
                 videoIsFullscreen ? "flex h-full w-full items-center justify-center bg-[oklch(0.9791_0.0041_91.45)] p-6" : "w-full",
               )}
             >
               <div
                 className={cn(
                   "relative max-w-full",
-                  videoIsFullscreen ? "w-fit" : "mx-auto w-fit max-w-[80%]",
+                  videoIsFullscreen ? "w-fit" : inline ? "w-full" : "mx-auto w-fit max-w-[80%]",
                 )}
+                onPointerEnter={handleVideoPointerEnter}
+                onPointerMove={handleVideoPointerMove}
+                onPointerLeave={handleVideoPointerLeave}
+                onFocus={handleVideoFocus}
+                onBlur={handleVideoBlur}
               >
                 <video
                   ref={mediaRef as React.RefObject<HTMLVideoElement>}
@@ -495,7 +529,8 @@ export function PreviewMedia({ kind, source, alt, contentType, toolbarContainer 
                   preload="metadata"
                   playsInline
                   className={cn(
-                    "block h-auto w-auto max-w-full rounded-[24px] bg-transparent object-contain shadow-[0_18px_44px_-34px_color-mix(in_oklch,var(--foreground)_30%,transparent)]",
+                    "block h-auto max-w-full rounded-[24px] bg-transparent object-contain shadow-[0_18px_44px_-34px_color-mix(in_oklch,var(--foreground)_30%,transparent)]",
+                    inline ? "w-full" : "w-auto",
                     videoIsFullscreen ? "max-h-[calc(100vh-48px)]" : "max-h-[min(62vh,720px)]",
                   )}
                   onClick={() => void togglePlay()}
@@ -505,33 +540,39 @@ export function PreviewMedia({ kind, source, alt, contentType, toolbarContainer 
                   onPlay={handleMediaPlay}
                   onPause={handleMediaPause}
                   onEnded={handleMediaEnded}
-                  onVolumeChange={handleMediaVolumeChange}
                 />
 
                 {!playing ? (
                   <button
                     type="button"
-                    className="absolute left-1/2 top-1/2 z-20 flex size-14 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-background/88 text-foreground shadow-[0_14px_32px_-20px_color-mix(in_oklch,var(--foreground)_34%,transparent)] backdrop-blur-sm transition hover:bg-background"
+                    className="absolute left-1/2 top-1/2 z-20 flex size-12 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-black/28 text-white/90 shadow-[0_14px_32px_-20px_rgba(0,0,0,0.7)] backdrop-blur-md transition hover:bg-black/38 hover:text-white"
                     onClick={() => void togglePlay()}
                   >
-                    <Play className="ml-0.5 size-6" strokeWidth={1.9} />
+                    <Play className="ml-0.5 size-5" strokeWidth={1.9} />
                   </button>
                 ) : null}
 
-                <div className="absolute inset-x-3 bottom-3 z-20">
-                  <div className="mx-auto max-w-[680px] rounded-2xl bg-background px-3 py-3">
-                    <div className="flex items-center gap-2 text-xs">
-                      <span className="truncate font-medium text-foreground">{videoTitle}</span>
-                      <span className="shrink-0 text-border">|</span>
-                      <span className="truncate text-muted-foreground">{videoLabel}</span>
-                    </div>
-
-                    <div className="mt-2 flex items-center gap-3 text-[10px] text-muted-foreground">
+                <div
+                  className={cn(
+                    "absolute inset-x-3 bottom-3 z-20 transition-opacity duration-200",
+                    videoControlsVisible ? "opacity-100" : "pointer-events-none opacity-0",
+                  )}
+                >
+                  <div className="rounded-full bg-black/28 px-3 py-2 text-white shadow-[0_14px_30px_-22px_rgba(0,0,0,0.7)] backdrop-blur-md">
+                    <div className="flex items-center gap-3 text-[10px] text-white/82">
+                      <button
+                        type="button"
+                        aria-label={playing ? "Pause video" : "Play video"}
+                        className="flex size-7 shrink-0 items-center justify-center rounded-full bg-white/12 text-white/90 transition hover:bg-white/20"
+                        onClick={() => void togglePlay()}
+                      >
+                        {playing ? <Pause className="size-3.5" strokeWidth={1.9} /> : <Play className="ml-0.5 size-3.5" strokeWidth={1.9} />}
+                      </button>
                       <span className="shrink-0 tabular-nums">{formatTime(currentTime)}</span>
-                      <div className="relative flex-1 h-1.5 rounded-full bg-muted">
+                      <div className="relative h-1 flex-1 rounded-full bg-white/24">
                         <div
-                          className="absolute inset-y-0 left-0 rounded-full bg-foreground/70 transition-[width] duration-200 ease-out"
-                          style={{ width: `${progress * 100}%` }}
+                          className="absolute inset-y-0 left-0 w-full origin-left rounded-full bg-white/86"
+                          style={{ transform: `scaleX(${progress})` }}
                         />
                         <input
                           type="range"
@@ -544,81 +585,14 @@ export function PreviewMedia({ kind, source, alt, contentType, toolbarContainer 
                         />
                       </div>
                       <span className="shrink-0 tabular-nums">{formatTime(duration)}</span>
-                    </div>
-
-                    <div className="mt-2 flex items-center justify-between gap-2">
-                      <div className="flex min-w-0 items-center gap-1.5">
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="size-8 rounded-full text-muted-foreground hover:bg-accent hover:text-foreground"
-                          onClick={() => toggleMute()}
-                        >
-                          {volume <= 0.001 ? <VolumeX className="size-3" strokeWidth={1.5} /> : <Volume2 className="size-3" strokeWidth={1.5} />}
-                        </Button>
-
-                        <div className="relative hidden h-5 w-16 shrink-0 md:block">
-                          <div className="absolute inset-x-0 top-1/2 h-1.5 -translate-y-1/2 rounded-full bg-muted" />
-                          <div
-                            className="absolute left-0 top-1/2 h-1.5 -translate-y-1/2 rounded-full bg-primary"
-                            style={{ width: `${Math.max(volume, 0) * 100}%` }}
-                          />
-                          <input
-                            type="range"
-                            min={0}
-                            max={1}
-                            step={0.01}
-                            value={volume}
-                            className="absolute inset-0 h-full w-full cursor-pointer appearance-none opacity-0"
-                            onChange={(event) => handleVolumeInput(event.target.value)}
-                          />
-                        </div>
-                      </div>
-
-                      <div className="flex shrink-0 items-center gap-1">
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-6 px-3 py-1 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
-                          onClick={() => seekBy(-5)}
-                        >
-                          <Rewind className="size-3.5" strokeWidth={1.6} />
-                          <span>5s</span>
-                        </Button>
-
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="size-8 rounded-full bg-muted/60 hover:bg-accent"
-                          onClick={() => void togglePlay()}
-                        >
-                          {playing ? <Pause className="size-4" strokeWidth={1.9} /> : <Play className="ml-0.5 size-4" strokeWidth={1.9} />}
-                        </Button>
-
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-6 px-3 py-1 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
-                          onClick={() => seekBy(5)}
-                        >
-                          <FastForward className="size-3.5" strokeWidth={1.6} />
-                          <span>5s</span>
-                        </Button>
-
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="size-6 px-3 py-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-                          onClick={() => void toggleVideoFullscreen()}
-                        >
-                          {videoIsFullscreen ? <Minimize2 className="size-3" strokeWidth={1.6} /> : <Maximize2 className="size-3" strokeWidth={1.6} />}
-                        </Button>
-                      </div>
+                      <button
+                        type="button"
+                        aria-label={videoIsFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+                        className="flex size-7 shrink-0 items-center justify-center rounded-full text-white/80 transition hover:bg-white/14 hover:text-white"
+                        onClick={() => void toggleVideoFullscreen()}
+                      >
+                        {videoIsFullscreen ? <Minimize2 className="size-3.5" strokeWidth={1.7} /> : <Maximize2 className="size-3.5" strokeWidth={1.7} />}
+                      </button>
                     </div>
                   </div>
                 </div>
@@ -638,13 +612,12 @@ export function PreviewMedia({ kind, source, alt, contentType, toolbarContainer 
               onPlay={handleMediaPlay}
               onPause={handleMediaPause}
               onEnded={handleMediaEnded}
-              onVolumeChange={handleMediaVolumeChange}
             />
             <div className="relative mx-auto flex w-full max-w-[520px] items-center gap-4 rounded-xl bg-muted/60 px-4 py-4">
               <div className="flex shrink-0 flex-col items-center">
                 <div className="group relative flex size-20 items-center justify-center overflow-hidden rounded-xl bg-foreground/5">
                   <div className="relative z-10 flex items-center justify-center rounded-full">
-                    <FileAudio2 className="size-8"/>
+                    <FileAudio2 className="size-8" />
                   </div>
                   <Button
                     type="button"

--- a/frontend/shared/lib/model-option-policy.ts
+++ b/frontend/shared/lib/model-option-policy.ts
@@ -9,6 +9,7 @@ export const MODEL_OPTION_POLICY_PROTOCOLS = [
   "anthropic_messages",
   "gemini_generate_content",
   "google_image_generation",
+  "gemini_interactions",
   "xai_responses",
   "xai_image",
   "xai_image_edits",
@@ -68,6 +69,7 @@ export const MODEL_OPTION_POLICY_PROTOCOL_LABELS: Record<ModelOptionPolicyProtoc
   anthropic_messages: "Anthropic（Messages）",
   gemini_generate_content: "Google（Generate Content）",
   google_image_generation: "Google（Image Generation）",
+  gemini_interactions: "Google（Interactions）",
   xai_responses: "xAI（Responses）",
   xai_image: "xAI（Images Generations）",
   xai_image_edits: "xAI（Images Edits）",
@@ -148,6 +150,8 @@ export function resolveModelOptionPolicyProtocol(protocol: string): ModelOptionP
       return "gemini_generate_content";
     case "google_image_generation":
       return "google_image_generation";
+    case "gemini_interactions":
+      return "gemini_interactions";
     default:
       return "openai_responses";
   }


### PR DESCRIPTION
## Summary

Adds Gemini Interactions as a general provider protocol for chat, streaming, image generation/editing, tool/function calling, and video generation. The backend now routes Gemini Interactions through `/v1beta/interactions`, normalizes supported generation/response options, handles Gemini-generated video Files URIs by downloading them server-side into our own file storage, and avoids uploading user files to Gemini Files.

Also adds the conversation video-generation API/streaming flow, inline video rendering in the real chat UI, shared transparent video player controls, MP4/WebM upload support, and a real-component preview page for the video generation lifecycle. File processing rules were reviewed so OCR images can enter RAG after recognition, while video remains media-only and does not enter extraction/RAG.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Refactor
- [x] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [x] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [x] Billing / payments
- [x] Admin console
- [x] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./...`
- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm build`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Preview route added:

- `/preview/video-generation`

Example Gemini Interactions payload supported by routing/options:

```json
{
  "input": "Create a short video",
  "model": "gemini-3.5-flash",
  "options": {
    "response_format": { "type": "video" }
  }
}
```

## Configuration, migration, and compatibility notes

- Adds `gemini_interactions` as a provider protocol.
- Adds video generation endpoint support in conversations.
- Adds `video/mp4` and `video/webm` to default allowed MIME types.
- Adds Gemini Interactions model option allowlist entries, including `response_format` and `generationConfig.videoConfig.task`.
- No database migration is included.
- Gemini-generated video Files URIs are downloaded into our own file storage; user-uploaded files are not uploaded to Gemini Files.
- Image OCR text can still enter RAG when OCR/extraction is enabled; video does not enter extraction or RAG.

## Documentation

- [ ] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [x] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [ ] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.