### PR TITLE
refactor: improve attachment handling and context management for images and historical data

### DIFF
--- a/backend/internal/application/conversation/prompt_plan.go
+++ b/backend/internal/application/conversation/prompt_plan.go
@@ -229,10 +229,7 @@ func estimateTranscriptTokens(messages []llm.Message) int64 {
 func countStableTextAttachments(attachments []AttachmentInput) int {
 	count := 0
 	for _, att := range attachments {
-		if normalizeAttachmentKind(att.Kind, att.MimeType) == "image" {
-			continue
-		}
-		if strings.TrimSpace(att.ExtractedText) == "" {
+		if !isStableTextAttachment(att) {
 			continue
 		}
 		count++
@@ -245,10 +242,7 @@ func stableAttachmentSourceRefs(attachments []AttachmentInput, currentArtifacts 
 	refs := make([]PromptSourceRef, 0, countStableTextAttachments(attachments))
 	fallbackArtifacts := contextArtifactsByKindAndSourceID(currentArtifacts, domainconversation.ContextArtifactFileRAGFallback)
 	for _, att := range attachments {
-		if normalizeAttachmentKind(att.Kind, att.MimeType) == "image" {
-			continue
-		}
-		if strings.TrimSpace(att.ExtractedText) == "" {
+		if !isStableTextAttachment(att) {
 			continue
 		}
 		sourceID := stableAttachmentSourceID(att)

--- a/backend/internal/application/conversation/service_file_context.go
+++ b/backend/internal/application/conversation/service_file_context.go
@@ -96,6 +96,25 @@ func filterAttachmentsByContextMode(items []AttachmentInput, contextMode string)
 	return result
 }
 
+func isStableTextAttachment(item AttachmentInput) bool {
+	if strings.EqualFold(strings.TrimSpace(item.ContextMode), fileContextModeDirectImage) {
+		return false
+	}
+	return strings.TrimSpace(item.ExtractedText) != ""
+}
+
+func shouldShowAttachmentProcessTrace(items []AttachmentInput) bool {
+	for _, item := range items {
+		if item.Current {
+			return true
+		}
+		if !strings.EqualFold(strings.TrimSpace(item.ContextMode), fileContextModeSkipped) {
+			return true
+		}
+	}
+	return false
+}
+
 func buildConversationFileContextPlan(
 	attachments []AttachmentInput,
 	fileMode string,
@@ -109,7 +128,7 @@ func buildConversationFileContextPlan(
 	}
 	for _, item := range attachments {
 		kind := normalizeAttachmentKind(item.Kind, item.DetectedMIME)
-		if kind == "image" {
+		if kind == "image" && item.Current {
 			item.ContextMode = fileContextModeDirectImage
 			plan.Attachments = append(plan.Attachments, item)
 			plan.FullAttachments = append(plan.FullAttachments, item)

--- a/backend/internal/application/conversation/service_file_context_test.go
+++ b/backend/internal/application/conversation/service_file_context_test.go
@@ -94,18 +94,39 @@ func TestPrependStableFileContextKeepsFilesAtPromptTop(t *testing.T) {
 	}
 }
 
-func TestPrependStableFileContextSkipsImages(t *testing.T) {
+func TestPrependStableFileContextIncludesHistoricalImageOCRText(t *testing.T) {
+	messages := []llm.Message{{Role: "user", Content: "继续看图"}}
+	attachments := []AttachmentInput{{
+		Kind:          "image",
+		MimeType:      "image/png",
+		FileName:      "photo.png",
+		ExtractedText: "图片 OCR 文字",
+		ContextMode:   fileContextModeFull,
+	}}
+
+	got := prependStableFileContext(messages, attachments)
+	if len(got) != len(messages)+1 {
+		t.Fatalf("expected historical image OCR text to be prepended, got %#v", got)
+	}
+	if !strings.Contains(got[0].Content, `<file name="photo.png">图片 OCR 文字</file>`) {
+		t.Fatalf("expected stable context to contain OCR text, got %q", got[0].Content)
+	}
+}
+
+func TestPrependStableFileContextSkipsCurrentDirectImageOCRText(t *testing.T) {
 	messages := []llm.Message{{Role: "user", Content: "看图"}}
 	attachments := []AttachmentInput{{
 		Kind:          "image",
 		MimeType:      "image/png",
 		FileName:      "photo.png",
-		ExtractedText: "image text should not be injected as stable file",
+		ExtractedText: "本轮图片 OCR 不应重复注入",
+		ContextMode:   fileContextModeDirectImage,
+		Current:       true,
 	}}
 
 	got := prependStableFileContext(messages, attachments)
 	if len(got) != len(messages) {
-		t.Fatalf("expected image attachment to stay out of stable text context, got %#v", got)
+		t.Fatalf("expected current direct image OCR text to stay out of stable context, got %#v", got)
 	}
 }
 
@@ -149,6 +170,142 @@ func TestBuildConversationFileContextPlanSkipsOversizedFileWhenRAGUnavailable(t 
 	}
 	if plan.Skipped[0].ContextMode != fileContextModeSkipped {
 		t.Fatalf("expected skipped context mode, got %#v", plan.Skipped[0])
+	}
+}
+
+func TestBuildConversationFileContextPlanOnlyDirectUploadsCurrentImages(t *testing.T) {
+	cfg := config.Config{RAGEnabled: true, EmbeddingEnabled: true}
+	plan := buildConversationFileContextPlan([]AttachmentInput{
+		{
+			FileID:       "file_current_image",
+			Kind:         "image",
+			MimeType:     "image/png",
+			DetectedMIME: "image/png",
+			Current:      true,
+		},
+		{
+			FileID:       "file_history_image",
+			Kind:         "image",
+			MimeType:     "image/png",
+			DetectedMIME: "image/png",
+			EmbedStatus:  "ready",
+		},
+	}, "auto", cfg, "gpt-5.5", "", true)
+
+	if len(plan.FullAttachments) != 1 || plan.FullAttachments[0].FileID != "file_current_image" {
+		t.Fatalf("expected only current image to be direct/full context, got %#v", plan.FullAttachments)
+	}
+	if plan.FullAttachments[0].ContextMode != fileContextModeDirectImage {
+		t.Fatalf("expected current image to use direct image mode, got %#v", plan.FullAttachments[0])
+	}
+	if len(plan.RAGAttachments) != 1 || plan.RAGAttachments[0].FileID != "file_history_image" {
+		t.Fatalf("expected historical OCR image to use RAG instead of direct upload, got %#v", plan.RAGAttachments)
+	}
+	if plan.RAGAttachments[0].ContextMode != fileContextModeRAG {
+		t.Fatalf("expected historical image context mode RAG, got %#v", plan.RAGAttachments[0])
+	}
+}
+
+func TestBuildConversationFileContextPlanUsesRAGForHistoricalImageOCRWhenRequested(t *testing.T) {
+	cfg := config.Config{RAGEnabled: true, EmbeddingEnabled: true}
+	plan := buildConversationFileContextPlan([]AttachmentInput{{
+		FileID:        "file_history_image",
+		Kind:          "image",
+		MimeType:      "image/png",
+		DetectedMIME:  "image/png",
+		EmbedStatus:   "ready",
+		ExtractedText: "historical image OCR",
+	}}, "rag", cfg, "gpt-5.5", "", true)
+
+	if len(plan.RAGAttachments) != 1 || plan.RAGAttachments[0].FileID != "file_history_image" {
+		t.Fatalf("expected historical image OCR to use RAG in rag mode, got %#v", plan.RAGAttachments)
+	}
+	if len(plan.FullAttachments) != 0 {
+		t.Fatalf("expected no full attachments while RAG is available in rag mode, got %#v", plan.FullAttachments)
+	}
+}
+
+func TestBuildConversationFileContextPlanUsesHistoricalImageOCRTextAsFullContext(t *testing.T) {
+	plan := buildConversationFileContextPlan([]AttachmentInput{{
+		FileID:        "file_history_image",
+		Kind:          "image",
+		MimeType:      "image/png",
+		DetectedMIME:  "image/png",
+		ExtractedText: "historical image OCR",
+		EmbedStatus:   "pending",
+	}}, "auto", config.Config{}, "gpt-5.5", "", false)
+
+	if len(plan.FullAttachments) != 1 || plan.FullAttachments[0].FileID != "file_history_image" {
+		t.Fatalf("expected historical image OCR text to use full context, got %#v", plan.FullAttachments)
+	}
+	if plan.FullAttachments[0].ContextMode != fileContextModeFull {
+		t.Fatalf("expected historical image OCR text context mode full, got %#v", plan.FullAttachments[0])
+	}
+	if len(plan.RAGAttachments) != 0 {
+		t.Fatalf("expected no RAG attachments when retrieval is unavailable, got %#v", plan.RAGAttachments)
+	}
+}
+
+func TestBuildConversationFileContextPlanKeepsVideoOutOfTextContext(t *testing.T) {
+	plan := buildConversationFileContextPlan([]AttachmentInput{{
+		FileID:        "file_video",
+		Kind:          "video",
+		MimeType:      "video/mp4",
+		DetectedMIME:  "video/mp4",
+		FileCategory:  fileCategoryVideo,
+		ExtractedText: "unexpected video text",
+	}}, "auto", config.Config{}, "gpt-5.5", "", false)
+
+	if len(plan.FullAttachments) != 0 || len(plan.RAGAttachments) != 0 {
+		t.Fatalf("expected video to stay out of text context, got %#v", plan)
+	}
+	if len(plan.Skipped) != 1 || plan.Skipped[0].ContextMode != fileContextModeSkipped {
+		t.Fatalf("expected video to be skipped, got %#v", plan.Skipped)
+	}
+}
+
+func TestImageAttachmentsForCurrentUserSkipsHistoricalImages(t *testing.T) {
+	got := imageAttachmentsForCurrentUser([]AttachmentInput{
+		{
+			FileID:   "file_history_image",
+			Kind:     "image",
+			MimeType: "image/png",
+		},
+		{
+			FileID:   "file_current_image",
+			Kind:     "image",
+			MimeType: "image/png",
+			Current:  true,
+		},
+	})
+
+	if len(got) != 1 || got[0].FileID != "file_current_image" {
+		t.Fatalf("expected only current image to be injected as image part, got %#v", got)
+	}
+}
+
+func TestShouldShowAttachmentProcessTraceSkipsHistoricalSkippedOnly(t *testing.T) {
+	if shouldShowAttachmentProcessTrace([]AttachmentInput{{
+		FileID:      "file_history_image",
+		ContextMode: fileContextModeSkipped,
+	}}) {
+		t.Fatal("expected historical skipped-only attachments to stay out of process trace")
+	}
+}
+
+func TestShouldShowAttachmentProcessTraceKeepsCurrentOrIncludedFiles(t *testing.T) {
+	if !shouldShowAttachmentProcessTrace([]AttachmentInput{{
+		FileID:      "file_current_image",
+		ContextMode: fileContextModeSkipped,
+		Current:     true,
+	}}) {
+		t.Fatal("expected current skipped attachments to be visible in process trace")
+	}
+	if !shouldShowAttachmentProcessTrace([]AttachmentInput{{
+		FileID:      "file_history_image",
+		ContextMode: fileContextModeRAG,
+	}}) {
+		t.Fatal("expected included historical attachments to be visible in process trace")
 	}
 }
 

--- a/backend/internal/application/conversation/service_file_pipeline.go
+++ b/backend/internal/application/conversation/service_file_pipeline.go
@@ -262,7 +262,7 @@ func (s *Service) hydrateAttachmentsForSend(
 	}
 
 	// 多文件并行等待：每个文件独立 WaitUntilReady，总耗时 = max(单个文件) 而非 sum。
-	// 图片和空 FileID 直接跳过等待，不启动 goroutine。
+	// 本轮图片会作为 image part 直传；历史图片仅在 OCR 开启时等待提取文本。
 	items := make([]AttachmentInput, len(attachments))
 	for i, att := range attachments {
 		items[i] = att // 预置，图片/空 FileID 直接保留
@@ -272,8 +272,13 @@ func (s *Service) hydrateAttachmentsForSend(
 	var mu sync.Mutex
 	g, gCtx := errgroup.WithContext(ctx)
 
+	cfg := config.Config{}
+	if s != nil && s.cfg != nil {
+		cfg = s.cfg.Snapshot()
+	}
 	for i, att := range attachments {
-		if strings.TrimSpace(att.FileID) == "" || att.FileCategory == fileCategoryImage {
+		if strings.TrimSpace(att.FileID) == "" ||
+			(att.FileCategory == fileCategoryImage && (att.Current || !cfg.ExtractImageOCREnabled)) {
 			continue
 		}
 		i, att := i, att // 闭包捕获
@@ -291,7 +296,10 @@ func (s *Service) hydrateAttachmentsForSend(
 				})
 			})
 			if err != nil {
-				if !att.Current {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return err
+				}
+				if !att.Current || att.FileCategory == fileCategoryImage {
 					if latestFile != nil {
 						items[i].ProcessingStatus = latestFile.ProcessingStatus
 						items[i].ProcessingReady = latestFile.ProcessingReady
@@ -333,7 +341,7 @@ func (s *Service) hydrateAttachmentsForSend(
 }
 
 func canUseAttachmentFullContext(att AttachmentInput, cfg config.Config) bool {
-	if att.FileCategory == fileCategoryImage {
+	if att.FileCategory == fileCategoryVideo {
 		return false
 	}
 	text := strings.TrimSpace(att.ExtractedText)

--- a/backend/internal/application/conversation/service_media_generation.go
+++ b/backend/internal/application/conversation/service_media_generation.go
@@ -678,8 +678,8 @@ func (s *Service) readGeneratedImage(ctx context.Context, image llm.GeneratedIma
 	if url == "" {
 		return nil, mimeType, ErrUpstreamEmptyResponse
 	}
-	if _, _, ok := geminiGeneratedFileURLs(url); ok {
-		return nil, mimeType, fmt.Errorf("Gemini Files generated image URI is unsupported")
+	if isGeminiFilesURL(url) {
+		return nil, mimeType, fmt.Errorf("Gemini Files generated image URI is not supported")
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/backend/internal/application/conversation/service_media_video.go
+++ b/backend/internal/application/conversation/service_media_video.go
@@ -542,6 +542,11 @@ func (s *Service) waitGeminiGeneratedVideoFileReady(ctx context.Context, metadat
 	return mimeType, nil
 }
 
+func isGeminiFilesURL(rawURL string) bool {
+	_, _, ok := geminiGeneratedFileURLs(rawURL)
+	return ok
+}
+
 func geminiGeneratedFileURLs(rawURL string) (string, string, bool) {
 	parsed, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" || !isGeminiFilesHost(parsed.Hostname()) {

--- a/backend/internal/application/conversation/service_media_video_test.go
+++ b/backend/internal/application/conversation/service_media_video_test.go
@@ -1,6 +1,12 @@
 package conversation
 
-import "testing"
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/llm"
+)
 
 func TestGeminiGeneratedFileURLsBuildsMetadataAndDownloadURLs(t *testing.T) {
 	metadataURL, downloadURL, ok := geminiGeneratedFileURLs("https://generativelanguage.googleapis.com/v1beta/files/video_123?alt=media&key=secret")
@@ -55,6 +61,17 @@ func TestGeminiGeneratedFileStateHelpers(t *testing.T) {
 	}
 	if geminiGeneratedFileReady("PROCESSING") || geminiGeneratedFileFailed("PROCESSING") {
 		t.Fatal("expected processing to stay pending")
+	}
+}
+
+func TestReadGeneratedVideoRequiresAPIKeyForGeminiFilesURL(t *testing.T) {
+	service := &Service{}
+	_, _, err := service.readGeneratedVideo(context.Background(), llm.GeneratedVideo{
+		URL:      "https://generativelanguage.googleapis.com/v1beta/files/video_123:download?alt=media",
+		MIMEType: "video/mp4",
+	}, "")
+	if err == nil || !strings.Contains(err.Error(), "requires an API key") {
+		t.Fatalf("expected missing Gemini API key to be rejected, got %v", err)
 	}
 }
 

--- a/backend/internal/application/conversation/service_message_context.go
+++ b/backend/internal/application/conversation/service_message_context.go
@@ -690,8 +690,7 @@ func buildStableFileContextXML(attachments []AttachmentInput) userContextXML {
 	}
 	items := make([]AttachmentInput, 0, len(attachments))
 	for _, att := range attachments {
-		kind := normalizeAttachmentKind(att.Kind, att.MimeType)
-		if kind == "image" || strings.TrimSpace(att.ExtractedText) == "" {
+		if !isStableTextAttachment(att) {
 			continue
 		}
 		items = append(items, att)
@@ -728,7 +727,7 @@ func imageAttachmentsForCurrentUser(attachments []AttachmentInput) []AttachmentI
 	}
 	result := make([]AttachmentInput, 0)
 	for _, att := range attachments {
-		if normalizeAttachmentKind(att.Kind, att.MimeType) == "image" {
+		if att.Current && normalizeAttachmentKind(att.Kind, att.MimeType) == "image" {
 			result = append(result, att)
 		}
 	}

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -520,7 +520,7 @@ func (s *Service) sendMessageInternal(
 		}
 	}
 	llmMessages, _ := assembler.Assemble(historyMsgs)
-	if traceRecorder != nil {
+	if traceRecorder != nil && shouldShowAttachmentProcessTrace(fileContextPlan.Attachments) {
 		summary, markdown, payload := buildAttachmentProcessTrace(fileMode, fileContextPlan.Attachments)
 		traceRecorder.appendProcessSection(summary, markdown, payload, messageTraceStatusStreaming)
 	}

--- a/backend/internal/application/conversation/service_trace.go
+++ b/backend/internal/application/conversation/service_trace.go
@@ -1435,8 +1435,7 @@ func buildAttachmentProcessTrace(
 		payload.FileNames = append(payload.FileNames, name)
 		ref := newAttachmentTraceFileRef(item, name)
 		payload.FileRefs = append(payload.FileRefs, ref)
-		kind := normalizeAttachmentKind(item.Kind, item.MimeType)
-		if kind == "image" {
+		if item.ContextMode == fileContextModeDirectImage {
 			payload.FileGroups.DirectImages = append(payload.FileGroups.DirectImages, name)
 			payload.FileGroupRefs.DirectImages = append(payload.FileGroupRefs.DirectImages, ref)
 			continue


### PR DESCRIPTION
## Summary

Improve historical file context handling in chat.

Current-turn image attachments are still sent to the model as image parts, but historical image bytes are no longer resent on later turns. Historical images can only participate through available OCR/extracted text, RAG, or RAG fallback. Historical files that are fully skipped are no longer shown as noisy “未纳入 1 个文件” file-context traces in later turns.

Video files remain media-only and stay excluded from extraction, embedding, and RAG.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [x] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./...`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Not applicable. This is a backend context-planning behavior change.

## Configuration, migration, and compatibility notes

No configuration, deployment, or database migration changes are required.

Compatibility notes:
- Current-turn images are still available to the model as image inputs.
- Historical image files are not resent as raw image bytes.
- Historical image OCR/extracted text may still be reused through full context, RAG, or RAG fallback.
- Historical skipped-only files are hidden from process trace output.
- Video files remain excluded from extraction, embedding, and RAG.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.