### PR TITLE
feat: enhance media generation handling with cancellation support and usage metrics

### DIFF
--- a/backend/internal/application/conversation/service.go
+++ b/backend/internal/application/conversation/service.go
@@ -175,6 +175,7 @@ type SendMessageResult struct {
 	CacheWrite1hTokens  int64
 	ServerSideToolUsage map[string]int64
 	LatencyMS           int64
+	DurationSeconds     int64
 	StartedAt           time.Time
 }
 

--- a/backend/internal/application/conversation/service_billing.go
+++ b/backend/internal/application/conversation/service_billing.go
@@ -180,6 +180,7 @@ func (s *Service) buildSendMessageUsageLedger(ctx context.Context, input SendMes
 		OutputTokens:        result.AssistantMessage.OutputTokens,
 		ReasoningTokens:     result.AssistantMessage.ReasoningTokens,
 		CallCount:           1,
+		DurationSeconds:     sendMessageBillingDurationSeconds(result, latencyMS),
 		LatencyMS:           latencyMS,
 		ServerSideToolUsage: result.ServerSideToolUsage,
 		RawUsageJSON:        result.RawUsageJSON,
@@ -215,6 +216,16 @@ func sendMessageBillingCacheWriteTokens(result *SendMessageResult) int64 {
 		return result.AssistantMessage.CacheWriteTokens
 	}
 	return result.UserMessage.CacheWriteTokens
+}
+
+func sendMessageBillingDurationSeconds(result *SendMessageResult, latencyMS int64) int64 {
+	if result != nil && result.DurationSeconds > 0 {
+		return result.DurationSeconds
+	}
+	if latencyMS <= 0 {
+		return 0
+	}
+	return (latencyMS + 999) / 1000
 }
 
 // sendMessageResultUsesAssistantSideInput 判断 prompt-side usage 是否归属 assistant 消息。

--- a/backend/internal/application/conversation/service_media_cancel.go
+++ b/backend/internal/application/conversation/service_media_cancel.go
@@ -1,0 +1,180 @@
+package conversation
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/channel"
+	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/llm"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
+)
+
+type canceledMediaGenerationInput struct {
+	Context             context.Context
+	Conversation        *model.Conversation
+	UserMessage         *model.Message
+	AssistantMessage    *model.Message
+	ReuseUserMessage    bool
+	Route               channel.ResolvedRoute
+	EffectiveOptions    map[string]interface{}
+	GenerateInput       llm.GenerateInput
+	StartedAt           time.Time
+	DurationSeconds     int64
+	MetadataRefreshHint string
+}
+
+func (s *Service) completeCanceledMediaGeneration(input canceledMediaGenerationInput) (*SendMessageResult, error) {
+	if input.Context == nil || input.UserMessage == nil || input.AssistantMessage == nil {
+		return nil, ErrMessageGenerationCanceled
+	}
+	persistCtx := context.WithoutCancel(input.Context)
+	latencyMS := time.Since(input.StartedAt).Milliseconds()
+	if latencyMS < 0 {
+		latencyMS = 0
+	}
+	inputTokens := estimateGenerateInputTokens(input.GenerateInput)
+	errorCode := classifyRunErrorCode(ErrMessageGenerationCanceled)
+	errorMessage := truncateError(ErrMessageGenerationCanceled.Error(), 255)
+
+	if input.ReuseUserMessage {
+		if err := s.repo.CompleteAssistantMessageWithGeneratedAttachments(
+			persistCtx,
+			input.AssistantMessage.ID,
+			repository.AssistantMessageCompletionUpdate{
+				ContentType:  input.AssistantMessage.ContentType,
+				Content:      "",
+				InputTokens:  inputTokens,
+				LatencyMS:    latencyMS,
+				Status:       "canceled",
+				ErrorCode:    errorCode,
+				ErrorMessage: errorMessage,
+			},
+			nil,
+		); err != nil {
+			return nil, err
+		}
+		input.AssistantMessage.InputTokens = inputTokens
+		input.AssistantMessage.TokenUsage = inputTokens
+	} else {
+		if err := s.repo.CompleteAssistantMessageWithAttachments(
+			persistCtx,
+			input.UserMessage.ID,
+			repository.MessageUsageUpdate{InputTokens: inputTokens},
+			input.AssistantMessage.ID,
+			repository.AssistantMessageCompletionUpdate{
+				ContentType:  input.AssistantMessage.ContentType,
+				Content:      "",
+				LatencyMS:    latencyMS,
+				Status:       "canceled",
+				ErrorCode:    errorCode,
+				ErrorMessage: errorMessage,
+			},
+			nil,
+		); err != nil {
+			return nil, err
+		}
+		input.UserMessage.InputTokens = inputTokens
+		input.UserMessage.TokenUsage = inputTokens
+	}
+
+	input.AssistantMessage.Content = ""
+	input.AssistantMessage.LatencyMS = latencyMS
+	input.AssistantMessage.Status = "canceled"
+	input.AssistantMessage.ErrorCode = errorCode
+	input.AssistantMessage.ErrorMessage = errorMessage
+
+	if input.MetadataRefreshHint == "" && input.Conversation != nil {
+		input.MetadataRefreshHint = conversationMetadataRefreshHint(*input.Conversation, *input.UserMessage)
+	}
+	return &SendMessageResult{
+		UserMessage:         *input.UserMessage,
+		AssistantMessage:    *input.AssistantMessage,
+		MetadataRefreshHint: input.MetadataRefreshHint,
+		Billable:            true,
+		UpstreamID:          input.Route.UpstreamID,
+		UpstreamName:        input.Route.UpstreamName,
+		PlatformModelName:   input.Route.PlatformModelName,
+		RoutedBindingCode:   input.Route.BindingCode,
+		UpstreamModelName:   input.Route.UpstreamModel,
+		UpstreamProtocol:    input.Route.Protocol,
+		EffectiveOptions:    input.EffectiveOptions,
+		LatencyMS:           latencyMS,
+		DurationSeconds:     input.DurationSeconds,
+		StartedAt:           input.StartedAt,
+	}, nil
+}
+
+func (s *Service) isCanceledMediaGeneration(ctx context.Context, runID string, err error) bool {
+	return errors.Is(ctx.Err(), context.Canceled) ||
+		s.isMessageGenerationCanceled(ctx, runID) ||
+		isMessageGenerationCanceledError(err)
+}
+
+func applyCanceledMediaRunUsage(run *model.Run, result *SendMessageResult) {
+	if run == nil || result == nil {
+		return
+	}
+	run.InputTokens = sendMessageBillingInputTokens(result)
+	run.CacheReadTokens = sendMessageBillingCacheReadTokens(result)
+	run.CacheWriteTokens = sendMessageBillingCacheWriteTokens(result)
+	run.OutputTokens = result.AssistantMessage.OutputTokens
+	run.ReasoningTokens = result.AssistantMessage.ReasoningTokens
+}
+
+func mediaDurationSecondsFromOptions(options map[string]interface{}) int64 {
+	for _, key := range []string{"durationSeconds", "duration_seconds", "duration"} {
+		if seconds := mediaDurationSecondsFromValue(options[key]); seconds > 0 {
+			return seconds
+		}
+	}
+	return 0
+}
+
+func mediaDurationSecondsFromValue(value interface{}) int64 {
+	switch v := value.(type) {
+	case int:
+		return positiveSeconds(int64(v))
+	case int64:
+		return positiveSeconds(v)
+	case float64:
+		return ceilPositiveSeconds(v)
+	case float32:
+		return ceilPositiveSeconds(float64(v))
+	case string:
+		text := strings.TrimSpace(strings.ToLower(v))
+		text = strings.TrimSuffix(text, "seconds")
+		text = strings.TrimSuffix(text, "second")
+		text = strings.TrimSuffix(text, "secs")
+		text = strings.TrimSuffix(text, "sec")
+		text = strings.TrimSuffix(text, "s")
+		parsed, err := strconv.ParseFloat(strings.TrimSpace(text), 64)
+		if err != nil {
+			return 0
+		}
+		return ceilPositiveSeconds(parsed)
+	default:
+		return 0
+	}
+}
+
+func ceilPositiveSeconds(value float64) int64 {
+	if value <= 0 {
+		return 0
+	}
+	seconds := int64(value)
+	if float64(seconds) < value {
+		seconds++
+	}
+	return seconds
+}
+
+func positiveSeconds(value int64) int64 {
+	if value <= 0 {
+		return 0
+	}
+	return value
+}

--- a/backend/internal/application/conversation/service_media_generation.go
+++ b/backend/internal/application/conversation/service_media_generation.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -183,6 +184,10 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 		run.TotalLatencyMS = endedAt.Sub(startedAt).Milliseconds()
 		if retErr == nil {
 			run.Status = "success"
+		} else if errors.Is(retErr, ErrMessageGenerationCanceled) {
+			run.Status = "canceled"
+			run.ErrorCode = classifyRunErrorCode(retErr)
+			run.ErrorMessage = truncateError(messageErrorSummary(retErr), 255)
 		} else {
 			run.Status = "error"
 			run.ErrorCode = classifyRunErrorCode(retErr)
@@ -354,6 +359,26 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 		output, err = s.llmClient.Generate(ctx, routeConfig, generateInput)
 	}
 	if err != nil {
+		if s.isCanceledMediaGeneration(ctx, runID, err) {
+			retErr = ErrMessageGenerationCanceled
+			result, cancelErr := s.completeCanceledMediaGeneration(canceledMediaGenerationInput{
+				Context:          ctx,
+				Conversation:     conversation,
+				UserMessage:      userMessage,
+				AssistantMessage: assistantMessage,
+				ReuseUserMessage: reuseUserMessage,
+				Route:            *route,
+				EffectiveOptions: filteredOptions,
+				GenerateInput:    generateInput,
+				StartedAt:        startedAt,
+			})
+			if cancelErr != nil {
+				retErr = cancelErr
+				return nil, cancelErr
+			}
+			applyCanceledMediaRunUsage(run, result)
+			return result, nil
+		}
 		s.routeResolver.MarkRouteFailure(ctx, route, err)
 		retErr = wrapUpstreamRequestError(err)
 		_ = s.repo.UpdateMessageState(ctx, assistantMessage.ID, "error", classifyRunErrorCode(retErr), truncateError(messageErrorSummary(retErr), 255))

--- a/backend/internal/application/conversation/service_media_video.go
+++ b/backend/internal/application/conversation/service_media_video.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -145,6 +146,10 @@ func (s *Service) StreamMediaVideo(ctx context.Context, input MediaVideoInput) (
 		run.TotalLatencyMS = endedAt.Sub(startedAt).Milliseconds()
 		if retErr == nil {
 			run.Status = "success"
+		} else if errors.Is(retErr, ErrMessageGenerationCanceled) {
+			run.Status = "canceled"
+			run.ErrorCode = classifyRunErrorCode(retErr)
+			run.ErrorMessage = truncateError(messageErrorSummary(retErr), 255)
 		} else {
 			run.Status = "error"
 			run.ErrorCode = classifyRunErrorCode(retErr)
@@ -246,6 +251,7 @@ func (s *Service) StreamMediaVideo(ctx context.Context, input MediaVideoInput) (
 	if llm.NormalizeAdapter(route.Protocol) == llm.AdapterGeminiInteractions {
 		filteredOptions = withGeminiInteractionResponseType(filteredOptions, "video")
 	}
+	durationSeconds := mediaDurationSecondsFromOptions(filteredOptions)
 
 	emitMediaEvent(input.OnEvent, "running", "generating video", "video")
 	generateInput := llm.GenerateInput{
@@ -266,6 +272,27 @@ func (s *Service) StreamMediaVideo(ctx context.Context, input MediaVideoInput) (
 
 	output, err := s.llmClient.Generate(ctx, routeConfig, generateInput)
 	if err != nil {
+		if s.isCanceledMediaGeneration(ctx, runID, err) {
+			retErr = ErrMessageGenerationCanceled
+			result, cancelErr := s.completeCanceledMediaGeneration(canceledMediaGenerationInput{
+				Context:          ctx,
+				Conversation:     conversation,
+				UserMessage:      userMessage,
+				AssistantMessage: assistantMessage,
+				ReuseUserMessage: reuseUserMessage,
+				Route:            *route,
+				EffectiveOptions: filteredOptions,
+				GenerateInput:    generateInput,
+				StartedAt:        startedAt,
+				DurationSeconds:  durationSeconds,
+			})
+			if cancelErr != nil {
+				retErr = cancelErr
+				return nil, cancelErr
+			}
+			applyCanceledMediaRunUsage(run, result)
+			return result, nil
+		}
 		s.routeResolver.MarkRouteFailure(ctx, route, err)
 		retErr = wrapUpstreamRequestError(err)
 		_ = s.repo.UpdateMessageState(ctx, assistantMessage.ID, "error", classifyRunErrorCode(retErr), truncateError(messageErrorSummary(retErr), 255))
@@ -410,6 +437,7 @@ func (s *Service) StreamMediaVideo(ctx context.Context, input MediaVideoInput) (
 		CacheWrite1hTokens:  usage.CacheWrite1hTokens,
 		StartedAt:           startedAt,
 		LatencyMS:           latencyMS,
+		DurationSeconds:     durationSeconds,
 	}, nil
 }
 

--- a/backend/internal/application/conversation/service_message_completion.go
+++ b/backend/internal/application/conversation/service_message_completion.go
@@ -364,14 +364,8 @@ func shouldPersistInterruptedMessageGeneration(input persistInterruptedMessageGe
 
 // resolveInterruptedMessageGenerationMetrics 统一处理中断消息的真实 usage 与估算兜底。
 func resolveInterruptedMessageGenerationMetrics(input persistInterruptedMessageGenerationInput) interruptedMessageGenerationMetrics {
-	inputTokens := input.Usage.InputTokens
-	if inputTokens <= 0 {
-		inputTokens = input.EstimatedInputTokens
-	}
-	outputTokens := input.Usage.OutputTokens
-	if outputTokens <= 0 && strings.TrimSpace(input.AssistantText) != "" {
-		outputTokens = estimateTokens(input.AssistantText)
-	}
+	inputTokens := resolveObservedOrHigherEstimatedTokens(input.Usage.InputTokens, input.EstimatedInputTokens)
+	outputTokens := resolveObservedOrHigherEstimatedOutputTokens(input.Usage.OutputTokens, input.AssistantText)
 	latencyMS := input.AssistantLatency
 	if latencyMS < 0 {
 		latencyMS = time.Since(input.StartedAt).Milliseconds()

--- a/backend/internal/application/conversation/service_message_completion_test.go
+++ b/backend/internal/application/conversation/service_message_completion_test.go
@@ -31,6 +31,22 @@ func TestCanceledGenerationWithObservedUsageIsRetainedForBilling(t *testing.T) {
 	}
 }
 
+func TestCanceledGenerationUsesEstimatedTotalWhenObservedUsageIsPartial(t *testing.T) {
+	input := persistInterruptedMessageGenerationInput{
+		UserMessage:          &model.Message{},
+		AssistantMessage:     &model.Message{},
+		EstimatedInputTokens: 96,
+		Usage:                llm.Usage{InputTokens: 40},
+		Error:                ErrMessageGenerationCanceled,
+		StartedAt:            time.Now(),
+	}
+
+	metrics := resolveInterruptedMessageGenerationMetrics(input)
+	if metrics.InputTokens != 96 {
+		t.Fatalf("expected estimated total input tokens to cover partial observed usage, got %#v", metrics)
+	}
+}
+
 func TestCanceledGenerationWithoutUsageOrOutputIsNotRetained(t *testing.T) {
 	input := persistInterruptedMessageGenerationInput{
 		UserMessage:      &model.Message{},

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -200,13 +200,13 @@ func (s *Service) sendMessageInternal(
 	var assistantMessage *model.Message
 	var traceRecorder *messageTraceRecorder
 	var streamedText strings.Builder
-	var streamUsageTotal llm.Usage
 	var toolCallRows []model.ToolCall
 	var persistedToolCallKeys map[string]struct{}
 	var resolvedRoute *channel.ResolvedRoute
 	var filteredOptions map[string]interface{}
 	var totalServerSideToolUsage map[string]int64
-	estimatedInputTokens := int64(0)
+	userContentEstimatedInputTokens := int64(0)
+	usageAccumulator := &messageUsageAccumulator{}
 	upstreamCallStarted := false
 	runState := newMessageSendRunState(s, input, conversation, startedAt, runID)
 	run := runState.run
@@ -219,9 +219,9 @@ func (s *Service) sendMessageInternal(
 				UserMessage:           userMessage,
 				AssistantMessage:      assistantMessage,
 				AssistantText:         streamedText.String(),
-				EstimatedInputTokens:  estimatedInputTokens,
+				EstimatedInputTokens:  usageAccumulator.interruptedInputTokens(),
 				UpstreamCallStarted:   upstreamCallStarted,
-				Usage:                 streamUsageTotal,
+				Usage:                 usageAccumulator.usage(),
 				AssistantLatency:      time.Since(startedAt).Milliseconds(),
 				Error:                 retErr,
 				ToolCallRows:          toolCallRows,
@@ -267,7 +267,7 @@ func (s *Service) sendMessageInternal(
 		return nil, err
 	}
 
-	estimatedInputTokens = estimateTokens(input.Content)
+	userContentEstimatedInputTokens = estimateTokens(input.Content)
 	assistantMessage = &model.Message{
 		ConversationID:   input.ConversationID,
 		UserID:           input.UserID,
@@ -313,8 +313,8 @@ func (s *Service) sendMessageInternal(
 			Content:          input.Content,
 			BranchReason:     normalizedBranchReason,
 			SourceMessageID:  branchState.SourceMessageID,
-			TokenUsage:       estimatedInputTokens,
-			InputTokens:      estimatedInputTokens,
+			TokenUsage:       userContentEstimatedInputTokens,
+			InputTokens:      userContentEstimatedInputTokens,
 			OutputTokens:     0,
 			CacheReadTokens:  0,
 			CacheWriteTokens: 0,
@@ -699,7 +699,7 @@ func (s *Service) sendMessageInternal(
 		StoreProvider:     s.storeProvider,
 	})
 	llmMessages = promptPlan.Messages
-	estimatedPromptTokens := estimatePromptTokens(llmMessages)
+	estimatedPromptTokens := int64(0)
 
 	attributionReferer, attributionTitle := s.llmAttribution()
 	routeConfig := llm.RouteConfig{
@@ -730,6 +730,7 @@ func (s *Service) sendMessageInternal(
 	}
 	fullLLMMessages := llmMessages
 	applyOpenAIResponsesInstructions(route, routeConfig.Endpoint, &generateInput)
+	estimatedPromptTokens = estimateGenerateInputTokens(generateInput)
 	statefulContextConfig := buildPromptContextConfigSignature(cfg)
 	statefulContextState := buildPromptContextStateSignature(stableFullContextAttachments, prefixMemories)
 	statefulPrefixFingerprint := buildPromptStateFingerprint(promptStateFingerprintInput{
@@ -756,7 +757,7 @@ func (s *Service) sendMessageInternal(
 		if len(statefulMessages) > 0 && len(statefulMessages) < len(llmMessages) {
 			generateInput.Messages = statefulMessages
 			generateInput.PreviousResponseID = statefulDecision.PreviousResponseID
-			estimatedPromptTokens = estimatePromptTokens(statefulMessages)
+			estimatedPromptTokens = estimateGenerateInputTokens(generateInput)
 			sendSpan.SetAttributes(
 				attribute.Bool("conversation.stateful_response", true),
 				attribute.Int("conversation.stateful_full_messages", len(llmMessages)),
@@ -823,6 +824,7 @@ func (s *Service) sendMessageInternal(
 			return nil
 		}
 		callPromptShape := summarizePromptShape(callPromptMode, currentInput.Messages, currentInput.Messages, currentInput.PreviousResponseID)
+		usageAccumulator.beginCall(currentInput)
 		generationCtx, generationSpan := platformtracing.Start(ctx, "conversation.llm.generate",
 			trace.WithAttributes(append([]attribute.KeyValue{
 				attribute.Int64("conversation.id", int64(input.ConversationID)),
@@ -884,6 +886,9 @@ func (s *Service) sendMessageInternal(
 					return output, generateErr
 				}
 			}
+			if generateErr == nil {
+				usageAccumulator.finishCall(output != nil && output.Usage.InputTokens > 0)
+			}
 			return output, err
 		}
 		thinkingRouter := &thinkingDeltaRouter{}
@@ -893,14 +898,16 @@ func (s *Service) sendMessageInternal(
 			if s.isMessageGenerationCanceled(generationCtx, runID) {
 				return ErrMessageGenerationCanceled
 			}
-			if event.Usage != (llm.Usage{}) && input.OnEvent != nil {
+			if event.Usage != (llm.Usage{}) {
 				// 上游流式 usage 通常是“本次 LLM 调用累计值”，但一条消息可能包含多轮 LLM 调用。
 				// 这里先换算成本次调用内增量，再累加成本轮消息总量，保证实时展示和最终账单口径一致。
 				usageDelta := diffLLMUsage(event.Usage, callStreamUsage)
 				callStreamUsage = event.Usage
-				streamUsageTotal = addLLMUsage(streamUsageTotal, usageDelta)
-				if err := emitLLMUsageEvent(input.OnEvent, streamUsageTotal); err != nil {
-					return err
+				currentUsage := usageAccumulator.addObservedUsage(usageDelta)
+				if input.OnEvent != nil {
+					if err := emitLLMUsageEvent(input.OnEvent, currentUsage); err != nil {
+						return err
+					}
 				}
 			}
 			if traceRecorder != nil && event.Reasoning != nil && event.Reasoning.Text != "" {
@@ -972,6 +979,9 @@ func (s *Service) sendMessageInternal(
 				generateErr = emitNonStreamingOutput(output)
 			}
 		}
+		if generateErr == nil {
+			usageAccumulator.finishCall((callStreamUsage.InputTokens > 0) || (output != nil && output.Usage.InputTokens > 0))
+		}
 		return output, generateErr
 	}
 
@@ -1004,7 +1014,7 @@ func (s *Service) sendMessageInternal(
 		generateInput.PreviousResponseID = ""
 		generateInput.Messages = fullLLMMessages
 		applyOpenAIResponsesInstructions(route, routeConfig.Endpoint, &generateInput)
-		estimatedPromptTokens = estimatePromptTokens(fullLLMMessages)
+		estimatedPromptTokens = estimateGenerateInputTokens(generateInput)
 		initialPromptShape = summarizePromptShape("full_retry", generateInput.Messages, fullLLMMessages, "")
 		if traceRecorder != nil {
 			traceRecorder.recordPromptTrace(buildMessagePromptTrace(messagePromptTraceInput{
@@ -1037,9 +1047,9 @@ func (s *Service) sendMessageInternal(
 	toolCallRows = append(toolCallRows, nativeToolRows...)
 	totalUsage := upstreamOutput.Usage
 	if totalUsage == (llm.Usage{}) {
-		totalUsage = streamUsageTotal
+		totalUsage = usageAccumulator.usage()
 	} else {
-		streamUsageTotal = totalUsage
+		usageAccumulator.setObservedUsage(totalUsage)
 	}
 	totalServerSideToolUsage = addServerSideToolUsage(nil, upstreamOutput.ServerSideToolUsage)
 	remainingToolCalls := s.resolveMaxToolCallsPerRun()
@@ -1136,9 +1146,9 @@ func (s *Service) sendMessageInternal(
 		s.routeResolver.MarkRouteSuccess(ctx, route)
 		totalUsage = addLLMUsage(totalUsage, nextOutput.Usage)
 		if nextOutput.Usage != (llm.Usage{}) {
-			streamUsageTotal = totalUsage
-		} else if streamUsageTotal != (llm.Usage{}) {
-			totalUsage = streamUsageTotal
+			usageAccumulator.setObservedUsage(totalUsage)
+		} else if usageAccumulator.usage() != (llm.Usage{}) {
+			totalUsage = usageAccumulator.usage()
 		}
 		totalServerSideToolUsage = addServerSideToolUsage(totalServerSideToolUsage, nextOutput.ServerSideToolUsage)
 		upstreamOutput = nextOutput
@@ -1166,9 +1176,9 @@ func (s *Service) sendMessageInternal(
 		s.routeResolver.MarkRouteSuccess(ctx, route)
 		totalUsage = addLLMUsage(totalUsage, nextOutput.Usage)
 		if nextOutput.Usage != (llm.Usage{}) {
-			streamUsageTotal = totalUsage
-		} else if streamUsageTotal != (llm.Usage{}) {
-			totalUsage = streamUsageTotal
+			usageAccumulator.setObservedUsage(totalUsage)
+		} else if usageAccumulator.usage() != (llm.Usage{}) {
+			totalUsage = usageAccumulator.usage()
 		}
 		totalServerSideToolUsage = addServerSideToolUsage(totalServerSideToolUsage, nextOutput.ServerSideToolUsage)
 		upstreamOutput = nextOutput
@@ -1178,14 +1188,8 @@ func (s *Service) sendMessageInternal(
 		toolCallRows = append(toolCallRows, nextNativeToolRows...)
 	}
 
-	effectiveInputTokens := totalUsage.InputTokens
-	if effectiveInputTokens <= 0 {
-		effectiveInputTokens = estimatedPromptTokens
-	}
-	effectiveOutputTokens := totalUsage.OutputTokens
-	if effectiveOutputTokens <= 0 {
-		effectiveOutputTokens = estimateTokens(assistantText)
-	}
+	effectiveInputTokens := usageAccumulator.effectiveInputTokens(estimatedPromptTokens)
+	effectiveOutputTokens := resolveObservedOrEstimatedOutputTokens(totalUsage.OutputTokens, assistantText)
 
 	if toolRunFinalAnswerMissing(upstreamOutput, len(toolCallRows) > 0, llmCallCount, maxLLMCalls, remainingToolCalls) {
 		retErr = ErrToolRunFinalAnswerMissing

--- a/backend/internal/application/conversation/service_message_usage.go
+++ b/backend/internal/application/conversation/service_message_usage.go
@@ -1,0 +1,119 @@
+package conversation
+
+import (
+	"strings"
+
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/llm"
+)
+
+type messageUsageAccumulator struct {
+	observedUsage                   llm.Usage
+	estimatedUnobservedInputTokens  int64
+	currentCallEstimatedInputTokens int64
+}
+
+func (a *messageUsageAccumulator) beginCall(input llm.GenerateInput) {
+	a.currentCallEstimatedInputTokens = estimateGenerateInputTokens(input)
+}
+
+func (a *messageUsageAccumulator) finishCall(observedInput bool) {
+	if observedInput {
+		a.currentCallEstimatedInputTokens = 0
+		return
+	}
+	if a.currentCallEstimatedInputTokens <= 0 {
+		return
+	}
+	a.estimatedUnobservedInputTokens += a.currentCallEstimatedInputTokens
+	a.currentCallEstimatedInputTokens = 0
+}
+
+func (a *messageUsageAccumulator) addObservedUsage(delta llm.Usage) llm.Usage {
+	if delta == (llm.Usage{}) {
+		return a.observedUsage
+	}
+	a.observedUsage = addLLMUsage(a.observedUsage, delta)
+	if delta.InputTokens > 0 {
+		a.currentCallEstimatedInputTokens = 0
+	}
+	return a.observedUsage
+}
+
+func (a *messageUsageAccumulator) setObservedUsage(usage llm.Usage) {
+	a.observedUsage = usage
+	if usage.InputTokens > 0 {
+		a.currentCallEstimatedInputTokens = 0
+	}
+}
+
+func (a *messageUsageAccumulator) usage() llm.Usage {
+	return a.observedUsage
+}
+
+func (a *messageUsageAccumulator) interruptedInputTokens() int64 {
+	return a.observedUsage.InputTokens + a.estimatedUnobservedInputTokens + a.currentCallEstimatedInputTokens
+}
+
+func (a *messageUsageAccumulator) effectiveInputTokens(promptFallback int64) int64 {
+	inputTokens := a.observedUsage.InputTokens + a.estimatedUnobservedInputTokens
+	if inputTokens > 0 {
+		return inputTokens
+	}
+	if promptFallback > 0 {
+		return promptFallback
+	}
+	return 0
+}
+
+func resolveObservedOrEstimatedOutputTokens(observedTokens int64, assistantText string) int64 {
+	return resolveObservedOrEstimatedTokens(observedTokens, estimateTokens(assistantText))
+}
+
+func resolveObservedOrEstimatedTokens(observedTokens int64, estimatedTokens int64) int64 {
+	if observedTokens > 0 {
+		return observedTokens
+	}
+	if estimatedTokens > 0 {
+		return estimatedTokens
+	}
+	return 0
+}
+
+func resolveObservedOrHigherEstimatedOutputTokens(observedTokens int64, assistantText string) int64 {
+	return resolveObservedOrHigherEstimatedTokens(observedTokens, estimateTokens(assistantText))
+}
+
+func resolveObservedOrHigherEstimatedTokens(observedTokens int64, estimatedTokens int64) int64 {
+	if estimatedTokens > observedTokens {
+		return estimatedTokens
+	}
+	if observedTokens > 0 {
+		return observedTokens
+	}
+	return 0
+}
+
+func estimateGenerateInputTokens(input llm.GenerateInput) int64 {
+	tokens := estimatePromptTokens(input.Messages)
+	if instructions := strings.TrimSpace(input.Instructions); instructions != "" {
+		tokens += estimateTokens(instructions) + 4
+	}
+	if !input.DisableTools {
+		tokens += estimateToolDefinitionTokens(input.Tools)
+	}
+	return tokens
+}
+
+func estimateToolDefinitionTokens(tools []llm.ToolDefinition) int64 {
+	if len(tools) == 0 {
+		return 0
+	}
+	var tokens int64 = 2
+	for _, tool := range tools {
+		tokens += estimateTokens(tool.Name)
+		tokens += estimateTokens(tool.Description)
+		tokens += estimateTokens(string(tool.InputSchema))
+		tokens += 12
+	}
+	return tokens
+}

--- a/backend/internal/application/conversation/service_message_usage_test.go
+++ b/backend/internal/application/conversation/service_message_usage_test.go
@@ -1,0 +1,99 @@
+package conversation
+
+import (
+	"testing"
+
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/llm"
+)
+
+func TestMessageUsageAccumulatorCombinesObservedAndUnobservedInput(t *testing.T) {
+	accumulator := &messageUsageAccumulator{}
+
+	firstCallMessages := []llm.Message{{Role: "user", Content: "hello"}}
+	accumulator.beginCall(llm.GenerateInput{Messages: firstCallMessages})
+	accumulator.addObservedUsage(llm.Usage{InputTokens: 12, OutputTokens: 3})
+
+	if got := accumulator.interruptedInputTokens(); got != 12 {
+		t.Fatalf("expected observed input tokens after first call, got %d", got)
+	}
+
+	secondCallMessages := []llm.Message{{Role: "tool", Content: "tool result"}}
+	secondCallInput := llm.GenerateInput{Messages: secondCallMessages}
+	secondCallEstimate := estimateGenerateInputTokens(secondCallInput)
+	accumulator.beginCall(secondCallInput)
+	accumulator.finishCall(false)
+
+	want := int64(12) + secondCallEstimate
+	if got := accumulator.interruptedInputTokens(); got != want {
+		t.Fatalf("expected observed plus unobserved input tokens, got %d want %d", got, want)
+	}
+	if got := accumulator.effectiveInputTokens(0); got != want {
+		t.Fatalf("expected effective input tokens to include unobserved estimate, got %d want %d", got, want)
+	}
+}
+
+func TestResolveObservedOrHigherEstimatedTokensKeepsLargerEstimate(t *testing.T) {
+	if got := resolveObservedOrHigherEstimatedTokens(40, 96); got != 96 {
+		t.Fatalf("expected larger input estimate, got %d", got)
+	}
+	if got := resolveObservedOrHigherEstimatedOutputTokens(2, "hello world this is a longer streamed response"); got <= 2 {
+		t.Fatalf("expected output estimate to cover partial observed usage, got %d", got)
+	}
+}
+
+func TestResolveObservedOrEstimatedTokensPrefersObservedUsage(t *testing.T) {
+	if got := resolveObservedOrEstimatedTokens(40, 96); got != 40 {
+		t.Fatalf("expected successful usage path to prefer observed tokens, got %d", got)
+	}
+	if got := resolveObservedOrEstimatedOutputTokens(7, "hello world this is a longer streamed response"); got != 7 {
+		t.Fatalf("expected successful output usage path to prefer observed tokens, got %d", got)
+	}
+}
+
+func TestEstimateGenerateInputTokensIncludesInstructionsAndTools(t *testing.T) {
+	input := llm.GenerateInput{
+		Messages:     []llm.Message{{Role: "user", Content: "hello"}},
+		Instructions: "answer tersely",
+		Tools: []llm.ToolDefinition{{
+			Name:        "lookup",
+			Description: "Search docs",
+			InputSchema: []byte(`{"type":"object","properties":{"query":{"type":"string"}}}`),
+		}},
+	}
+
+	messageOnly := estimatePromptTokens(input.Messages)
+	withInputShape := estimateGenerateInputTokens(input)
+	if withInputShape <= messageOnly {
+		t.Fatalf("expected generate input estimate to include instructions and tools, got %d <= %d", withInputShape, messageOnly)
+	}
+
+	input.DisableTools = true
+	withoutTools := estimateGenerateInputTokens(input)
+	if withoutTools >= withInputShape {
+		t.Fatalf("expected disabled tools to be excluded from estimate, got %d >= %d", withoutTools, withInputShape)
+	}
+}
+
+func TestSendMessageBillingDurationSeconds(t *testing.T) {
+	if got := sendMessageBillingDurationSeconds(&SendMessageResult{DurationSeconds: 5}, 1200); got != 5 {
+		t.Fatalf("expected explicit duration seconds to win, got %d", got)
+	}
+	if got := sendMessageBillingDurationSeconds(&SendMessageResult{}, 1201); got != 2 {
+		t.Fatalf("expected latency to be rounded up to seconds, got %d", got)
+	}
+	if got := sendMessageBillingDurationSeconds(&SendMessageResult{}, 0); got != 0 {
+		t.Fatalf("expected empty duration for zero latency, got %d", got)
+	}
+}
+
+func TestMediaDurationSecondsFromOptions(t *testing.T) {
+	if got := mediaDurationSecondsFromOptions(map[string]interface{}{"durationSeconds": float64(5)}); got != 5 {
+		t.Fatalf("expected numeric duration seconds, got %d", got)
+	}
+	if got := mediaDurationSecondsFromOptions(map[string]interface{}{"duration": "5.2s"}); got != 6 {
+		t.Fatalf("expected string duration to round up, got %d", got)
+	}
+	if got := mediaDurationSecondsFromOptions(map[string]interface{}{"duration": "bad"}); got != 0 {
+		t.Fatalf("expected invalid duration to be ignored, got %d", got)
+	}
+}

--- a/backend/internal/transport/http/conversation/handler_media.go
+++ b/backend/internal/transport/http/conversation/handler_media.go
@@ -212,6 +212,14 @@ func (h *Handler) streamMediaTask(
 	}
 	appconversation.ApplyUsageBilling(&result.AssistantMessage, usageLedger)
 
+	if result.AssistantMessage.Status == "canceled" {
+		payload := streamErrorPayload(appconversation.ErrMessageGenerationCanceled)
+		payload["data"] = toSendMessageResponse(result)
+		_ = flushStreamEvent(payload)
+		h.service.FinishMessageGeneration(clientRunID)
+		return
+	}
+
 	_ = flushStreamEvent(map[string]interface{}{
 		"type": "completed",
 		"data": toSendMessageResponse(result),


### PR DESCRIPTION
## Summary

User-initiated generation cancellation now remains billable when an upstream request has started. Canceled text/chat generations retain observed usage when available and fall back to local input/output token estimates when upstream usage is missing or partial. Media generation cancellation now persists a canceled assistant message and continues through the normal billing path instead of releasing the usage reservation.

This also centralizes message usage accumulation, adds duration-second billing support for send-message results, and keeps call/duration pricing modes billable on active cancellation.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [x] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./...`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Not applicable. Backend billing and cancellation behavior only.

## Configuration, migration, and compatibility notes

No configuration, database schema, migration, Docker, CORS, or public API contract changes.

Existing cancel APIs are unchanged. User-initiated cancellation may now produce billable canceled/interrupted message results when an upstream request has started.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.