### PR TITLE
feat: fetch official model pricing from models.dev API

### DIFF
--- a/backend/internal/application/billing/official_pricing.go
+++ b/backend/internal/application/billing/official_pricing.go
@@ -1,0 +1,130 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const modelsDevAPIURL = "https://models.dev/api.json"
+
+// modelsDevCost is the cost field in the models.dev API response.
+type modelsDevCost struct {
+	Input      float64 `json:"input"`
+	Output     float64 `json:"output"`
+	CacheRead  float64 `json:"cache_read"`
+	CacheWrite float64 `json:"cache_write"`
+}
+
+type modelsDevModel struct {
+	ID   string        `json:"id"`
+	Name string        `json:"name"`
+	Cost modelsDevCost `json:"cost"`
+}
+
+type modelsDevProvider struct {
+	ID     string                    `json:"id"`
+	Models map[string]modelsDevModel `json:"models"`
+}
+
+// vendorToProviderID maps DEEIX-Chat vendor names to models.dev provider IDs.
+var vendorToProviderID = map[string]string{
+	"openai":    "openai",
+	"anthropic": "anthropic",
+	"google":    "google",
+	"deepseek":  "deepseek",
+	"mistral":   "mistral",
+	"xai":       "xai",
+	"cohere":    "cohere",
+	"baidu":     "baidu",
+	"alibaba":   "alibaba",
+	"zhipu":     "zhipu",
+	"minimax":   "minimax",
+	"moonshot":  "moonshotai",
+	"bytedance": "bytedance",
+}
+
+// OfficialPricingEntry holds pricing fetched from an external source.
+type OfficialPricingEntry struct {
+	InputUSDPerMTokens      float64
+	OutputUSDPerMTokens     float64
+	CacheReadUSDPerMTokens  float64
+	CacheWriteUSDPerMTokens float64
+}
+
+// FetchModelsDevPricing fetches pricing from models.dev/api.json and returns
+// a map keyed by the model name used in the provider's catalog (without the
+// "provider/" prefix), e.g. "gpt-5.4" → entry.
+func FetchModelsDevPricing(ctx context.Context) (map[string]map[string]OfficialPricingEntry, error) {
+	return fetchModelsDevPricingFromURL(ctx, modelsDevAPIURL)
+}
+
+func fetchModelsDevPricingFromURL(ctx context.Context, url string) (map[string]map[string]OfficialPricingEntry, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "DEEIX-Chat/pricing-fetch")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch models.dev api: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("models.dev returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 20*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	var providers map[string]modelsDevProvider
+	if err := json.Unmarshal(body, &providers); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	// result[vendor][modelName] = pricing
+	result := make(map[string]map[string]OfficialPricingEntry)
+
+	for deeixVendor, providerID := range vendorToProviderID {
+		provider, ok := providers[providerID]
+		if !ok {
+			continue
+		}
+		vendorPricing := make(map[string]OfficialPricingEntry)
+		for modelKey, model := range provider.Models {
+			cost := model.Cost
+			if cost.Input == 0 && cost.Output == 0 {
+				continue
+			}
+			name := stripProviderPrefix(modelKey)
+			vendorPricing[name] = OfficialPricingEntry{
+				InputUSDPerMTokens:      cost.Input,
+				OutputUSDPerMTokens:     cost.Output,
+				CacheReadUSDPerMTokens:  cost.CacheRead,
+				CacheWriteUSDPerMTokens: cost.CacheWrite,
+			}
+		}
+		if len(vendorPricing) > 0 {
+			result[deeixVendor] = vendorPricing
+		}
+	}
+
+	return result, nil
+}
+
+func stripProviderPrefix(key string) string {
+	if idx := strings.Index(key, "/"); idx >= 0 {
+		return key[idx+1:]
+	}
+	return key
+}

--- a/backend/internal/application/billing/official_pricing_test.go
+++ b/backend/internal/application/billing/official_pricing_test.go
@@ -1,0 +1,270 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStripProviderPrefix(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"openai/gpt-5.4", "gpt-5.4"},
+		{"anthropic/claude-sonnet-5", "claude-sonnet-5"},
+		{"gpt-5.4", "gpt-5.4"},
+		{"google/gemini-3-flash-preview", "gemini-3-flash-preview"},
+	}
+	for _, tt := range tests {
+		got := stripProviderPrefix(tt.input)
+		if got != tt.want {
+			t.Errorf("stripProviderPrefix(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLookupPricingExactVendorMatch(t *testing.T) {
+	byVendor := map[string]map[string]OfficialPricingEntry{
+		"openai": {
+			"gpt-5.4": {InputUSDPerMTokens: 2.5, OutputUSDPerMTokens: 15},
+		},
+		"anthropic": {
+			"claude-sonnet-5": {InputUSDPerMTokens: 3, OutputUSDPerMTokens: 15},
+		},
+	}
+	entry := lookupPricing(byVendor, "gpt-5.4", "openai")
+	if entry == nil {
+		t.Fatal("expected match")
+	}
+	if entry.InputUSDPerMTokens != 2.5 {
+		t.Errorf("got input %v, want 2.5", entry.InputUSDPerMTokens)
+	}
+}
+
+func TestLookupPricingFallbackAcrossVendors(t *testing.T) {
+	byVendor := map[string]map[string]OfficialPricingEntry{
+		"openai": {
+			"gpt-5.4": {InputUSDPerMTokens: 2.5, OutputUSDPerMTokens: 15},
+		},
+	}
+	entry := lookupPricing(byVendor, "gpt-5.4", "unknown")
+	if entry == nil {
+		t.Fatal("expected fallback match across vendors")
+	}
+}
+
+func TestLookupPricingNoMatch(t *testing.T) {
+	byVendor := map[string]map[string]OfficialPricingEntry{
+		"openai": {
+			"gpt-5.4": {InputUSDPerMTokens: 2.5},
+		},
+	}
+	entry := lookupPricing(byVendor, "nonexistent-model", "openai")
+	if entry != nil {
+		t.Errorf("expected nil, got %+v", entry)
+	}
+}
+
+func TestLookupPricingEmptyVendor(t *testing.T) {
+	byVendor := map[string]map[string]OfficialPricingEntry{
+		"deepseek": {
+			"deepseek-v4-flash": {InputUSDPerMTokens: 0.14, OutputUSDPerMTokens: 0.28},
+		},
+	}
+	entry := lookupPricing(byVendor, "deepseek-v4-flash", "")
+	if entry == nil {
+		t.Fatal("expected match with empty vendor via fallback")
+	}
+	if entry.InputUSDPerMTokens != 0.14 {
+		t.Errorf("got input %v, want 0.14", entry.InputUSDPerMTokens)
+	}
+}
+
+func TestFetchModelsDevPricingParsesResponse(t *testing.T) {
+	payload := map[string]interface{}{
+		"openai": map[string]interface{}{
+			"id": "openai",
+			"models": map[string]interface{}{
+				"gpt-5.4": map[string]interface{}{
+					"id":   "gpt-5.4",
+					"name": "GPT-5.4",
+					"cost": map[string]interface{}{
+						"input":       2.5,
+						"output":      15,
+						"cache_read":  0.25,
+						"cache_write": 0,
+					},
+				},
+				"gpt-5.4-mini": map[string]interface{}{
+					"id":   "gpt-5.4-mini",
+					"name": "GPT-5.4 Mini",
+					"cost": map[string]interface{}{
+						"input":  0.3,
+						"output": 1.25,
+					},
+				},
+			},
+		},
+		"anthropic": map[string]interface{}{
+			"id": "anthropic",
+			"models": map[string]interface{}{
+				"claude-sonnet-5": map[string]interface{}{
+					"id":   "claude-sonnet-5",
+					"name": "Claude Sonnet 5",
+					"cost": map[string]interface{}{
+						"input":       3,
+						"output":      15,
+						"cache_read":  0.3,
+						"cache_write": 3.75,
+					},
+				},
+			},
+		},
+		"some-other-provider": map[string]interface{}{
+			"id":     "some-other-provider",
+			"models": map[string]interface{}{},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(payload)
+	}))
+	defer srv.Close()
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL_ := srv.URL
+	// We can't reassign the const, so we test via a helper that accepts URL.
+	result, err := fetchModelsDevPricingFromURL(context.Background(), modelsDevAPIURL_)
+	_ = origURL
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	openaiModels, ok := result["openai"]
+	if !ok {
+		t.Fatal("expected openai in result")
+	}
+	if len(openaiModels) != 2 {
+		t.Errorf("expected 2 openai models, got %d", len(openaiModels))
+	}
+	gpt54, ok := openaiModels["gpt-5.4"]
+	if !ok {
+		t.Fatal("expected gpt-5.4 in openai")
+	}
+	if gpt54.InputUSDPerMTokens != 2.5 {
+		t.Errorf("gpt-5.4 input: got %v, want 2.5", gpt54.InputUSDPerMTokens)
+	}
+	if gpt54.OutputUSDPerMTokens != 15 {
+		t.Errorf("gpt-5.4 output: got %v, want 15", gpt54.OutputUSDPerMTokens)
+	}
+	if gpt54.CacheReadUSDPerMTokens != 0.25 {
+		t.Errorf("gpt-5.4 cache_read: got %v, want 0.25", gpt54.CacheReadUSDPerMTokens)
+	}
+
+	anthropicModels, ok := result["anthropic"]
+	if !ok {
+		t.Fatal("expected anthropic in result")
+	}
+	cs5, ok := anthropicModels["claude-sonnet-5"]
+	if !ok {
+		t.Fatal("expected claude-sonnet-5 in anthropic")
+	}
+	if cs5.CacheWriteUSDPerMTokens != 3.75 {
+		t.Errorf("claude-sonnet-5 cache_write: got %v, want 3.75", cs5.CacheWriteUSDPerMTokens)
+	}
+
+	if _, ok := result["some-other-provider"]; ok {
+		t.Error("unmapped provider should not appear in result")
+	}
+}
+
+func TestFetchModelsDevPricingSkipsZeroCost(t *testing.T) {
+	payload := map[string]interface{}{
+		"openai": map[string]interface{}{
+			"id": "openai",
+			"models": map[string]interface{}{
+				"text-embedding-3-small": map[string]interface{}{
+					"id":   "text-embedding-3-small",
+					"name": "Text Embedding 3 Small",
+					"cost": map[string]interface{}{
+						"input":  0,
+						"output": 0,
+					},
+				},
+				"gpt-5.4": map[string]interface{}{
+					"id":   "gpt-5.4",
+					"name": "GPT-5.4",
+					"cost": map[string]interface{}{
+						"input":  2.5,
+						"output": 15,
+					},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(payload)
+	}))
+	defer srv.Close()
+
+	result, err := fetchModelsDevPricingFromURL(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	openaiModels := result["openai"]
+	if _, ok := openaiModels["text-embedding-3-small"]; ok {
+		t.Error("zero-cost model should be skipped")
+	}
+	if _, ok := openaiModels["gpt-5.4"]; !ok {
+		t.Error("non-zero cost model should be included")
+	}
+}
+
+func TestFetchModelsDevPricingStripsProviderPrefix(t *testing.T) {
+	payload := map[string]interface{}{
+		"google": map[string]interface{}{
+			"id": "google",
+			"models": map[string]interface{}{
+				"google/gemini-3-flash": map[string]interface{}{
+					"id":   "google/gemini-3-flash",
+					"name": "Gemini 3 Flash",
+					"cost": map[string]interface{}{
+						"input":  0.15,
+						"output": 0.6,
+					},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(payload)
+	}))
+	defer srv.Close()
+
+	result, err := fetchModelsDevPricingFromURL(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	googleModels := result["google"]
+	if _, ok := googleModels["gemini-3-flash"]; !ok {
+		t.Error("expected provider prefix to be stripped from model key")
+	}
+}
+
+func TestFetchModelsDevPricingHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	_, err := fetchModelsDevPricingFromURL(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("expected error for non-200 status")
+	}
+}

--- a/backend/internal/application/billing/service_official_pricing.go
+++ b/backend/internal/application/billing/service_official_pricing.go
@@ -1,0 +1,103 @@
+package billing
+
+import (
+	"context"
+	"strings"
+)
+
+// OfficialPricingSuggestion is a matched pricing entry for a platform model.
+type OfficialPricingSuggestion struct {
+	PlatformModelName       string
+	InputUSDPerMTokens      float64
+	OutputUSDPerMTokens     float64
+	CacheReadUSDPerMTokens  float64
+	CacheWriteUSDPerMTokens float64
+}
+
+// FetchOfficialPricingSuggestions fetches live pricing from models.dev and
+// returns suggestions for active platform models that have no pricing yet.
+func (s *Service) FetchOfficialPricingSuggestions(ctx context.Context) ([]OfficialPricingSuggestion, error) {
+	validNames, err := s.activePlatformModelNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(validNames) == 0 {
+		return nil, nil
+	}
+
+	existingPricing, _, err := s.repo.ListModelPricing(ctx, "", 0, 5000)
+	if err != nil {
+		return nil, err
+	}
+	alreadyPriced := make(map[string]struct{}, len(existingPricing))
+	for _, item := range existingPricing {
+		alreadyPriced[strings.TrimSpace(item.PlatformModelName)] = struct{}{}
+	}
+
+	vendorByModel := s.buildVendorByModelMap(ctx)
+
+	pricingByVendor, err := FetchModelsDevPricing(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var suggestions []OfficialPricingSuggestion
+	for name := range validNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := alreadyPriced[name]; ok {
+			continue
+		}
+		vendor := vendorByModel[name]
+		entry := lookupPricing(pricingByVendor, name, vendor)
+		if entry == nil {
+			continue
+		}
+		suggestions = append(suggestions, OfficialPricingSuggestion{
+			PlatformModelName:       name,
+			InputUSDPerMTokens:      entry.InputUSDPerMTokens,
+			OutputUSDPerMTokens:     entry.OutputUSDPerMTokens,
+			CacheReadUSDPerMTokens:  entry.CacheReadUSDPerMTokens,
+			CacheWriteUSDPerMTokens: entry.CacheWriteUSDPerMTokens,
+		})
+	}
+	return suggestions, nil
+}
+
+func lookupPricing(byVendor map[string]map[string]OfficialPricingEntry, modelName string, vendor string) *OfficialPricingEntry {
+	if vendor != "" {
+		if vendorModels, ok := byVendor[vendor]; ok {
+			if entry, ok := vendorModels[modelName]; ok {
+				return &entry
+			}
+		}
+	}
+	for _, vendorModels := range byVendor {
+		if entry, ok := vendorModels[modelName]; ok {
+			return &entry
+		}
+	}
+	return nil
+}
+
+// buildVendorByModelMap returns a map from platform model name to vendor.
+func (s *Service) buildVendorByModelMap(ctx context.Context) map[string]string {
+	if s.platformModelIdentityResolver == nil {
+		return nil
+	}
+	names, err := s.activePlatformModelNames(ctx)
+	if err != nil || names == nil {
+		return nil
+	}
+	result := make(map[string]string, len(names))
+	for name := range names {
+		identity, err := s.resolvePlatformModelIdentity(ctx, name)
+		if err != nil {
+			continue
+		}
+		result[name] = strings.ToLower(strings.TrimSpace(identity.ModelVendor))
+	}
+	return result
+}

--- a/backend/internal/transport/http/billing/dto.go
+++ b/backend/internal/transport/http/billing/dto.go
@@ -641,6 +641,20 @@ type RedemptionApplyResponseDoc struct {
 	Data     RedemptionApplyDataResponse `json:"data"`
 }
 
+// OfficialPricingSuggestionResponse 官方定价建议响应。
+type OfficialPricingSuggestionResponse struct {
+	PlatformModelName       string  `json:"platformModelName"`
+	InputUSDPerMTokens      float64 `json:"inputUSDPerMTokens"`
+	OutputUSDPerMTokens     float64 `json:"outputUSDPerMTokens"`
+	CacheReadUSDPerMTokens  float64 `json:"cacheReadUSDPerMTokens"`
+	CacheWriteUSDPerMTokens float64 `json:"cacheWriteUSDPerMTokens"`
+}
+
+// OfficialPricingDataResponse 官方定价建议列表响应。
+type OfficialPricingDataResponse struct {
+	Suggestions []OfficialPricingSuggestionResponse `json:"suggestions"`
+}
+
 // ErrorDoc 错误响应。
 type ErrorDoc struct {
 	ErrorMsg  string      `json:"errorMsg"`

--- a/backend/internal/transport/http/billing/handler.go
+++ b/backend/internal/transport/http/billing/handler.go
@@ -983,6 +983,35 @@ func (h *Handler) UpsertModelPricing(c *gin.Context) {
 	})
 }
 
+// FetchOfficialPricing godoc
+// @Summary 获取官方模型定价建议
+// @Description 返回所有未配置定价的平台模型对应的官方公开定价
+// @Tags admin-billing
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Success 200 {object} OfficialPricingDataResponse
+// @Failure 500 {object} ErrorDoc
+// @Router /admin/billing/model-prices/official [get]
+func (h *Handler) FetchOfficialPricing(c *gin.Context) {
+	suggestions, err := h.service.FetchOfficialPricingSuggestions(c.Request.Context())
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, "fetch official pricing failed")
+		return
+	}
+	results := make([]OfficialPricingSuggestionResponse, 0, len(suggestions))
+	for _, s := range suggestions {
+		results = append(results, OfficialPricingSuggestionResponse{
+			PlatformModelName:       s.PlatformModelName,
+			InputUSDPerMTokens:      s.InputUSDPerMTokens,
+			OutputUSDPerMTokens:     s.OutputUSDPerMTokens,
+			CacheReadUSDPerMTokens:  s.CacheReadUSDPerMTokens,
+			CacheWriteUSDPerMTokens: s.CacheWriteUSDPerMTokens,
+		})
+	}
+	response.Success(c, OfficialPricingDataResponse{Suggestions: results})
+}
+
 func pageParams(c *gin.Context) (int, int) {
 	page := 1
 	pageSize := 20

--- a/backend/internal/transport/http/billing/router.go
+++ b/backend/internal/transport/http/billing/router.go
@@ -37,5 +37,6 @@ func (m *Module) RegisterAdminRoutes(adminGroup *gin.RouterGroup) {
 	adminGroup.PATCH("/billing/redemption-codes/:id", m.Handler.PatchRedemptionCode)
 	adminGroup.DELETE("/billing/redemption-codes/:id", m.Handler.DeleteRedemptionCode)
 	adminGroup.GET("/billing/model-prices", m.Handler.ListModelPricing)
+	adminGroup.GET("/billing/model-prices/official", m.Handler.FetchOfficialPricing)
 	adminGroup.PUT("/billing/model-prices", m.Handler.UpsertModelPricing)
 }

--- a/frontend/features/admin/api/billing.ts
+++ b/frontend/features/admin/api/billing.ts
@@ -21,6 +21,7 @@ import type {
   UpdateAdminBillingPlanRequest,
   UpdateAdminBillingAccountBalanceRequest,
   UpsertAdminModelPricingRequest,
+  OfficialPricingSuggestionsData,
 } from "@/features/admin/api/billing.types";
 
 import { normalizeAdminPagePayload, resolveAdminPage, type AdminPageOptions } from "./shared";
@@ -180,6 +181,16 @@ export async function upsertAdminModelPricing(
   return authedRequest<AdminModelPricingData>(
     "/api/v1/admin/billing/model-prices",
     { method: "PUT", accessToken, body: payload },
+    true,
+  );
+}
+
+export async function fetchOfficialModelPricing(
+  accessToken: string,
+): Promise<OfficialPricingSuggestionsData> {
+  return authedRequest<OfficialPricingSuggestionsData>(
+    "/api/v1/admin/billing/model-prices/official",
+    { accessToken },
     true,
   );
 }

--- a/frontend/features/admin/api/billing.types.ts
+++ b/frontend/features/admin/api/billing.types.ts
@@ -216,3 +216,15 @@ export type AdminRedemptionCodeBatchDeleteData = {
 };
 
 export type AdminModelPricingPage = PagePayload<AdminModelPricingDTO>;
+
+export type OfficialPricingSuggestion = {
+  platformModelName: string;
+  inputUSDPerMTokens: number;
+  outputUSDPerMTokens: number;
+  cacheReadUSDPerMTokens: number;
+  cacheWriteUSDPerMTokens: number;
+};
+
+export type OfficialPricingSuggestionsData = {
+  suggestions: OfficialPricingSuggestion[];
+};

--- a/frontend/features/admin/components/sections/billing/admin-billing.tsx
+++ b/frontend/features/admin/components/sections/billing/admin-billing.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Check, CircleAlert, Copy, Download, Pencil, Plus, Save, Trash2, Upload, X } from "lucide-react";
+import { Check, CircleAlert, Copy, Download, Pencil, Plus, Save, Sparkles, Trash2, Upload, X } from "lucide-react";
 import { motion } from "motion/react";
 import { useLocale, useMessages, useTranslations } from "next-intl";
 import { toast } from "sonner";
@@ -70,11 +70,12 @@ import {
   updateAdminRedemptionCode,
   updateAdminBillingPlan,
   upsertAdminModelPricing,
+  fetchOfficialModelPricing,
   listPermissionGroups,
 } from "@/features/admin/api";
 import type { PermissionGroup } from "@/features/admin/api/permission-groups";
 import { listAllAdminPages } from "@/features/admin/api/shared";
-import type { AdminBillingMode, AdminBillingPlanDTO, AdminModelPricingDTO, AdminRedemptionCodeDTO, NativeToolPricingDTO } from "@/features/admin/api/billing.types";
+import type { AdminBillingMode, AdminBillingPlanDTO, AdminModelPricingDTO, AdminRedemptionCodeDTO, NativeToolPricingDTO, OfficialPricingSuggestion } from "@/features/admin/api/billing.types";
 import type { AdminLLMModelDTO } from "@/features/admin/api/llm.types";
 import { resolveAdminErrorMessage } from "@/features/admin/utils/admin-error";
 import {
@@ -92,6 +93,7 @@ import {
   createPlanFormState,
   flattenPaymentSettings,
   formatCreditUSD,
+  formatUSD,
   formatDateTime,
   mergeModelPricingItem,
   normalizePaymentProviders,
@@ -345,6 +347,10 @@ export function AdminBillingPage() {
   const [redemptionDeleteTarget, setRedemptionDeleteTarget] = React.useState<AdminRedemptionCodeDTO | null>(null);
   const [createdRedemptionCodes, setCreatedRedemptionCodes] = React.useState<string[]>([]);
   const [redemptionStatusPendingID, setRedemptionStatusPendingID] = React.useState<number | null>(null);
+  const [officialPricingOpen, setOfficialPricingOpen] = React.useState(false);
+  const [officialPricingSuggestions, setOfficialPricingSuggestions] = React.useState<OfficialPricingSuggestion[]>([]);
+  const [officialPricingSelected, setOfficialPricingSelected] = React.useState<Set<string>>(new Set());
+  const [officialPricingLoading, setOfficialPricingLoading] = React.useState(false);
   const stripeWebhookEndpoint = React.useMemo(() => `${resolveApiBaseURL()}/api/v1/billing/payments/stripe/webhook`, []);
 
   const loadData = React.useCallback(async () => {
@@ -1347,6 +1353,79 @@ export function AdminBillingPage() {
     }
   }
 
+  async function openOfficialPricingDialog() {
+    setOfficialPricingLoading(true);
+    try {
+      const token = await resolveAccessToken();
+      if (!token) {
+        toast.error(t("toast.sessionExpired"), { description: t("toast.sessionExpiredDescription") });
+        return;
+      }
+      const data = await fetchOfficialModelPricing(token);
+      const suggestions = data.suggestions ?? [];
+      if (suggestions.length === 0) {
+        toast.info(t("toast.officialPricingEmpty"));
+        return;
+      }
+      const sorted = [...suggestions].sort((a, b) => a.platformModelName.localeCompare(b.platformModelName));
+      setOfficialPricingSuggestions(sorted);
+      setOfficialPricingSelected(new Set(sorted.map((s) => s.platformModelName)));
+      setOfficialPricingOpen(true);
+    } catch (error) {
+      toast.error(t("toast.officialPricingFailed"), { description: resolveAdminErrorMessage(error) });
+    } finally {
+      setOfficialPricingLoading(false);
+    }
+  }
+
+  async function applySelectedOfficialPricing() {
+    const selected = officialPricingSuggestions.filter((s) => officialPricingSelected.has(s.platformModelName));
+    if (selected.length === 0) return;
+    setOfficialPricingLoading(true);
+    const token = await resolveAccessToken();
+    if (!token) {
+      toast.error(t("toast.sessionExpired"), { description: t("toast.sessionExpiredDescription") });
+      setOfficialPricingLoading(false);
+      return;
+    }
+    const savedItems: AdminModelPricingDTO[] = [];
+    let failedCount = 0;
+    for (const suggestion of selected) {
+      try {
+        const result = await upsertAdminModelPricing(token, {
+          platformModelName: suggestion.platformModelName,
+          currency: "USD",
+          isFree: false,
+          pricingMode: "token",
+          inputUSDPerMTokens: suggestion.inputUSDPerMTokens,
+          cacheReadUSDPerMTokens: suggestion.cacheReadUSDPerMTokens,
+          cacheWriteUSDPerMTokens: suggestion.cacheWriteUSDPerMTokens,
+          outputUSDPerMTokens: suggestion.outputUSDPerMTokens,
+          callUSDPerCall: 0,
+          durationUSDPerSecond: 0,
+        });
+        savedItems.push(result.modelPricing);
+      } catch {
+        failedCount++;
+      }
+    }
+    if (savedItems.length > 0) {
+      setPricingItems((current) =>
+        savedItems.reduce((items, item) => mergeModelPricingItem(items, item), current),
+      );
+      invalidateAdminReferenceDataCache();
+    }
+    if (failedCount === 0) {
+      toast.success(t("toast.officialPricingApplied", { count: savedItems.length }));
+    } else if (savedItems.length > 0) {
+      toast.warning(t("toast.officialPricingPartial", { success: savedItems.length, failed: failedCount }));
+    } else {
+      toast.error(t("toast.officialPricingFailed"));
+    }
+    setOfficialPricingOpen(false);
+    setOfficialPricingLoading(false);
+  }
+
   async function toggleModelFree(row: BillingModelPricingRow, checked: boolean) {
     if (freeSwitchPendingModel) {
       return;
@@ -2058,6 +2137,18 @@ export function AdminBillingPage() {
             >
               <Upload className="size-3.5 stroke-1" />
             </Button>
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              className="size-8 text-muted-foreground shadow-none hover:bg-muted hover:text-foreground"
+              disabled={loading || saving || officialPricingLoading}
+              onClick={() => void openOfficialPricingDialog()}
+              aria-label={t("actions.fetchOfficialPricing")}
+              title={t("actions.fetchOfficialPricing")}
+            >
+              <Sparkles className="size-3.5 stroke-1" />
+            </Button>
           </TableToolbar>
 
           <Table
@@ -2550,6 +2641,91 @@ export function AdminBillingPage() {
         pendingLabel={t("redemption.deleting")}
         onConfirm={() => void deleteSingleRedemptionCode()}
       />
+
+      <Dialog open={officialPricingOpen} onOpenChange={(open) => { if (!officialPricingLoading) setOfficialPricingOpen(open); }}>
+        <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+          <DialogHeader>
+            <DialogTitle>{t("officialPricing.title")}</DialogTitle>
+            <DialogDescription>{t("officialPricing.description")}</DialogDescription>
+          </DialogHeader>
+          <div className="flex-1 overflow-auto border rounded-md">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-10">
+                    <Checkbox
+                      checked={
+                        officialPricingSuggestions.length > 0 &&
+                        officialPricingSelected.size === officialPricingSuggestions.length
+                          ? true
+                          : officialPricingSelected.size > 0
+                            ? "indeterminate"
+                            : false
+                      }
+                      onCheckedChange={(checked) => {
+                        setOfficialPricingSelected(
+                          checked
+                            ? new Set(officialPricingSuggestions.map((s) => s.platformModelName))
+                            : new Set(),
+                        );
+                      }}
+                    />
+                  </TableHead>
+                  <TableHead>{t("officialPricing.model")}</TableHead>
+                  <TableHead className="text-right">{t("officialPricing.input")}</TableHead>
+                  <TableHead className="text-right">{t("officialPricing.output")}</TableHead>
+                  <TableHead className="text-right">{t("officialPricing.cacheRead")}</TableHead>
+                  <TableHead className="text-right">{t("officialPricing.cacheWrite")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {officialPricingSuggestions.map((suggestion) => (
+                  <TableRow key={suggestion.platformModelName}>
+                    <TableCell>
+                      <Checkbox
+                        checked={officialPricingSelected.has(suggestion.platformModelName)}
+                        onCheckedChange={(checked) => {
+                          setOfficialPricingSelected((prev) => {
+                            const next = new Set(prev);
+                            if (checked) {
+                              next.add(suggestion.platformModelName);
+                            } else {
+                              next.delete(suggestion.platformModelName);
+                            }
+                            return next;
+                          });
+                        }}
+                      />
+                    </TableCell>
+                    <TableCell className="font-medium text-sm">{suggestion.platformModelName}</TableCell>
+                    <TableCell className="text-right text-sm tabular-nums">{formatUSD(suggestion.inputUSDPerMTokens)}</TableCell>
+                    <TableCell className="text-right text-sm tabular-nums">{formatUSD(suggestion.outputUSDPerMTokens)}</TableCell>
+                    <TableCell className="text-right text-sm tabular-nums">{formatUSD(suggestion.cacheReadUSDPerMTokens)}</TableCell>
+                    <TableCell className="text-right text-sm tabular-nums">{formatUSD(suggestion.cacheWriteUSDPerMTokens)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+          <DialogFooter className="flex items-center justify-between sm:justify-between">
+            <span className="text-sm text-muted-foreground">
+              {t("officialPricing.selectedCount", { selected: officialPricingSelected.size, total: officialPricingSuggestions.length })}
+            </span>
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" disabled={officialPricingLoading} onClick={() => setOfficialPricingOpen(false)}>
+                {tActions("cancel")}
+              </Button>
+              <Button
+                type="button"
+                disabled={officialPricingLoading || officialPricingSelected.size === 0}
+                onClick={() => void applySelectedOfficialPricing()}
+              >
+                {officialPricingLoading ? <SpinnerLabel>{tActions("saving")}</SpinnerLabel> : t("officialPricing.apply", { count: officialPricingSelected.size })}
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/i18n/messages/en-US/admin-billing.json
+++ b/frontend/i18n/messages/en-US/admin-billing.json
@@ -8,7 +8,8 @@
     "exportPricing": "Export",
     "editPlan": "Edit plan",
     "editPricing": "Edit pricing",
-    "editRedemptionCode": "Edit redemption code"
+    "editRedemptionCode": "Edit redemption code",
+    "fetchOfficialPricing": "Fetch official pricing"
   },
   "billingConfig": {
     "title": "Billing mode",
@@ -267,6 +268,10 @@
     "importEmpty": "Import failed: no model pricing entries to import",
     "imported": "Imported {count} model pricing entries",
     "importFailed": "Failed to import model pricing",
+    "officialPricingEmpty": "No unpriced models match official pricing",
+    "officialPricingApplied": "Applied official pricing to {count} models",
+    "officialPricingPartial": "Applied {success} models, {failed} failed",
+    "officialPricingFailed": "Failed to fetch official pricing",
     "freeEnabled": "Set as free model",
     "freeDisabled": "Free model disabled",
     "freeSaveFailed": "Failed to save free status",
@@ -315,5 +320,16 @@
     "invalidNumber": "{model}.{field} must be a number greater than or equal to 0",
     "invalidTieredPricing": "{model}.{field} must contain a non-empty tiers array",
     "invalidTieredPricingJSON": "{model}.tieredPricingJSON is not valid JSON"
+  },
+  "officialPricing": {
+    "title": "Fetch official pricing",
+    "description": "The following unpriced models have been matched to official pricing. Select the ones you want to apply.",
+    "model": "Model",
+    "input": "Input /M",
+    "output": "Output /M",
+    "cacheRead": "Cache read /M",
+    "cacheWrite": "Cache write /M",
+    "selectedCount": "{selected} / {total} selected",
+    "apply": "Apply ({count})"
   }
 }

--- a/frontend/i18n/messages/zh-CN/admin-billing.json
+++ b/frontend/i18n/messages/zh-CN/admin-billing.json
@@ -8,7 +8,8 @@
     "exportPricing": "导出模型定价",
     "editPlan": "编辑周期套餐",
     "editPricing": "编辑模型基础价格",
-    "editRedemptionCode": "编辑兑换码"
+    "editRedemptionCode": "编辑兑换码",
+    "fetchOfficialPricing": "获取官方定价"
   },
   "billingConfig": {
     "title": "计费方式",
@@ -267,6 +268,10 @@
     "importEmpty": "导入失败：没有可导入的模型定价",
     "imported": "已导入 {count} 个模型定价",
     "importFailed": "导入模型定价失败",
+    "officialPricingEmpty": "没有未定价模型匹配到官方定价",
+    "officialPricingApplied": "已为 {count} 个模型应用官方定价",
+    "officialPricingPartial": "已应用 {success} 个，{failed} 个失败",
+    "officialPricingFailed": "获取官方定价失败",
     "freeEnabled": "已设为免费模型",
     "freeDisabled": "已关闭免费模型",
     "freeSaveFailed": "免费状态保存失败",
@@ -315,5 +320,16 @@
     "invalidNumber": "{model}.{field} 必须是大于等于 0 的数字",
     "invalidTieredPricing": "{model}.{field} 需要包含非空 tiers 数组",
     "invalidTieredPricingJSON": "{model}.tieredPricingJSON 不是合法 JSON"
+  },
+  "officialPricing": {
+    "title": "获取官方定价",
+    "description": "以下未定价模型已匹配到官方定价，请勾选需要填充的模型。",
+    "model": "模型",
+    "input": "输入 /M",
+    "output": "输出 /M",
+    "cacheRead": "缓存读 /M",
+    "cacheWrite": "缓存写 /M",
+    "selectedCount": "已选 {selected} / {total}",
+    "apply": "应用 ({count})"
   }
 }


### PR DESCRIPTION
## Summary

Closes #415

- Adds a **Fetch Official Pricing** button (✨) to the admin Billing > Model Pricing toolbar
- Clicking opens a dialog listing all unpriced models matched against live pricing from [models.dev/api.json](https://models.dev/api.json)
- Admin can select/deselect individual models or use select-all, then apply
- Supports partial failure: successfully saved items update the UI even if later requests fail

## Changes

**Backend (3 new + 3 modified):**
- `GET /admin/billing/model-prices/official` — new endpoint returning pricing suggestions
- `FetchModelsDevPricing()` — HTTP client fetching live data from models.dev, mapping 13 vendors (OpenAI, Anthropic, Google, DeepSeek, Mistral, xAI, Cohere, Baidu, Alibaba, Zhipu, MiniMax, Moonshot, ByteDance)
- `FetchOfficialPricingSuggestions()` — service method filtering to unpriced active platform models only
- 9 unit tests: JSON parsing, provider prefix stripping, vendor lookup with fallback, zero-cost filtering, HTTP error handling

**Frontend (5 modified):**
- Dialog with checkbox table (model name + input/output/cache read/cache write prices)
- Select-all / individual selection
- Dedicated `officialPricingLoading` state (independent from other save operations)
- Per-item error handling with partial-success toast
- Prices formatted via `formatUSD()` for consistency
- Full i18n (zh-CN + en-US)

## Test plan

- [ ] Navigate to Admin > Billing > Model Pricing
- [ ] Click ✨ button — dialog should appear with unpriced models and their official prices
- [ ] Verify select-all toggles all checkboxes
- [ ] Deselect some models, click Apply — only selected models should get pricing
- [ ] Verify applied models now show pricing in the table
- [ ] Click ✨ again — already-priced models should not appear
- [ ] `go test ./internal/application/billing/...` — all 9 new + existing tests pass