### PR TITLE
fix: preserve last selected model across new conversations

### DIFF
--- a/frontend/features/chat/hooks/use-chat-model-options.ts
+++ b/frontend/features/chat/hooks/use-chat-model-options.ts
@@ -25,6 +25,7 @@ import type { PublicModelDTO } from "@/shared/api/model.types";
 import type { ModelNativeToolConfig, ModelOptionPolicy } from "@/shared/lib/model-option-policy";
 import { parseKindsJSON } from "@/shared/model/llm-schema";
 import { resolveConversationDefaultModel } from "@/shared/model/conversation-default-model";
+import { writeLastSelectedModel } from "@/shared/model/last-selected-model";
 import type { ConversationOptions } from "@/shared/api/conversation.types";
 import type { SendShortcut } from "@/features/settings/types/settings";
 import { parseSendShortcut } from "@/features/settings/utils/chat-settings";
@@ -357,6 +358,7 @@ export function useChatModelOptions({
   const selectPlatformModelName = React.useCallback((platformModelName: string) => {
     userSelectedModelRef.current = true;
     setSelectedPlatformModelName(platformModelName);
+    writeLastSelectedModel(platformModelName);
   }, []);
 
   const loadModelCatalog = React.useCallback((accessToken?: string): Promise<ModelCatalogRefreshResult> => {

--- a/frontend/shared/model/conversation-default-model.ts
+++ b/frontend/shared/model/conversation-default-model.ts
@@ -2,8 +2,9 @@ import { getConversationDefaultModelCandidate } from "@/shared/api/conversation"
 import { listPublicModels } from "@/shared/api/model";
 import type { PublicModelDTO } from "@/shared/api/model.types";
 import { getUserSettings } from "@/shared/api/user-settings";
+import { readLastSelectedModel } from "@/shared/model/last-selected-model";
 
-export type ConversationDefaultModelSource = "explicit" | "user_default" | "system_default" | "recommended" | "none";
+export type ConversationDefaultModelSource = "explicit" | "last_selected" | "user_default" | "system_default" | "recommended" | "none";
 
 export type ConversationDefaultModelResult = {
   platformModelName: string;
@@ -15,6 +16,7 @@ type ResolveConversationDefaultModelInput = {
   explicitModel?: string;
   availableModels?: PublicModelDTO[];
   userDefaultModel?: string;
+  lastSelectedModel?: string;
 };
 
 function findAvailableModel(models: PublicModelDTO[], platformModelName: string): string {
@@ -30,11 +32,17 @@ export async function resolveConversationDefaultModel({
   explicitModel,
   availableModels,
   userDefaultModel,
+  lastSelectedModel,
 }: ResolveConversationDefaultModelInput): Promise<ConversationDefaultModelResult> {
   const models = availableModels ?? await listPublicModels(accessToken);
   const explicit = findAvailableModel(models, explicitModel ?? "");
   if (explicit) {
     return { platformModelName: explicit, source: "explicit" };
+  }
+
+  const lastSelected = findAvailableModel(models, lastSelectedModel ?? readLastSelectedModel());
+  if (lastSelected) {
+    return { platformModelName: lastSelected, source: "last_selected" };
   }
 
   const defaultModel = userDefaultModel ?? (await getUserSettings(accessToken).catch(() => ({})))["chat.default_model"];

--- a/frontend/shared/model/last-selected-model.ts
+++ b/frontend/shared/model/last-selected-model.ts
@@ -1,0 +1,28 @@
+const LAST_SELECTED_MODEL_STORAGE_KEY = "deeix-chat:last-selected-model:v1";
+
+export function readLastSelectedModel(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  try {
+    return window.localStorage.getItem(LAST_SELECTED_MODEL_STORAGE_KEY)?.trim() ?? "";
+  } catch {
+    // localStorage may be unavailable in private browsing or strict environments.
+    return "";
+  }
+}
+
+export function writeLastSelectedModel(platformModelName: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const normalized = platformModelName.trim();
+  if (!normalized) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(LAST_SELECTED_MODEL_STORAGE_KEY, normalized);
+  } catch {
+    // localStorage may be unavailable in private browsing or strict environments.
+  }
+}


### PR DESCRIPTION
## Summary

Closes #416

When a user switches models in the chat selector and clicks "New Conversation", the model now stays on the last manually selected one instead of resetting to the admin-configured default.

- Persist user's model selection to `localStorage` on manual switch
- Insert `last_selected` source before `user_default` in the default model resolution chain:
  `explicit → last_selected → user_default → system_default → recommended`
- Both sidebar "New Chat" and in-chat new conversation paths benefit since they share `resolveConversationDefaultModel`

## Changes

| File | Change |
|------|--------|
| `frontend/shared/model/last-selected-model.ts` | New: localStorage read/write helpers |
| `frontend/shared/model/conversation-default-model.ts` | Add `last_selected` source in resolution chain |
| `frontend/features/chat/hooks/use-chat-model-options.ts` | Write to localStorage on user model switch |

## Test plan

- [ ] Open a conversation, switch model selector to Model B
- [ ] Click "New Conversation" — model selector should show Model B (not admin default)
- [ ] Refresh the page, click "New Conversation" — should still show Model B (persisted in localStorage)
- [ ] Clear localStorage, click "New Conversation" — should fall back to user default → system default → first model
- [ ] Setting a user default model in Settings still works as fallback when no last-selected exists