### PR TITLE
fix: retain user selected model when no conversation ID is present

### DIFF
--- a/frontend/features/chat/hooks/use-chat-model-options.ts
+++ b/frontend/features/chat/hooks/use-chat-model-options.ts
@@ -484,8 +484,8 @@ export function useChatModelOptions({
   React.useEffect(() => {
     const normalizedConversationID = conversationPublicID?.trim() || null;
     if (!normalizedConversationID) {
+      // 无会话状态也可能来自当前页点击“新对话”，要保留用户刚在选择器里切换的模型。
       activeConversationRef.current = null;
-      userSelectedModelRef.current = false;
       return;
     }
 


### PR DESCRIPTION
## Summary

Fix new conversation model selection after introducing the admin-configured new conversation default model.

When a user switches the model in the current browser page and then clicks “New conversation”, the new conversation should keep the current model picker selection instead of being reset to the admin-configured default model. The admin default model remains the fallback for initial/default model resolution when the user has not selected a model in the current page.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && env CI=true pnpm lint`
- [x] `cd frontend && env CI=true pnpm exec tsc --noEmit`
- [x] `git diff --check`
- [ ] Not run; reason: frontend build was not run.

## Screenshots, API examples, or logs

No screenshots. Behavior-only frontend state fix.

Expected flow:

1. Open an existing conversation using model A.
2. Switch the model picker to model B.
3. Click “New conversation”.
4. The new conversation keeps model B instead of resetting to the admin-configured default model.

## Configuration, migration, and compatibility notes

No configuration, migration, API, or storage changes.

The admin-configured new conversation default model is still used as the fallback when there is no current in-page manual model selection.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.