### PR TITLE
feat: improve MCP tool interaction handling

### DIFF
--- a/frontend/features/chat/components/sections/chat-mcp.tsx
+++ b/frontend/features/chat/components/sections/chat-mcp.tsx
@@ -308,6 +308,9 @@ export function ChatMCP({
         sideOffset={8}
         data-mcp-tools-popover-content
         className="w-[22rem] p-1.5"
+        onPointerDown={(event) => event.stopPropagation()}
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
         onPointerDownOutside={(event) => {
           const target = event.target as HTMLElement | null;
           if (target?.closest("[data-mcp-tools-popover-content]")) {
@@ -335,9 +338,6 @@ export function ChatMCP({
         </div>
         <div
           className="px-1 py-1"
-          onPointerDown={(event) => event.stopPropagation()}
-          onMouseDown={(event) => event.stopPropagation()}
-          onClick={(event) => event.stopPropagation()}
         >
           <Input
             value={search}


### PR DESCRIPTION
## Summary

Fix MCP tool selection popover closing unexpectedly when clicking inside the dropdown. The popover now keeps internal interactions open by stopping click/pointer event propagation at the popover content boundary.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [x] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && env CI=true pnpm lint`
- [x] `cd frontend && env CI=true pnpm exec tsc --noEmit`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Bug report reference: clicking inside the MCP tool selection popover could close it unexpectedly.

## Configuration, migration, and compatibility notes

No configuration, migration, API contract, or backend changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.