### PR TITLE
fix: Add logo URL validation and update dompurify version

### DIFF
--- a/backend/internal/application/auth/provider.go
+++ b/backend/internal/application/auth/provider.go
@@ -598,13 +598,8 @@ func (s *Service) normalizeProviderInput(input UpsertIdentityProviderInput, curr
 		return nil, ErrIdentityProviderSuperAdminDefaultRoleNotAllowed
 	}
 	logoURL := strings.TrimSpace(input.LogoURL)
-	if logoURL != "" {
-		parsedLogoURL, err := url.Parse(logoURL)
-		isHTTPLogoURL := (parsedLogoURL.Scheme == "http" || parsedLogoURL.Scheme == "https") && parsedLogoURL.Host != ""
-		isAbsolutePathLogoURL := strings.HasPrefix(logoURL, "/")
-		if err != nil || (!isHTTPLogoURL && !isAbsolutePathLogoURL) {
-			return nil, fmt.Errorf("logo url must be a valid http(s) or absolute path")
-		}
+	if logoURL != "" && !isValidProviderLogoURL(logoURL) {
+		return nil, fmt.Errorf("logo url must be a valid http(s) or absolute path")
 	}
 	provider := &domainuser.IdentityProvider{
 		Type:                providerType,
@@ -658,6 +653,21 @@ func (s *Service) normalizeProviderInput(input UpsertIdentityProviderInput, curr
 		return nil, fmt.Errorf("OAuth2 auth url, token url and userinfo url are required")
 	}
 	return provider, nil
+}
+
+func isValidProviderLogoURL(value string) bool {
+	parsedLogoURL, err := url.Parse(value)
+	if err != nil {
+		return false
+	}
+	if (parsedLogoURL.Scheme == "http" || parsedLogoURL.Scheme == "https") && parsedLogoURL.Host != "" {
+		return true
+	}
+	return parsedLogoURL.Scheme == "" &&
+		parsedLogoURL.Host == "" &&
+		strings.HasPrefix(value, "/") &&
+		!strings.HasPrefix(value, "//") &&
+		!strings.Contains(value, "\\")
 }
 
 func toProviderViews(items []domainuser.IdentityProvider, includeSensitive bool) []IdentityProviderView {

--- a/backend/internal/application/auth/provider_test.go
+++ b/backend/internal/application/auth/provider_test.go
@@ -90,6 +90,47 @@ func TestNormalizeProviderInputProtectsSuperAdminDefaultRole(t *testing.T) {
 	}
 }
 
+func TestNormalizeProviderInputValidatesLogoURL(t *testing.T) {
+	service := NewService(config.Config{JWTSecret: "test-secret"}, &providerLoginRepo{}, nil)
+
+	cases := []struct {
+		name    string
+		logoURL string
+		wantErr bool
+	}{
+		{name: "https url", logoURL: "https://example.com/logo.svg"},
+		{name: "http url", logoURL: "http://example.com/logo.svg"},
+		{name: "absolute path", logoURL: "/identity-providers/acme.svg"},
+		{name: "protocol relative url", logoURL: "//example.com/logo.svg", wantErr: true},
+		{name: "data url", logoURL: "data:image/svg+xml,<svg/>", wantErr: true},
+		{name: "javascript url", logoURL: "javascript:alert(1)", wantErr: true},
+		{name: "relative path", logoURL: "identity-providers/acme.svg", wantErr: true},
+		{name: "backslash path", logoURL: `/\example.svg`, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := service.normalizeProviderInput(UpsertIdentityProviderInput{
+				ActorRole:           domainuser.RoleAdmin,
+				Type:                domainuser.IdentityProviderTypeOIDC,
+				Name:                "Acme SSO",
+				LogoURL:             tc.logoURL,
+				ClientID:            "client",
+				ClientSecret:        "secret",
+				DiscoveryURL:        "https://example.com/.well-known/openid-configuration",
+				RegistrationEnabled: boolPtr(true),
+				DefaultRole:         domainuser.RoleUser,
+			}, nil)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected logo URL %q to be rejected", tc.logoURL)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected logo URL %q to be accepted, got %v", tc.logoURL, err)
+			}
+		})
+	}
+}
+
 func TestResolveProviderUserAutoRegistrationAddsUsernameSuffixOnCollision(t *testing.T) {
 	repo := &providerLoginRepo{duplicateUsernameAttempts: 1}
 	service := NewService(config.Config{JWTSecret: "test-secret"}, repo, nil)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
       "@babel/core": "7.29.7",
       "brace-expansion@1": "1.1.15",
       "brace-expansion@5": "5.0.6",
-      "dompurify": "3.4.10",
+      "dompurify": "3.4.11",
       "flatted": "3.4.2",
       "js-yaml": "4.2.0",
       "mermaid": "11.15.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@babel/core': 7.29.7
   brace-expansion@1: 1.1.15
   brace-expansion@5: 5.0.6
-  dompurify: 3.4.10
+  dompurify: 3.4.11
   flatted: 3.4.2
   js-yaml: 4.2.0
   mermaid: 11.15.0
@@ -2842,8 +2842,8 @@ packages:
   docx-preview@0.3.7:
     resolution: {integrity: sha512-Lav69CTA/IYZPJTsKH7oYeoZjyg96N0wEJMNslGJnZJ+dMUZK85Lt5ASC79yUlD48ecWjuv+rkcmFt6EVPV0Xg==}
 
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dot-prop@6.0.1:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
@@ -7876,7 +7876,7 @@ snapshots:
     dependencies:
       jszip: 3.10.1
 
-  dompurify@3.4.10:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -9267,7 +9267,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       es-toolkit: 1.46.1
       katex: 0.16.45
       khroma: 2.1.0
@@ -9548,7 +9548,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       marked: 14.0.0
 
   motion-dom@12.38.0:

--- a/frontend/shared/components/identity-provider-icon.tsx
+++ b/frontend/shared/components/identity-provider-icon.tsx
@@ -17,7 +17,10 @@ function resolveCustomIdentityProviderLogoURL(logoURL: string | undefined, slug:
   if (/^https?:\/\//i.test(trimmed)) {
     return `/api/v1/auth/providers/${encodeURIComponent(slug)}/logo`;
   }
-  return trimmed;
+  if (trimmed.startsWith("/") && !trimmed.startsWith("//") && !trimmed.includes("\\")) {
+    return trimmed;
+  }
+  return "";
 }
 
 export function IdentityProviderIcon({


### PR DESCRIPTION
## Summary

Fix CodeQL alert for identity provider logo rendering by restricting custom logo URLs to safe sources. Custom HTTP(S) logos continue to be loaded through the backend proxy, while same-origin absolute paths remain supported. Unsafe schemes and protocol-relative URLs are rejected before rendering and at the backend provider configuration boundary.

## Change type

- [x] Security hardening
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [x] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && corepack pnpm lint`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/application/auth`
- [x] `git diff --check`

## Screenshots, API examples, or logs

CodeQL alert addressed: DOM text reinterpreted as HTML in `identity-provider-icon.tsx`.

## Configuration, migration, and compatibility notes

Normal provider icons, HTTP(S) custom logos, and same-origin absolute-path logos are unaffected. Unsafe or invalid logo URL values such as `data:`, `javascript:`, protocol-relative URLs, relative paths, and backslash paths are rejected or ignored.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.
```

```markdown
## Summary

Upgrade `dompurify` from `3.4.10` to `3.4.11` to resolve the Dependabot security alert for the DOMPurify `ALLOWED_ATTR` pollution issue. The lockfile now resolves all transitive DOMPurify consumers to the patched version.

## Change type

- [x] Security hardening
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && corepack pnpm lint`
- [x] `cd frontend && corepack pnpm audit --prod`
- [x] `git diff --check`

## Screenshots, API examples, or logs

`pnpm audit --prod` result:

```text
No known vulnerabilities found
```

## Configuration, migration, and compatibility notes

No runtime configuration or migration is required. This only updates the frontend dependency override and lockfile resolution for `dompurify`.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.