### PR TITLE
feat: implement OpenAI responses background mode support and related error handling

### DIFF
--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -215,6 +215,8 @@ func (s *Service) sendMessageInternal(
 	var resolvedRoute *channel.ResolvedRoute
 	var filteredOptions map[string]interface{}
 	var totalServerSideToolUsage map[string]int64
+	var responsesBackgroundRouteConfig llm.RouteConfig
+	var responsesBackgroundRecovery openAIResponsesBackgroundRecoveryState
 	userContentEstimatedInputTokens := int64(0)
 	usageAccumulator := &messageUsageAccumulator{}
 	upstreamCallStarted := false
@@ -224,6 +226,13 @@ func (s *Service) sendMessageInternal(
 	runState.bind(&userMessage, &assistantMessage, &traceRecorder, &result, ctx)
 	defer func() {
 		if retErr != nil {
+			if errors.Is(retErr, ErrMessageGenerationCanceled) {
+				if usage, ok := s.recoverOpenAIResponsesBackgroundUsage(responsesBackgroundRouteConfig, responsesBackgroundRecovery); ok {
+					if delta := diffLLMUsage(usage, responsesBackgroundRecovery.ObservedUsage); delta != (llm.Usage{}) {
+						usageAccumulator.addObservedUsage(delta)
+					}
+				}
+			}
 			if retained := s.persistInterruptedMessageGeneration(ctx, persistInterruptedMessageGenerationInput{
 				SendInput:             input,
 				UserMessage:           userMessage,
@@ -728,6 +737,7 @@ func (s *Service) sendMessageInternal(
 		AttributionReferer:  attributionReferer,
 		AttributionTitle:    attributionTitle,
 	}
+	responsesBackgroundRouteConfig = routeConfig
 	filteredOptions = filterModelOptions(input.Options, route.Protocol, modelOptionPolicyConfig{
 		Mode:                  cfg.ModelOptionPolicyMode,
 		AllowedPathsJSON:      cfg.ModelOptionAllowedPaths,
@@ -740,6 +750,10 @@ func (s *Service) sendMessageInternal(
 		Messages:       llmMessages,
 		Tools:          toolRuntime.definitions,
 		Options:        filteredOptions,
+	}
+	if supportsOpenAIResponsesBackgroundMode(route) {
+		generateInput.ResponsesBackground = true
+		sendSpan.SetAttributes(attribute.Bool("conversation.responses_background", true))
 	}
 	fullLLMMessages := llmMessages
 	applyOpenAIResponsesInstructions(route, routeConfig.Endpoint, &generateInput)
@@ -838,6 +852,11 @@ func (s *Service) sendMessageInternal(
 		}
 		callPromptShape := summarizePromptShape(callPromptMode, currentInput.Messages, currentInput.Messages, currentInput.PreviousResponseID)
 		usageAccumulator.beginCall(currentInput)
+		if currentInput.ResponsesBackground {
+			responsesBackgroundRecovery = openAIResponsesBackgroundRecoveryState{Enabled: true}
+		} else {
+			responsesBackgroundRecovery = openAIResponsesBackgroundRecoveryState{}
+		}
 		generationCtx, generationSpan := platformtracing.Start(ctx, "conversation.llm.generate",
 			trace.WithAttributes(append([]attribute.KeyValue{
 				attribute.Int64("conversation.id", int64(input.ConversationID)),
@@ -846,6 +865,7 @@ func (s *Service) sendMessageInternal(
 				attribute.String("llm.endpoint", routeConfig.Endpoint),
 				attribute.Bool("llm.stream", streamRequested && streamSupported),
 				attribute.Bool("llm.tools_disabled", currentInput.DisableTools),
+				attribute.Bool("llm.responses_background", currentInput.ResponsesBackground),
 				attribute.Int("llm.message_count", len(currentInput.Messages)),
 				attribute.Int("llm.tool_count", len(currentInput.Tools)),
 			}, promptShapeTraceAttributes("llm.prompt", callPromptShape)...)...),
@@ -908,6 +928,11 @@ func (s *Service) sendMessageInternal(
 		callStreamUsage := llm.Usage{}
 		upstreamCallStarted = true
 		output, streamErr := s.llmClient.GenerateStream(generationCtx, routeConfig, currentInput, func(event llm.GenerateStreamEvent) error {
+			if currentInput.ResponsesBackground {
+				if responseID := strings.TrimSpace(event.ResponseID); responseID != "" {
+					responsesBackgroundRecovery.ResponseID = responseID
+				}
+			}
 			if s.isMessageGenerationCanceled(generationCtx, runID) {
 				return ErrMessageGenerationCanceled
 			}
@@ -916,6 +941,9 @@ func (s *Service) sendMessageInternal(
 				// 这里先换算成本次调用内增量，再累加成本轮消息总量，保证实时展示和最终账单口径一致。
 				usageDelta := diffLLMUsage(event.Usage, callStreamUsage)
 				callStreamUsage = event.Usage
+				if currentInput.ResponsesBackground {
+					responsesBackgroundRecovery.ObservedUsage = callStreamUsage
+				}
 				currentUsage := usageAccumulator.addObservedUsage(usageDelta)
 				if input.OnEvent != nil {
 					if err := emitLLMUsageEvent(input.OnEvent, currentUsage); err != nil {
@@ -1010,6 +1038,25 @@ func (s *Service) sendMessageInternal(
 	upstreamOutput, err = runGenerate(generateInput)
 	if handleCanceledGeneration(err) {
 		return nil, retErr
+	}
+	if err != nil && generateInput.ResponsesBackground &&
+		strings.TrimSpace(streamedText.String()) == "" &&
+		shouldRetryWithoutResponsesBackground(err) {
+		if s.logger != nil {
+			s.logger.Warn("openai_responses_background_rejected_retry_standard",
+				zap.String("trace_id", traceid.FromContext(ctx)),
+				zap.Uint("conversation_id", input.ConversationID),
+				zap.String("protocol", route.Protocol),
+				zap.String("upstream_name", route.UpstreamName),
+				zap.Error(err),
+			)
+		}
+		generateInput.ResponsesBackground = false
+		responsesBackgroundRecovery = openAIResponsesBackgroundRecoveryState{}
+		upstreamOutput, err = runGenerate(generateInput)
+		if handleCanceledGeneration(err) {
+			return nil, retErr
+		}
 	}
 	if err != nil && strings.TrimSpace(generateInput.PreviousResponseID) != "" &&
 		strings.TrimSpace(streamedText.String()) == "" &&

--- a/backend/internal/application/conversation/service_responses_background.go
+++ b/backend/internal/application/conversation/service_responses_background.go
@@ -1,0 +1,62 @@
+package conversation
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/llm"
+	"go.uber.org/zap"
+)
+
+type openAIResponsesBackgroundRecoveryState struct {
+	Enabled       bool
+	ResponseID    string
+	ObservedUsage llm.Usage
+}
+
+func (s *Service) recoverOpenAIResponsesBackgroundUsage(route llm.RouteConfig, state openAIResponsesBackgroundRecoveryState) (llm.Usage, bool) {
+	responseID := strings.TrimSpace(state.ResponseID)
+	if s == nil || s.llmClient == nil || !state.Enabled || responseID == "" {
+		return llm.Usage{}, false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	var cancelErr error
+	if output, err := s.llmClient.CancelOpenAIResponse(ctx, route, responseID); err == nil {
+		if output != nil && output.Usage != (llm.Usage{}) {
+			return output.Usage, true
+		}
+	} else {
+		cancelErr = err
+	}
+
+	var retrieveErr error
+	for attempt := 0; attempt < 4; attempt++ {
+		select {
+		case <-ctx.Done():
+			return llm.Usage{}, false
+		case <-time.After(600 * time.Millisecond):
+		}
+		output, err := s.llmClient.RetrieveOpenAIResponse(ctx, route, responseID)
+		if err != nil {
+			retrieveErr = err
+			continue
+		}
+		if output != nil && output.Usage != (llm.Usage{}) {
+			return output.Usage, true
+		}
+	}
+	if s.logger != nil {
+		s.logger.Warn("openai_responses_background_usage_recovery_failed",
+			zap.String("response_id", responseID),
+			zap.String("protocol", route.Protocol),
+			zap.NamedError("cancel_error", cancelErr),
+			zap.NamedError("retrieve_error", retrieveErr),
+		)
+	}
+
+	return llm.Usage{}, false
+}

--- a/backend/internal/application/conversation/service_stateful_responses.go
+++ b/backend/internal/application/conversation/service_stateful_responses.go
@@ -1,6 +1,7 @@
 package conversation
 
 import (
+	"encoding/json"
 	"errors"
 	"net/url"
 	"strings"
@@ -54,6 +55,43 @@ func supportsPreviousResponseIDRoute(route *channel.ResolvedRoute) bool {
 	return route != nil &&
 		llm.SupportsPreviousResponseID(route.Protocol) &&
 		isOfficialOpenAIBaseURL(route.BaseURL)
+}
+
+func supportsOpenAIResponsesBackgroundMode(route *channel.ResolvedRoute) bool {
+	if route == nil ||
+		!strings.EqualFold(strings.TrimSpace(route.Protocol), llm.AdapterOpenAIResponses) ||
+		!isOfficialOpenAIBaseURL(route.BaseURL) {
+		return false
+	}
+	capabilities := decodeModelCapabilities(route.ModelCapabilitiesJSON)
+	return boolCapability(capabilities, "responsesBackgroundMode") ||
+		nestedBoolCapability(capabilities, "responses", "backgroundMode")
+}
+
+func decodeModelCapabilities(raw string) map[string]interface{} {
+	parsed := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &parsed); err != nil {
+		return nil
+	}
+	return parsed
+}
+
+func boolCapability(capabilities map[string]interface{}, key string) bool {
+	value, ok := capabilities[key]
+	if !ok {
+		return false
+	}
+	enabled, ok := value.(bool)
+	return ok && enabled
+}
+
+func nestedBoolCapability(capabilities map[string]interface{}, parentKey string, childKey string) bool {
+	parent, ok := capabilities[parentKey].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	enabled, ok := parent[childKey].(bool)
+	return ok && enabled
 }
 
 func isOfficialOpenAIBaseURL(raw string) bool {
@@ -148,4 +186,29 @@ func shouldRetryWithoutPreviousResponseID(err error) bool {
 		strings.Contains(text, "previous response") ||
 		strings.Contains(text, "response_id") ||
 		strings.Contains(text, "unknown parameter")
+}
+
+func shouldRetryWithoutResponsesBackground(err error) bool {
+	if err == nil {
+		return false
+	}
+	var upstreamErr *llm.UpstreamError
+	if !errors.As(err, &upstreamErr) {
+		return false
+	}
+	if upstreamErr.StatusCode != 400 && upstreamErr.StatusCode != 409 && upstreamErr.StatusCode != 422 {
+		return false
+	}
+	text := strings.ToLower(upstreamErr.Message + "\n" + upstreamErr.Body)
+	if !strings.Contains(text, "background") && !strings.Contains(text, "store") &&
+		!strings.Contains(text, "zero data retention") && !strings.Contains(text, "zdr") {
+		return false
+	}
+	return strings.Contains(text, "unsupported") ||
+		strings.Contains(text, "not supported") ||
+		strings.Contains(text, "unknown parameter") ||
+		strings.Contains(text, "unrecognized") ||
+		strings.Contains(text, "invalid") ||
+		strings.Contains(text, "zero data retention") ||
+		strings.Contains(text, "zdr")
 }

--- a/backend/internal/application/conversation/service_stateful_responses_test.go
+++ b/backend/internal/application/conversation/service_stateful_responses_test.go
@@ -71,6 +71,66 @@ func TestSupportsPreviousResponseIDRouteOnlyAllowsOfficialOpenAIResponses(t *tes
 	}
 }
 
+func TestSupportsOpenAIResponsesBackgroundModeRequiresOfficialRouteAndCapability(t *testing.T) {
+	if !supportsOpenAIResponsesBackgroundMode(&channel.ResolvedRoute{
+		Protocol:              llm.AdapterOpenAIResponses,
+		BaseURL:               "https://api.openai.com/v1",
+		ModelCapabilitiesJSON: `{"responsesBackgroundMode":true}`,
+	}) {
+		t.Fatalf("expected explicit official OpenAI Responses capability to enable background")
+	}
+	if !supportsOpenAIResponsesBackgroundMode(&channel.ResolvedRoute{
+		Protocol:              llm.AdapterOpenAIResponses,
+		BaseURL:               "https://api.openai.com/v1",
+		ModelCapabilitiesJSON: `{"responses":{"backgroundMode":true}}`,
+	}) {
+		t.Fatalf("expected nested official OpenAI Responses capability to enable background")
+	}
+	if supportsOpenAIResponsesBackgroundMode(&channel.ResolvedRoute{
+		Protocol:              llm.AdapterOpenAIResponses,
+		BaseURL:               "https://reverse.example.com/v1",
+		ModelCapabilitiesJSON: `{"responsesBackgroundMode":true}`,
+	}) {
+		t.Fatalf("expected custom Responses-compatible route to disable background")
+	}
+	if supportsOpenAIResponsesBackgroundMode(&channel.ResolvedRoute{
+		Protocol:              llm.AdapterOpenRouterResponses,
+		BaseURL:               "https://openrouter.ai/api/v1",
+		ModelCapabilitiesJSON: `{"responsesBackgroundMode":true}`,
+	}) {
+		t.Fatalf("expected non-official protocol to disable background")
+	}
+	if supportsOpenAIResponsesBackgroundMode(&channel.ResolvedRoute{
+		Protocol:              llm.AdapterOpenAIResponses,
+		BaseURL:               "https://api.openai.com/v1",
+		ModelCapabilitiesJSON: `{"responsesBackgroundMode":"true"}`,
+	}) {
+		t.Fatalf("expected non-boolean capability to disable background")
+	}
+}
+
+func TestShouldRetryWithoutResponsesBackground(t *testing.T) {
+	err := &llm.UpstreamError{
+		StatusCode: 400,
+		Message:    "Unknown parameter: background",
+	}
+	if !shouldRetryWithoutResponsesBackground(err) {
+		t.Fatalf("expected unsupported background error to be retryable")
+	}
+	if shouldRetryWithoutResponsesBackground(&llm.UpstreamError{
+		StatusCode: 429,
+		Message:    "rate limit",
+	}) {
+		t.Fatalf("expected rate limit to stay non-retryable")
+	}
+	if shouldRetryWithoutResponsesBackground(&llm.UpstreamError{
+		StatusCode: 400,
+		Message:    "invalid temperature",
+	}) {
+		t.Fatalf("expected unrelated validation error to stay non-retryable")
+	}
+}
+
 func TestBuildStatefulResponseMessagesKeepsLatestUserOnly(t *testing.T) {
 	messages := []llm.Message{
 		{Role: "system", Content: "behavior"},

--- a/backend/internal/infra/llm/client.go
+++ b/backend/internal/infra/llm/client.go
@@ -141,6 +141,9 @@ type GenerateInput struct {
 	// 非空时：仅在 input 中发送本轮新消息，服务端从存储状态续接历史。
 	// 空串时：退回全量发送模式，适用于所有 adapter。
 	PreviousResponseID string
+	// ResponsesBackground 表示官方 OpenAI Responses 请求使用 background mode。
+	// 这是服务端能力开关，不从用户 Options 透传，避免改变未显式启用模型的数据保留语义。
+	ResponsesBackground bool
 	// ImageEditMask 仅供图片编辑 adapter 使用，表示透明区域掩码。
 	ImageEditMask *ContentPart
 }

--- a/backend/internal/infra/llm/openai.go
+++ b/backend/internal/infra/llm/openai.go
@@ -171,6 +171,7 @@ func (c *Client) listModelsOpenAICompatible(ctx context.Context, route RouteConf
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Content-Type", "application/json")
 	if apiKey := strings.TrimSpace(route.APIKey); apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
@@ -192,6 +193,57 @@ func (c *Client) listModelsOpenAICompatible(ctx context.Context, route RouteConf
 	}
 
 	return parseOpenAIModelList(body)
+}
+
+// RetrieveOpenAIResponse 获取官方 OpenAI Responses 后台任务结果。
+func (c *Client) RetrieveOpenAIResponse(ctx context.Context, route RouteConfig, responseID string) (*GenerateOutput, error) {
+	return c.fetchOpenAIResponse(ctx, route, http.MethodGet, responseID, "")
+}
+
+// CancelOpenAIResponse 取消官方 OpenAI Responses 后台任务，并解析上游返回的 response。
+func (c *Client) CancelOpenAIResponse(ctx context.Context, route RouteConfig, responseID string) (*GenerateOutput, error) {
+	return c.fetchOpenAIResponse(ctx, route, http.MethodPost, responseID, "cancel")
+}
+
+func (c *Client) fetchOpenAIResponse(ctx context.Context, route RouteConfig, method string, responseID string, action string) (*GenerateOutput, error) {
+	requestURL := buildOpenAIResponseResourceURL(route.BaseURL, responseID, action)
+	if requestURL == "" {
+		return nil, fmt.Errorf("invalid response url")
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, resolveReadTimeout(route.ReadTimeoutMS))
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(requestCtx, method, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey := strings.TrimSpace(route.APIKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	setAdditionalHeaders(req, route.HeadersJSON)
+
+	resp, err := c.httpClientForRoute(route).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, err := readUpstreamBody(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, parseUpstreamError(resp.StatusCode, body, upstreamDebugSnapshot(req, nil, resp, body))
+	}
+
+	debug := upstreamDebugSnapshot(req, nil, resp, body)
+	output, err := parseOpenAIGenerateOutput(EndpointResponses, AdapterOpenAIResponses, body, false)
+	if err != nil {
+		return nil, attachUpstreamDebug(err, debug)
+	}
+	output.Debug = debug
+	return output, nil
 }
 
 func buildOpenAIRequestBody(protocol string, model string, endpoint string, input GenerateInput, stream bool) (map[string]interface{}, error) {
@@ -318,6 +370,18 @@ func buildOpenAIRequestURL(baseURL string, endpoint string) string {
 
 func buildOpenAIModelsURL(baseURL string) string {
 	return buildVersionedEndpointURL(baseURL, "v1", "/models")
+}
+
+func buildOpenAIResponseResourceURL(baseURL string, responseID string, action string) string {
+	id := strings.TrimSpace(responseID)
+	if id == "" {
+		return ""
+	}
+	path := "/responses/" + url.PathEscape(id)
+	if suffix := strings.Trim(strings.TrimSpace(action), "/"); suffix != "" {
+		path += "/" + suffix
+	}
+	return buildVersionedEndpointURL(baseURL, "v1", path)
 }
 
 func setOpenRouterAttributionHeaders(req *http.Request, route RouteConfig) {

--- a/backend/internal/infra/llm/openai_responses.go
+++ b/backend/internal/infra/llm/openai_responses.go
@@ -47,6 +47,10 @@ func buildResponsesRequestBody(
 		"input":  items,
 		"stream": stream,
 	}
+	if adapter == AdapterOpenAIResponses && input.ResponsesBackground {
+		payload["background"] = true
+		payload["store"] = true
+	}
 	if instructions := strings.TrimSpace(input.Instructions); adapter == AdapterOpenAIResponses && instructions != "" {
 		payload["instructions"] = instructions
 	}
@@ -100,6 +104,9 @@ func responsesProtectedProviderOptionKeys(adapter string, hasManagedInstructions
 		"systemInstruction",
 		"text",
 		"tools",
+	}
+	if adapter == AdapterOpenAIResponses {
+		keys = append(keys, "background", "store")
 	}
 	if adapter != AdapterOpenAIResponses {
 		keys = append(keys, "instructions", "metadata", "prompt")
@@ -314,12 +321,17 @@ func applyResponsesStreamEvent(
 
 	switch eventType {
 	case "response.created":
+		var eventErr error
 		if responseID := strings.TrimSpace(getStringFromPath(parsed, "response", "id")); responseID != "" {
 			result.ResponseID = responseID
+			if onEvent != nil {
+				eventErr = onEvent(GenerateStreamEvent{ResponseID: responseID})
+			}
 		}
 		if serviceTier := strings.TrimSpace(getStringFromPath(parsed, "response", "service_tier")); serviceTier != "" {
 			result.Usage.ServiceTier = serviceTier
 		}
+		return eventErr
 	case "response.output_item.added", "response.output_item.in_progress":
 		return mergeResponsesStreamOutputItem(result, asMap(parsed["item"]), onEvent)
 	case "response.output_item.done":

--- a/backend/internal/infra/llm/request_params_test.go
+++ b/backend/internal/infra/llm/request_params_test.go
@@ -38,6 +38,63 @@ func TestBuildOpenAIResponsesMinimalRequestHasOnlyProtocolDefaults(t *testing.T)
 	}
 }
 
+func TestBuildOpenAIResponsesBackgroundRequestSetsStore(t *testing.T) {
+	payload := mustBuildRequestBody(t, AdapterOpenAIResponses, "gpt-5", EndpointResponses, GenerateInput{
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+		ResponsesBackground: true,
+	}, true)
+
+	if payload["background"] != true || payload["store"] != true {
+		t.Fatalf("expected background store request, got %#v", payload)
+	}
+}
+
+func TestBuildOpenAIResponsesBackgroundIgnoresProviderOverride(t *testing.T) {
+	payload := mustBuildRequestBody(t, AdapterOpenAIResponses, "gpt-5", EndpointResponses, GenerateInput{
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+		ResponsesBackground: true,
+		Options: map[string]interface{}{
+			"background": false,
+			"store":      false,
+		},
+	}, true)
+
+	if payload["background"] != true || payload["store"] != true {
+		t.Fatalf("expected internal background fields to win, got %#v", payload)
+	}
+}
+
+func TestOpenAIResponsesCreatedEventEmitsResponseID(t *testing.T) {
+	result := &GenerateOutput{}
+	var got string
+	err := applyResponsesStreamEvent(
+		AdapterOpenAIResponses,
+		"response.created",
+		map[string]interface{}{
+			"type": "response.created",
+			"response": map[string]interface{}{
+				"id":           "resp_123",
+				"service_tier": "default",
+			},
+		},
+		"",
+		result,
+		func(event GenerateStreamEvent) error {
+			got = event.ResponseID
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected event error: %v", err)
+	}
+	if got != "resp_123" || result.ResponseID != "resp_123" {
+		t.Fatalf("expected response id event and result, got event=%q result=%q", got, result.ResponseID)
+	}
+	if result.Usage.ServiceTier != "default" {
+		t.Fatalf("expected service tier to continue parsing, got %q", result.Usage.ServiceTier)
+	}
+}
+
 func TestBuildOpenAIResponsesUsesOutputTextForAssistantHistory(t *testing.T) {
 	payload := mustBuildRequestBody(t, AdapterOpenAIResponses, "gpt-5", EndpointResponses, GenerateInput{
 		Messages: []Message{


### PR DESCRIPTION
## Summary

Support OpenAI Responses API background mode for interrupted streaming requests so real upstream usage can be recovered when available.

This change enables `background: true` + `store: true` only for explicitly configured official OpenAI Responses routes, captures `response.id` from `response.created`, and attempts `cancel` / `retrieve` on user interruption to replace local usage estimation with upstream usage. Existing estimation remains the fallback when response id or upstream usage recovery is unavailable.

## Change type

- [x] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Backend / API
- [ ] Frontend / UI
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [x] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./internal/infra/llm ./internal/application/conversation`
- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./...`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Model capability opt-in examples:

```json
{"responsesBackgroundMode": true}
```

```json
{"responses": {"backgroundMode": true}}
```

When enabled, official OpenAI Responses requests include:

```json
{
  "background": true,
  "store": true,
  "stream": true
}
```

## Configuration, migration, and compatibility notes

No database migration.

Background mode is opt-in per model capability and only applies to official OpenAI Responses routes using `api.openai.com`. OpenRouter, xAI, and custom Responses-compatible routes are not enabled.

If upstream rejects `background` / `store`, the request retries once without background mode before any visible output is emitted. If cancel/retrieve fails after user interruption, existing local usage estimation remains the fallback.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

Note: OpenAI background mode requires `store=true` and changes upstream data retention semantics, so this implementation requires explicit model capability opt-in instead of enabling it by default.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.