### PR TITLE
feat: add raw HTML math rendering plugin to Streamdown

### DIFF
--- a/frontend/shared/components/markdown/streamdown-html-math.ts
+++ b/frontend/shared/components/markdown/streamdown-html-math.ts
@@ -1,0 +1,122 @@
+const HTML_TOKEN_RE = /<!--[\s\S]*?-->|<![^>]*>|<\/?[A-Za-z][^>]*>|[^<]+/g;
+const HTML_TAG_NAME_RE = /^<\/?\s*([A-Za-z][A-Za-z0-9-]*)/;
+const RAW_HTML_MATH_SKIP_TAGS = new Set(["code", "pre", "script", "style", "textarea"]);
+
+type HASTNode = {
+  type?: string;
+  value?: string;
+  children?: HASTNode[];
+};
+
+function isEscapedCharacter(source: string, index: number): boolean {
+  let slashCount = 0;
+  for (let cursor = index - 1; cursor >= 0 && source[cursor] === "\\"; cursor -= 1) {
+    slashCount += 1;
+  }
+  return slashCount % 2 === 1;
+}
+
+function getMathDelimiterLength(source: string, index: number): number {
+  if (source[index] !== "$" || isEscapedCharacter(source, index) || source[index - 1] === "$") {
+    return 0;
+  }
+  if (source[index + 1] === "$" && source[index + 2] !== "$") {
+    return 2;
+  }
+  return source[index + 1] === "$" ? 0 : 1;
+}
+
+function escapeMathHTML(source: string): string {
+  return source
+    .replace(/&(?!(?:#\d+|#x[\da-f]+|[a-z][\w-]*);)/gi, "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function renderMathInHTMLText(source: string): string {
+  if (!source.includes("$")) {
+    return source;
+  }
+
+  let output = "";
+  let cursor = 0;
+  let index = 0;
+
+  while (index < source.length) {
+    const delimiterLength = getMathDelimiterLength(source, index);
+    if (!delimiterLength) {
+      index += 1;
+      continue;
+    }
+
+    let closingIndex = -1;
+    for (let candidate = index + delimiterLength; candidate < source.length; candidate += 1) {
+      if (getMathDelimiterLength(source, candidate) === delimiterLength) {
+        closingIndex = candidate;
+        break;
+      }
+    }
+
+    if (closingIndex < 0) {
+      break;
+    }
+
+    const math = source.slice(index + delimiterLength, closingIndex).trim();
+    if (!math || (delimiterLength === 1 && math.includes("\n"))) {
+      index = closingIndex + delimiterLength;
+      continue;
+    }
+
+    output += source.slice(cursor, index);
+    const code = `<code class="language-math">${escapeMathHTML(math)}</code>`;
+    output += delimiterLength === 2 ? `<pre>${code}</pre>` : code;
+    cursor = closingIndex + delimiterLength;
+    index = cursor;
+  }
+
+  return cursor > 0 ? output + source.slice(cursor) : source;
+}
+
+function renderMathInRawHTML(source: string): string {
+  if (!source.includes("$")) {
+    return source;
+  }
+
+  const skippedTags: string[] = [];
+  return source.replace(HTML_TOKEN_RE, (token) => {
+    if (!token.startsWith("<")) {
+      return skippedTags.length > 0 ? token : renderMathInHTMLText(token);
+    }
+
+    const tagName = HTML_TAG_NAME_RE.exec(token)?.[1]?.toLowerCase();
+    if (!tagName || !RAW_HTML_MATH_SKIP_TAGS.has(tagName)) {
+      return token;
+    }
+
+    if (/^<\//.test(token)) {
+      const matchingIndex = skippedTags.lastIndexOf(tagName);
+      if (matchingIndex >= 0) {
+        skippedTags.splice(matchingIndex, 1);
+      }
+    } else if (!/\/\s*>$/.test(token)) {
+      skippedTags.push(tagName);
+    }
+    return token;
+  });
+}
+
+function visitRawHTMLNodes(node: HASTNode) {
+  if (node.type === "raw" && node.value?.includes("$")) {
+    node.value = renderMathInRawHTML(node.value);
+  }
+
+  for (const child of node.children ?? []) {
+    visitRawHTMLNodes(child);
+  }
+}
+
+export function renderRawHTMLMathRehypePlugin() {
+  return (tree: HASTNode) => {
+    visitRawHTMLNodes(tree);
+  };
+}

--- a/frontend/shared/components/markdown/streamdown-render.tsx
+++ b/frontend/shared/components/markdown/streamdown-render.tsx
@@ -47,6 +47,7 @@ import {
   MarkdownHTMLSpan,
   MarkdownHTMLSummary,
 } from "./streamdown-html";
+import { renderRawHTMLMathRehypePlugin } from "./streamdown-html-math";
 import {
   normalizeContent,
   normalizeCurrencyDollars,
@@ -146,6 +147,7 @@ function buildStreamdownRehypePlugins(): StreamdownRehypePlugins {
   const sanitizeWithAllowedTags = [sanitizePlugin, schema] as StreamdownRehypePlugin;
 
   return [
+    renderRawHTMLMathRehypePlugin,
     defaultRehypePlugins.raw,
     sanitizeWithAllowedTags,
     normalizeBareURLRehypePlugin,


### PR DESCRIPTION
## Summary

Fix LaTeX formulas appearing as raw source inside visual HTML/card layouts.

Math inside raw HTML was not processed by `remark-math` because raw HTML is parsed later in the rendering pipeline. Add a focused rehype preprocessor that converts `$...$` and `$$...$$` within raw HTML text into KaTeX-compatible nodes before `rehype-raw` runs.

Code, preformatted content, scripts, styles, and textareas are excluded. Generated nodes continue through the existing HTML sanitization pipeline.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm exec tsc --noEmit`
- [x] `git diff --check`
- [x] Rendered the reported HTML/LaTeX examples through Streamdown and KaTeX and confirmed that `\mathbb`, `\frac`, `\nabla`, and `(P,Q)` produce KaTeX output without raw dollar-delimited source.
- [ ] Build was not run because this is a focused frontend rendering fix.

## Screenshots, API examples, or logs

Verified with the reported patterns:

```markdown
<div>
  <ul>
    <li>适用范围：$\mathbb{R}^2$</li>
    <li>核心对象：$(P,Q)$</li>
    <li>联系量：$\frac{\partial Q}{\partial x}-\frac{\partial P}{\partial y}$</li>
    <li>联系量：$\nabla\times\mathbf{F}$</li>
  </ul>
</div>
```

All formulas are rendered by KaTeX instead of being displayed as raw LaTeX.

## Configuration, migration, and compatibility notes

No configuration, API, database, deployment, or migration changes.

Existing raw HTML sanitization remains enabled. The new preprocessing step only creates `language-math` nodes already supported by the current KaTeX renderer.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Raw HTML and generated math nodes continue through the existing sanitization and hardening pipeline.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.