### PR TITLE
feat: implement image generation handling in conversation service

### DIFF
--- a/backend/internal/application/conversation/service_assistant_image_content.go
+++ b/backend/internal/application/conversation/service_assistant_image_content.go
@@ -11,6 +11,7 @@ import (
 
 	appupload "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/upload"
 	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/llm"
 )
 
 const maxAssistantImageContentItems = 8
@@ -28,6 +29,11 @@ type assistantImageCandidate struct {
 	MIMEType string
 }
 
+type assistantImagePayload struct {
+	Bytes    []byte
+	MIMEType string
+}
+
 func (s *Service) normalizeAssistantImageContent(
 	ctx context.Context,
 	userID uint,
@@ -40,23 +46,68 @@ func (s *Service) normalizeAssistantImageContent(
 	if len(candidates) == 0 {
 		return nil, nil
 	}
-
-	uploaded := make([]model.FileObject, 0, len(candidates))
-	attachmentRows := make([]model.Attachment, 0, len(candidates))
-	now := time.Now()
+	images := make([]assistantImagePayload, 0, len(candidates))
 	for _, candidate := range candidates {
 		data, mimeType, ok := decodeAssistantImageCandidate(candidate)
 		if !ok {
 			continue
 		}
-		fileName := generatedImageFileName(modelName, now, len(uploaded), len(candidates), mimeType)
+		images = append(images, assistantImagePayload{Bytes: data, MIMEType: mimeType})
+		if len(images) >= maxAssistantImageContentItems {
+			break
+		}
+	}
+	return s.saveAssistantImages(ctx, userID, conversationID, assistantMessageID, modelName, images)
+}
+
+// normalizeAssistantGeneratedImages 将协议层结构化图片结果转换为消息附件。
+func (s *Service) normalizeAssistantGeneratedImages(
+	ctx context.Context,
+	userID uint,
+	conversationID uint,
+	assistantMessageID uint,
+	modelName string,
+	generatedImages []llm.GeneratedImage,
+) (*assistantImageContentNormalization, error) {
+	images := make([]assistantImagePayload, 0, len(generatedImages))
+	for _, image := range generatedImages {
+		data, mimeType, err := s.readGeneratedImage(ctx, image)
+		if err != nil {
+			return nil, err
+		}
+		images = append(images, assistantImagePayload{Bytes: data, MIMEType: mimeType})
+		if len(images) >= maxAssistantImageContentItems {
+			break
+		}
+	}
+	return s.saveAssistantImages(ctx, userID, conversationID, assistantMessageID, modelName, images)
+}
+
+// saveAssistantImages 统一保存助手生成的图片，并构造消息附件快照。
+func (s *Service) saveAssistantImages(
+	ctx context.Context,
+	userID uint,
+	conversationID uint,
+	assistantMessageID uint,
+	modelName string,
+	images []assistantImagePayload,
+) (*assistantImageContentNormalization, error) {
+	if len(images) == 0 {
+		return nil, nil
+	}
+
+	uploaded := make([]model.FileObject, 0, len(images))
+	attachmentRows := make([]model.Attachment, 0, len(images))
+	now := time.Now()
+	for _, image := range images {
+		fileName := generatedImageFileName(modelName, now, len(uploaded), len(images), image.MIMEType)
 		uploadResult, uploadErr := s.UploadFile(ctx, appupload.UploadFileInput{
 			UserID:       userID,
 			Purpose:      "generated_image",
 			FileName:     fileName,
-			MimeType:     mimeType,
-			DeclaredSize: int64(len(data)),
-			Reader:       bytes.NewReader(data),
+			MimeType:     image.MIMEType,
+			DeclaredSize: int64(len(image.Bytes)),
+			Reader:       bytes.NewReader(image.Bytes),
 		})
 		if uploadErr != nil {
 			return nil, uploadErr
@@ -77,9 +128,6 @@ func (s *Service) normalizeAssistantImageContent(
 			Status:         "active",
 			UploadedAt:     now,
 		})
-		if len(uploaded) >= maxAssistantImageContentItems {
-			break
-		}
 	}
 	if len(uploaded) == 0 {
 		return nil, nil

--- a/backend/internal/application/conversation/service_message_completion.go
+++ b/backend/internal/application/conversation/service_message_completion.go
@@ -21,6 +21,7 @@ type persistMessageGenerationInput struct {
 	AssistantMessage          *model.Message
 	AssistantText             string
 	AssistantReasoningContent string
+	GeneratedImages           []llm.GeneratedImage
 	InputTokens               int64
 	CacheReadTokens           int64
 	CacheWriteTokens          int64
@@ -152,17 +153,37 @@ func assistantCompletionCacheWriteTokens(input persistMessageGenerationInput) in
 	return 0
 }
 
+// persistAssistantImagePayloadIfPresent 保存结构化图片或兼容旧文本图片载荷。
 func (s *Service) persistAssistantImagePayloadIfPresent(ctx context.Context, input persistMessageGenerationInput) (bool, error) {
-	normalized, err := s.normalizeAssistantImageContent(
-		ctx,
-		input.SendInput.UserID,
-		input.SendInput.ConversationID,
-		input.AssistantMessage.ID,
-		successfulMessageGenerationModelName(input),
-		input.AssistantText,
-	)
+	var normalized *assistantImageContentNormalization
+	var err error
+	if len(input.GeneratedImages) > 0 {
+		normalized, err = s.normalizeAssistantGeneratedImages(
+			ctx,
+			input.SendInput.UserID,
+			input.SendInput.ConversationID,
+			input.AssistantMessage.ID,
+			successfulMessageGenerationModelName(input),
+			input.GeneratedImages,
+		)
+	} else {
+		normalized, err = s.normalizeAssistantImageContent(
+			ctx,
+			input.SendInput.UserID,
+			input.SendInput.ConversationID,
+			input.AssistantMessage.ID,
+			successfulMessageGenerationModelName(input),
+			input.AssistantText,
+		)
+	}
 	if err != nil || normalized == nil {
 		return false, err
+	}
+	contentType := "image"
+	content := normalized.Content
+	if len(input.GeneratedImages) > 0 && strings.TrimSpace(input.AssistantText) != "" {
+		contentType = "mixed"
+		content = strings.TrimSpace(input.AssistantText) + "\n\n" + normalized.Content
 	}
 
 	if input.ReuseUserMessage {
@@ -170,8 +191,9 @@ func (s *Service) persistAssistantImagePayloadIfPresent(ctx context.Context, inp
 			ctx,
 			input.AssistantMessage.ID,
 			repository.AssistantMessageCompletionUpdate{
-				ContentType:      "image",
-				Content:          normalized.Content,
+				ContentType:      contentType,
+				Content:          content,
+				ReasoningContent: input.AssistantReasoningContent,
 				InputTokens:      input.InputTokens,
 				OutputTokens:     input.OutputTokens,
 				CacheReadTokens:  input.CacheReadTokens,
@@ -195,12 +217,13 @@ func (s *Service) persistAssistantImagePayloadIfPresent(ctx context.Context, inp
 			},
 			input.AssistantMessage.ID,
 			repository.AssistantMessageCompletionUpdate{
-				ContentType:     "image",
-				Content:         normalized.Content,
-				OutputTokens:    input.OutputTokens,
-				ReasoningTokens: input.ReasoningTokens,
-				LatencyMS:       input.AssistantLatency,
-				Status:          "success",
+				ContentType:      contentType,
+				Content:          content,
+				ReasoningContent: input.AssistantReasoningContent,
+				OutputTokens:     input.OutputTokens,
+				ReasoningTokens:  input.ReasoningTokens,
+				LatencyMS:        input.AssistantLatency,
+				Status:           "success",
 			},
 			normalized.AttachmentRows,
 		); err != nil {
@@ -208,8 +231,9 @@ func (s *Service) persistAssistantImagePayloadIfPresent(ctx context.Context, inp
 		}
 	}
 
-	input.AssistantMessage.ContentType = "image"
-	input.AssistantMessage.Content = normalized.Content
+	input.AssistantMessage.ContentType = contentType
+	input.AssistantMessage.Content = content
+	input.AssistantMessage.ReasoningContent = input.AssistantReasoningContent
 	if input.ReuseUserMessage {
 		input.AssistantMessage.InputTokens = input.InputTokens
 		input.AssistantMessage.CacheReadTokens = input.CacheReadTokens

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -951,6 +951,11 @@ func (s *Service) sendMessageInternal(
 					}
 				}
 			}
+			if event.GeneratedImage != nil {
+				if err := emitMediaImageDelta(input.OnEvent, event); err != nil {
+					return err
+				}
+			}
 			if traceRecorder != nil && event.Reasoning != nil && event.Reasoning.Text != "" {
 				traceRecorder.appendUpstreamReasoning(event.Reasoning.Kind, event.Reasoning.Text, reasoningPayload(event.Reasoning))
 				if strings.EqualFold(strings.TrimSpace(event.Reasoning.Status), "completed") {
@@ -1255,7 +1260,7 @@ func (s *Service) sendMessageInternal(
 		retErr = ErrToolRunFinalAnswerMissing
 		return nil, retErr
 	}
-	if strings.TrimSpace(assistantText) == "" {
+	if strings.TrimSpace(assistantText) == "" && len(upstreamOutput.GeneratedImages) == 0 {
 		retErr = ErrUpstreamEmptyResponse
 		return nil, retErr
 	}
@@ -1332,6 +1337,7 @@ func (s *Service) sendMessageInternal(
 		AssistantMessage:          assistantMessage,
 		AssistantText:             assistantText,
 		AssistantReasoningContent: assistantReasoningContent,
+		GeneratedImages:           upstreamOutput.GeneratedImages,
 		InputTokens:               effectiveInputTokens,
 		CacheReadTokens:           totalUsage.CacheReadTokens,
 		CacheWriteTokens:          totalUsage.CacheWriteTokens,

--- a/backend/internal/application/conversation/service_tool_loop.go
+++ b/backend/internal/application/conversation/service_tool_loop.go
@@ -109,7 +109,7 @@ func normalizeStreamServerToolStatus(status string) string {
 	switch strings.TrimSpace(status) {
 	case "", "completed", "success":
 		return "success"
-	case "in_progress", "queued", "searching":
+	case "in_progress", "queued", "searching", "generating":
 		return "streaming"
 	case "failed", "error":
 		return "error"

--- a/backend/internal/infra/llm/client.go
+++ b/backend/internal/infra/llm/client.go
@@ -682,7 +682,7 @@ type GenerateStreamEvent struct {
 	ServerToolCall        *ToolCall
 	ResponseID            string
 	GeneratedImage        *GeneratedImage
-	GeneratedImageIndex   int
+	GeneratedImageIndex   int64
 	GeneratedImagePartial bool
 }
 

--- a/backend/internal/infra/llm/openai.go
+++ b/backend/internal/infra/llm/openai.go
@@ -451,7 +451,7 @@ func consumeOpenAIGenerateStream(
 	allowTextEncodedToolCalls bool,
 ) error {
 	scanner := bufio.NewScanner(reader)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxUpstreamBodyBytes)
 
 	var eventName string
 	dataLines := make([]string, 0, 4)
@@ -628,6 +628,9 @@ func mergeGenerateOutput(dst *GenerateOutput, src *GenerateOutput) {
 	}
 	if len(src.Citations) > 0 {
 		dst.Citations = append(dst.Citations[:0], src.Citations...)
+	}
+	if len(src.GeneratedImages) > 0 {
+		dst.GeneratedImages = append(dst.GeneratedImages[:0], src.GeneratedImages...)
 	}
 	if strings.TrimSpace(src.RawJSON) != "" {
 		dst.RawJSON = src.RawJSON

--- a/backend/internal/infra/llm/openai_images.go
+++ b/backend/internal/infra/llm/openai_images.go
@@ -855,10 +855,10 @@ func emitOpenAIImagePartial(
 	if !ok {
 		return nil
 	}
-	index := int(firstNonZero(
+	index := firstNonZero(
 		getInt64FromPath(parsed, "partial_image_index"),
 		getInt64FromPath(parsed, "index"),
-	))
+	)
 	return onEvent(GenerateStreamEvent{
 		GeneratedImage:        &image,
 		GeneratedImageIndex:   index,

--- a/backend/internal/infra/llm/openai_responses.go
+++ b/backend/internal/infra/llm/openai_responses.go
@@ -379,7 +379,7 @@ func applyResponsesStreamEvent(
 		}
 		return onEvent(GenerateStreamEvent{
 			GeneratedImage:        &image,
-			GeneratedImageIndex:   int(toInt64(parsed["partial_image_index"])),
+			GeneratedImageIndex:   toInt64(parsed["partial_image_index"]),
 			GeneratedImagePartial: true,
 			ResponseID:            result.ResponseID,
 		})

--- a/backend/internal/infra/llm/openai_responses.go
+++ b/backend/internal/infra/llm/openai_responses.go
@@ -372,6 +372,17 @@ func applyResponsesStreamEvent(
 		if text != "" && !strings.Contains(result.Text, text) {
 			result.Text += text
 		}
+	case "response.image_generation_call.partial_image":
+		image, ok := parseResponsesPartialImage(parsed)
+		if !ok || onEvent == nil {
+			return nil
+		}
+		return onEvent(GenerateStreamEvent{
+			GeneratedImage:        &image,
+			GeneratedImageIndex:   int(toInt64(parsed["partial_image_index"])),
+			GeneratedImagePartial: true,
+			ResponseID:            result.ResponseID,
+		})
 	case "response.reasoning_summary_text.delta", "response.reasoning_text.delta", "response.thinking.delta":
 		reasoning := parseResponsesReasoningDelta(eventType, parsed)
 		if reasoning == nil || reasoning.Text == "" {
@@ -431,7 +442,7 @@ func parseResponsesServerToolStatusEvent(eventType string, parsed map[string]int
 		return ToolCall{}, false
 	}
 	status := ""
-	for _, suffix := range []string{".in_progress", ".searching", ".completed", ".failed", ".error"} {
+	for _, suffix := range []string{".in_progress", ".searching", ".generating", ".completed", ".failed", ".error"} {
 		if strings.HasSuffix(value, suffix) {
 			status = strings.TrimPrefix(suffix, ".")
 			value = strings.TrimSuffix(strings.TrimPrefix(value, "response."), suffix)
@@ -739,6 +750,9 @@ func mergeResponsesOutputItem(result *GenerateOutput, item map[string]interface{
 	case itemType == "reasoning":
 		mergeReasoningOutput(&result.Reasoning, parseReasoningOutputItem(item))
 	case isResponsesServerToolCallItem(item):
+		if image, ok := parseResponsesGeneratedImage(item); ok {
+			result.GeneratedImages = appendUniqueGeneratedImage(result.GeneratedImages, image)
+		}
 		appendUniqueToolCall(&result.ServerToolCalls, parseResponseServerToolCall(item))
 		result.Citations = appendUniqueStrings(result.Citations, parseResponseCitations(item)...)
 	case isResponsesClientToolCallType(itemType):
@@ -819,6 +833,9 @@ func parseResponseServerToolCall(item map[string]interface{}) ToolCall {
 		normalizeJSONString(item["result"]),
 		actionOutputJSON,
 	)
+	if isResponsesImageGenerationCallType(itemType) {
+		outputJSON = responsesImageGenerationToolOutputJSON(item)
+	}
 	errorJSON := normalizeJSONString(item["error"])
 	return ToolCall{
 		ToolCallID:    toolCallID,
@@ -829,6 +846,87 @@ func parseResponseServerToolCall(item map[string]interface{}) ToolCall {
 		OutputJSON:    outputJSON,
 		ErrorJSON:     errorJSON,
 	}
+}
+
+// parseResponsesPartialImage 解析 Responses 图片生成过程中的预览帧。
+func parseResponsesPartialImage(parsed map[string]interface{}) (GeneratedImage, bool) {
+	b64 := strings.TrimSpace(getString(parsed["partial_image_b64"]))
+	if b64 == "" {
+		return GeneratedImage{}, false
+	}
+	return GeneratedImage{
+		B64JSON:  b64,
+		MIMEType: openAIImageMIMEType(getString(parsed["output_format"])),
+	}, true
+}
+
+// parseResponsesGeneratedImage 从最终 image_generation_call 中提取可持久化图片。
+func parseResponsesGeneratedImage(item map[string]interface{}) (GeneratedImage, bool) {
+	if !isResponsesImageGenerationCallType(getString(item["type"])) {
+		return GeneratedImage{}, false
+	}
+	outputFormat := getString(item["output_format"])
+	revisedPrompt := strings.TrimSpace(getString(item["revised_prompt"]))
+	if b64 := strings.TrimSpace(getString(item["result"])); b64 != "" {
+		return GeneratedImage{
+			B64JSON:       b64,
+			MIMEType:      openAIImageMIMEType(outputFormat),
+			RevisedPrompt: revisedPrompt,
+		}, true
+	}
+	image, ok := parseOpenAIImagePayload(asMap(item["result"]), outputFormat)
+	if !ok {
+		image, ok = parseOpenAIImagePayload(item, outputFormat)
+	}
+	if !ok {
+		return GeneratedImage{}, false
+	}
+	if image.RevisedPrompt == "" {
+		image.RevisedPrompt = revisedPrompt
+	}
+	return image, true
+}
+
+// appendUniqueGeneratedImage 合并同一响应内重复出现的最终图片结果。
+func appendUniqueGeneratedImage(images []GeneratedImage, image GeneratedImage) []GeneratedImage {
+	for _, existing := range images {
+		if existing.B64JSON != "" && existing.B64JSON == image.B64JSON {
+			return images
+		}
+		if existing.URL != "" && existing.URL == image.URL {
+			return images
+		}
+	}
+	return append(images, image)
+}
+
+// isResponsesImageGenerationCallType 判断 Responses 输出项是否为图片生成结果。
+func isResponsesImageGenerationCallType(itemType string) bool {
+	switch strings.TrimSpace(itemType) {
+	case "image_generation_call", "image_generation_call_output":
+		return true
+	default:
+		return false
+	}
+}
+
+// responsesImageGenerationToolOutputJSON 只保留图片工具元数据，避免把 base64 写入 trace。
+func responsesImageGenerationToolOutputJSON(item map[string]interface{}) string {
+	payload := make(map[string]interface{})
+	for _, key := range []string{"background", "output_format", "quality", "revised_prompt", "size", "status"} {
+		if value, ok := item[key]; ok {
+			payload[key] = value
+		}
+	}
+	if _, ok := parseResponsesGeneratedImage(item); ok {
+		payload["image_generated"] = true
+	}
+	if result := asMap(item["result"]); len(result) > 0 {
+		if imageURL := strings.TrimSpace(getString(result["url"])); imageURL != "" {
+			payload["url"] = imageURL
+		}
+	}
+	return normalizeJSONString(payload)
 }
 
 func responseServerToolCallID(item map[string]interface{}, itemType string) string {

--- a/backend/internal/infra/llm/request_tools_test.go
+++ b/backend/internal/infra/llm/request_tools_test.go
@@ -1283,6 +1283,110 @@ func TestParseResponsesCapturesOpenAINativeShellAndImageTools(t *testing.T) {
 	}
 }
 
+func TestParseResponsesCapturesGeneratedImageWithoutBase64Trace(t *testing.T) {
+	payload := mustDecodeObject(t, `{
+		"id": "resp_1",
+		"output": [
+			{
+				"type":"image_generation_call",
+				"id":"img_1",
+				"status":"completed",
+				"output_format":"png",
+				"revised_prompt":"A dog running",
+				"result":"ZmluYWw="
+			}
+		]
+	}`)
+
+	result := buildGenerateOutputFromParsed(EndpointResponses, payload)
+	if len(result.GeneratedImages) != 1 {
+		t.Fatalf("expected one generated image, got %#v", result.GeneratedImages)
+	}
+	image := result.GeneratedImages[0]
+	if image.B64JSON != "ZmluYWw=" || image.MIMEType != "image/png" || image.RevisedPrompt != "A dog running" {
+		t.Fatalf("unexpected generated image: %#v", image)
+	}
+	if len(result.ServerToolCalls) != 1 {
+		t.Fatalf("expected one image tool trace, got %#v", result.ServerToolCalls)
+	}
+	outputJSON := result.ServerToolCalls[0].OutputJSON
+	if strings.Contains(outputJSON, "ZmluYWw=") {
+		t.Fatalf("expected image base64 to be excluded from tool trace, got %q", outputJSON)
+	}
+	if !strings.Contains(outputJSON, `"image_generated":true`) {
+		t.Fatalf("expected generated image metadata in tool trace, got %q", outputJSON)
+	}
+}
+
+func TestResponsesStreamAcceptsLargePartialImageAndKeepsOnlyFinalImage(t *testing.T) {
+	partial := strings.Repeat("A", 2*1024*1024)
+	partialPayload, err := json.Marshal(map[string]interface{}{
+		"type":                "response.image_generation_call.partial_image",
+		"item_id":             "img_1",
+		"output_format":       "png",
+		"output_index":        0,
+		"partial_image_index": 3,
+		"partial_image_b64":   partial,
+	})
+	if err != nil {
+		t.Fatalf("marshal partial image event: %v", err)
+	}
+	completedPayload, err := json.Marshal(map[string]interface{}{
+		"type": "response.completed",
+		"response": map[string]interface{}{
+			"id": "resp_1",
+			"output": []interface{}{
+				map[string]interface{}{
+					"type":          "image_generation_call",
+					"id":            "img_1",
+					"status":        "completed",
+					"output_format": "png",
+					"result":        "ZmluYWw=",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal completed event: %v", err)
+	}
+	rawStream := strings.Join([]string{
+		"event: response.image_generation_call.partial_image",
+		"data: " + string(partialPayload),
+		"",
+		"event: response.completed",
+		"data: " + string(completedPayload),
+		"",
+	}, "\n")
+
+	result := &GenerateOutput{ToolCalls: make([]ToolCall, 0), ServerToolCalls: make([]ToolCall, 0)}
+	partialEvents := 0
+	err = consumeOpenAIGenerateStream(EndpointResponses, AdapterOpenAIResponses, strings.NewReader(rawStream), result, func(event GenerateStreamEvent) error {
+		if event.GeneratedImage == nil {
+			return nil
+		}
+		partialEvents++
+		if !event.GeneratedImagePartial || event.GeneratedImageIndex != 3 {
+			t.Fatalf("unexpected partial image event metadata: %#v", event)
+		}
+		if event.GeneratedImage.B64JSON != partial || event.GeneratedImage.MIMEType != "image/png" {
+			t.Fatalf("unexpected partial image event: %#v", event.GeneratedImage)
+		}
+		return nil
+	}, false)
+	if err != nil {
+		t.Fatalf("consume large image stream: %v", err)
+	}
+	if partialEvents != 1 {
+		t.Fatalf("expected one partial image event, got %d", partialEvents)
+	}
+	if len(result.GeneratedImages) != 1 || result.GeneratedImages[0].B64JSON != "ZmluYWw=" {
+		t.Fatalf("expected only the final image to be persisted, got %#v", result.GeneratedImages)
+	}
+	if len(result.ServerToolCalls) != 1 || strings.Contains(result.ServerToolCalls[0].OutputJSON, "ZmluYWw=") {
+		t.Fatalf("expected sanitized final image tool trace, got %#v", result.ServerToolCalls)
+	}
+}
+
 func TestParseResponsesTreatsXSearchCustomCallsAsServerSide(t *testing.T) {
 	payload := mustDecodeObject(t, `{
 		"id": "resp_1",


### PR DESCRIPTION
## Summary

Fix OpenAI Responses native `image_generation` streaming and persistence in regular conversations.

Large `response.image_generation_call.partial_image` events could exceed the previous 1 MiB scanner limit, causing an HTTP 200 stream to fail as an incompatible or incomplete response.

This change:

- Raises the OpenAI-compatible SSE token limit to the existing 64 MiB upstream body limit.
- Parses and emits `partial_image_b64` events through the existing `media_image_delta` flow.
- Extracts final images from completed `image_generation_call` output items.
- Supports image-only and mixed text/image assistant responses.
- Uploads final images to project storage and persists them as message attachments.
- Preserves reasoning content and usage when completing image messages.
- Excludes large image base64 payloads from tool trace JSON.
- Handles the `generating` server-tool status as an active streaming state.
- Uses `int64` for generated image indexes to avoid unsafe integer narrowing on 32-bit platforms.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [x] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./...`
- [x] `git diff --check`

Added regression coverage for:

- A single `partial_image_b64` SSE event larger than 1 MiB.
- Partial image event metadata and streaming delivery.
- Final generated image extraction.
- Exclusion of image base64 from tool trace JSON.
- Preservation of only the final image for persistence.

## Screenshots, API examples, or logs

Supported Responses event sequence:

```text
response.created
response.output_item.added
response.image_generation_call.in_progress
response.image_generation_call.generating
response.image_generation_call.partial_image
response.completed
```

Large partial images are forwarded using the existing `media_image_delta` stream event. Final images are uploaded and returned through normal message attachments.

## Configuration, migration, and compatibility notes

No database migration or configuration change is required.

The OpenAI-compatible stream scanner now permits individual SSE tokens up to the existing 64 MiB upstream response limit. Its initial allocation remains 64 KiB and grows only when required.

Image-generation tool traces no longer contain complete base64 payloads. They retain lightweight metadata such as status, format, revised prompt, URL when available, and `image_generated: true`.

If an external integration depends on reading generated image base64 directly from tool trace JSON, it should use the persisted message attachment instead.

Malformed events already truncated by the upstream provider cannot be recovered.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

Generated image bytes are validated before upload, stored through the existing user-scoped attachment flow, and excluded from tool trace JSON to avoid unnecessary persistence of large payloads.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.