### PR TITLE
refactor: update conversation handling and improve message state management

### DIFF
--- a/backend/internal/application/conversation/service_message_completion.go
+++ b/backend/internal/application/conversation/service_message_completion.go
@@ -272,7 +272,10 @@ func (s *Service) finishSuccessfulMessageGeneration(ctx context.Context, input p
 		return err
 	}
 
-	s.updateStatefulResponseAsync(input.SendInput.ConversationID, input.ResponseID, input.StatefulPromptFingerprint)
+	// 非默认分支不代表会话主链，不能覆盖后续默认消息使用的 Responses 状态。
+	if normalizeBranchReason(input.SendInput.BranchReason) == "default" {
+		s.updateStatefulResponseAsync(input.SendInput.ConversationID, input.ResponseID, input.StatefulPromptFingerprint)
+	}
 	if input.ReuseUserMessage {
 		s.embedMessagePairAsync(input.SendInput, nil, input.AssistantMessage)
 	} else {

--- a/frontend/features/chat/components/app-chat-area.tsx
+++ b/frontend/features/chat/components/app-chat-area.tsx
@@ -544,6 +544,7 @@ export function AppChatArea() {
   });
 
   const {
+    currentLeafMessage,
     onCycleMessageBranch,
     onEditAssistantMessage,
     onEditUserMessage,
@@ -592,12 +593,21 @@ export function AppChatArea() {
   const generating = sending || Boolean(resumingRunID);
   const uploadDropDisabled = loading || uploading;
   const onStopActiveMessage = React.useCallback(() => {
-    if (sending) {
-      onStopMessage();
+    const visibleRunID = currentLeafMessage?.runID?.trim() || "";
+    if (resumingRunID && visibleRunID === resumingRunID) {
+      void cancelResumedGeneration();
+      return;
+    }
+    if (onStopMessage()) {
       return;
     }
     void cancelResumedGeneration();
-  }, [cancelResumedGeneration, onStopMessage, sending]);
+  }, [
+    cancelResumedGeneration,
+    currentLeafMessage?.runID,
+    onStopMessage,
+    resumingRunID,
+  ]);
 
   const messageContentRef = React.useRef<HTMLDivElement | null>(null);
   const loadingOlderInFlightRef = React.useRef(false);

--- a/frontend/features/chat/components/message/message-bot.tsx
+++ b/frontend/features/chat/components/message/message-bot.tsx
@@ -125,7 +125,7 @@ function resolveEditableImageAttachment(
 
 type ChatMessageBotProps = {
   item: ChatAreaMessage;
-  busy: boolean;
+  busy?: boolean;
   reaction: AssistantReaction;
   onRetryAssistantMessage: (message: ChatAreaMessage) => Promise<void> | void;
   onContinueAssistantMessage?: (message: ChatAreaMessage) => Promise<void> | void;
@@ -152,7 +152,7 @@ type ChatMessageBotProps = {
 
 export function ChatMessageBot({
   item,
-  busy,
+  busy = false,
   reaction,
   onRetryAssistantMessage,
   onContinueAssistantMessage,

--- a/frontend/features/chat/components/message/message-meta.tsx
+++ b/frontend/features/chat/components/message/message-meta.tsx
@@ -245,7 +245,6 @@ function MetaIconButton({
 
 export function UserMessageMeta({
   item,
-  busy,
   showRetry,
   onCycleBranch,
   onRetry,
@@ -257,7 +256,6 @@ export function UserMessageMeta({
   showBranchNavigator = true,
 }: {
   item: ChatMetaMessage;
-  busy: boolean;
   showRetry: boolean;
   onCycleBranch: (parentPublicID: string | null, direction: "previous" | "next") => void;
   onRetry: () => void;
@@ -272,7 +270,8 @@ export function UserMessageMeta({
   const timeT = useTranslations("common.time");
   const timestamp = formatMessageTimestamp(item.createdAt, (key, values) => timeT(key, values));
   const hasPersistedMessage = Boolean(resolvePersistedPublicID(item.publicID));
-  const canShowBranchNavigator = Boolean(showBranchNavigator && item.branchNavigator && !busy && !item.isPending);
+  const messagePending = Boolean(item.isPending || item.status?.trim().toLowerCase() === "pending");
+  const canShowBranchNavigator = Boolean(showBranchNavigator && item.branchNavigator);
 
   return (
     <MetaContainer align="end" alwaysVisible={alwaysVisible}>
@@ -282,7 +281,7 @@ export function UserMessageMeta({
           {showRetry && hasPersistedMessage ? (
             <MetaIconButton
               label={t("retryMessage")}
-              disabled={item.isPending}
+              disabled={messagePending}
               onClick={onRetry}
             >
               <RotateCcw size={14} strokeWidth={1.8} animateOnHover="default" />
@@ -290,14 +289,14 @@ export function UserMessageMeta({
           ) : null}
           <MetaIconButton
             label={t("editMessage")}
-            disabled={item.isPending || !hasPersistedMessage}
+            disabled={messagePending || !hasPersistedMessage}
             onClick={onEdit}
           >
             <Brush size={14} strokeWidth={1.8} animateOnHover="default" />
           </MetaIconButton>
           <MetaIconButton
             label={t("copyMessage")}
-            disabled={item.isPending}
+            disabled={messagePending}
             onClick={onCopy}
           >
             {copySucceeded ? (
@@ -986,10 +985,12 @@ export function AssistantMessageMeta({
     isLive ? item.createdAt : item.updatedAt || item.createdAt,
     (key, values) => timeT(key, values),
   );
-  const canRetry = !readOnly && !busy && !isLive;
-  const canEdit = Boolean(canRetry && onEdit && resolvePersistedPublicID(item.publicID));
-  const canContinue = Boolean(canRetry && resolvePersistedPublicID(item.publicID) && item.status === "interrupted");
-  const canShowBranchNavigator = Boolean(showBranchNavigator && item.branchNavigator && !busy && !isLive);
+  const messagePending = Boolean(isLive || item.status?.trim().toLowerCase() === "pending");
+  const hasPersistedMessage = Boolean(resolvePersistedPublicID(item.publicID));
+  const canRetry = !readOnly && !messagePending && hasPersistedMessage;
+  const canEdit = Boolean(canRetry && !busy && onEdit);
+  const canContinue = Boolean(canRetry && !busy && item.status === "interrupted");
+  const canShowBranchNavigator = Boolean(showBranchNavigator && item.branchNavigator);
   const hasTokenUsage = Boolean(
     (item.inputTokens ?? 0) > 0 ||
     (item.outputTokens ?? 0) > 0 ||
@@ -1067,7 +1068,7 @@ export function AssistantMessageMeta({
                 <MetaIconButton
                   label={t("likeReply")}
                   className={reaction === "up" ? "text-foreground" : undefined}
-                  disabled={isLive}
+                  disabled={messagePending}
                   onClick={() => onReact(reaction === "up" ? null : "up")}
                 >
                   <ThumbsUp size={14} strokeWidth={1.8} animateOnHover="default" />
@@ -1075,7 +1076,7 @@ export function AssistantMessageMeta({
                 <MetaIconButton
                   label={t("dislikeReply")}
                   className={reaction === "down" ? "text-foreground" : undefined}
-                  disabled={isLive}
+                  disabled={messagePending}
                   onClick={() => onReact(reaction === "down" ? null : "down")}
                 >
                   <ThumbsDown size={14} strokeWidth={1.8} animateOnHover="default" />
@@ -1096,7 +1097,7 @@ export function AssistantMessageMeta({
                     <Forward className="size-3.5" strokeWidth={1.8} />
                   </MetaIconButton>
                 ) : null}
-                <QuickMemoryPin disabled={isLive} />
+                <QuickMemoryPin disabled={messagePending} />
               </>
             ) : null}
             {canShowBranchNavigator ? <BranchSwitcher item={item} onCycle={onCycleBranch} /> : null}

--- a/frontend/features/chat/components/message/message-user.tsx
+++ b/frontend/features/chat/components/message/message-user.tsx
@@ -35,7 +35,6 @@ const EDIT_MESSAGE_EMPTY_TOOL_IDS = [];
 
 type ChatMessageUserProps = {
   item: ChatAreaMessage;
-  busy: boolean;
   onRetryUserMessage: (message: ChatAreaMessage) => Promise<void> | void;
   onEditUserMessage: (message: ChatAreaMessage, content: string) => Promise<boolean> | boolean;
   modelOptions?: ChatModelOption[];
@@ -53,7 +52,6 @@ type ChatMessageUserProps = {
 
 export function ChatMessageUser({
   item,
-  busy,
   onRetryUserMessage,
   onEditUserMessage,
   modelOptions = [],
@@ -164,7 +162,7 @@ export function ChatMessageUser({
     attachments: EDIT_MESSAGE_EMPTY_ATTACHMENTS,
     availableTools: EDIT_MESSAGE_EMPTY_TOOLS,
     defaultFileLabel: "",
-    disabled: busy || readOnly || !isEditing,
+    disabled: readOnly || !isEditing,
     draft: editingValue,
     enabledKinds: EDIT_MESSAGE_MENTION_KINDS,
     maxSelectedSkills: 0,
@@ -250,7 +248,7 @@ export function ChatMessageUser({
               <Button
                 variant="default"
                 className="rounded-lg text-xs font-medium shadow-none hover:bg-primary/60"
-                disabled={busy || nextContent.length === 0 || unchanged}
+                disabled={nextContent.length === 0 || unchanged}
                 onClick={() => void onEditSave()}
               >
                 {tCommon("save")}
@@ -315,8 +313,7 @@ export function ChatMessageUser({
       {screenshotMeta}
       <UserMessageMeta
         item={item}
-        busy={busy}
-        showRetry={!busy && !item.isPending}
+        showRetry={!item.isPending && item.status?.trim().toLowerCase() !== "pending"}
         onCycleBranch={onCycleMessageBranch}
         onRetry={onRetry}
         onEdit={() => setIsEditing(true)}

--- a/frontend/features/chat/components/sections/chat-area.tsx
+++ b/frontend/features/chat/components/sections/chat-area.tsx
@@ -327,7 +327,6 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
     return (
       <ChatMessageUser
         item={item}
-        busy={busy}
         onRetryUserMessage={onRetryUserMessage}
         onEditUserMessage={onEditUserMessage}
         modelOptions={modelOptions}

--- a/frontend/features/chat/hooks/use-chat-branch-state.ts
+++ b/frontend/features/chat/hooks/use-chat-branch-state.ts
@@ -4,45 +4,31 @@ import * as React from "react";
 import { useTranslations } from "next-intl";
 
 import type { ChatAreaMessage, MessageAttachment } from "@/features/chat/types/messages";
-import type { PendingExchange } from "@/features/chat/types/chat-runtime";
+import type { PendingExchange, PendingExchangeMap } from "@/features/chat/types/chat-runtime";
 import {
-  applyBranchSelectionPath,
   buildVisibleMessages,
   mapServerMessage,
   reconcileBranchSelections,
-  resolveBranchSelectionPath,
 } from "@/features/chat/model/chat-thread";
-import type { BranchSelectionPathItem } from "@/features/chat/model/chat-thread";
 import type { MessageDTO } from "@/shared/api/conversation.types";
 import type { UpstreamDebugInfo } from "@/shared/api/conversation.types";
 import { ApiError } from "@/shared/api/http-client";
 import { useLocalizedErrorMessage } from "@/i18n/use-localized-error";
 
-type PendingBranchSelectionInput = {
-  parentPublicID: string | null;
-  userPublicID?: string;
-  assistantPublicID?: string;
-  tempUserPublicID: string;
-  tempAssistantPublicID: string;
-};
-
-function buildPendingMessages({
+function appendPendingExchangeMessages({
   conversationID,
   pendingExchange,
-  serverTreeMessages,
+  messages,
   serverMessagePublicIDs,
 }: {
   conversationID: string | null;
-  pendingExchange: PendingExchange | null;
-  serverTreeMessages: ChatAreaMessage[];
+  pendingExchange: PendingExchange;
+  messages: ChatAreaMessage[];
   serverMessagePublicIDs: Set<string>;
 }) {
-  const nextMessages = [...serverTreeMessages];
+  const nextMessages = [...messages];
   const activePublicID = conversationID?.trim() || null;
-  const pendingConversationPublicID = pendingExchange?.conversationPublicID?.trim() || null;
-  if (!pendingExchange) {
-    return nextMessages;
-  }
+  const pendingConversationPublicID = pendingExchange.conversationPublicID?.trim() || null;
   if (pendingConversationPublicID && pendingConversationPublicID !== activePublicID) {
     return nextMessages;
   }
@@ -52,7 +38,7 @@ function buildPendingMessages({
   const pendingRunID = pendingExchange.runID?.trim() || "";
   if (
     pendingRunID &&
-    serverTreeMessages.some((item) => item.role === "assistant" && item.runID === pendingRunID)
+    messages.some((item) => item.role === "assistant" && item.runID === pendingRunID)
   ) {
     return mergePendingAssistantState(nextMessages, pendingExchange);
   }
@@ -103,7 +89,7 @@ function buildPendingMessages({
       key: `${pendingExchange.key}-assistant`,
       publicID: assistantPublicID,
       parentPublicID: userPublicID,
-      sourcePublicID: pendingExchange.userPublicID ? pendingExchange.sourcePublicID : null,
+      sourcePublicID: pendingExchange.reuseUserMessage ? pendingExchange.sourcePublicID : null,
       role: "assistant",
       contentType: pendingExchange.assistantContentType,
       content: pendingExchange.assistantText,
@@ -133,6 +119,29 @@ function buildPendingMessages({
   }
 
   return nextMessages;
+}
+
+function buildPendingMessages({
+  conversationID,
+  pendingExchanges,
+  serverTreeMessages,
+  serverMessagePublicIDs,
+}: {
+  conversationID: string | null;
+  pendingExchanges: PendingExchangeMap;
+  serverTreeMessages: ChatAreaMessage[];
+  serverMessagePublicIDs: Set<string>;
+}) {
+  return Object.values(pendingExchanges).reduce(
+    (messages, pendingExchange) =>
+      appendPendingExchangeMessages({
+        conversationID,
+        pendingExchange,
+        messages,
+        serverMessagePublicIDs,
+      }),
+    serverTreeMessages,
+  );
 }
 
 function mergePendingAssistantState(messages: ChatAreaMessage[], pendingExchange: PendingExchange) {
@@ -189,65 +198,25 @@ function mergePendingAssistantState(messages: ChatAreaMessage[], pendingExchange
   });
 }
 
-function resolvePendingBranchSelectionPath(
-  messages: ChatAreaMessage[],
-  pendingExchange: PendingBranchSelectionInput | null,
-): BranchSelectionPathItem[] {
-  if (!pendingExchange) {
-    return [];
-  }
-
-  const assistantPublicID = pendingExchange.assistantPublicID || pendingExchange.tempAssistantPublicID;
-  const resolvedPath = resolveBranchSelectionPath(messages, assistantPublicID);
-  if (resolvedPath.length > 0) {
-    return resolvedPath;
-  }
-
-  const userPublicID = pendingExchange.userPublicID || pendingExchange.tempUserPublicID;
-  return [
-    { parentPublicID: pendingExchange.parentPublicID, publicID: userPublicID },
-    { parentPublicID: userPublicID, publicID: assistantPublicID },
-  ];
-}
-
-function serializeBranchSelectionPath(path: BranchSelectionPathItem[]): string {
-  return path.map((item) => `${item.parentPublicID?.trim() || ""}>${item.publicID?.trim() || ""}`).join("|");
-}
-
-function branchSelectionPathResolvedByServer(
-  path: BranchSelectionPathItem[],
-  serverMessagePublicIDs: Set<string>,
-): boolean {
-  if (path.length === 0) {
-    return false;
-  }
-  return path.every((item) => {
-    const publicID = item.publicID?.trim() || "";
-    return Boolean(publicID && serverMessagePublicIDs.has(publicID));
-  });
-}
-
 export function useChatBranchState({
   conversationID,
   resetToken,
   messages,
-  pendingExchange,
+  pendingExchanges,
   liveRunIDs,
 }: {
   conversationID: string | null;
   resetToken: number;
   messages: MessageDTO[];
-  pendingExchange: PendingExchange | null;
+  pendingExchanges: PendingExchangeMap;
   liveRunIDs?: ReadonlySet<string>;
 }) {
   const t = useTranslations("chat.messages");
   const resolveErrorMessage = useLocalizedErrorMessage();
   const [branchSelections, setBranchSelections] = React.useState<Record<string, string>>({});
-  const [submittedBranchSelectionPath, setSubmittedBranchSelectionPath] = React.useState<BranchSelectionPathItem[]>([]);
 
   React.useEffect(() => {
     setBranchSelections({});
-    setSubmittedBranchSelectionPath([]);
   }, [conversationID, resetToken]);
 
   const serverTreeMessages = React.useMemo(
@@ -276,82 +245,16 @@ export function useChatBranchState({
     () =>
       buildPendingMessages({
         conversationID,
-        pendingExchange,
+        pendingExchanges,
         serverTreeMessages,
         serverMessagePublicIDs,
       }),
-    [conversationID, pendingExchange, serverMessagePublicIDs, serverTreeMessages],
+    [conversationID, pendingExchanges, serverMessagePublicIDs, serverTreeMessages],
   );
   const combinedMessagesRef = React.useRef(combinedMessages);
   React.useEffect(() => {
     combinedMessagesRef.current = combinedMessages;
   }, [combinedMessages]);
-  const pendingParentPublicID = pendingExchange?.parentPublicID ?? null;
-  const pendingUserPublicID = pendingExchange?.userPublicID;
-  const pendingAssistantPublicID = pendingExchange?.assistantPublicID;
-  const pendingTempUserPublicID = pendingExchange?.tempUserPublicID;
-  const pendingTempAssistantPublicID = pendingExchange?.tempAssistantPublicID;
-  const pendingBranchSelectionInput = React.useMemo<PendingBranchSelectionInput | null>(
-    () =>
-      pendingTempUserPublicID && pendingTempAssistantPublicID
-        ? {
-            parentPublicID: pendingParentPublicID,
-            userPublicID: pendingUserPublicID,
-            assistantPublicID: pendingAssistantPublicID,
-            tempUserPublicID: pendingTempUserPublicID,
-            tempAssistantPublicID: pendingTempAssistantPublicID,
-          }
-        : null,
-    [
-      pendingAssistantPublicID,
-      pendingParentPublicID,
-      pendingTempAssistantPublicID,
-      pendingTempUserPublicID,
-      pendingUserPublicID,
-    ],
-  );
-  const pendingBranchSelectionPath = React.useMemo(
-    () => resolvePendingBranchSelectionPath(combinedMessages, pendingBranchSelectionInput),
-    [combinedMessages, pendingBranchSelectionInput],
-  );
-  const pendingBranchSelectionKey = React.useMemo(
-    () => serializeBranchSelectionPath(pendingBranchSelectionPath),
-    [pendingBranchSelectionPath],
-  );
-  React.useEffect(() => {
-    if (pendingBranchSelectionPath.length === 0) {
-      return;
-    }
-    setSubmittedBranchSelectionPath((prev) =>
-      serializeBranchSelectionPath(prev) === pendingBranchSelectionKey ? prev : pendingBranchSelectionPath,
-    );
-  }, [pendingBranchSelectionKey, pendingBranchSelectionPath]);
-  const submittedBranchSelectionKey = React.useMemo(
-    () => serializeBranchSelectionPath(submittedBranchSelectionPath),
-    [submittedBranchSelectionPath],
-  );
-  const activeBranchSelectionPath = pendingBranchSelectionPath.length > 0
-    ? pendingBranchSelectionPath
-    : submittedBranchSelectionPath;
-  const activeBranchSelectionKey = pendingBranchSelectionPath.length > 0
-    ? pendingBranchSelectionKey
-    : submittedBranchSelectionKey;
-  const pendingBranchSelectionPathRef = React.useRef(pendingBranchSelectionPath);
-  React.useEffect(() => {
-    pendingBranchSelectionPathRef.current = activeBranchSelectionPath;
-  }, [activeBranchSelectionPath, activeBranchSelectionKey]);
-  const pendingObsoletePublicIDs = React.useMemo(
-    () => [pendingTempUserPublicID, pendingTempAssistantPublicID],
-    [pendingTempAssistantPublicID, pendingTempUserPublicID],
-  );
-  const pendingObsoletePublicIDKey = React.useMemo(
-    () => pendingObsoletePublicIDs.map((item) => item?.trim() || "").join("|"),
-    [pendingObsoletePublicIDs],
-  );
-  const pendingObsoletePublicIDsRef = React.useRef(pendingObsoletePublicIDs);
-  React.useEffect(() => {
-    pendingObsoletePublicIDsRef.current = pendingObsoletePublicIDs;
-  }, [pendingObsoletePublicIDs]);
   const messageStructureKey = React.useMemo(
     () =>
       combinedMessages
@@ -361,26 +264,8 @@ export function useChatBranchState({
   );
 
   React.useEffect(() => {
-    setBranchSelections((prev) => {
-      const reconciled = reconcileBranchSelections(combinedMessagesRef.current, prev);
-      const targetPath = pendingBranchSelectionPathRef.current;
-      if (targetPath.length === 0) {
-        return reconciled;
-      }
-      return applyBranchSelectionPath(reconciled, targetPath, pendingObsoletePublicIDsRef.current);
-    });
-  }, [activeBranchSelectionKey, messageStructureKey, pendingObsoletePublicIDKey]);
-
-  React.useEffect(() => {
-    if (pendingBranchSelectionPath.length > 0 || submittedBranchSelectionPath.length === 0) {
-      return;
-    }
-    if (!branchSelectionPathResolvedByServer(submittedBranchSelectionPath, serverMessagePublicIDs)) {
-      return;
-    }
-    setBranchSelections((prev) => applyBranchSelectionPath(prev, submittedBranchSelectionPath));
-    setSubmittedBranchSelectionPath([]);
-  }, [pendingBranchSelectionPath.length, serverMessagePublicIDs, submittedBranchSelectionKey, submittedBranchSelectionPath]);
+    setBranchSelections((prev) => reconcileBranchSelections(combinedMessagesRef.current, prev));
+  }, [messageStructureKey]);
 
   const visibleMessages = React.useMemo(
     () => buildVisibleMessages(combinedMessages, branchSelections),

--- a/frontend/features/chat/hooks/use-chat-data.ts
+++ b/frontend/features/chat/hooks/use-chat-data.ts
@@ -151,13 +151,24 @@ export function useChatData(
           return;
         }
 
-        setState({
-          loading: false,
-          loadingOlder: false,
-          errorMsg: "",
-          messages: data.results,
-          total: data.total,
-          hasOlder: data.results.length < data.total,
+        setState((prev) => {
+          const firstTailMessageID = data.results[0]?.id ?? 0;
+          // 只有已加载过额外历史页时才保留旧区间，避免普通 reload 无限累积 tail 消息。
+          const loadedOlderMessages =
+            isConversationSwitch ||
+            firstTailMessageID <= 0 ||
+            prev.messages.length <= MESSAGE_PAGE_SIZE
+              ? []
+              : prev.messages.filter((message) => message.id < firstTailMessageID);
+          const messages = [...loadedOlderMessages, ...data.results];
+          return {
+            loading: false,
+            loadingOlder: false,
+            errorMsg: "",
+            messages,
+            total: data.total,
+            hasOlder: messages.length < data.total,
+          };
         });
       } catch {
         if (!cancelled) {

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -9,6 +9,7 @@ import type {
   ChatModelOption,
   PendingAttachment,
   PendingExchange,
+  PendingExchangeMap,
 } from "@/features/chat/types/chat-runtime";
 import type { ChatSubmitBlockReason } from "@/features/chat/model/chat-task";
 import { resolveChatSubmitDecision } from "@/features/chat/model/chat-task";
@@ -23,13 +24,10 @@ import {
   resolveErrorDetails,
   resolveErrorMessage,
   resolveErrorSummary,
-  toConversationPatch,
 } from "@/features/chat/utils/chat-runtime";
 import {
-  applyBranchSelectionPath,
   buildChildrenIndex,
   parseAttachments,
-  resolveBranchSelectionPath,
   toBranchKey,
 } from "@/features/chat/model/chat-thread";
 import { sanitizeConversationOptions } from "@/features/chat/model/conversation-options";
@@ -64,6 +62,7 @@ const CONVERSATION_METADATA_REFRESH_MAX_WAIT_MS = 45_000;
 const CONVERSATION_METADATA_REFRESH_INITIAL_DELAY_MS = 800;
 const CONVERSATION_METADATA_REFRESH_MAX_DELAY_MS = 5_000;
 const CONVERSATION_METADATA_REFRESH_BACKOFF = 1.5;
+const MAX_CONCURRENT_RUNS = 3;
 
 function resolveSubmitBlockDescription(
   reason: ChatSubmitBlockReason,
@@ -140,6 +139,39 @@ type ActiveStream = {
   runID: string;
   accessToken: string | null;
 };
+
+function replaceCompletedBranchSelection(
+  previous: Record<string, string>,
+  branch: Pick<
+    PendingExchange,
+    "parentPublicID" | "tempUserPublicID" | "tempAssistantPublicID" | "reuseUserMessage"
+  >,
+  userPublicID: string,
+  assistantPublicID: string,
+): Record<string, string> {
+  const next = { ...previous };
+  let changed = false;
+  const parentKey = toBranchKey(branch.parentPublicID);
+  const tempUserPublicID = branch.tempUserPublicID;
+  const tempAssistantPublicID = branch.tempAssistantPublicID;
+
+  if (!branch.reuseUserMessage && next[parentKey] === tempUserPublicID) {
+    next[parentKey] = userPublicID;
+    changed = true;
+  }
+  if (next[tempUserPublicID] === tempAssistantPublicID) {
+    delete next[tempUserPublicID];
+    if (!branch.reuseUserMessage && next[parentKey] === userPublicID) {
+      next[userPublicID] = assistantPublicID;
+    }
+    changed = true;
+  }
+  if (branch.reuseUserMessage && next[toBranchKey(userPublicID)] === tempAssistantPublicID) {
+    next[toBranchKey(userPublicID)] = assistantPublicID;
+    changed = true;
+  }
+  return changed ? next : previous;
+}
 
 type QueuedChatSubmission = {
   id: string;
@@ -291,8 +323,8 @@ export function useChatMessageSubmit({
   setDraft,
   setAttachments,
   releaseAttachments,
-  pendingExchange,
-  setPendingExchange,
+  pendingExchanges,
+  setPendingExchanges,
   setBranchSelections,
   showConversationLayout,
   setShowConversationLayout,
@@ -334,8 +366,8 @@ export function useChatMessageSubmit({
   setDraft: React.Dispatch<React.SetStateAction<string>>;
   setAttachments: React.Dispatch<React.SetStateAction<PendingAttachment[]>>;
   releaseAttachments: (items: PendingAttachment[]) => void;
-  pendingExchange: PendingExchange | null;
-  setPendingExchange: React.Dispatch<React.SetStateAction<PendingExchange | null>>;
+  pendingExchanges: PendingExchangeMap;
+  setPendingExchanges: React.Dispatch<React.SetStateAction<PendingExchangeMap>>;
   setBranchSelections: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   showConversationLayout: boolean;
   setShowConversationLayout: React.Dispatch<React.SetStateAction<boolean>>;
@@ -344,27 +376,47 @@ export function useChatMessageSubmit({
   visibleMessages: ChatAreaMessage[];
   combinedMessages: ChatAreaMessage[];
   serverMessagePublicIDs: Set<string>;
-  enqueueUpstreamThinkDelta: (event: Extract<StreamMessageEvent, { type: "upstream_think_delta" }>) => void;
-  enqueueStreamText: (delta: string) => void;
-  flushStreamTextNow: () => void;
-  flushUpstreamThinkNow: () => void;
-  resetStreamBuffer: () => void;
+  enqueueUpstreamThinkDelta: (exchangeKey: string, event: Extract<StreamMessageEvent, { type: "upstream_think_delta" }>) => void;
+  enqueueStreamText: (exchangeKey: string, delta: string) => void;
+  flushStreamTextNow: (exchangeKey: string) => void;
+  flushUpstreamThinkNow: (exchangeKey: string) => void;
+  resetStreamBuffer: (exchangeKey?: string) => void;
   startStream: (exchangeKey: string, runID?: string) => void;
   activeGenerationRunsRef?: React.RefObject<Set<string>>;
   failedGenerationRunsRef?: React.RefObject<Set<string>>;
   resumeGenerationActive?: boolean;
 }) {
   const t = useTranslations("chat.submit");
-  const [sending, setSending] = React.useState(false);
-  const activeStreamRef = React.useRef<ActiveStream | null>(null);
+  const [activeRunCount, setActiveRunCount] = React.useState(0);
+  const activeStreamsRef = React.useRef(new Map<string, ActiveStream>());
   const activeGenerationRunsRefRef = React.useRef(activeGenerationRunsRef);
   const previousResetTokenRef = React.useRef(resetToken);
   const conversationIDRef = React.useRef(conversationID);
   const activeConversationRef = React.useRef(activeConversation);
-  const lastCompletedAssistantPublicIDRef = React.useRef<string | null>(null);
+  const nextModelRunSequenceRef = React.useRef(0);
+  const latestCompletedModelRunSequenceRef = React.useRef(0);
   const sendQueuedAfterCurrentRef = React.useRef(false);
   const [queuedSubmissions, setQueuedSubmissions] = React.useState<QueuedChatSubmission[]>([]);
   const queuedSubmissionsRef = React.useRef<QueuedChatSubmission[]>([]);
+  const sending = activeRunCount > 0;
+
+  const syncActiveRunCount = React.useCallback(() => {
+    setActiveRunCount(activeStreamsRef.current.size);
+  }, []);
+
+  const updatePendingExchange = React.useCallback(
+    (exchangeKey: string, update: (current: PendingExchange) => PendingExchange) => {
+      setPendingExchanges((current) => {
+        const exchange = current[exchangeKey];
+        if (!exchange) {
+          return current;
+        }
+        const nextExchange = update(exchange);
+        return nextExchange === exchange ? current : { ...current, [exchangeKey]: nextExchange };
+      });
+    },
+    [setPendingExchanges],
+  );
 
   React.useEffect(() => {
     conversationIDRef.current = conversationID;
@@ -388,73 +440,88 @@ export function useChatMessageSubmit({
     }
     previousResetTokenRef.current = resetToken;
 
-    const active = activeStreamRef.current;
-    if (active) {
-      // A new chat navigation should detach this view from the active stream without
-      // canceling the server-side run. Reopening the conversation can resume it.
+    for (const active of activeStreamsRef.current.values()) {
+      // 会话切换只解除当前页面订阅，不取消服务端仍在执行的 run。
       active.controller.abort();
       activeGenerationRunsRefRef.current?.current.delete(active.runID);
-      activeStreamRef.current = null;
     }
+    activeStreamsRef.current.clear();
 
     resetStreamBuffer();
-    setPendingExchange(null);
-    setSending(false);
-    lastCompletedAssistantPublicIDRef.current = null;
+    setPendingExchanges({});
+    setActiveRunCount(0);
+    nextModelRunSequenceRef.current = 0;
+    latestCompletedModelRunSequenceRef.current = 0;
     sendQueuedAfterCurrentRef.current = false;
     releaseAttachments(queuedSubmissionsRef.current.flatMap((item) => item.attachments));
     setQueuedSubmissions([]);
-  }, [releaseAttachments, resetStreamBuffer, resetToken, setPendingExchange]);
+  }, [releaseAttachments, resetStreamBuffer, resetToken, setPendingExchanges]);
 
   React.useEffect(() => {
-    if (!pendingExchange) {
-      return;
-    }
-    const userPublicID = pendingExchange.userPublicID || pendingExchange.tempUserPublicID;
-    const assistantPublicID = pendingExchange.assistantPublicID || pendingExchange.tempAssistantPublicID;
-    if (serverMessagePublicIDs.has(userPublicID) && serverMessagePublicIDs.has(assistantPublicID)) {
-      const serverPath = resolveBranchSelectionPath(combinedMessages, assistantPublicID);
-      if (serverPath.length > 0) {
-        setBranchSelections((prev) =>
-          applyBranchSelectionPath(
-            prev,
-            serverPath,
-            [pendingExchange.tempUserPublicID, pendingExchange.tempAssistantPublicID],
-          ),
-        );
+    const completedKeys: string[] = [];
+    const completedBranches: Array<{
+      exchange: PendingExchange;
+      userPublicID: string;
+      assistantPublicID: string;
+    }> = [];
+    for (const [exchangeKey, exchange] of Object.entries(pendingExchanges)) {
+      const userPublicID = exchange.userPublicID || exchange.tempUserPublicID;
+      const assistantPublicID = exchange.assistantPublicID || exchange.tempAssistantPublicID;
+      if (serverMessagePublicIDs.has(userPublicID) && serverMessagePublicIDs.has(assistantPublicID)) {
+        completedKeys.push(exchangeKey);
+        continue;
       }
-      setPendingExchange(null);
-      return;
-    }
-
-    const pendingRunID = pendingExchange.runID?.trim();
-    if (!pendingRunID || pendingExchange.assistantPending) {
-      return;
-    }
-    const serverAssistant = combinedMessages.find(
-      (item) =>
-        item.role === "assistant" &&
-        item.runID === pendingRunID &&
-        serverMessagePublicIDs.has(item.publicID) &&
-        resolvePersistedPublicID(item.publicID) &&
-        !item.isPending &&
-        !item.isStreaming &&
-        item.status !== "pending",
-    );
-    if (serverAssistant) {
-      const serverPath = resolveBranchSelectionPath(combinedMessages, serverAssistant.publicID);
-      if (serverPath.length > 0) {
-        setBranchSelections((prev) =>
-          applyBranchSelectionPath(
-            prev,
-            serverPath,
-            [pendingExchange.tempUserPublicID, pendingExchange.tempAssistantPublicID],
-          ),
-        );
+      if (exchange.assistantPending || !exchange.runID?.trim()) {
+        continue;
       }
-      setPendingExchange(null);
+      const serverAssistant = combinedMessages.find(
+        (item) =>
+          item.role === "assistant" &&
+          item.runID === exchange.runID &&
+          serverMessagePublicIDs.has(item.publicID) &&
+          !item.isPending &&
+          !item.isStreaming &&
+          item.status !== "pending",
+      );
+      if (!serverAssistant?.parentPublicID) {
+        continue;
+      }
+      completedKeys.push(exchangeKey);
+      completedBranches.push({
+        exchange,
+        userPublicID: serverAssistant.parentPublicID,
+        assistantPublicID: serverAssistant.publicID,
+      });
     }
-  }, [combinedMessages, pendingExchange, serverMessagePublicIDs, setBranchSelections, setPendingExchange]);
+    if (completedBranches.length > 0) {
+      setBranchSelections((current) =>
+        completedBranches.reduce(
+          (next, completed) =>
+            replaceCompletedBranchSelection(
+              next,
+              {
+                parentPublicID: completed.exchange.parentPublicID,
+                tempUserPublicID: completed.exchange.tempUserPublicID,
+                tempAssistantPublicID: completed.exchange.tempAssistantPublicID,
+                reuseUserMessage: completed.exchange.reuseUserMessage,
+              },
+              completed.userPublicID,
+              completed.assistantPublicID,
+            ),
+          current,
+        ),
+      );
+    }
+    if (completedKeys.length > 0) {
+      setPendingExchanges((current) => {
+        const next = { ...current };
+        for (const key of completedKeys) {
+          delete next[key];
+        }
+        return next;
+      });
+    }
+  }, [combinedMessages, pendingExchanges, serverMessagePublicIDs, setBranchSelections, setPendingExchanges]);
 
   const submitMessage = React.useCallback(
     async ({
@@ -482,8 +549,31 @@ export function useChatMessageSubmit({
       const requestHTMLVisualPromptEnabled = queuedSubmission?.htmlVisualPromptEnabled ?? htmlVisualPromptEnabled;
       const requestHTMLVisualColorMode = queuedSubmission?.htmlVisualColorMode ?? htmlVisualColorMode;
       const selectedModel = modelOptions.find((item) => item.platformModelName === requestPlatformModelName) ?? null;
-      if ((!content && currentAttachments.length === 0) || uploading || activeStreamRef.current) {
+      const resolvedBranchReason = branchReason ?? "default";
+      const concurrentBranchRun = resolvedBranchReason === "retry" || resolvedBranchReason === "edit";
+      if (
+        (!content && currentAttachments.length === 0) ||
+        uploading ||
+        (!concurrentBranchRun && activeStreamsRef.current.size > 0)
+      ) {
         return false;
+      }
+      if (concurrentBranchRun) {
+        const activeRunIDs = new Set(activeStreamsRef.current.keys());
+        for (const message of combinedMessages) {
+          const runID = message.runID?.trim() || "";
+          if (
+            message.role === "assistant" &&
+            runID &&
+            (message.isPending || message.isStreaming || message.status?.trim().toLowerCase() === "pending")
+          ) {
+            activeRunIDs.add(runID);
+          }
+        }
+        if (activeRunIDs.size >= MAX_CONCURRENT_RUNS) {
+          toast.error(t("concurrentGenerationLimit", { count: MAX_CONCURRENT_RUNS }));
+          return false;
+        }
       }
       const effectiveAttachments =
         maxFilesPerMessage > 0 && currentAttachments.length > maxFilesPerMessage
@@ -509,14 +599,22 @@ export function useChatMessageSubmit({
       }
 
       const wasConversationMode = showConversationLayout || visibleMessageCount > 0;
-      const exchangeKey = `local-exchange-${Date.now()}`;
+      const clientRunID = createClientRunID();
+      const exchangeKey = `local-exchange-${clientRunID}`;
       const resolvedParentPublicID = resolvePersistedPublicID(parentMessagePublicID);
       const resolvedSourcePublicID = resolvePersistedPublicID(sourceMessagePublicID);
-      const resolvedBranchReason = branchReason ?? "default";
       const assistantOnlyBranch =
         resolvedBranchReason === "retry" &&
         Boolean(resolvedParentPublicID && resolvedSourcePublicID) &&
         combinedMessages.some((item) => item.publicID === resolvedSourcePublicID && item.role === "assistant");
+      const reusedUserMessage = assistantOnlyBranch
+        ? combinedMessages.find(
+            (item) => item.publicID === resolvedParentPublicID && item.role === "user",
+          ) ?? null
+        : null;
+      const pendingParentPublicID = assistantOnlyBranch
+        ? reusedUserMessage?.parentPublicID ?? null
+        : resolvedParentPublicID;
       const tempUserPublicID = `${exchangeKey}-user`;
       const tempAssistantPublicID = `${exchangeKey}-assistant`;
       const pendingUserPublicID = assistantOnlyBranch && resolvedParentPublicID ? resolvedParentPublicID : tempUserPublicID;
@@ -524,7 +622,6 @@ export function useChatMessageSubmit({
       let sentSuccessfully = false;
       let shouldKeepConversationLayout = false;
       const streamAbortController = new AbortController();
-      const clientRunID = createClientRunID();
       const assistantImageAspectRatio =
         submitTask === "image_generation" || submitTask === "image_edit"
           ? resolveImageLoadingAspectRatio(sanitizedOptions)
@@ -534,43 +631,48 @@ export function useChatMessageSubmit({
       let targetConversationID = conversationIDRef.current;
       let targetConversation = activeConversationRef.current;
       let metadataRefreshInFlight = false;
+      let modelRunSequence = 0;
 
       activeGenerationRunsRef?.current.add(clientRunID);
       setShowConversationLayout(true);
-      setSending(true);
-      activeStreamRef.current = {
+      activeStreamsRef.current.set(clientRunID, {
         controller: streamAbortController,
         runID: clientRunID,
         accessToken: null,
-      };
+      });
+      syncActiveRunCount();
       if (resetComposer) {
         setDraft("");
         setAttachments([]);
       }
       startStream(exchangeKey, clientRunID);
-      setPendingExchange({
-        key: exchangeKey,
-        conversationPublicID: targetConversationID?.trim() || null,
-        userPublicID: assistantOnlyBranch ? pendingUserPublicID : undefined,
-        tempUserPublicID,
-        tempAssistantPublicID,
-        runID: clientRunID,
-        platformModelName: requestPlatformModelName,
-        parentPublicID: resolvedParentPublicID,
-        sourcePublicID: resolvedSourcePublicID,
-        branchReason: resolvedBranchReason,
-        userContent: payloadContent,
-        userAttachments: effectiveAttachments.length > 0 ? effectiveAttachments : undefined,
-        userCreatedAt: createdAt,
-        assistantText: "",
-        assistantPending: true,
-        assistantStreaming: true,
-        assistantContentType,
-        assistantImageAspectRatio,
-        assistantInlineAlert: undefined,
-        assistantCreatedAt: createdAt,
-        assistantProcessTrace: undefined,
-      });
+      setPendingExchanges((current) => ({
+        ...current,
+        [exchangeKey]: {
+          key: exchangeKey,
+          conversationPublicID: targetConversationID?.trim() || null,
+          userPublicID: assistantOnlyBranch ? pendingUserPublicID : undefined,
+          tempUserPublicID,
+          tempAssistantPublicID,
+          runID: clientRunID,
+          platformModelName: requestPlatformModelName,
+          parentPublicID: pendingParentPublicID,
+          sourcePublicID: resolvedSourcePublicID,
+          branchReason: resolvedBranchReason,
+          reuseUserMessage: assistantOnlyBranch,
+          userContent: payloadContent,
+          userAttachments: effectiveAttachments.length > 0 ? effectiveAttachments : undefined,
+          userCreatedAt: createdAt,
+          assistantText: "",
+          assistantPending: true,
+          assistantStreaming: true,
+          assistantContentType,
+          assistantImageAspectRatio,
+          assistantInlineAlert: undefined,
+          assistantCreatedAt: createdAt,
+          assistantProcessTrace: undefined,
+        },
+      }));
       setBranchSelections((prev) => ({
         ...prev,
         ...(assistantOnlyBranch ? {} : { [toBranchKey(resolvedParentPublicID)]: pendingUserPublicID }),
@@ -585,12 +687,13 @@ export function useChatMessageSubmit({
         if (!token) {
           throw new Error(t("signInRequired"));
         }
-        if (activeStreamRef.current?.controller === streamAbortController) {
-          activeStreamRef.current = {
+        const activeStream = activeStreamsRef.current.get(clientRunID);
+        if (activeStream?.controller === streamAbortController) {
+          activeStreamsRef.current.set(clientRunID, {
             controller: streamAbortController,
             runID: clientRunID,
             accessToken: token,
-          };
+          });
         }
         let metadataFallbackTitle = "";
         const startMetadataRefresh = (result?: SendMessageResult | null) => {
@@ -629,14 +732,10 @@ export function useChatMessageSubmit({
           targetConversation = created;
           conversationIDRef.current = created.publicID;
           activeConversationRef.current = created;
-          setPendingExchange((prev) =>
-            prev && prev.key === exchangeKey
-              ? {
-                  ...prev,
-                  conversationPublicID: created.publicID,
-                }
-              : prev,
-          );
+          updatePendingExchange(exchangeKey, (current) => ({
+            ...current,
+            conversationPublicID: created.publicID,
+          }));
           // Update the URL without triggering Next.js RSC navigation, which can interrupt an active stream.
           window.history.replaceState(null, "", `/chat?conversation_id=${created.publicID}`);
           onConversationCreated?.(created.publicID);
@@ -674,94 +773,83 @@ export function useChatMessageSubmit({
             terminalStreamError = event;
           },
           onFileProc: (message) => {
-            setPendingExchange((prev) =>
-              prev && prev.key === exchangeKey
-                ? { ...prev, assistantFileProc: true, assistantActivityLabel: message.trim() || t("processingAttachments") }
-                : prev,
-            );
+            updatePendingExchange(exchangeKey, (current) => ({
+              ...current,
+              assistantFileProc: true,
+              assistantActivityLabel: message.trim() || t("processingAttachments"),
+            }));
           },
           onRagSearch: (message) => {
-            setPendingExchange((prev) =>
-              prev && prev.key === exchangeKey
-                ? { ...prev, assistantFileProc: true, assistantActivityLabel: message.trim() || t("retrievingContent") }
-                : prev,
-            );
+            updatePendingExchange(exchangeKey, (current) => ({
+              ...current,
+              assistantFileProc: true,
+              assistantActivityLabel: message.trim() || t("retrievingContent"),
+            }));
           },
           onMediaStatus: (event) => {
             const activityLabel = resolveMediaStatusLabel(event.status, event.message, event.content_type, t);
-            setPendingExchange((prev) =>
-              prev && prev.key === exchangeKey
-                ? { ...prev, assistantFileProc: true, assistantActivityLabel: activityLabel }
-                : prev,
-            );
+            updatePendingExchange(exchangeKey, (current) => ({
+              ...current,
+              assistantFileProc: true,
+              assistantActivityLabel: activityLabel,
+            }));
           },
           onMediaImageDelta: (event) => {
             const previewMarkdown = buildMediaImagePreviewMarkdown(event, t("imagePreviewAlt"));
             if (!previewMarkdown) {
               return;
             }
-            setPendingExchange((prev) =>
-              prev && prev.key === exchangeKey
-                ? {
-                    ...prev,
-                    assistantPending: false,
-                    assistantStreaming: true,
-                    assistantFileProc: false,
-                    assistantActivityLabel: undefined,
-                    assistantText: previewMarkdown,
-                  }
-                : prev,
-            );
+            updatePendingExchange(exchangeKey, (current) => ({
+              ...current,
+              assistantPending: false,
+              assistantStreaming: true,
+              assistantFileProc: false,
+              assistantActivityLabel: undefined,
+              assistantText: previewMarkdown,
+            }));
           },
           onCompactDone: (event) => {
-            setPendingExchange((prev) =>
-              prev && prev.key === exchangeKey
-                ? { ...prev, compactDone: { method: event.method, freed_tokens: event.freed_tokens, summary_preview: event.summary_preview } }
-                : prev,
-            );
+            updatePendingExchange(exchangeKey, (current) => ({
+              ...current,
+              compactDone: { method: event.method, freed_tokens: event.freed_tokens, summary_preview: event.summary_preview },
+            }));
           },
           onProcessUpdate: (event) => {
-            setPendingExchange((prev) =>
-              prev && prev.key === exchangeKey
-                ? {
-                    ...prev,
-                    assistantFileProc: false,
-                    assistantActivityLabel: undefined,
-                    assistantProcessTrace: event.trace ? toPendingProcessTrace(event.trace) : prev.assistantProcessTrace,
-                  }
-                : prev,
-            );
+            updatePendingExchange(exchangeKey, (current) => ({
+              ...current,
+              assistantFileProc: false,
+              assistantActivityLabel: undefined,
+              assistantProcessTrace: event.trace ? toPendingProcessTrace(event.trace) : current.assistantProcessTrace,
+            }));
           },
           onUpstreamThinkDelta: (event) => {
-            enqueueUpstreamThinkDelta(event);
+            enqueueUpstreamThinkDelta(exchangeKey, event);
           },
           onDelta: (delta) => {
             // Always clear assistantFileProc so batched React updates cannot keep the file_proc spinner alive.
-            setPendingExchange((prev) =>
-              prev && prev.key === exchangeKey && prev.assistantFileProc
-                ? { ...prev, assistantFileProc: false, assistantActivityLabel: undefined }
-                : prev,
+            updatePendingExchange(exchangeKey, (current) =>
+              current.assistantFileProc
+                ? { ...current, assistantFileProc: false, assistantActivityLabel: undefined }
+                : current,
             );
-            enqueueStreamText(delta);
+            enqueueStreamText(exchangeKey, delta);
           },
           onUsage: (event) => {
-            setPendingExchange((prev) =>
-              prev && prev.key === exchangeKey
-                ? {
-                    ...prev,
-                    assistantInputTokens: event.input_tokens > 0 ? event.input_tokens : prev.assistantInputTokens,
-                    assistantOutputTokens: event.output_tokens > 0 ? event.output_tokens : prev.assistantOutputTokens,
-                    assistantCacheReadTokens:
-                      event.cache_read_tokens > 0 ? event.cache_read_tokens : prev.assistantCacheReadTokens,
-                    assistantCacheWriteTokens:
-                      event.cache_write_tokens > 0 ? event.cache_write_tokens : prev.assistantCacheWriteTokens,
-                    assistantReasoningTokens:
-                      event.reasoning_tokens > 0 ? event.reasoning_tokens : prev.assistantReasoningTokens,
-                  }
-                : prev,
-            );
+            updatePendingExchange(exchangeKey, (current) => ({
+              ...current,
+              assistantInputTokens: event.input_tokens > 0 ? event.input_tokens : current.assistantInputTokens,
+              assistantOutputTokens: event.output_tokens > 0 ? event.output_tokens : current.assistantOutputTokens,
+              assistantCacheReadTokens:
+                event.cache_read_tokens > 0 ? event.cache_read_tokens : current.assistantCacheReadTokens,
+              assistantCacheWriteTokens:
+                event.cache_write_tokens > 0 ? event.cache_write_tokens : current.assistantCacheWriteTokens,
+              assistantReasoningTokens:
+                event.reasoning_tokens > 0 ? event.reasoning_tokens : current.assistantReasoningTokens,
+            }));
           },
         };
+        modelRunSequence = nextModelRunSequenceRef.current + 1;
+        nextModelRunSequenceRef.current = modelRunSequence;
         let completed: SendMessageResult;
         if (submitTask === "chat") {
           const chatPayload: SendMessageRequest = {
@@ -793,17 +881,13 @@ export function useChatMessageSubmit({
 
         failedGenerationRunsRef?.current.delete(clientRunID);
         sentSuccessfully = true;
-        lastCompletedAssistantPublicIDRef.current = completed.assistantMessage.publicID;
-        flushStreamTextNow();
-        flushUpstreamThinkNow();
-        resetStreamBuffer();
+        flushStreamTextNow(exchangeKey);
+        flushUpstreamThinkNow(exchangeKey);
+        resetStreamBuffer(exchangeKey);
         const assistantMessageStatus = completed.assistantMessage.status || "success";
         const assistantMessageSucceeded = assistantMessageStatus === "success";
-        setPendingExchange((prev) => {
-          if (!prev || prev.key !== exchangeKey) {
-            return prev;
-          }
-          const streamedText = prev.assistantText;
+        updatePendingExchange(exchangeKey, (current) => {
+          const streamedText = current.assistantText;
           const terminalErrorMessage = terminalStreamError
             ? resolveErrorMessage(streamEventErrorToApiError(terminalStreamError, t("retryLater")), terminalStreamError.message || t("retryLater"))
             : "";
@@ -819,10 +903,10 @@ export function useChatMessageSubmit({
               )
             : completed.assistantMessage.errorMessage;
           return {
-            ...prev,
+            ...current,
             userPublicID: completed.userMessage.publicID,
             assistantPublicID: completed.assistantMessage.publicID,
-            platformModelName: completed.assistantMessage.platformModelName?.trim() || prev.platformModelName,
+            platformModelName: completed.assistantMessage.platformModelName?.trim() || current.platformModelName,
             userContent: completed.userMessage.content,
             userServerMessageID: completed.userMessage.id,
             userCreatedAt: completed.userMessage.createdAt,
@@ -833,23 +917,23 @@ export function useChatMessageSubmit({
             assistantServerMessageID: completed.assistantMessage.id,
             assistantCreatedAt: completed.assistantMessage.createdAt,
             assistantUpdatedAt: completed.assistantMessage.updatedAt,
-            assistantContentType: completed.assistantMessage.contentType || prev.assistantContentType,
+            assistantContentType: completed.assistantMessage.contentType || current.assistantContentType,
             assistantAttachments: parseAttachments(completed.assistantMessage.attachments),
             assistantInputTokens: resolveInputSideUsageValue(
               completed.assistantMessage.inputTokens,
               completed.userMessage.inputTokens,
-              prev.assistantInputTokens,
+              current.assistantInputTokens,
             ),
             assistantOutputTokens: completed.assistantMessage.outputTokens,
             assistantCacheReadTokens: resolveInputSideUsageValue(
               completed.assistantMessage.cacheReadTokens,
               completed.userMessage.cacheReadTokens,
-              prev.assistantCacheReadTokens,
+              current.assistantCacheReadTokens,
             ),
             assistantCacheWriteTokens: resolveInputSideUsageValue(
               completed.assistantMessage.cacheWriteTokens,
               completed.userMessage.cacheWriteTokens,
-              prev.assistantCacheWriteTokens,
+              current.assistantCacheWriteTokens,
             ),
             assistantReasoningTokens: completed.assistantMessage.reasoningTokens,
             assistantLatencyMS: completed.assistantMessage.latencyMS,
@@ -867,34 +951,41 @@ export function useChatMessageSubmit({
                 : undefined,
             assistantText:
               streamedText === completed.assistantMessage.content
-                ? prev.assistantText
+                ? current.assistantText
                 : completed.assistantMessage.content,
           };
         });
-        setBranchSelections((prev) =>
-          applyBranchSelectionPath(
-            prev,
-            [
-              ...(assistantOnlyBranch
-                ? []
-                : [
-                    {
-                      parentPublicID: completed.userMessage.parentPublicID || resolvedParentPublicID,
-                      publicID: completed.userMessage.publicID,
-                    },
-                  ]),
-              {
-                parentPublicID: completed.userMessage.publicID,
-                publicID: completed.assistantMessage.publicID,
-              },
-            ],
-            [tempUserPublicID, tempAssistantPublicID],
+        setBranchSelections((current) =>
+          replaceCompletedBranchSelection(
+            current,
+            {
+              parentPublicID: resolvedParentPublicID,
+              tempUserPublicID,
+              tempAssistantPublicID,
+              reuseUserMessage: assistantOnlyBranch,
+            },
+            completed.userMessage.publicID,
+            completed.assistantMessage.publicID,
           ),
         );
-        touchByPublicID(
-          targetConversationID,
-          toConversationPatch(targetConversation, requestPlatformModelName),
-        );
+        const currentConversation =
+          activeConversationRef.current?.publicID === targetConversationID
+            ? activeConversationRef.current
+            : targetConversation;
+        const shouldUpdateConversationModel =
+          modelRunSequence > latestCompletedModelRunSequenceRef.current;
+        if (shouldUpdateConversationModel) {
+          latestCompletedModelRunSequenceRef.current = modelRunSequence;
+        }
+        const conversationPatch: Partial<ConversationDTO> = {
+          ...(shouldUpdateConversationModel ? { model: requestPlatformModelName } : {}),
+          updatedAt: new Date().toISOString(),
+          messageCount: (currentConversation?.messageCount ?? 0) + (assistantOnlyBranch ? 1 : 2),
+        };
+        if (currentConversation) {
+          activeConversationRef.current = { ...currentConversation, ...conversationPatch };
+        }
+        touchByPublicID(targetConversationID, conversationPatch);
         if (assistantMessageSucceeded) {
           startMetadataRefresh(completed);
         }
@@ -908,25 +999,21 @@ export function useChatMessageSubmit({
         }
         reload();
       } catch (error) {
-        flushStreamTextNow();
-        flushUpstreamThinkNow();
-        resetStreamBuffer();
+        flushStreamTextNow(exchangeKey);
+        flushUpstreamThinkNow(exchangeKey);
+        resetStreamBuffer(exchangeKey);
         if (streamAbortController.signal.aborted) {
           shouldKeepConversationLayout = true;
           releaseAttachments(effectiveAttachments);
-          setPendingExchange((prev) =>
-            prev && prev.key === exchangeKey
-              ? {
-                  ...prev,
-                  assistantPending: false,
-                  assistantStreaming: false,
-                  assistantFileProc: false,
-                  assistantActivityLabel: undefined,
-                  assistantProcessTrace: readLiveUpstreamThinkTrace(clientRunID) ?? prev.assistantProcessTrace,
-                  assistantInlineAlert: undefined,
-                }
-              : prev,
-          );
+          updatePendingExchange(exchangeKey, (current) => ({
+            ...current,
+            assistantPending: false,
+            assistantStreaming: false,
+            assistantFileProc: false,
+            assistantActivityLabel: undefined,
+            assistantProcessTrace: readLiveUpstreamThinkTrace(clientRunID) ?? current.assistantProcessTrace,
+            assistantInlineAlert: undefined,
+          }));
           return false;
         }
         const errorMessage = resolveErrorMessage(error, t("retryLater"));
@@ -938,39 +1025,35 @@ export function useChatMessageSubmit({
           setDraft(content);
           setAttachments(currentAttachments);
         }
-        setPendingExchange((prev) =>
-          prev && prev.key === exchangeKey
-            ? {
-                ...prev,
-                assistantPending: false,
-                assistantStreaming: false,
-                assistantFileProc: false,
-                assistantActivityLabel: undefined,
-                assistantProcessTrace: readLiveUpstreamThinkTrace(clientRunID) ?? prev.assistantProcessTrace,
-                assistantStatus: "error",
-                assistantErrorMessage: errorMessage,
-                assistantInlineAlert: {
-                  title: t("generationInterrupted"),
-                  message: errorMessage,
-                  details: errorDetails,
-                },
-              }
-            : prev,
-        );
+        updatePendingExchange(exchangeKey, (current) => ({
+          ...current,
+          assistantPending: false,
+          assistantStreaming: false,
+          assistantFileProc: false,
+          assistantActivityLabel: undefined,
+          assistantProcessTrace: readLiveUpstreamThinkTrace(clientRunID) ?? current.assistantProcessTrace,
+          assistantStatus: "error",
+          assistantErrorMessage: errorMessage,
+          assistantInlineAlert: {
+            title: t("generationInterrupted"),
+            message: errorMessage,
+            details: errorDetails,
+          },
+        }));
         toast.error(t("sendFailed"), { description: errorSummary });
         if (targetConversationID) {
           reload();
         }
         return false;
       } finally {
-        if (activeStreamRef.current?.controller === streamAbortController) {
-          activeStreamRef.current = null;
+        if (activeStreamsRef.current.get(clientRunID)?.controller === streamAbortController) {
+          activeStreamsRef.current.delete(clientRunID);
         }
         activeGenerationRunsRef?.current.delete(clientRunID);
         if (!sentSuccessfully && !wasConversationMode && !shouldKeepConversationLayout) {
           setShowConversationLayout(false);
         }
-        setSending(false);
+        syncActiveRunCount();
       }
       return true;
     },
@@ -997,7 +1080,7 @@ export function useChatMessageSubmit({
       setAttachments,
       setBranchSelections,
       setDraft,
-      setPendingExchange,
+      setPendingExchanges,
       setShowConversationLayout,
       showConversationLayout,
       startStream,
@@ -1005,6 +1088,8 @@ export function useChatMessageSubmit({
       uploading,
       maxFilesPerMessage,
       t,
+      syncActiveRunCount,
+      updatePendingExchange,
       visibleMessageCount,
       combinedMessages,
     ],
@@ -1048,15 +1133,40 @@ export function useChatMessageSubmit({
   ]);
 
   const onStopMessage = React.useCallback(() => {
-    const active = activeStreamRef.current;
+    const visibleRunID = currentLeafMessage?.runID?.trim() || "";
+    const visibleRunPending = Boolean(
+      visibleRunID &&
+        (currentLeafMessage?.isPending ||
+          currentLeafMessage?.isStreaming ||
+          currentLeafMessage?.status?.trim().toLowerCase() === "pending"),
+    );
+    const visibleActive = visibleRunID ? activeStreamsRef.current.get(visibleRunID) : undefined;
+    if (!visibleActive && visibleRunPending) {
+      void resolveAccessToken().then(async (token) => {
+        if (!token) {
+          return;
+        }
+        await cancelMessageGeneration(token, visibleRunID).catch(() => undefined);
+        reload();
+      });
+      return true;
+    }
+    const active = visibleActive ?? Array.from(activeStreamsRef.current.values()).at(-1);
     if (!active) {
-      return;
+      return false;
     }
     if (active.accessToken) {
       void cancelMessageGeneration(active.accessToken, active.runID).catch(() => undefined);
     }
     active.controller.abort();
-  }, []);
+    return true;
+  }, [
+    currentLeafMessage?.isPending,
+    currentLeafMessage?.isStreaming,
+    currentLeafMessage?.runID,
+    currentLeafMessage?.status,
+    reload,
+  ]);
 
   const onDeleteQueuedMessage = React.useCallback((id: string) => {
     const target = queuedSubmissionsRef.current.find((item) => item.id === id);
@@ -1084,7 +1194,7 @@ export function useChatMessageSubmit({
   }, []);
 
   const onSendMessage = React.useCallback(async () => {
-    if (activeStreamRef.current || sending || resumeGenerationActive) {
+    if (activeStreamsRef.current.size > 0 || sending || resumeGenerationActive) {
       enqueueSubmission();
       return;
     }
@@ -1103,11 +1213,22 @@ export function useChatMessageSubmit({
   }, [attachments, currentLeafMessage?.publicID, draft, enqueueSubmission, resumeGenerationActive, sending, submitMessage, visibleMessages]);
 
   React.useEffect(() => {
+    const hasUnresolvedDefaultExchange = Object.values(pendingExchanges).some(
+      (exchange) => exchange.branchReason === "default" && !exchange.assistantPublicID,
+    );
+    const hasPendingServerGeneration = combinedMessages.some(
+      (message) =>
+        message.role === "assistant" &&
+        (message.isPending ||
+          message.isStreaming ||
+          message.status?.trim().toLowerCase() === "pending"),
+    );
     if (
       sending ||
       resumeGenerationActive ||
-      activeStreamRef.current ||
-      (pendingExchange && !sendQueuedAfterCurrentRef.current) ||
+      activeStreamsRef.current.size > 0 ||
+      hasPendingServerGeneration ||
+      (hasUnresolvedDefaultExchange && !sendQueuedAfterCurrentRef.current) ||
       queuedSubmissions.length === 0 ||
       uploading
     ) {
@@ -1120,7 +1241,6 @@ export function useChatMessageSubmit({
     sendQueuedAfterCurrentRef.current = false;
     setQueuedSubmissions((current) => current.filter((item) => item.id !== queuedSubmission.id));
     const parentMessagePublicID =
-      lastCompletedAssistantPublicIDRef.current ??
       resolvePersistedPublicID(currentLeafMessage?.publicID) ??
       resolveDefaultSubmissionParentMessage(visibleMessages)?.publicID ??
       null;
@@ -1132,7 +1252,17 @@ export function useChatMessageSubmit({
       branchReason: "default",
       queuedSubmission,
     });
-  }, [currentLeafMessage?.publicID, pendingExchange, queuedSubmissions, resumeGenerationActive, sending, submitMessage, uploading, visibleMessages]);
+  }, [
+    combinedMessages,
+    currentLeafMessage?.publicID,
+    pendingExchanges,
+    queuedSubmissions,
+    resumeGenerationActive,
+    sending,
+    submitMessage,
+    uploading,
+    visibleMessages,
+  ]);
 
   const onRetryUserMessage = React.useCallback(
     async (message: ChatAreaMessage) => {

--- a/frontend/features/chat/hooks/use-chat-runtime.ts
+++ b/frontend/features/chat/hooks/use-chat-runtime.ts
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 
-import type { PendingAttachment, PendingExchange } from "@/features/chat/types/chat-runtime";
+import type { PendingAttachment, PendingExchangeMap } from "@/features/chat/types/chat-runtime";
 import type { ChatModelOption } from "@/features/chat/types/chat-runtime";
 import { useChatBranchState } from "@/features/chat/hooks/use-chat-branch-state";
 import { useChatSubmitStream } from "@/features/chat/hooks/use-chat-submit-stream";
@@ -71,7 +71,7 @@ export function useChatRuntime({
   resumingRunID?: string;
 }) {
   const [showConversationLayout, setShowConversationLayout] = React.useState(false);
-  const [pendingExchange, setPendingExchange] = React.useState<PendingExchange | null>(null);
+  const [pendingExchanges, setPendingExchanges] = React.useState<PendingExchangeMap>({});
   const previousResetTokenRef = React.useRef(resetToken);
   const liveServerRunIDs = React.useMemo(() => {
     const normalized = resumingRunID.trim();
@@ -82,7 +82,7 @@ export function useChatRuntime({
     conversationID,
     resetToken,
     messages,
-    pendingExchange,
+    pendingExchanges,
     liveRunIDs: liveServerRunIDs,
   });
 
@@ -109,8 +109,8 @@ export function useChatRuntime({
     setDraft,
     setAttachments,
     releaseAttachments,
-    pendingExchange,
-    setPendingExchange,
+    pendingExchanges,
+    setPendingExchanges,
     setBranchSelections: branchState.setBranchSelections,
     showConversationLayout,
     setShowConversationLayout,
@@ -140,7 +140,6 @@ export function useChatRuntime({
       return;
     }
     previousResetTokenRef.current = resetToken;
-    setPendingExchange(null);
     setShowConversationLayout(false);
   }, [resetToken]);
 

--- a/frontend/features/chat/hooks/use-chat-stream-buffer.ts
+++ b/frontend/features/chat/hooks/use-chat-stream-buffer.ts
@@ -2,8 +2,8 @@
 
 import * as React from "react";
 
-import type { PendingExchange } from "@/features/chat/types/chat-runtime";
 import { clearLiveUpstreamThinkTrace, upsertLiveUpstreamThinkTrace } from "@/features/chat/model/upstream-think-store";
+import type { PendingExchangeMap } from "@/features/chat/types/chat-runtime";
 import type { StreamMessageEvent } from "@/shared/api/conversation.types";
 
 const STREAM_TEXT_FLUSH_INTERVAL_MS = 50;
@@ -14,6 +14,34 @@ const STREAM_THINK_CATCHUP_CHARS_PER_FLUSH = 256;
 
 type UpstreamThinkDeltaEvent = Extract<StreamMessageEvent, { type: "upstream_think_delta" }>;
 
+type StreamBuffer = {
+  runID: string | null;
+  pendingText: string;
+  textFrame: number | null;
+  textTimeout: number | null;
+  lastTextFlushAt: number;
+  pendingThinkDelta: string;
+  pendingThinkEvent: UpstreamThinkDeltaEvent | null;
+  thinkFrame: number | null;
+  thinkTimeout: number | null;
+  lastThinkFlushAt: number;
+};
+
+function createStreamBuffer(runID?: string): StreamBuffer {
+  return {
+    runID: runID?.trim() || null,
+    pendingText: "",
+    textFrame: null,
+    textTimeout: null,
+    lastTextFlushAt: 0,
+    pendingThinkDelta: "",
+    pendingThinkEvent: null,
+    thinkFrame: null,
+    thinkTimeout: null,
+    lastThinkFlushAt: 0,
+  };
+}
+
 function resolveThinkFlushSize(pendingLength: number) {
   if (pendingLength > STREAM_THINK_CATCHUP_THRESHOLD) {
     return Math.min(pendingLength, STREAM_THINK_CATCHUP_CHARS_PER_FLUSH);
@@ -21,119 +49,117 @@ function resolveThinkFlushSize(pendingLength: number) {
   return Math.min(pendingLength, STREAM_THINK_BASE_CHARS_PER_FLUSH);
 }
 
-export function useChatStreamBuffer({
-  setPendingExchange,
-}: {
-  setPendingExchange: React.Dispatch<React.SetStateAction<PendingExchange | null>>;
-}) {
-  const streamingMessageKeyRef = React.useRef<string | null>(null);
-  const streamingRunIDRef = React.useRef<string | null>(null);
-  const pendingStreamTextRef = React.useRef("");
-  const streamFlushFrameRef = React.useRef<number | null>(null);
-  const streamFlushTimeoutRef = React.useRef<number | null>(null);
-  const lastStreamFlushAtRef = React.useRef(0);
-  const pendingThinkDeltaRef = React.useRef("");
-  const pendingThinkEventRef = React.useRef<UpstreamThinkDeltaEvent | null>(null);
-  const thinkFlushFrameRef = React.useRef<number | null>(null);
-  const thinkFlushTimeoutRef = React.useRef<number | null>(null);
-  const lastThinkFlushAtRef = React.useRef(0);
-  const scheduleThinkFlushRef = React.useRef<(() => void) | null>(null);
+function cancelBufferTimers(buffer: StreamBuffer) {
+  if (buffer.textFrame !== null) {
+    window.cancelAnimationFrame(buffer.textFrame);
+  }
+  if (buffer.textTimeout !== null) {
+    window.clearTimeout(buffer.textTimeout);
+  }
+  if (buffer.thinkFrame !== null) {
+    window.cancelAnimationFrame(buffer.thinkFrame);
+  }
+  if (buffer.thinkTimeout !== null) {
+    window.clearTimeout(buffer.thinkTimeout);
+  }
+}
 
-  const flushStreamText = React.useCallback(function flushStreamText() {
-    streamFlushFrameRef.current = null;
-    lastStreamFlushAtRef.current = performance.now();
-    const pendingText = pendingStreamTextRef.current;
-    const exchangeKey = streamingMessageKeyRef.current;
-    if (!exchangeKey || !pendingText) {
+export function useChatStreamBuffer({
+  setPendingExchanges,
+}: {
+  setPendingExchanges: React.Dispatch<React.SetStateAction<PendingExchangeMap>>;
+}) {
+  const buffersRef = React.useRef(new Map<string, StreamBuffer>());
+  const scheduleThinkFlushRef = React.useRef<(exchangeKey: string) => void>(() => undefined);
+
+  const flushStreamText = React.useCallback((exchangeKey: string) => {
+    const buffer = buffersRef.current.get(exchangeKey);
+    if (!buffer) {
       return;
     }
-    pendingStreamTextRef.current = "";
+    buffer.textFrame = null;
+    buffer.lastTextFlushAt = performance.now();
+    const pendingText = buffer.pendingText;
+    if (!pendingText) {
+      return;
+    }
+    buffer.pendingText = "";
 
-    setPendingExchange((prev) => {
-      if (!prev || prev.key !== exchangeKey) {
-        return prev;
+    setPendingExchanges((current) => {
+      const exchange = current[exchangeKey];
+      if (!exchange) {
+        return current;
       }
       return {
-        ...prev,
-        assistantPending: false,
-        assistantStreaming: true,
-        assistantText: prev.assistantText + pendingText,
+        ...current,
+        [exchangeKey]: {
+          ...exchange,
+          assistantPending: false,
+          assistantStreaming: true,
+          assistantText: exchange.assistantText + pendingText,
+        },
       };
     });
-  }, [setPendingExchange]);
+  }, [setPendingExchanges]);
 
-  const flushUpstreamThink = React.useCallback(function flushUpstreamThink() {
-    thinkFlushFrameRef.current = null;
-    lastThinkFlushAtRef.current = performance.now();
-    const runID = streamingRunIDRef.current;
-    const pendingEvent = pendingThinkEventRef.current;
-    if (!runID || !pendingEvent) {
+  const flushUpstreamThink = React.useCallback((exchangeKey: string) => {
+    const buffer = buffersRef.current.get(exchangeKey);
+    if (!buffer) {
+      return;
+    }
+    buffer.thinkFrame = null;
+    buffer.lastThinkFlushAt = performance.now();
+    if (!buffer.runID || !buffer.pendingThinkEvent) {
       return;
     }
 
-    const pendingDelta = pendingThinkDeltaRef.current;
-    const flushSize = resolveThinkFlushSize(pendingDelta.length);
-    const delta = flushSize > 0 ? pendingDelta.slice(0, flushSize) : "";
-    pendingThinkDeltaRef.current = flushSize > 0 ? pendingDelta.slice(flushSize) : "";
-    if (!pendingThinkDeltaRef.current) {
-      pendingThinkEventRef.current = null;
-    }
-
+    const flushSize = resolveThinkFlushSize(buffer.pendingThinkDelta.length);
+    const delta = flushSize > 0 ? buffer.pendingThinkDelta.slice(0, flushSize) : "";
+    buffer.pendingThinkDelta = flushSize > 0 ? buffer.pendingThinkDelta.slice(flushSize) : "";
     const event: UpstreamThinkDeltaEvent = {
-      ...pendingEvent,
+      ...buffer.pendingThinkEvent,
       delta,
-      contentMarkdown: flushSize > 0 ? undefined : pendingEvent.contentMarkdown,
+      contentMarkdown: flushSize > 0 ? undefined : buffer.pendingThinkEvent.contentMarkdown,
     };
+    if (!buffer.pendingThinkDelta) {
+      buffer.pendingThinkEvent = null;
+    }
+    upsertLiveUpstreamThinkTrace(buffer.runID, event);
 
-    upsertLiveUpstreamThinkTrace(runID, event);
-
-    if (pendingThinkDeltaRef.current) {
-      scheduleThinkFlushRef.current?.();
+    if (buffer.pendingThinkDelta) {
+      scheduleThinkFlushRef.current(exchangeKey);
     }
   }, []);
 
-  const scheduleStreamFlush = React.useCallback(() => {
-    if (streamFlushFrameRef.current !== null || streamFlushTimeoutRef.current !== null) {
+  const scheduleStreamFlush = React.useCallback((exchangeKey: string) => {
+    const buffer = buffersRef.current.get(exchangeKey);
+    if (!buffer || buffer.textFrame !== null || buffer.textTimeout !== null) {
       return;
     }
-
-    const elapsed = performance.now() - lastStreamFlushAtRef.current;
+    const elapsed = performance.now() - buffer.lastTextFlushAt;
     if (elapsed >= STREAM_TEXT_FLUSH_INTERVAL_MS) {
-      streamFlushFrameRef.current = window.requestAnimationFrame(flushStreamText);
+      buffer.textFrame = window.requestAnimationFrame(() => flushStreamText(exchangeKey));
       return;
     }
-
-    streamFlushTimeoutRef.current = window.setTimeout(() => {
-      streamFlushTimeoutRef.current = null;
-      streamFlushFrameRef.current = window.requestAnimationFrame(flushStreamText);
+    buffer.textTimeout = window.setTimeout(() => {
+      buffer.textTimeout = null;
+      buffer.textFrame = window.requestAnimationFrame(() => flushStreamText(exchangeKey));
     }, STREAM_TEXT_FLUSH_INTERVAL_MS - elapsed);
   }, [flushStreamText]);
 
-  const enqueueStreamText = React.useCallback(
-    (delta: string) => {
-      if (!delta) {
-        return;
-      }
-      pendingStreamTextRef.current += delta;
-      scheduleStreamFlush();
-    },
-    [scheduleStreamFlush],
-  );
-
-  const scheduleUpstreamThinkFlush = React.useCallback(() => {
-    if (thinkFlushFrameRef.current !== null || thinkFlushTimeoutRef.current !== null) {
+  const scheduleUpstreamThinkFlush = React.useCallback((exchangeKey: string) => {
+    const buffer = buffersRef.current.get(exchangeKey);
+    if (!buffer || buffer.thinkFrame !== null || buffer.thinkTimeout !== null) {
       return;
     }
-
-    const elapsed = performance.now() - lastThinkFlushAtRef.current;
+    const elapsed = performance.now() - buffer.lastThinkFlushAt;
     if (elapsed >= STREAM_THINK_FLUSH_INTERVAL_MS) {
-      thinkFlushFrameRef.current = window.requestAnimationFrame(flushUpstreamThink);
+      buffer.thinkFrame = window.requestAnimationFrame(() => flushUpstreamThink(exchangeKey));
       return;
     }
-
-    thinkFlushTimeoutRef.current = window.setTimeout(() => {
-      thinkFlushTimeoutRef.current = null;
-      thinkFlushFrameRef.current = window.requestAnimationFrame(flushUpstreamThink);
+    buffer.thinkTimeout = window.setTimeout(() => {
+      buffer.thinkTimeout = null;
+      buffer.thinkFrame = window.requestAnimationFrame(() => flushUpstreamThink(exchangeKey));
     }, STREAM_THINK_FLUSH_INTERVAL_MS - elapsed);
   }, [flushUpstreamThink]);
 
@@ -141,103 +167,101 @@ export function useChatStreamBuffer({
     scheduleThinkFlushRef.current = scheduleUpstreamThinkFlush;
   }, [scheduleUpstreamThinkFlush]);
 
-  const enqueueUpstreamThinkDelta = React.useCallback(
-    (event: UpstreamThinkDeltaEvent) => {
-      if (event.trace?.enabled || typeof event.contentMarkdown === "string") {
-        pendingThinkDeltaRef.current = "";
-        pendingThinkEventRef.current = event;
-        scheduleUpstreamThinkFlush();
-        return;
-      }
-      if (event.delta) {
-        pendingThinkDeltaRef.current += event.delta;
-      }
-      pendingThinkEventRef.current = {
-        ...event,
-        delta: "",
-      };
-      scheduleUpstreamThinkFlush();
-    },
-    [scheduleUpstreamThinkFlush],
-  );
-
-  const startStream = React.useCallback((exchangeKey: string, runID?: string) => {
-    pendingStreamTextRef.current = "";
-    pendingThinkDeltaRef.current = "";
-    pendingThinkEventRef.current = null;
-    streamingMessageKeyRef.current = exchangeKey;
-    streamingRunIDRef.current = runID?.trim() || null;
-    clearLiveUpstreamThinkTrace(streamingRunIDRef.current);
-    lastStreamFlushAtRef.current = 0;
-    lastThinkFlushAtRef.current = 0;
-  }, []);
-
-  const flushStreamTextNow = React.useCallback(() => {
-    if (streamFlushFrameRef.current !== null) {
-      window.cancelAnimationFrame(streamFlushFrameRef.current);
-      streamFlushFrameRef.current = null;
-    }
-    if (streamFlushTimeoutRef.current !== null) {
-      window.clearTimeout(streamFlushTimeoutRef.current);
-      streamFlushTimeoutRef.current = null;
-    }
-    flushStreamText();
-  }, [flushStreamText]);
-
-  const flushUpstreamThinkNow = React.useCallback(() => {
-    if (thinkFlushFrameRef.current !== null) {
-      window.cancelAnimationFrame(thinkFlushFrameRef.current);
-      thinkFlushFrameRef.current = null;
-    }
-    if (thinkFlushTimeoutRef.current !== null) {
-      window.clearTimeout(thinkFlushTimeoutRef.current);
-      thinkFlushTimeoutRef.current = null;
-    }
-    const runID = streamingRunIDRef.current;
-    const pendingEvent = pendingThinkEventRef.current;
-    if (!runID || !pendingEvent) {
+  const enqueueStreamText = React.useCallback((exchangeKey: string, delta: string) => {
+    const buffer = buffersRef.current.get(exchangeKey);
+    if (!buffer || !delta) {
       return;
     }
-    const event: UpstreamThinkDeltaEvent = {
-      ...pendingEvent,
-      delta: pendingThinkDeltaRef.current,
-      contentMarkdown: pendingThinkDeltaRef.current ? undefined : pendingEvent.contentMarkdown,
-    };
-    pendingThinkDeltaRef.current = "";
-    pendingThinkEventRef.current = null;
+    buffer.pendingText += delta;
+    scheduleStreamFlush(exchangeKey);
+  }, [scheduleStreamFlush]);
 
-    upsertLiveUpstreamThinkTrace(runID, event);
+  const enqueueUpstreamThinkDelta = React.useCallback((exchangeKey: string, event: UpstreamThinkDeltaEvent) => {
+    const buffer = buffersRef.current.get(exchangeKey);
+    if (!buffer) {
+      return;
+    }
+    if (event.trace?.enabled || typeof event.contentMarkdown === "string") {
+      buffer.pendingThinkDelta = "";
+      buffer.pendingThinkEvent = event;
+      scheduleUpstreamThinkFlush(exchangeKey);
+      return;
+    }
+    if (event.delta) {
+      buffer.pendingThinkDelta += event.delta;
+    }
+    buffer.pendingThinkEvent = { ...event, delta: "" };
+    scheduleUpstreamThinkFlush(exchangeKey);
+  }, [scheduleUpstreamThinkFlush]);
+
+  const startStream = React.useCallback((exchangeKey: string, runID?: string) => {
+    const existing = buffersRef.current.get(exchangeKey);
+    if (existing) {
+      cancelBufferTimers(existing);
+    }
+    const buffer = createStreamBuffer(runID);
+    buffersRef.current.set(exchangeKey, buffer);
+    clearLiveUpstreamThinkTrace(buffer.runID);
   }, []);
 
-  const resetStreamBuffer = React.useCallback(() => {
-    if (streamFlushFrameRef.current !== null) {
-      window.cancelAnimationFrame(streamFlushFrameRef.current);
-      streamFlushFrameRef.current = null;
+  const flushStreamTextNow = React.useCallback((exchangeKey: string) => {
+    const buffer = buffersRef.current.get(exchangeKey);
+    if (!buffer) {
+      return;
     }
-    if (streamFlushTimeoutRef.current !== null) {
-      window.clearTimeout(streamFlushTimeoutRef.current);
-      streamFlushTimeoutRef.current = null;
+    if (buffer.textFrame !== null) {
+      window.cancelAnimationFrame(buffer.textFrame);
+      buffer.textFrame = null;
     }
-    if (thinkFlushFrameRef.current !== null) {
-      window.cancelAnimationFrame(thinkFlushFrameRef.current);
-      thinkFlushFrameRef.current = null;
+    if (buffer.textTimeout !== null) {
+      window.clearTimeout(buffer.textTimeout);
+      buffer.textTimeout = null;
     }
-    if (thinkFlushTimeoutRef.current !== null) {
-      window.clearTimeout(thinkFlushTimeoutRef.current);
-      thinkFlushTimeoutRef.current = null;
+    flushStreamText(exchangeKey);
+  }, [flushStreamText]);
+
+  const flushUpstreamThinkNow = React.useCallback((exchangeKey: string) => {
+    const buffer = buffersRef.current.get(exchangeKey);
+    if (!buffer) {
+      return;
     }
-    pendingStreamTextRef.current = "";
-    pendingThinkDeltaRef.current = "";
-    pendingThinkEventRef.current = null;
-    streamingMessageKeyRef.current = null;
-    streamingRunIDRef.current = null;
+    if (buffer.thinkFrame !== null) {
+      window.cancelAnimationFrame(buffer.thinkFrame);
+      buffer.thinkFrame = null;
+    }
+    if (buffer.thinkTimeout !== null) {
+      window.clearTimeout(buffer.thinkTimeout);
+      buffer.thinkTimeout = null;
+    }
+    if (!buffer.runID || !buffer.pendingThinkEvent) {
+      return;
+    }
+    upsertLiveUpstreamThinkTrace(buffer.runID, {
+      ...buffer.pendingThinkEvent,
+      delta: buffer.pendingThinkDelta,
+      contentMarkdown: buffer.pendingThinkDelta ? undefined : buffer.pendingThinkEvent.contentMarkdown,
+    });
+    buffer.pendingThinkDelta = "";
+    buffer.pendingThinkEvent = null;
   }, []);
 
-  React.useEffect(() => {
-    return () => {
-      resetStreamBuffer();
-    };
-  }, [resetStreamBuffer]);
+  const resetStreamBuffer = React.useCallback((exchangeKey?: string) => {
+    if (exchangeKey) {
+      const buffer = buffersRef.current.get(exchangeKey);
+      if (!buffer) {
+        return;
+      }
+      cancelBufferTimers(buffer);
+      buffersRef.current.delete(exchangeKey);
+      return;
+    }
+    for (const buffer of buffersRef.current.values()) {
+      cancelBufferTimers(buffer);
+    }
+    buffersRef.current.clear();
+  }, []);
+
+  React.useEffect(() => () => resetStreamBuffer(), [resetStreamBuffer]);
 
   return {
     enqueueUpstreamThinkDelta,

--- a/frontend/features/chat/hooks/use-chat-submit-stream.ts
+++ b/frontend/features/chat/hooks/use-chat-submit-stream.ts
@@ -8,7 +8,7 @@ import type { ChatAreaMessage } from "@/features/chat/types/messages";
 import type {
   ChatModelOption,
   PendingAttachment,
-  PendingExchange,
+  PendingExchangeMap,
 } from "@/features/chat/types/chat-runtime";
 import type {
   ConversationDTO,
@@ -41,8 +41,8 @@ export function useChatSubmitStream({
   setDraft,
   setAttachments,
   releaseAttachments,
-  pendingExchange,
-  setPendingExchange,
+  pendingExchanges,
+  setPendingExchanges,
   setBranchSelections,
   showConversationLayout,
   setShowConversationLayout,
@@ -78,8 +78,8 @@ export function useChatSubmitStream({
   setDraft: React.Dispatch<React.SetStateAction<string>>;
   setAttachments: React.Dispatch<React.SetStateAction<PendingAttachment[]>>;
   releaseAttachments: (items: PendingAttachment[]) => void;
-  pendingExchange: PendingExchange | null;
-  setPendingExchange: React.Dispatch<React.SetStateAction<PendingExchange | null>>;
+  pendingExchanges: PendingExchangeMap;
+  setPendingExchanges: React.Dispatch<React.SetStateAction<PendingExchangeMap>>;
   setBranchSelections: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   showConversationLayout: boolean;
   setShowConversationLayout: React.Dispatch<React.SetStateAction<boolean>>;
@@ -93,7 +93,7 @@ export function useChatSubmitStream({
   resumeGenerationActive?: boolean;
 }) {
   const streamBuffer = useChatStreamBuffer({
-    setPendingExchange,
+    setPendingExchanges,
   });
 
   const messageSubmit = useChatMessageSubmit({
@@ -119,8 +119,8 @@ export function useChatSubmitStream({
     setDraft,
     setAttachments,
     releaseAttachments,
-    pendingExchange,
-    setPendingExchange,
+    pendingExchanges,
+    setPendingExchanges,
     setBranchSelections,
     showConversationLayout,
     setShowConversationLayout,
@@ -141,8 +141,5 @@ export function useChatSubmitStream({
     resumeGenerationActive,
   });
 
-  return {
-    ...messageSubmit,
-    pendingExchange,
-  };
+  return messageSubmit;
 }

--- a/frontend/features/chat/model/chat-thread.ts
+++ b/frontend/features/chat/model/chat-thread.ts
@@ -155,11 +155,6 @@ function extractInlineAlertDetails(item: MessageDTO): UpstreamDebugInfo | undefi
 
 const ROOT_BRANCH_KEY = "__root__";
 
-export type BranchSelectionPathItem = {
-  parentPublicID?: string | null;
-  publicID?: string | null;
-};
-
 type MessageLabels = {
   generationInterrupted: string;
   streamInterrupted?: string;
@@ -257,63 +252,6 @@ export function buildChildrenIndex(messages: ChatAreaMessage[]) {
     children.set(parentKey, siblings);
   }
   return children;
-}
-
-export function applyBranchSelectionPath(
-  previous: Record<string, string>,
-  path: BranchSelectionPathItem[],
-  obsoletePublicIDs: Array<string | null | undefined> = [],
-): Record<string, string> {
-  const obsolete = new Set(obsoletePublicIDs.map((item) => item?.trim() || "").filter(Boolean));
-  let changed = false;
-  const next = { ...previous };
-
-  for (const [key, value] of Object.entries(next)) {
-    if (obsolete.has(key) || obsolete.has(value)) {
-      delete next[key];
-      changed = true;
-    }
-  }
-
-  for (const item of path) {
-    const publicID = item.publicID?.trim() || "";
-    if (!publicID) {
-      continue;
-    }
-    const parentKey = toBranchKey(item.parentPublicID);
-    if (next[parentKey] !== publicID) {
-      next[parentKey] = publicID;
-      changed = true;
-    }
-  }
-
-  return changed ? next : previous;
-}
-
-export function resolveBranchSelectionPath(
-  messages: ChatAreaMessage[],
-  leafPublicID: string | null | undefined,
-): BranchSelectionPathItem[] {
-  const leafID = leafPublicID?.trim() || "";
-  if (!leafID) {
-    return [];
-  }
-
-  const byPublicID = new Map(messages.map((item) => [item.publicID, item]));
-  const path: BranchSelectionPathItem[] = [];
-  const visited = new Set<string>();
-  let current = byPublicID.get(leafID) ?? null;
-
-  while (current && !visited.has(current.publicID)) {
-    visited.add(current.publicID);
-    path.push({
-      parentPublicID: current.parentPublicID,
-      publicID: current.publicID,
-    });
-    current = current.parentPublicID ? byPublicID.get(current.parentPublicID) ?? null : null;
-  }
-
-  return path;
 }
 
 export function reconcileBranchSelections(messages: ChatAreaMessage[], previous: Record<string, string>) {

--- a/frontend/features/chat/types/chat-runtime.ts
+++ b/frontend/features/chat/types/chat-runtime.ts
@@ -77,6 +77,7 @@ export type PendingExchange = {
   parentPublicID: string | null;
   sourcePublicID: string | null;
   branchReason: "default" | "retry" | "edit";
+  reuseUserMessage: boolean;
   userContent: string;
   userAttachments?: PendingAttachment[];
   userServerMessageID?: number;
@@ -105,3 +106,5 @@ export type PendingExchange = {
   assistantLatencyMS?: number;
   compactDone?: { method: string; freed_tokens: number; summary_preview: string };
 };
+
+export type PendingExchangeMap = Record<string, PendingExchange>;

--- a/frontend/features/chat/utils/chat-runtime.ts
+++ b/frontend/features/chat/utils/chat-runtime.ts
@@ -1,4 +1,4 @@
-import type { ConversationDTO, UpstreamDebugInfo } from "@/shared/api/conversation.types";
+import type { UpstreamDebugInfo } from "@/shared/api/conversation.types";
 import { resolveLocalizedErrorMessage } from "@/i18n/resolve-error-message";
 
 const DEFAULT_MAX_FILES_PER_MESSAGE = 10;
@@ -180,12 +180,4 @@ function isUpstreamDebugInfo(value: unknown): value is UpstreamDebugInfo {
   }
   const candidate = value as UpstreamDebugInfo;
   return typeof candidate.request === "object" || typeof candidate.response === "object";
-}
-
-export function toConversationPatch(item: ConversationDTO | null, platformModelName: string): Partial<ConversationDTO> {
-  return {
-    model: platformModelName,
-    updatedAt: new Date().toISOString(),
-    messageCount: (item?.messageCount ?? 0) + 2,
-  };
 }

--- a/frontend/features/share/components/public-share-page.tsx
+++ b/frontend/features/share/components/public-share-page.tsx
@@ -166,7 +166,6 @@ function PublicSharedMessage({
     return (
       <ChatMessageUser
         item={item}
-        busy={false}
         onRetryUserMessage={noopAsync}
         onEditUserMessage={async () => false}
         onCycleMessageBranch={onCycleBranch}
@@ -182,7 +181,6 @@ function PublicSharedMessage({
     return (
       <ChatMessageBot
         item={item}
-        busy={false}
         reaction={null}
         onRetryAssistantMessage={noopAsync}
         onEditAssistantMessage={async () => false}

--- a/frontend/i18n/messages/en-US/chat.json
+++ b/frontend/i18n/messages/en-US/chat.json
@@ -260,6 +260,7 @@
     "processingAttachments": "Processing attachments...",
     "retrievingContent": "Retrieving relevant content...",
     "retryLater": "Please try again later.",
+    "concurrentGenerationLimit": "Up to {count} generations can run at once. Wait for an active generation to finish.",
     "imagePreviewAlt": "Generated image preview",
     "mediaInputUnsupported": "The selected model cannot process this input",
     "mediaInputBlocked": {

--- a/frontend/i18n/messages/zh-CN/chat.json
+++ b/frontend/i18n/messages/zh-CN/chat.json
@@ -260,6 +260,7 @@
     "processingAttachments": "正在处理附件…",
     "retrievingContent": "正在检索相关内容…",
     "retryLater": "请稍后重试。",
+    "concurrentGenerationLimit": "最多同时进行 {count} 个生成任务，请等待当前生成完成。",
     "imagePreviewAlt": "生成图片预览",
     "mediaInputUnsupported": "当前输入无法使用所选模型",
     "mediaInputBlocked": {


### PR DESCRIPTION
## Summary

支持模型生成期间的分支切换、历史消息重试和用户消息编辑。

本次将聊天运行时从单一 pending exchange 重构为按 `runID` 隔离的并发状态，确保每个生成任务拥有独立的流缓冲、推理内容、定时器和取消控制器。同时修复并发完成顺序、队列父节点、历史分页、服务端 pending 状态和 OpenAI Responses 会话状态覆盖问题。

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm exec tsc --noEmit`
- [x] `cd frontend && pnpm lint`
- [x] `cd backend && go test ./...`
- [x] `git diff --check`
- [ ] Frontend build not run by design.

## Screenshots, API examples, or logs

Not applicable. This change does not introduce a new standalone UI surface.

## Configuration, migration, and compatibility notes

- No API contract, database schema, configuration, or migration changes.
- Normal composer submissions continue to queue while generation is active.
- Historical retry/edit branches may run concurrently with active generation.
- Concurrent generation is limited to three unique active runs on the current page.
- Non-default branches do not overwrite the conversation’s main OpenAI Responses state.
- After page reload, multiple pending runs are recovered sequentially.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] No authentication, authorization, billing, or permission behavior was changed.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior and compatibility impact are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.