### PR TITLE
refactor: simplify skill display logic in ChatInputComponent

### DIFF
--- a/frontend/features/chat/components/sections/chat-input.tsx
+++ b/frontend/features/chat/components/sections/chat-input.tsx
@@ -368,8 +368,6 @@ function ChatInputComponent({
   const showHTMLVisualPromptButton = !isMediaMode;
   const hasComposerAttachments = attachments.length > 0 || uploadingAttachments.length > 0;
   const showSelectedSkills = selectedSkills.length > 0 && !isMediaMode;
-  const inlineSelectedSkills = showSelectedSkills && (hasComposerAttachments || queuedMessages.length > 0);
-  const overlaySelectedSkills = showSelectedSkills && !hasComposerAttachments && queuedMessages.length === 0;
   const {
     activeIndex: mentionActiveIndex,
     handleBlur: handleMentionBlur,
@@ -597,7 +595,7 @@ function ChatInputComponent({
         style={inputGroupHeight === null ? undefined : { height: inputGroupHeight }}
       >
         <div ref={inputGroupMeasureRef} className="flex w-full flex-col">
-          {inlineSelectedSkills ? (
+          {showSelectedSkills ? (
             <div className="flex w-full max-h-14 flex-wrap items-center justify-start gap-x-3 gap-y-1 overflow-y-auto px-5 pt-3">
               {selectedSkills.map((skill) => (
                 <button
@@ -737,29 +735,6 @@ function ChatInputComponent({
             onSelect={selectMentionItem}
           />
 
-          {overlaySelectedSkills ? (
-            <div className="absolute left-5 right-5 top-4 z-10 flex max-h-14 flex-wrap items-center gap-x-3 gap-y-1 overflow-y-auto">
-              {selectedSkills.map((skill) => (
-                <button
-                  key={skill.id}
-                  type="button"
-                  className="group inline-flex h-6 max-w-48 items-center gap-1.5 text-sm font-medium text-primary transition-colors hover:text-primary/85 disabled:opacity-60"
-                  disabled={loading || uploading}
-                  onClick={() => onSelectedSkillsChange(selectedSkills.filter((item) => item.id !== skill.id))}
-                  aria-label={skill.title}
-                >
-                  <Box className="size-4 shrink-0" strokeWidth={1.7} />
-                  <span className="min-w-0 truncate">{skill.trigger || skill.title}</span>
-                  <XIcon
-                    size={12}
-                    strokeWidth={1.7}
-                    className="shrink-0 opacity-45 transition-opacity group-hover:opacity-80"
-                  />
-                </button>
-              ))}
-            </div>
-          ) : null}
-
           <InputGroupTextarea
             ref={textareaRef}
             value={draft}
@@ -772,7 +747,7 @@ function ChatInputComponent({
             style={{ fontFamily: "var(--font-chat)", fontWeight: "var(--font-chat-weight)" }}
             className={cn(
               "rounded-3xl min-h-12 overflow-y-auto px-5 text-[15px] leading-6 placeholder:text-muted-foreground placeholder:font-[inherit] placeholder:leading-[inherit]",
-              overlaySelectedSkills ? "pt-12" : hasComposerAttachments ? "pt-2" : "pt-4",
+              showSelectedSkills || hasComposerAttachments ? "pt-2" : "pt-4",
               inputHeightClassName,
               speechInput.active ? "placeholder:font-normal placeholder:text-muted-foreground" : "",
             )}


### PR DESCRIPTION
## Summary

Fix the chat composer layout when Skills are enabled and the input contains multiple lines.

The selected Skill indicator now occupies its own layout row above the textarea instead of being absolutely positioned over it. This prevents long or scrolling input text from overlapping the Skill label and removes the duplicated overlay rendering path.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm exec tsc --noEmit`
- [x] `git diff --check`
- [ ] Frontend build not run; lint and TypeScript verification passed.

## Screenshots, API examples, or logs

The reproduction screenshot is included in the linked issue. No API or backend behavior changed.

## Configuration, migration, and compatibility notes

No configuration, migration, deployment, or API contract changes are required.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.