### PR TITLE
fix: settle usage beyond available balance

### DIFF
--- a/backend/internal/application/billing/service_subscription_timeline_test.go
+++ b/backend/internal/application/billing/service_subscription_timeline_test.go
@@ -319,6 +319,26 @@ func TestEnsureModelUsableRejectsPeriodOverageWhenBalanceIsInsufficient(t *testi
 	}
 }
 
+func TestEnsureModelUsableRejectsUsageAccountWithNegativeBalance(t *testing.T) {
+	repo := &billingRepositoryStub{
+		mode:           "usage",
+		account:        &domainbilling.BillingAccount{UserID: 1, BalanceNanousd: -200, Currency: "USD", Status: "active"},
+		prepaidNanousd: 0,
+		pricing: &domainbilling.ModelPricing{
+			PlatformModelName:       "gpt-test",
+			Currency:                "USD",
+			InputNanousdPerMTokens:  1,
+			OutputNanousdPerMTokens: 1,
+		},
+	}
+	service := NewService(repo)
+
+	err := service.EnsureModelUsable(context.Background(), 1, "gpt-test", time.Now())
+	if !errors.Is(err, ErrUsageBalanceInsufficient) {
+		t.Fatalf("EnsureModelUsable() error = %v, want ErrUsageBalanceInsufficient", err)
+	}
+}
+
 func TestEnsureModelUsableAllowsZeroCreditPeriodPlanWhenBalanceIsAvailable(t *testing.T) {
 	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 	endAt := now.Add(30 * 24 * time.Hour)

--- a/backend/internal/infra/persistence/postgres/billing/repository.go
+++ b/backend/internal/infra/persistence/postgres/billing/repository.go
@@ -547,9 +547,6 @@ func (r *Repo) AddUsageAndSettleBalance(ctx context.Context, usage *domainbillin
 			if err != nil {
 				return err
 			}
-			if deltaNanousd > 0 && account.BalanceNanousd < deltaNanousd {
-				return repository.ErrInsufficientBalance
-			}
 		}
 
 		if err := tx.Create(&record).Error; err != nil {
@@ -559,6 +556,7 @@ func (r *Repo) AddUsageAndSettleBalance(ctx context.Context, usage *domainbillin
 			return nil
 		}
 
+		// 上游已产生真实用量时必须完整入账；允许余额为负，后续调用会被余额校验拦截。
 		nextBalance := account.BalanceNanousd - deltaNanousd
 		if err := tx.Model(account).Updates(map[string]interface{}{
 			"balance_nanousd": nextBalance,
@@ -637,9 +635,6 @@ func (r *Repo) AddPeriodUsageAndSettleOverage(
 			}
 		}
 		deltaNanousd := overageNanousd - reservedNanousd
-		if deltaNanousd > 0 && account.BalanceNanousd < deltaNanousd {
-			return repository.ErrInsufficientBalance
-		}
 
 		ledger := *usage
 		ledger.PricingSnapshotJSON = withPeriodSettlementSnapshot(ledger.PricingSnapshotJSON, map[string]interface{}{
@@ -661,6 +656,7 @@ func (r *Repo) AddPeriodUsageAndSettleOverage(
 			return nil
 		}
 
+		// 上游已产生真实用量时必须完整入账；允许余额为负，后续调用会被余额校验拦截。
 		nextBalance := account.BalanceNanousd - deltaNanousd
 		if err := tx.Model(account).Updates(map[string]interface{}{
 			"balance_nanousd": nextBalance,

--- a/backend/internal/infra/persistence/postgres/billing/repository_sqlite_test.go
+++ b/backend/internal/infra/persistence/postgres/billing/repository_sqlite_test.go
@@ -90,6 +90,203 @@ func TestUsageQueriesUseSQLitePortableExpressions(t *testing.T) {
 	}
 }
 
+func TestAddUsageAndSettleBalanceRecordsDebtWithoutReservation(t *testing.T) {
+	db := openBillingSQLiteTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+	now := time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC)
+
+	account := model.BillingAccount{
+		UserID:         1,
+		Currency:       "USD",
+		BalanceNanousd: 100,
+		Status:         "active",
+	}
+	if err := db.Create(&account).Error; err != nil {
+		t.Fatalf("create billing account: %v", err)
+	}
+	usage := &domainbilling.UsageLedger{
+		UserID:            1,
+		PlatformModelName: "gpt-test",
+		BillingAt:         now,
+		UsageDate:         now,
+		BilledCurrency:    "USD",
+		BilledNanousd:     300,
+	}
+
+	if err := repo.AddUsageAndSettleBalance(ctx, usage, nil); err != nil {
+		t.Fatalf("AddUsageAndSettleBalance() error = %v", err)
+	}
+
+	assertUsageSettlement(t, db, 1, "gpt-test", -200, -300, -200, "")
+}
+
+func TestAddUsageAndSettleBalanceRecordsDebtBeyondReservation(t *testing.T) {
+	db := openBillingSQLiteTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+	now := time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC)
+
+	account := model.BillingAccount{
+		UserID:         1,
+		Currency:       "USD",
+		BalanceNanousd: 200,
+		Status:         "active",
+	}
+	if err := db.Create(&account).Error; err != nil {
+		t.Fatalf("create billing account: %v", err)
+	}
+	reservation, err := repo.ReserveUsageBalance(ctx, 1, 100, "run-debt")
+	if err != nil {
+		t.Fatalf("ReserveUsageBalance() error = %v", err)
+	}
+	usage := &domainbilling.UsageLedger{
+		UserID:            1,
+		PlatformModelName: "gpt-reserved",
+		BillingAt:         now,
+		UsageDate:         now,
+		BilledCurrency:    "USD",
+		BilledNanousd:     350,
+	}
+
+	if err = repo.AddUsageAndSettleBalance(ctx, usage, reservation); err != nil {
+		t.Fatalf("AddUsageAndSettleBalance() error = %v", err)
+	}
+
+	assertUsageSettlement(t, db, 1, "gpt-reserved", -150, -250, -150, "run-debt")
+}
+
+func TestAddUsageAndSettleBalanceRefundsUnusedReservation(t *testing.T) {
+	db := openBillingSQLiteTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+	now := time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC)
+
+	account := model.BillingAccount{
+		UserID:         1,
+		Currency:       "USD",
+		BalanceNanousd: 300,
+		Status:         "active",
+	}
+	if err := db.Create(&account).Error; err != nil {
+		t.Fatalf("create billing account: %v", err)
+	}
+	reservation, err := repo.ReserveUsageBalance(ctx, 1, 200, "run-refund")
+	if err != nil {
+		t.Fatalf("ReserveUsageBalance() error = %v", err)
+	}
+	usage := &domainbilling.UsageLedger{
+		UserID:            1,
+		PlatformModelName: "gpt-refund",
+		BillingAt:         now,
+		UsageDate:         now,
+		BilledCurrency:    "USD",
+		BilledNanousd:     50,
+	}
+
+	if err = repo.AddUsageAndSettleBalance(ctx, usage, reservation); err != nil {
+		t.Fatalf("AddUsageAndSettleBalance() error = %v", err)
+	}
+
+	assertUsageSettlement(t, db, 1, "gpt-refund", 250, 150, 250, "run-refund")
+}
+
+func TestAddUsageAndSettleBalanceLeavesFreeModelBalanceUnchanged(t *testing.T) {
+	db := openBillingSQLiteTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+	now := time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC)
+
+	account := model.BillingAccount{
+		UserID:         1,
+		Currency:       "USD",
+		BalanceNanousd: 100,
+		Status:         "active",
+	}
+	if err := db.Create(&account).Error; err != nil {
+		t.Fatalf("create billing account: %v", err)
+	}
+	usage := &domainbilling.UsageLedger{
+		UserID:            1,
+		PlatformModelName: "free-model",
+		IsFreeModel:       true,
+		BillingAt:         now,
+		UsageDate:         now,
+		BilledCurrency:    "USD",
+		BilledNanousd:     0,
+	}
+
+	if err := repo.AddUsageAndSettleBalance(ctx, usage, nil); err != nil {
+		t.Fatalf("AddUsageAndSettleBalance() error = %v", err)
+	}
+
+	var refreshed model.BillingAccount
+	if err := db.Where("user_id = ?", 1).First(&refreshed).Error; err != nil {
+		t.Fatalf("load billing account: %v", err)
+	}
+	if refreshed.BalanceNanousd != 100 {
+		t.Fatalf("balance = %d, want unchanged 100", refreshed.BalanceNanousd)
+	}
+	var ledger model.UsageLedger
+	if err := db.Where("user_id = ? AND platform_model_name = ?", 1, "free-model").First(&ledger).Error; err != nil {
+		t.Fatalf("load usage ledger: %v", err)
+	}
+	var transactionCount int64
+	if err := db.Model(&model.BalanceTransaction{}).Where("user_id = ?", 1).Count(&transactionCount).Error; err != nil {
+		t.Fatalf("count balance transactions: %v", err)
+	}
+	if transactionCount != 0 {
+		t.Fatalf("balance transaction count = %d, want 0", transactionCount)
+	}
+}
+
+func assertUsageSettlement(
+	t *testing.T,
+	db *gorm.DB,
+	userID uint,
+	platformModelName string,
+	wantBalance int64,
+	wantTransactionAmount int64,
+	wantTransactionBalance int64,
+	wantRefNo string,
+) {
+	t.Helper()
+
+	var account model.BillingAccount
+	if err := db.Where("user_id = ?", userID).First(&account).Error; err != nil {
+		t.Fatalf("load billing account: %v", err)
+	}
+	if account.BalanceNanousd != wantBalance {
+		t.Fatalf("balance = %d, want %d", account.BalanceNanousd, wantBalance)
+	}
+
+	var ledger model.UsageLedger
+	if err := db.Where("user_id = ? AND platform_model_name = ?", userID, platformModelName).First(&ledger).Error; err != nil {
+		t.Fatalf("load usage ledger: %v", err)
+	}
+
+	transactionType := domainbilling.BalanceTransactionTypeUsage
+	if wantTransactionAmount > 0 {
+		transactionType = domainbilling.BalanceTransactionTypeUsageRefund
+	}
+	var transaction model.BalanceTransaction
+	if err := db.Where("user_id = ? AND type = ? AND ref_id = ?", userID, transactionType, ledger.ID).First(&transaction).Error; err != nil {
+		t.Fatalf("load settlement transaction: %v", err)
+	}
+	if transaction.AmountNanousd != wantTransactionAmount || transaction.BalanceAfterNanousd != wantTransactionBalance {
+		t.Fatalf(
+			"transaction amount/balance = %d/%d, want %d/%d",
+			transaction.AmountNanousd,
+			transaction.BalanceAfterNanousd,
+			wantTransactionAmount,
+			wantTransactionBalance,
+		)
+	}
+	if transaction.RefNo != wantRefNo {
+		t.Fatalf("transaction ref no = %q, want %q", transaction.RefNo, wantRefNo)
+	}
+}
+
 func TestAddPeriodUsageAndSettleOverageSplitsCreditAndBalance(t *testing.T) {
 	db := openBillingSQLiteTestDB(t)
 	repo := NewRepo(db)
@@ -172,6 +369,62 @@ func TestAddPeriodUsageAndSettleOverageSplitsCreditAndBalance(t *testing.T) {
 	delta := int64(snapshot["period_balance_settlement_delta_nanousd"].(float64))
 	if charged != 300 || delta != 300 {
 		t.Fatalf("snapshot balance = charged %d delta %d, want 300/300", charged, delta)
+	}
+}
+
+func TestAddPeriodUsageAndSettleOverageRecordsDebt(t *testing.T) {
+	db := openBillingSQLiteTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	periodStart := now.Add(-2 * time.Hour)
+	periodEnd := now.Add(2 * time.Hour)
+
+	account := model.BillingAccount{
+		UserID:         1,
+		Currency:       "USD",
+		BalanceNanousd: 100,
+		Status:         "active",
+	}
+	if err := db.Create(&account).Error; err != nil {
+		t.Fatalf("create billing account: %v", err)
+	}
+	if err := db.Create(&model.UsageLedger{
+		BaseModel:           model.BaseModel{CreatedAt: now.Add(-time.Hour)},
+		UserID:              1,
+		PlatformModelName:   "gpt-before-debt",
+		BillingAt:           now.Add(-time.Hour),
+		UsageDate:           now.Add(-time.Hour),
+		BilledCurrency:      "USD",
+		BilledNanousd:       900,
+		PricingSnapshotJSON: `{}`,
+	}).Error; err != nil {
+		t.Fatalf("create previous usage: %v", err)
+	}
+	usage := &domainbilling.UsageLedger{
+		UserID:              1,
+		PlatformModelName:   "gpt-period-debt",
+		BillingAt:           now,
+		UsageDate:           now,
+		BilledCurrency:      "USD",
+		BilledNanousd:       500,
+		PricingSnapshotJSON: `{"pricing_mode":"token"}`,
+	}
+
+	if err := repo.AddPeriodUsageAndSettleOverage(ctx, usage, periodStart, periodEnd, 1000, nil); err != nil {
+		t.Fatalf("AddPeriodUsageAndSettleOverage() error = %v", err)
+	}
+
+	assertUsageSettlement(t, db, 1, "gpt-period-debt", -300, -400, -300, "")
+	var snapshot map[string]interface{}
+	if err := json.Unmarshal([]byte(usage.PricingSnapshotJSON), &snapshot); err != nil {
+		t.Fatalf("decode pricing snapshot: %v", err)
+	}
+	if got := int64(snapshot["period_credit_covered_nanousd"].(float64)); got != 100 {
+		t.Fatalf("period credit covered = %d, want 100", got)
+	}
+	if got := int64(snapshot["period_overage_billed_nanousd"].(float64)); got != 400 {
+		t.Fatalf("period overage = %d, want 400", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- persist billable usage even when the final charge exceeds the available balance
- allow usage and period-overage settlement to produce a negative balance
- preserve reservation reconciliation and block later paid requests through the existing balance check

Fixes #471.

## Root cause

The final settlement transactions returned `ErrInsufficientBalance` when the actual charge exceeded the remaining balance after reservation. That rolled back both the usage ledger and the balance update. The HTTP layer then treated settlement as failed and released the reservation, restoring the account to a usable balance even though the upstream request had already consumed tokens.

## Changes

- treat completed upstream usage as authoritative and settle the full amount in the existing account-row transaction
- record negative balances instead of rolling back usage and balance transactions
- apply the same behavior to usage billing and period-plan overage settlement
- retain normal refunds when actual usage is lower than the reservation
- add coverage for settlement without a reservation, settlement beyond a reservation, reservation refunds, free models, period overage debt, and rejection of later calls from a negative-balance account

No API, schema, configuration, or frontend changes are included.

## Concurrency and behavior

The existing account row lock remains the serialization point for balance updates and period-credit recalculation. Requests that are already in flight can still complete and are charged in commit order, potentially increasing the negative balance; once a settlement records debt, subsequent paid-model access is rejected by the existing balance check.

This pull request intentionally does not add per-model maximum-cost estimation or change the prepaid amount configuration.

## Testing

- `cd backend && go test ./...`
- `cd backend && go test -race ./internal/infra/persistence/postgres/billing ./internal/application/billing`
- `git diff --check`
