### PR TITLE
feat: add buttonRef prop and focus management

### DIFF
--- a/frontend/features/chat/components/sections/chat-model-picker.tsx
+++ b/frontend/features/chat/components/sections/chat-model-picker.tsx
@@ -365,6 +365,7 @@ function ChatModelMenuItem({
   pricingLabels,
   viewPricingLabel,
   pricingTooltipSide,
+  buttonRef,
 }: {
   model: ChatModelOption;
   selected: boolean;
@@ -373,6 +374,7 @@ function ChatModelMenuItem({
   pricingLabels: React.ComponentProps<typeof ModelPricingTooltipContent>["labels"];
   viewPricingLabel: string;
   pricingTooltipSide: "right";
+  buttonRef?: React.Ref<HTMLButtonElement>;
 }) {
   const platformModelName = model.platformModelName.trim();
   const identity = React.useMemo(
@@ -392,6 +394,7 @@ function ChatModelMenuItem({
       className="group flex h-7 items-center rounded-md text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-within:bg-accent focus-within:text-accent-foreground data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground"
     >
       <button
+        ref={buttonRef}
         type="button"
         className="flex h-7 min-w-0 flex-1 items-center gap-2 rounded-md bg-transparent py-0 pl-2 pr-1 text-left text-[11px] font-medium leading-none text-inherit outline-none"
         onClick={onSelect}
@@ -462,6 +465,7 @@ export function ChatModelPicker({
   const desktopMenuRootRef = React.useRef<HTMLDivElement | null>(null);
   const desktopVendorMenuRef = React.useRef<HTMLDivElement | null>(null);
   const desktopSubmenuRef = React.useRef<HTMLDivElement | null>(null);
+  const selectedModelButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const desktopVendorItemRefs = React.useRef(new Map<string, HTMLButtonElement>());
   const selectedModel = React.useMemo(
     () => modelOptions.find((item) => item.platformModelName === selectedPlatformModelName) ?? null,
@@ -695,6 +699,12 @@ export function ChatModelPicker({
             side="bottom"
             sideOffset={8}
             collisionPadding={24}
+            onOpenAutoFocus={(event) => {
+              if (!isMobile && selectedModelButtonRef.current) {
+                event.preventDefault();
+                selectedModelButtonRef.current.focus();
+              }
+            }}
             className={cn(
               "relative overflow-visible rounded-xl",
               isMobile
@@ -796,6 +806,7 @@ export function ChatModelPicker({
                             key={item.platformModelName}
                             model={item}
                             selected={item.platformModelName === selectedPlatformModelName}
+                            buttonRef={item.platformModelName === selectedPlatformModelName ? selectedModelButtonRef : undefined}
                             onSelect={() => {
                               onModelChange(item.platformModelName);
                               closeMenu();


### PR DESCRIPTION
## Summary

Fix the model picker showing two visually highlighted models when reopening it after selecting a model that is not first in its vendor list.

The picker previously used the same background for the selected model and the automatically focused first item. It now places the initial desktop focus on the currently selected model, keeping selection and focus aligned while preserving keyboard accessibility.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm exec tsc --noEmit`
- [x] `git diff --check`
- [ ] Frontend build not run; lint and TypeScript verification passed.

## Screenshots, API examples, or logs

The reproduction screenshot is included in the linked issue. No API or backend behavior changed.

## Configuration, migration, and compatibility notes

No configuration, migration, deployment, API contract, or model routing changes are required. Mobile model picker behavior remains unchanged.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.