### PR TITLE
feat: implement cancellation handling for chat message submissions

### DIFF
--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -62,6 +62,7 @@ const CONVERSATION_METADATA_REFRESH_INITIAL_DELAY_MS = 800;
 const CONVERSATION_METADATA_REFRESH_MAX_DELAY_MS = 5_000;
 const CONVERSATION_METADATA_REFRESH_BACKOFF = 1.5;
 const MAX_CONCURRENT_RUNS = 5;
+const GENERATION_CANCEL_SETTLEMENT_TIMEOUT_MS = 25_000;
 
 function resolveSubmitBlockDescription(
   reason: ChatSubmitBlockReason,
@@ -137,7 +138,17 @@ type ActiveStream = {
   controller: AbortController;
   runID: string;
   accessToken: string | null;
+  cancelRequested: boolean;
+  cancelSettlementTimer: number | null;
 };
+
+function clearCancelSettlementTimer(active: ActiveStream) {
+  if (active.cancelSettlementTimer === null) {
+    return;
+  }
+  window.clearTimeout(active.cancelSettlementTimer);
+  active.cancelSettlementTimer = null;
+}
 
 function replaceCompletedBranchSelection(
   previous: Record<string, string>,
@@ -438,6 +449,7 @@ export function useChatMessageSubmit({
 
     for (const active of activeStreamsRef.current.values()) {
       // 会话切换只解除当前页面订阅，不取消服务端仍在执行的 run。
+      clearCancelSettlementTimer(active);
       active.controller.abort();
       activeGenerationRunsRefRef.current?.current.delete(active.runID);
     }
@@ -634,6 +646,8 @@ export function useChatMessageSubmit({
         controller: streamAbortController,
         runID: clientRunID,
         accessToken: null,
+        cancelRequested: false,
+        cancelSettlementTimer: null,
       });
       syncActiveRunCount();
       if (resetComposer) {
@@ -684,11 +698,7 @@ export function useChatMessageSubmit({
         }
         const activeStream = activeStreamsRef.current.get(clientRunID);
         if (activeStream?.controller === streamAbortController) {
-          activeStreamsRef.current.set(clientRunID, {
-            controller: streamAbortController,
-            runID: clientRunID,
-            accessToken: token,
-          });
+          activeStream.accessToken = token;
         }
         let metadataFallbackTitle = "";
         const startMetadataRefresh = (result?: SendMessageResult | null) => {
@@ -1040,7 +1050,9 @@ export function useChatMessageSubmit({
         }
         return false;
       } finally {
-        if (activeStreamsRef.current.get(clientRunID)?.controller === streamAbortController) {
+        const activeStream = activeStreamsRef.current.get(clientRunID);
+        if (activeStream?.controller === streamAbortController) {
+          clearCancelSettlementTimer(activeStream);
           activeStreamsRef.current.delete(clientRunID);
         }
         activeGenerationRunsRef?.current.delete(clientRunID);
@@ -1146,10 +1158,33 @@ export function useChatMessageSubmit({
     if (!active) {
       return false;
     }
-    if (active.accessToken) {
-      void cancelMessageGeneration(active.accessToken, active.runID).catch(() => undefined);
+    if (active.cancelRequested) {
+      return true;
     }
-    active.controller.abort();
+    if (!active.accessToken) {
+      active.controller.abort();
+      return true;
+    }
+
+    active.cancelRequested = true;
+    active.cancelSettlementTimer = window.setTimeout(() => {
+      if (activeStreamsRef.current.get(active.runID) !== active) {
+        return;
+      }
+      active.controller.abort();
+      reload();
+    }, GENERATION_CANCEL_SETTLEMENT_TIMEOUT_MS);
+
+    // Keep the stream connected so its terminal payload can replace optimistic IDs
+    // and retain the final partial content/usage produced during cancellation.
+    void cancelMessageGeneration(active.accessToken, active.runID).catch(() => {
+      if (activeStreamsRef.current.get(active.runID) !== active) {
+        return;
+      }
+      clearCancelSettlementTimer(active);
+      active.controller.abort();
+      reload();
+    });
     return true;
   }, [
     currentLeafMessage?.isPending,


### PR DESCRIPTION
## Summary

Fix retry and edit actions remaining unavailable after manually stopping a model response.

The frontend previously aborted the stream immediately after requesting cancellation, preventing the terminal payload from replacing optimistic message IDs with persisted IDs. The cancellation flow now keeps the stream connected until the backend returns the canceled message state, preserving partial content, usage, message IDs, and branch state.

A bounded 25-second fallback aborts and reloads the conversation if cancellation settlement does not complete, preventing the UI from remaining stuck indefinitely.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm --filter @deeix/web check`
- [x] `pnpm --filter @deeix/web build`
- [ ] Not run; reason:

## Screenshots, API examples, or logs

No screenshots are included. This change updates the stream cancellation lifecycle without changing the visible layout.

## Configuration, migration, and compatibility notes

No configuration, database migration, API contract, or deployment changes are required.

The existing cancellation API and terminal stream payload remain unchanged. Failed cancellation requests and settlement timeouts retain the existing abort-and-reload fallback behavior.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including cancellation authorization and usage/billing settlement.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.