### PR TITLE
fix: defer new conversation creation until first message

### DIFF
--- a/frontend/features/recent/hooks/use-recent-page.ts
+++ b/frontend/features/recent/hooks/use-recent-page.ts
@@ -14,6 +14,7 @@ import {
   upsertByPublicID,
   useSidebarConversations,
 } from "@/entities/conversation";
+import { useChatSession } from "@/features/chat";
 import { useLocalizedErrorMessage } from "@/i18n/use-localized-error";
 import { useLoadMoreSentinel } from "@/shared/hooks/use-load-more-sentinel";
 import { useSettingsChatPreferences } from "@/features/settings";
@@ -100,8 +101,8 @@ export function useRecentPage() {
   const t = useTranslations("recent");
   const resolveErrorMessage = useLocalizedErrorMessage();
   const router = useRouter();
+  const { requestNewConversation } = useChatSession();
   const {
-    prependNewConversation,
     renameByPublicID,
     regenerateTitleByPublicID,
     updateLabelsByPublicID,
@@ -338,15 +339,11 @@ export function useRecentPage() {
     }
   }, [exportingAll, t]);
 
-  const onCreateConversation = React.useCallback(async () => {
+  const onCreateConversation = React.useCallback(() => {
     const currentProjectID = projectFilter !== "all" && projectFilter !== "unassigned" ? projectFilter : "";
-    const created = await prependNewConversation(undefined, currentProjectID);
-    if (created?.publicID) {
-      router.push(`/chat?conversation_id=${created.publicID}`);
-      return;
-    }
-    router.push("/chat");
-  }, [prependNewConversation, projectFilter, router]);
+    requestNewConversation({ projectID: currentProjectID });
+    router.push(currentProjectID ? `/chat?project_id=${encodeURIComponent(currentProjectID)}` : "/chat");
+  }, [projectFilter, requestNewConversation, router]);
 
   const onProjectFilterChange = React.useCallback(
     (value: ConversationProjectFilter) => {


### PR DESCRIPTION
## Summary

Fix the New Chat action on the All Conversations page creating an empty conversation immediately.

The action now uses the same deferred creation flow as the sidebar:

- Enter a local new-conversation state without creating a database record.
- Create the conversation only when the first message is sent.
- Apply starred MCP defaults correctly.
- Preserve project-specific MCP and Skill defaults when opened from a project filter.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [x] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm --filter @deeix/web check`
- [x] `git diff --check`

## Screenshots, API examples, or logs

No screenshots required. The change aligns the All Conversations New Chat action with the existing sidebar behavior.

## Configuration, migration, and compatibility notes

No configuration, database migration, or API contract changes are required.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior and compatibility impact are documented.
- [x] Generated artifacts are included only when explicitly required.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.