### PR TITLE
fix: preserve fallback title after stopping generation

### DIFF
--- a/backend/internal/application/conversation/service_metadata.go
+++ b/backend/internal/application/conversation/service_metadata.go
@@ -95,20 +95,7 @@ func (s *Service) maybeGenerateConversationMetadataAsync(conversation model.Conv
 			return
 		}
 
-		fallbackTitle := ""
-		if plan.replaceTitle {
-			fallbackTitle = conversationTitleFromFirstUserMessage(userMsg.Content)
-		}
-
-		if fallbackTitle != "" {
-			if _, err := s.repo.UpdateConversationMetadata(asyncCtx, conversation.ID, repository.ConversationMetadataPatch{Title: fallbackTitle}); err != nil && s.logger != nil {
-				s.logger.Warn("conversation_fallback_title_update_failed",
-					zap.Uint("conversation_id", conversation.ID),
-					zap.String("model", conversation.Model),
-					zap.Error(err),
-				)
-			}
-		}
+		s.persistConversationFallbackTitle(asyncCtx, conversation, userMsg)
 
 		if _, err := s.generateConversationMetadata(asyncCtx, conversation, userMsg, plan); err != nil && s.logger != nil {
 			if errors.Is(err, ErrInvalidConversationTitle) {
@@ -411,6 +398,40 @@ func conversationTitleFromMessages(messages []model.Message) string {
 		}
 	}
 	return ""
+}
+
+func conversationFallbackTitlePatch(
+	conversation model.Conversation,
+	userMsg model.Message,
+) (repository.ConversationMetadataPatch, bool) {
+	if !shouldAutoReplaceConversationTitle(conversation.Title) {
+		return repository.ConversationMetadataPatch{}, false
+	}
+	title := conversationTitleFromFirstUserMessage(userMsg.Content)
+	if title == "" {
+		return repository.ConversationMetadataPatch{}, false
+	}
+	return repository.ConversationMetadataPatch{Title: title}, true
+}
+
+// persistConversationFallbackTitle 不依赖模型调用，用户消息落库后即可写入基础标题。
+// 仓储层只替换占位标题，因此不会覆盖用户手动标题或已生成标题。
+func (s *Service) persistConversationFallbackTitle(
+	ctx context.Context,
+	conversation model.Conversation,
+	userMsg model.Message,
+) {
+	patch, ok := conversationFallbackTitlePatch(conversation, userMsg)
+	if !ok {
+		return
+	}
+	if _, err := s.repo.UpdateConversationMetadata(ctx, conversation.ID, patch); err != nil && s.logger != nil {
+		s.logger.Warn("conversation_fallback_title_update_failed",
+			zap.Uint("conversation_id", conversation.ID),
+			zap.String("model", conversation.Model),
+			zap.Error(err),
+		)
+	}
 }
 
 func renderConversationMetadataPrompt(raw string, fallback string, messages string) string {

--- a/backend/internal/application/conversation/service_metadata_test.go
+++ b/backend/internal/application/conversation/service_metadata_test.go
@@ -117,6 +117,38 @@ func TestConversationFallbackTitleUsesUnifiedLimit(t *testing.T) {
 	}
 }
 
+func TestConversationFallbackTitlePatchOnlyReplacesPlaceholder(t *testing.T) {
+	userMsg := model.Message{Content: "帮我分析模型终止后的标题行为"}
+
+	patch, ok := conversationFallbackTitlePatch(model.Conversation{Title: "新对话"}, userMsg)
+	if !ok {
+		t.Fatal("expected placeholder title to receive a fallback patch")
+	}
+	if patch.Title != "帮我分析模型终止后的标题行为" {
+		t.Fatalf("fallback title = %q", patch.Title)
+	}
+
+	if _, ok = conversationFallbackTitlePatch(model.Conversation{Title: "手动标题"}, userMsg); ok {
+		t.Fatal("expected an existing title not to receive a fallback patch")
+	}
+	if _, ok = conversationFallbackTitlePatch(model.Conversation{Title: "新对话"}, model.Message{}); ok {
+		t.Fatal("expected empty user content not to receive a fallback patch")
+	}
+}
+
+func TestFallbackTitleSettlementOnlyRunsForCanceledGeneration(t *testing.T) {
+	userMsg := &model.Message{Content: "首条用户消息"}
+	if !shouldPersistConversationFallbackTitleAfterSend(ErrMessageGenerationCanceled, userMsg) {
+		t.Fatal("expected canceled generation to settle the fallback title")
+	}
+	if shouldPersistConversationFallbackTitleAfterSend(errors.New("upstream failed"), userMsg) {
+		t.Fatal("expected ordinary generation errors not to settle the fallback title")
+	}
+	if shouldPersistConversationFallbackTitleAfterSend(ErrMessageGenerationCanceled, nil) {
+		t.Fatal("expected cancellation without a persisted user message to skip title settlement")
+	}
+}
+
 func TestBuildConversationMetadataMessagesEmptyWhenNoText(t *testing.T) {
 	got := buildConversationMetadataMessages(model.Message{})
 	if got != "" {

--- a/backend/internal/application/conversation/service_run.go
+++ b/backend/internal/application/conversation/service_run.go
@@ -14,6 +14,7 @@ import (
 
 type messageSendRunState struct {
 	service          *Service
+	conversation     *model.Conversation
 	run              *model.Run
 	startedAt        time.Time
 	userMessage      **model.Message
@@ -32,8 +33,9 @@ func newMessageSendRunState(
 	runID string,
 ) *messageSendRunState {
 	return &messageSendRunState{
-		service:   service,
-		startedAt: startedAt,
+		service:      service,
+		conversation: conversation,
+		startedAt:    startedAt,
 		run: &model.Run{
 			RunID:              runID,
 			RequestID:          strings.TrimSpace(input.RequestID),
@@ -94,8 +96,16 @@ func (r *messageSendRunState) finalize(ctx context.Context, retErr error) {
 
 	r.finalizeRun(retErr)
 	r.finalizeUserMessage(finalizeCtx, retErr)
+	userMessage := r.currentUserMessage()
+	if shouldPersistConversationFallbackTitleAfterSend(retErr, userMessage) && r.conversation != nil {
+		r.service.persistConversationFallbackTitle(finalizeCtx, *r.conversation, *userMessage)
+	}
 	r.finalizeAssistantMessage(finalizeCtx, retErr)
 	r.createRun(finalizeCtx)
+}
+
+func shouldPersistConversationFallbackTitleAfterSend(retErr error, userMessage *model.Message) bool {
+	return userMessage != nil && errors.Is(retErr, ErrMessageGenerationCanceled)
 }
 
 func (r *messageSendRunState) finalizeRun(retErr error) {


### PR DESCRIPTION
## Summary

Fix conversations reverting to the default “New Chat” title after the user manually stops the first model response.

The fallback title was previously persisted only by the post-billing metadata workflow. Explicit cancellation can bypass that workflow even though the first user message has already been saved.

This change:

- Settles the fallback title as part of canceled generation finalization.
- Uses the first user message, limited to the existing 16-character rule.
- Runs only for explicit generation cancellation.
- Preserves the existing successful generation and metadata workflow.
- Does not affect ordinary upstream errors or routing failures.
- Uses the repository’s conditional update to avoid overwriting manual or generated titles.
- Does not invoke an auxiliary model or consume additional tokens.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./internal/application/conversation ./internal/infra/persistence/postgres/conversation`
- [x] `gofmt` applied to changed Go files.
- [x] `git diff --check HEAD`

## Screenshots, API examples, or logs

Reproduction verified through the cancellation settlement path:

1. Disable automatic title generation.
2. Send the first message in a new conversation.
3. Stop model generation.
4. Refresh the page.
5. The conversation retains the first-message fallback title instead of reverting to “New Chat”.

## Configuration, migration, and compatibility notes

No configuration, API contract, Swagger, or database migration changes are required.

Automatic title generation remains unchanged. When enabled, successful generations continue using the existing post-billing metadata workflow.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] Conversation updates remain scoped to the existing conversation ownership context.
- [x] Conditional title updates prevent overwriting manually managed titles.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior is documented in this PR.
- [x] No generated artifacts are required for this change.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.