### PR TITLE
fix: preserve interrupted reasoning and improve usage settlement

### DIFF
--- a/backend/internal/application/billing/service.go
+++ b/backend/internal/application/billing/service.go
@@ -138,6 +138,7 @@ type UsagePricingInput struct {
 	UsageSpeed          string
 	RequestServiceTier  string
 	UsageServiceTier    string
+	UsageSource         string
 	ServiceOnly         bool
 	InputTokens         int64
 	CacheReadTokens     int64
@@ -1746,6 +1747,9 @@ func (s *Service) BuildUsageLedger(ctx context.Context, input UsagePricingInput)
 		"native_tool_billed_nanousd":               nativeToolBilledNanousd,
 		"base_service_billed_nanousd":              serviceBilledNanousd,
 		"service_items":                            usageServiceItemSnapshots(serviceItems),
+	}
+	if usageSource := strings.TrimSpace(input.UsageSource); usageSource != "" {
+		snapshot["usage_source"] = usageSource
 	}
 	snapshotJSON := "{}"
 	if raw, marshalErr := json.Marshal(snapshot); marshalErr == nil {

--- a/backend/internal/application/billing/service_model_identity_test.go
+++ b/backend/internal/application/billing/service_model_identity_test.go
@@ -495,6 +495,7 @@ func TestBuildUsageLedgerSnapshotsModelIdentity(t *testing.T) {
 		UpstreamModelName: "gpt-5.5-upstream",
 		InputTokens:       1_000_000,
 		OutputTokens:      1_000_000,
+		UsageSource:       "estimated",
 		RawUsageJSON:      `{"input_tokens":1000000,"output_tokens":1000000,"vendor_extra":"kept"}`,
 		ServerSideToolUsage: map[string]int64{
 			"web_search": 2,
@@ -527,6 +528,9 @@ func TestBuildUsageLedgerSnapshotsModelIdentity(t *testing.T) {
 	}
 	if snapshot["upstream_name"] != "premium-channel" {
 		t.Fatalf("expected upstream name snapshot, got %#v", snapshot["upstream_name"])
+	}
+	if snapshot["usage_source"] != "estimated" {
+		t.Fatalf("expected usage source snapshot, got %#v", snapshot["usage_source"])
 	}
 	if snapshot["routed_binding_code"] != "upm_gpt55_20260514" || snapshot["upstream_model_name"] != "gpt-5.5-upstream" {
 		t.Fatalf("expected routed binding/upstream snapshot, got routed=%#v upstream_model=%#v", snapshot["routed_binding_code"], snapshot["upstream_model_name"])

--- a/backend/internal/application/conversation/service.go
+++ b/backend/internal/application/conversation/service.go
@@ -178,6 +178,7 @@ type SendMessageResult struct {
 	EffectiveOptions      map[string]interface{}
 	UsageSpeed            string
 	UsageServiceTier      string
+	UsageSource           string
 	RawUsageJSON          string
 	CacheWrite5mTokens    int64
 	CacheWrite1hTokens    int64

--- a/backend/internal/application/conversation/service_billing.go
+++ b/backend/internal/application/conversation/service_billing.go
@@ -271,6 +271,7 @@ func (s *Service) buildSendMessageUsageLedger(ctx context.Context, input SendMes
 		UsageSpeed:          strings.TrimSpace(result.UsageSpeed),
 		RequestServiceTier:  messageRequestServiceTier(result.EffectiveOptions),
 		UsageServiceTier:    strings.TrimSpace(result.UsageServiceTier),
+		UsageSource:         strings.TrimSpace(result.UsageSource),
 		InputTokens:         sendMessageBillingInputTokens(result),
 		CacheReadTokens:     sendMessageBillingCacheReadTokens(result),
 		CacheWriteTokens:    sendMessageBillingCacheWriteTokens(result),

--- a/backend/internal/application/conversation/service_message_completion.go
+++ b/backend/internal/application/conversation/service_message_completion.go
@@ -36,23 +36,25 @@ type persistMessageGenerationInput struct {
 }
 
 type persistInterruptedMessageGenerationInput struct {
-	SendInput             SendMessageInput
-	UserMessage           *model.Message
-	AssistantMessage      *model.Message
-	AssistantText         string
-	EstimatedInputTokens  int64
-	UpstreamCallStarted   bool
-	Usage                 llm.Usage
-	AssistantLatency      int64
-	Error                 error
-	ToolCallRows          []model.ToolCall
-	PersistedToolCallKeys map[string]struct{}
-	TraceRecorder         *messageTraceRecorder
-	Route                 *channel.ResolvedRoute
-	EffectiveOptions      map[string]interface{}
-	ServerSideToolUsage   map[string]int64
-	StartedAt             time.Time
-	ReuseUserMessage      bool
+	SendInput              SendMessageInput
+	UserMessage            *model.Message
+	AssistantMessage       *model.Message
+	AssistantText          string
+	AssistantReasoningText string
+	EstimatedInputTokens   int64
+	UpstreamCallStarted    bool
+	Usage                  llm.Usage
+	UsageRecovered         bool
+	AssistantLatency       int64
+	Error                  error
+	ToolCallRows           []model.ToolCall
+	PersistedToolCallKeys  map[string]struct{}
+	TraceRecorder          *messageTraceRecorder
+	Route                  *channel.ResolvedRoute
+	EffectiveOptions       map[string]interface{}
+	ServerSideToolUsage    map[string]int64
+	StartedAt              time.Time
+	ReuseUserMessage       bool
 }
 
 type interruptedMessageGenerationMetrics struct {
@@ -65,6 +67,13 @@ type interruptedMessageGenerationMetrics struct {
 	CacheWriteTokens int64
 	ReasoningTokens  int64
 }
+
+const (
+	interruptedUsageSourceObserved  = "observed"
+	interruptedUsageSourceRecovered = "recovered"
+	interruptedUsageSourceEstimated = "estimated"
+	interruptedUsageSourceMixed     = "mixed"
+)
 
 type persistMessageToolCallsInput struct {
 	SendInput             SendMessageInput
@@ -368,7 +377,7 @@ func (s *Service) persistInterruptedMessageGeneration(ctx context.Context, input
 		)
 	}
 	if input.TraceRecorder != nil {
-		input.TraceRecorder.fail(input.Error)
+		input.TraceRecorder.failWithContext(persistCtx, input.Error)
 		input.TraceRecorder.attachToMessage(input.AssistantMessage)
 	}
 
@@ -395,7 +404,11 @@ func shouldPersistInterruptedMessageGeneration(input persistInterruptedMessageGe
 // resolveInterruptedMessageGenerationMetrics 统一处理中断消息的真实 usage 与估算兜底。
 func resolveInterruptedMessageGenerationMetrics(input persistInterruptedMessageGenerationInput) interruptedMessageGenerationMetrics {
 	inputTokens := resolveObservedOrHigherEstimatedTokens(input.Usage.InputTokens, input.EstimatedInputTokens)
-	outputTokens := resolveObservedOrHigherEstimatedOutputTokens(input.Usage.OutputTokens, input.AssistantText)
+	outputTokens := input.Usage.OutputTokens
+	reasoningTokens := input.Usage.ReasoningTokens
+	if !input.UsageRecovered {
+		outputTokens, reasoningTokens = resolveInterruptedOutputUsage(input)
+	}
 	latencyMS := input.AssistantLatency
 	if latencyMS < 0 {
 		latencyMS = time.Since(input.StartedAt).Milliseconds()
@@ -411,7 +424,47 @@ func resolveInterruptedMessageGenerationMetrics(input persistInterruptedMessageG
 		ErrorMessage:     truncateError(messageErrorSummary(input.Error), 255),
 		CacheReadTokens:  input.Usage.CacheReadTokens,
 		CacheWriteTokens: input.Usage.CacheWriteTokens,
-		ReasoningTokens:  input.Usage.ReasoningTokens,
+		ReasoningTokens:  reasoningTokens,
+	}
+}
+
+func resolveInterruptedOutputUsage(input persistInterruptedMessageGenerationInput) (int64, int64) {
+	estimatedOutputTokens := estimateTokens(input.AssistantText)
+	estimatedReasoningTokens := estimateTokens(input.AssistantReasoningText)
+	observedOutputTokens := input.Usage.OutputTokens
+	observedReasoningTokens := input.Usage.ReasoningTokens
+
+	if observedReasoningTokens > 0 {
+		return resolveObservedOrHigherEstimatedTokens(observedOutputTokens, estimatedOutputTokens),
+			resolveObservedOrHigherEstimatedTokens(observedReasoningTokens, estimatedReasoningTokens)
+	}
+	if observedOutputTokens > 0 {
+		return resolveObservedOrHigherEstimatedTokens(
+			observedOutputTokens,
+			estimatedOutputTokens+estimatedReasoningTokens,
+		), 0
+	}
+	return estimatedOutputTokens, estimatedReasoningTokens
+}
+
+func interruptedUsageSource(input persistInterruptedMessageGenerationInput, metrics interruptedMessageGenerationMetrics) string {
+	hasObserved := input.Usage != (llm.Usage{})
+	hasEstimated := metrics.InputTokens > input.Usage.InputTokens ||
+		metrics.OutputTokens > input.Usage.OutputTokens ||
+		metrics.ReasoningTokens > input.Usage.ReasoningTokens
+	if input.UsageRecovered {
+		if hasEstimated {
+			return interruptedUsageSourceMixed
+		}
+		return interruptedUsageSourceRecovered
+	}
+	switch {
+	case hasObserved && hasEstimated:
+		return interruptedUsageSourceMixed
+	case hasObserved:
+		return interruptedUsageSourceObserved
+	default:
+		return interruptedUsageSourceEstimated
 	}
 }
 
@@ -482,6 +535,7 @@ func buildInterruptedSendMessageResult(input persistInterruptedMessageGeneration
 		EffectiveOptions:    input.EffectiveOptions,
 		UsageSpeed:          input.Usage.Speed,
 		UsageServiceTier:    input.Usage.ServiceTier,
+		UsageSource:         interruptedUsageSource(input, metrics),
 		RawUsageJSON:        input.Usage.RawUsageJSON,
 		CacheWrite5mTokens:  input.Usage.CacheWrite5mTokens,
 		CacheWrite1hTokens:  input.Usage.CacheWrite1hTokens,

--- a/backend/internal/application/conversation/service_message_completion_test.go
+++ b/backend/internal/application/conversation/service_message_completion_test.go
@@ -78,3 +78,85 @@ func TestCanceledGenerationAfterUpstreamCallUsesEstimatedInputFallback(t *testin
 		t.Fatalf("expected estimated input fallback without output charge, got %#v", metrics)
 	}
 }
+
+func TestCanceledGenerationEstimatesVisibleReasoningUsage(t *testing.T) {
+	reasoningText := "正在分析用户请求，并检查终止时已经显示的思考内容。"
+	input := persistInterruptedMessageGenerationInput{
+		UserMessage:            &model.Message{},
+		AssistantMessage:       &model.Message{},
+		AssistantReasoningText: reasoningText,
+		EstimatedInputTokens:   12,
+		Error:                  ErrMessageGenerationCanceled,
+		StartedAt:              time.Now(),
+	}
+
+	metrics := resolveInterruptedMessageGenerationMetrics(input)
+	if metrics.OutputTokens != 0 || metrics.ReasoningTokens != estimateTokens(reasoningText) {
+		t.Fatalf("expected visible reasoning to be estimated separately, got %#v", metrics)
+	}
+	if source := interruptedUsageSource(input, metrics); source != interruptedUsageSourceEstimated {
+		t.Fatalf("usage source = %q, want estimated", source)
+	}
+}
+
+func TestCanceledGenerationDoesNotDoubleCountCombinedObservedOutput(t *testing.T) {
+	input := persistInterruptedMessageGenerationInput{
+		UserMessage:            &model.Message{},
+		AssistantMessage:       &model.Message{},
+		AssistantText:          "可见回复",
+		AssistantReasoningText: "可见思考内容",
+		Usage:                  llm.Usage{OutputTokens: 2},
+		Error:                  ErrMessageGenerationCanceled,
+		StartedAt:              time.Now(),
+	}
+
+	metrics := resolveInterruptedMessageGenerationMetrics(input)
+	wantOutput := resolveObservedOrHigherEstimatedTokens(
+		input.Usage.OutputTokens,
+		estimateTokens(input.AssistantText)+estimateTokens(input.AssistantReasoningText),
+	)
+	if metrics.OutputTokens != wantOutput || metrics.ReasoningTokens != 0 {
+		t.Fatalf("expected combined output without duplicated reasoning, got %#v", metrics)
+	}
+}
+
+func TestCanceledGenerationRecoveredUsageIsAuthoritative(t *testing.T) {
+	input := persistInterruptedMessageGenerationInput{
+		UserMessage:            &model.Message{},
+		AssistantMessage:       &model.Message{},
+		AssistantText:          "这是一段明显更长的可见回复，用于确认恢复值不会被估算覆盖。",
+		AssistantReasoningText: "这是一段明显更长的思考内容，用于确认恢复值不会被估算覆盖。",
+		Usage:                  llm.Usage{InputTokens: 10, OutputTokens: 48, ReasoningTokens: 16},
+		UsageRecovered:         true,
+		Error:                  ErrMessageGenerationCanceled,
+		StartedAt:              time.Now(),
+	}
+
+	metrics := resolveInterruptedMessageGenerationMetrics(input)
+	if metrics.InputTokens != 10 || metrics.OutputTokens != 48 || metrics.ReasoningTokens != 16 {
+		t.Fatalf("expected recovered usage to remain authoritative, got %#v", metrics)
+	}
+	if source := interruptedUsageSource(input, metrics); source != interruptedUsageSourceRecovered {
+		t.Fatalf("usage source = %q, want recovered", source)
+	}
+}
+
+func TestCanceledGenerationRecoveredUsageRetainsEarlierEstimatedInput(t *testing.T) {
+	input := persistInterruptedMessageGenerationInput{
+		UserMessage:          &model.Message{},
+		AssistantMessage:     &model.Message{},
+		EstimatedInputTokens: 38,
+		Usage:                llm.Usage{InputTokens: 24, OutputTokens: 12},
+		UsageRecovered:       true,
+		Error:                ErrMessageGenerationCanceled,
+		StartedAt:            time.Now(),
+	}
+
+	metrics := resolveInterruptedMessageGenerationMetrics(input)
+	if metrics.InputTokens != 38 || metrics.OutputTokens != 12 {
+		t.Fatalf("expected recovered current-call usage plus earlier estimated input, got %#v", metrics)
+	}
+	if source := interruptedUsageSource(input, metrics); source != interruptedUsageSourceMixed {
+		t.Fatalf("usage source = %q, want mixed", source)
+	}
+}

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -217,6 +217,7 @@ func (s *Service) sendMessageInternal(
 	var totalServerSideToolUsage map[string]int64
 	var responsesBackgroundRouteConfig llm.RouteConfig
 	var responsesBackgroundRecovery openAIResponsesBackgroundRecoveryState
+	responsesBackgroundUsageRecovered := false
 	userContentEstimatedInputTokens := int64(0)
 	usageAccumulator := &messageUsageAccumulator{}
 	upstreamCallStarted := false
@@ -228,29 +229,32 @@ func (s *Service) sendMessageInternal(
 		if retErr != nil {
 			if errors.Is(retErr, ErrMessageGenerationCanceled) {
 				if usage, ok := s.recoverOpenAIResponsesBackgroundUsage(responsesBackgroundRouteConfig, responsesBackgroundRecovery); ok {
+					responsesBackgroundUsageRecovered = true
 					if delta := diffLLMUsage(usage, responsesBackgroundRecovery.ObservedUsage); delta != (llm.Usage{}) {
 						usageAccumulator.addObservedUsage(delta)
 					}
 				}
 			}
 			if retained := s.persistInterruptedMessageGeneration(ctx, persistInterruptedMessageGenerationInput{
-				SendInput:             input,
-				UserMessage:           userMessage,
-				AssistantMessage:      assistantMessage,
-				AssistantText:         streamedText.String(),
-				EstimatedInputTokens:  usageAccumulator.interruptedInputTokens(),
-				UpstreamCallStarted:   upstreamCallStarted,
-				Usage:                 usageAccumulator.usage(),
-				AssistantLatency:      time.Since(startedAt).Milliseconds(),
-				Error:                 retErr,
-				ToolCallRows:          toolCallRows,
-				PersistedToolCallKeys: persistedToolCallKeys,
-				TraceRecorder:         traceRecorder,
-				Route:                 resolvedRoute,
-				EffectiveOptions:      filteredOptions,
-				ServerSideToolUsage:   totalServerSideToolUsage,
-				StartedAt:             startedAt,
-				ReuseUserMessage:      reuseUserMessage,
+				SendInput:              input,
+				UserMessage:            userMessage,
+				AssistantMessage:       assistantMessage,
+				AssistantText:          streamedText.String(),
+				AssistantReasoningText: traceRecorder.upstreamThinkContent(),
+				EstimatedInputTokens:   usageAccumulator.interruptedInputTokens(),
+				UpstreamCallStarted:    upstreamCallStarted,
+				Usage:                  usageAccumulator.usage(),
+				UsageRecovered:         responsesBackgroundUsageRecovered,
+				AssistantLatency:       time.Since(startedAt).Milliseconds(),
+				Error:                  retErr,
+				ToolCallRows:           toolCallRows,
+				PersistedToolCallKeys:  persistedToolCallKeys,
+				TraceRecorder:          traceRecorder,
+				Route:                  resolvedRoute,
+				EffectiveOptions:       filteredOptions,
+				ServerSideToolUsage:    totalServerSideToolUsage,
+				StartedAt:              startedAt,
+				ReuseUserMessage:       reuseUserMessage,
 			}); retained != nil {
 				result = retained
 				applyRetainedGenerationRunUsage(run, retained, len(toolCallRows), startedAt)

--- a/backend/internal/application/conversation/service_trace.go
+++ b/backend/internal/application/conversation/service_trace.go
@@ -95,6 +95,7 @@ type messageTraceRecorder struct {
 	upstreamThinkPendingKind    string
 	upstreamThinkPendingReason  map[string]interface{}
 	upstreamThinkBufferedByte   int
+	failed                      bool
 }
 
 func formatTraceStep(label string, detail string) string {
@@ -553,9 +554,17 @@ func (r *messageTraceRecorder) complete() {
 }
 
 func (r *messageTraceRecorder) fail(err error) {
+	r.failWithContext(r.ctx, err)
+}
+
+func (r *messageTraceRecorder) failWithContext(ctx context.Context, err error) {
 	if !r.enabled() {
 		return
 	}
+	if r.failed {
+		return
+	}
+	r.failed = true
 	now := time.Now()
 	summary := traceErrorSummary(err)
 	detail := traceErrorDetail(err)
@@ -574,17 +583,18 @@ func (r *messageTraceRecorder) fail(err error) {
 		}
 		mergeTracePayload(process.payload, payload)
 		process.endedAt = &now
-		r.persistDraft(process, true)
+		r.persistDraftCtx(ctx, process, true)
 	}
 	if r.upstreamThink != nil {
 		r.upstreamThink.status = messageTraceStatusError
 		r.upstreamThink.endedAt = &now
-		r.persistDraft(r.upstreamThink, true)
+		r.flushUpstreamThinkLiveUpdate(r.upstreamThink, true, false)
+		r.persistDraftCtx(ctx, r.upstreamThink, true)
 	}
 	if r.tools != nil {
 		r.tools.status = messageTraceStatusError
 		r.tools.endedAt = &now
-		r.persistDraft(r.tools, true)
+		r.persistDraftCtx(ctx, r.tools, true)
 	}
 }
 
@@ -593,6 +603,13 @@ func (r *messageTraceRecorder) attachToMessage(message *model.Message) {
 		return
 	}
 	message.ProcessTrace = r.snapshot()
+}
+
+func (r *messageTraceRecorder) upstreamThinkContent() string {
+	if r == nil || r.upstreamThink == nil {
+		return ""
+	}
+	return r.upstreamThink.contentMarkdown
 }
 
 func (r *messageTraceRecorder) snapshot() *model.MessageProcessTrace {
@@ -669,6 +686,9 @@ func (r *messageTraceRecorder) persistDraftCtx(ctx context.Context, draft *messa
 		r.upsertSnapshotEvent(draft, payloadJSON)
 	}
 	if !force && !r.cfg.ProcessTracePersistInflight {
+		return
+	}
+	if r.service == nil || r.service.repo == nil {
 		return
 	}
 	r.persistMessageTraceRow(ctx, draft, payloadJSON)

--- a/backend/internal/application/conversation/service_trace_integration_test.go
+++ b/backend/internal/application/conversation/service_trace_integration_test.go
@@ -1,0 +1,65 @@
+package conversation
+
+import (
+	"context"
+	"testing"
+
+	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
+	persistencemodels "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/models"
+	persistenceconversation "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/postgres/conversation"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestCanceledTraceSettlementPersistsCompleteReasoningForReload(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:trace_cancel_settlement?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&persistencemodels.ChatRunEvent{}); err != nil {
+		t.Fatalf("migrate trace table: %v", err)
+	}
+
+	repo := persistenceconversation.NewRepo(db)
+	cfg := config.Config{
+		ProcessTraceEnabled:            true,
+		ProcessTraceVisibleToUser:      true,
+		ProcessTraceStoreUpstreamThink: true,
+	}
+	service := &Service{cfg: config.NewRuntime(cfg), repo: repo}
+	assistant := &model.Message{
+		ID:             41,
+		ConversationID: 17,
+		UserID:         9,
+		RunID:          "run_cancel_settlement",
+		Role:           "assistant",
+	}
+
+	generationCtx, cancelGeneration := context.WithCancel(context.Background())
+	recorder := newMessageTraceRecorder(service, generationCtx, assistant, nil)
+	recorder.appendUpstreamReasoning(messageTraceThinkKindContent, "嗯", nil)
+	recorder.appendUpstreamReasoning(messageTraceThinkKindContent, "，继续分析并保留终止前的完整思考", nil)
+	cancelGeneration()
+	if generationCtx.Err() == nil {
+		t.Fatal("expected generation context to be canceled")
+	}
+
+	recorder.failWithContext(context.Background(), ErrMessageGenerationCanceled)
+
+	reloaded := []model.Message{{ID: assistant.ID, Role: "assistant"}}
+	reloadService := &Service{cfg: config.NewRuntime(cfg), repo: repo}
+	if err := reloadService.hydrateMessageProcessTraces(context.Background(), reloaded); err != nil {
+		t.Fatalf("hydrate persisted trace: %v", err)
+	}
+	trace := reloaded[0].ProcessTrace
+	if trace == nil || trace.UpstreamThink == nil {
+		t.Fatalf("expected persisted upstream reasoning after reload, got %#v", trace)
+	}
+	if got, want := trace.UpstreamThink.ContentMarkdown, "嗯，继续分析并保留终止前的完整思考"; got != want {
+		t.Fatalf("reloaded reasoning = %q, want %q", got, want)
+	}
+	if trace.UpstreamThink.Status != messageTraceStatusError {
+		t.Fatalf("reloaded reasoning status = %q, want %q", trace.UpstreamThink.Status, messageTraceStatusError)
+	}
+}

--- a/backend/internal/application/conversation/service_trace_tool_test.go
+++ b/backend/internal/application/conversation/service_trace_tool_test.go
@@ -1,6 +1,7 @@
 package conversation
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -218,6 +219,42 @@ func TestUpstreamThinkingDeltaIsCoalescedBetweenFlushes(t *testing.T) {
 	}
 	if events[1]["delta"] != "bc" || events[1]["status"] != messageTraceStatusCompleted {
 		t.Fatalf("expected completion to flush coalesced delta with completed status, got %#v", events[1])
+	}
+}
+
+func TestFailedUpstreamThinkingFlushesBufferedContent(t *testing.T) {
+	var events []map[string]interface{}
+	recorder := &messageTraceRecorder{
+		cfg: config.Config{
+			ProcessTraceEnabled:            true,
+			ProcessTraceVisibleToUser:      true,
+			ProcessTraceStoreUpstreamThink: true,
+		},
+		assistant: &model.Message{ID: 1, ConversationID: 2, UserID: 3, RunID: "run_cancel"},
+		onEvent: func(eventType string, payload map[string]interface{}) error {
+			if eventType == "upstream_think_delta" {
+				events = append(events, payload)
+			}
+			return nil
+		},
+	}
+	recorderCtx, cancelRecorder := context.WithCancel(context.Background())
+	recorder.ctx = recorderCtx
+	cancelRecorder()
+
+	recorder.appendUpstreamReasoning(messageTraceThinkKindContent, "嗯", nil)
+	recorder.appendUpstreamReasoning(messageTraceThinkKindContent, "，继续分析完整内容", nil)
+	recorder.failWithContext(context.Background(), ErrMessageGenerationCanceled)
+
+	if len(events) != 2 {
+		t.Fatalf("expected cancellation to flush the buffered reasoning, got %d events", len(events))
+	}
+	if events[1]["delta"] != "，继续分析完整内容" || events[1]["status"] != messageTraceStatusError {
+		t.Fatalf("unexpected terminal reasoning event: %#v", events[1])
+	}
+	trace := recorder.snapshot()
+	if trace == nil || trace.UpstreamThink == nil || trace.UpstreamThink.ContentMarkdown != "嗯，继续分析完整内容" {
+		t.Fatalf("expected complete reasoning snapshot after cancellation, got %#v", trace)
 	}
 }
 

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -19,7 +19,10 @@ import {
   toPendingAttachments,
   toPendingProcessTrace,
 } from "@/features/chat/model/message-submit";
-import { readLiveUpstreamThinkTrace } from "@/features/chat/model/upstream-think-store";
+import {
+  preserveRicherLiveUpstreamThinkTrace,
+  readLiveUpstreamThinkTrace,
+} from "@/features/chat/model/upstream-think-store";
 import {
   resolveErrorDetails,
   resolveErrorMessage,
@@ -954,7 +957,13 @@ export function useChatMessageSubmit({
             ),
             assistantReasoningTokens: completed.assistantMessage.reasoningTokens,
             assistantLatencyMS: completed.assistantMessage.latencyMS,
-            assistantProcessTrace: toPendingProcessTrace(completed.assistantMessage.processTrace),
+            assistantProcessTrace:
+              assistantMessageStatus === "interrupted"
+                ? preserveRicherLiveUpstreamThinkTrace(
+                    toPendingProcessTrace(completed.assistantMessage.processTrace),
+                    readLiveUpstreamThinkTrace(clientRunID),
+                  )
+                : toPendingProcessTrace(completed.assistantMessage.processTrace),
             assistantStatus: assistantMessageStatus,
             assistantErrorCode: completed.assistantMessage.errorCode,
             assistantErrorMessage: completed.assistantMessage.errorMessage,

--- a/frontend/features/chat/model/upstream-think-store.ts
+++ b/frontend/features/chat/model/upstream-think-store.ts
@@ -133,6 +133,18 @@ export function mergeLiveUpstreamThinkTrace(
   };
 }
 
+export function preserveRicherLiveUpstreamThinkTrace(
+  base: ChatMessageProcessTrace | undefined,
+  live: ChatMessageProcessTrace | undefined,
+) {
+  const baseContent = base?.upstreamThink?.contentMarkdown ?? "";
+  const liveContent = live?.upstreamThink?.contentMarkdown ?? "";
+  if (!live?.upstreamThink || liveContent.length <= baseContent.length) {
+    return base ?? live;
+  }
+  return mergeLiveUpstreamThinkTrace(base, live);
+}
+
 export function useLiveUpstreamThinkTrace(runID: string | null | undefined) {
   const key = normalizeRunID(runID);
   return React.useSyncExternalStore(

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Fix interrupted model generations losing streamed reasoning content and reporting incomplete token usage.

This change:

- Flushes and persists buffered reasoning with an independent settlement context after cancellation.
- Prevents canceled request contexts from blocking terminal trace persistence.
- Preserves the richer live reasoning trace on the frontend for interrupted responses only.
- Uses upstream usage when available and estimates missing output/reasoning usage from visible content.
- Records usage provenance as `observed`, `recovered`, `estimated`, or `mixed`.
- Retains estimated input usage from earlier tool-loop calls when the current Responses API usage is recovered.
- Adds an SQLite-backed integration test covering cancellation, persistence, and trace reload.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [x] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm --filter @deeix/web check`
- [x] `pnpm --filter @deeix/web build`
- [x] `cd backend && go test ./internal/application/conversation ./internal/application/billing -count=1`
- [x] `git diff --check HEAD`
- [x] Verified cancellation against the locally configured PostgreSQL `LongCat-2.1` model.

## Screenshots, API examples, or logs

Local `LongCat-2.1` cancellation verification:

- Reasoning received before cancellation: 80 bytes
- Persisted reasoning after reload: 80 bytes
- Estimated reasoning usage: 18 tokens
- Usage source: `estimated`

The upstream did not return final usage after cancellation, so visible-content estimation was used as the fallback.

## Configuration, migration, and compatibility notes

- No database migration is required.
- No public API contract or Swagger changes are required.
- Existing successful generation behavior is unchanged.
- Recovered upstream output and reasoning usage remains authoritative.
- Token estimates are used only when final upstream usage is unavailable or incomplete.
- Usage provenance is stored in the existing pricing snapshot JSON.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.