### PR TITLE
fix: enhance resume state management and cleanup in chat data hook

### DIFF
--- a/frontend/features/chat/hooks/use-chat-data.ts
+++ b/frontend/features/chat/hooks/use-chat-data.ts
@@ -99,6 +99,15 @@ export function useChatData(
   const pendingAssistantContentRef = React.useRef("");
   const resumeTextReplayByRunRef = React.useRef<Record<string, ResumeTextReplayState>>({});
   const activeResumeStreamRef = React.useRef<ActiveResumeStream | null>(null);
+  // 恢复游标只在对应的可见内容仍被保留时有效，两者必须同步清理。
+  const clearResumeCheckpoint = React.useCallback((runID: string) => {
+    const normalizedRunID = runID.trim();
+    if (!normalizedRunID) {
+      return;
+    }
+    delete resumeSeqByRunRef.current[normalizedRunID];
+    delete resumeTextReplayByRunRef.current[normalizedRunID];
+  }, []);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -287,6 +296,7 @@ export function useChatData(
     }
 
     active.controller.abort();
+    clearResumeCheckpoint(active.runID);
     setResumingRunID("");
 
     const token = active.accessToken ?? (await resolveAccessToken());
@@ -297,7 +307,7 @@ export function useChatData(
     const result = await cancelMessageGeneration(token, active.runID).catch(() => null);
     reload();
     return Boolean(result?.canceled);
-  }, [reload]);
+  }, [clearResumeCheckpoint, reload]);
 
   const pendingAssistant = React.useMemo(() => {
     for (let index = state.messages.length - 1; index >= 0; index -= 1) {
@@ -334,6 +344,10 @@ export function useChatData(
     const clearResumeTextReplay = () => {
       delete resumeTextReplayByRun[pendingRunID];
     };
+    const isResumeInactive = () => closed || controller.signal.aborted;
+    const updateResumeState = (update: (current: ChatDataState) => ChatDataState) => {
+      setState((current) => isResumeInactive() ? current : update(current));
+    };
     resumeTextReplayByRun[pendingRunID] = {
       baseContent,
       replayedContent: afterSeq > 0 ? baseContent : "",
@@ -359,6 +373,9 @@ export function useChatData(
           signal: controller.signal,
           afterSeq,
           onEventSeq: (seq) => {
+            if (isResumeInactive()) {
+              return;
+            }
             resumeSeqByRunRef.current[pendingRunID] = Math.max(resumeSeqByRunRef.current[pendingRunID] ?? 0, seq);
           },
           onMediaStatus: (event) => {
@@ -372,7 +389,7 @@ export function useChatData(
                   : status === "saving_artifact"
                     ? tSubmit(contentType === "video" ? "mediaStatus.videoSavingArtifact" : "mediaStatus.savingArtifact")
                     : event.message.trim() || status;
-            setState((prev) => ({
+            updateResumeState((prev) => ({
               ...prev,
               messages: prev.messages.map((message) =>
                 message.runID === pendingRunID && message.role === "assistant" && message.status === "pending"
@@ -382,12 +399,15 @@ export function useChatData(
             }));
           },
           onMediaImageDelta: (event) => {
+            if (isResumeInactive()) {
+              return;
+            }
             clearResumeTextReplay();
             const previewMarkdown = buildMediaImagePreviewMarkdown(event, tSubmit("imagePreviewAlt"));
             if (!previewMarkdown) {
               return;
             }
-            setState((prev) => ({
+            updateResumeState((prev) => ({
               ...prev,
               messages: prev.messages.map((message) =>
                 message.runID === pendingRunID && message.role === "assistant" && message.status === "pending"
@@ -397,6 +417,9 @@ export function useChatData(
             }));
           },
           onDelta: (delta) => {
+            if (isResumeInactive()) {
+              return;
+            }
             let replayState = resumeTextReplayByRun[pendingRunID];
             if (!replayState) {
               replayState = {
@@ -407,7 +430,7 @@ export function useChatData(
               resumeTextReplayByRun[pendingRunID] = replayState;
             }
             const nextContent = appendResumedTextDelta(replayState, delta);
-            setState((prev) => ({
+            updateResumeState((prev) => ({
               ...prev,
               messages: prev.messages.map((message) =>
                 message.runID === pendingRunID && message.role === "assistant" && message.status === "pending"
@@ -417,7 +440,7 @@ export function useChatData(
             }));
           },
           onProcessUpdate: (event) => {
-            setState((prev) => ({
+            updateResumeState((prev) => ({
               ...prev,
               messages: prev.messages.map((message) =>
                 message.runID === pendingRunID && message.role === "assistant" && message.status === "pending"
@@ -427,10 +450,13 @@ export function useChatData(
             }));
           },
           onUpstreamThinkDelta: (event) => {
+            if (isResumeInactive()) {
+              return;
+            }
             upsertLiveUpstreamThinkTrace(pendingRunID, event);
           },
           onUsage: (event) => {
-            setState((prev) => ({
+            updateResumeState((prev) => ({
               ...prev,
               messages: prev.messages.map((message) =>
                 message.runID === pendingRunID && message.role === "assistant" && message.status === "pending"
@@ -451,17 +477,16 @@ export function useChatData(
           },
         });
         if (!controller.signal.aborted && completed === null) {
-          clearResumeTextReplay();
+          clearResumeCheckpoint(pendingRunID);
           reload();
         }
         if (!controller.signal.aborted && completed) {
-          delete resumeSeqByRunRef.current[pendingRunID];
-          clearResumeTextReplay();
+          clearResumeCheckpoint(pendingRunID);
           reload();
         }
       } catch (error) {
         if (!controller.signal.aborted && error instanceof Error && error.name !== "AbortError") {
-          clearResumeTextReplay();
+          clearResumeCheckpoint(pendingRunID);
           setResumingRunID("");
           reload();
         }
@@ -479,12 +504,20 @@ export function useChatData(
     return () => {
       closed = true;
       controller.abort();
-      clearResumeTextReplay();
+      clearResumeCheckpoint(pendingRunID);
       if (activeResumeStreamRef.current?.controller === controller) {
         activeResumeStreamRef.current = null;
       }
     };
-  }, [activeGenerationRunsRef, conversationID, failedGenerationRunsRef, pendingRunID, reload, tSubmit]);
+  }, [
+    activeGenerationRunsRef,
+    clearResumeCheckpoint,
+    conversationID,
+    failedGenerationRunsRef,
+    pendingRunID,
+    reload,
+    tSubmit,
+  ]);
 
   React.useEffect(() => {
     if (


### PR DESCRIPTION
## Summary

Fix media job creation failures when video generation requests include large Base64 reference images.

- Increase the `media_jobs.input_json` limit from 1 MiB to 32 MiB.
- Add idempotent constraint migrations for existing SQLite and PostgreSQL databases.
- Extend SQLite migration tests to cover legacy constraints, large payloads, data preservation, and repeated initialization.
- Keep existing HTTP request body and provider-specific size limits unchanged.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [x] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./...`

SQLite migration coverage verifies:

- Existing 1 MiB constraints are upgraded to 32 MiB.
- Payloads larger than 1 MiB can be persisted.
- Existing media jobs remain intact.
- Repeated schema initialization is idempotent.
- Foreign key enforcement is restored after table reconstruction.

## Screenshots, API examples, or logs

No UI changes.

Before this fix, valid video-generation requests containing larger Base64 reference images could fail while inserting `media_jobs`, before reaching the upstream provider. The database error was then exposed as a generic `502 upstream_unavailable`.

## Configuration, migration, and compatibility notes

- Existing SQLite and PostgreSQL databases are upgraded automatically during schema initialization.
- New databases are created with the 32 MiB constraint directly.
- The migration only replaces the legacy `1048576` constraint and is safe to execute repeatedly.
- Existing media job records are preserved.
- No environment variables, public API contracts, or manual deployment steps are introduced.
- The 32 MiB limit matches the default HTTP request body limit and accommodates Base64 expansion for provider-supported 20 MiB source images.
- Other request body, media, and provider-specific limits remain unchanged.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including request and provider size limits. Existing validation boundaries remain in place.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.