### PR TITLE
fix: restore chat autoscroll on send

### DIFF
--- a/frontend/features/chat/components/sections/chat-area.tsx
+++ b/frontend/features/chat/components/sections/chat-area.tsx
@@ -12,6 +12,7 @@ import {
   ChatMessageBot,
 } from "@/features/chat/components/message/message-bot";
 import { areChatAreaMessagesRenderEqual } from "@/features/chat/model/chat-message-render";
+import { resolveLiveAnchorMessageKey } from "@/features/chat/model/chat-scroll";
 import { type AssistantReaction } from "@/features/chat/components/message/message-meta";
 import type { ChatAreaMessage, MessageAttachment } from "@/features/chat/types/messages";
 import { ChatMessageUser } from "@/features/chat/components/message/message-user";
@@ -493,24 +494,11 @@ export function ChatArea({
     }
     pruneScreenshotSelection?.(selectableMessagePublicIDs);
   }, [pruneScreenshotSelection, selectableMessagePublicIDs, selectionMode]);
-  const hasLiveMessage = React.useMemo(
-    () => messages.some((item) => item.isPending || item.isStreaming),
+  const messageViewportBoundaryRef = React.useRef<HTMLDivElement | null>(null);
+  const liveAnchorMessageKey = React.useMemo(
+    () => resolveLiveAnchorMessageKey(messages),
     [messages],
   );
-  const messageViewportBoundaryRef = React.useRef<HTMLDivElement | null>(null);
-  const liveAnchorMessageKey = React.useMemo(() => {
-    if (!hasLiveMessage) {
-      return "";
-    }
-    const liveMessageIndex = messages.findIndex((item) => item.isPending || item.isStreaming);
-    for (let index = liveMessageIndex - 1; index >= 0; index -= 1) {
-      const item = messages[index];
-      if (item?.role === "user") {
-        return item.key;
-      }
-    }
-    return "";
-  }, [hasLiveMessage, messages]);
 
   return (
     <>

--- a/frontend/features/chat/components/sections/chat-area.tsx
+++ b/frontend/features/chat/components/sections/chat-area.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/features/chat/components/message/message-bot";
 import { areChatAreaMessagesRenderEqual } from "@/features/chat/model/chat-message-render";
 import {
-  PENDING_USER_SCROLL_OPTIONS,
+  animateChatScrollToBottom,
   resolveLiveAnchorMessageKey,
   resolvePendingUserScrollKey,
   schedulePendingUserScroll,
@@ -39,7 +39,6 @@ import {
   MessageScrollerItem,
   MessageScrollerProvider,
   MessageScrollerViewport,
-  useMessageScroller,
 } from "@/components/ui/message-scroller";
 import {
   ChatMessagePositionRail,
@@ -50,8 +49,13 @@ import { AppLogo, DeeixLogo } from "@/shared/components/app-logo";
 import { useBranding } from "@/shared/config/branding-provider";
 import { PoweredByDeeix } from "@/shared/components/powered-by-deeix";
 
-function ScrollToPendingUser({ scrollKey }: { scrollKey: string }) {
-  const { scrollToEnd } = useMessageScroller();
+function ScrollToPendingUser({
+  scrollKey,
+  viewportRef,
+}: {
+  scrollKey: string;
+  viewportRef: React.RefObject<HTMLDivElement | null>;
+}) {
   const handledScrollKeyRef = React.useRef("");
 
   React.useLayoutEffect(() => {
@@ -64,12 +68,28 @@ function ScrollToPendingUser({ scrollKey }: { scrollKey: string }) {
     }
 
     handledScrollKeyRef.current = scrollKey;
-    return schedulePendingUserScroll(
+    let cancelAnimation = () => undefined;
+    const cancelSchedule = schedulePendingUserScroll(
       (callback) => window.requestAnimationFrame(callback),
       (frameID) => window.cancelAnimationFrame(frameID),
-      () => scrollToEnd(PENDING_USER_SCROLL_OPTIONS),
+      () => {
+        const viewport = viewportRef.current;
+        if (!viewport) {
+          return;
+        }
+        cancelAnimation = animateChatScrollToBottom(
+          viewport,
+          (callback) => window.requestAnimationFrame(callback),
+          (frameID) => window.cancelAnimationFrame(frameID),
+        );
+      },
     );
-  }, [scrollKey, scrollToEnd]);
+
+    return () => {
+      cancelSchedule();
+      cancelAnimation();
+    };
+  }, [scrollKey, viewportRef]);
 
   return null;
 }
@@ -592,7 +612,10 @@ export function ChatArea({
       <div className="relative min-h-0 flex-1 overflow-hidden">
         <MessageScrollerProvider autoScroll defaultScrollPosition="end" scrollEdgeThreshold={16}>
           <MessageScroller>
-            <ScrollToPendingUser scrollKey={pendingUserScrollKey} />
+            <ScrollToPendingUser
+              scrollKey={pendingUserScrollKey}
+              viewportRef={messageViewportBoundaryRef}
+            />
             <MessageScrollerViewport
               ref={messageViewportBoundaryRef}
               className="px-3 pb-8 pt-2 [overflow-anchor:none] md:px-6"

--- a/frontend/features/chat/components/sections/chat-area.tsx
+++ b/frontend/features/chat/components/sections/chat-area.tsx
@@ -12,7 +12,10 @@ import {
   ChatMessageBot,
 } from "@/features/chat/components/message/message-bot";
 import { areChatAreaMessagesRenderEqual } from "@/features/chat/model/chat-message-render";
-import { resolveLiveAnchorMessageKey } from "@/features/chat/model/chat-scroll";
+import {
+  resolveLiveAnchorMessageKey,
+  resolvePendingUserScrollKey,
+} from "@/features/chat/model/chat-scroll";
 import { type AssistantReaction } from "@/features/chat/components/message/message-meta";
 import type { ChatAreaMessage, MessageAttachment } from "@/features/chat/types/messages";
 import { ChatMessageUser } from "@/features/chat/components/message/message-user";
@@ -34,6 +37,7 @@ import {
   MessageScrollerItem,
   MessageScrollerProvider,
   MessageScrollerViewport,
+  useMessageScroller,
 } from "@/components/ui/message-scroller";
 import {
   ChatMessagePositionRail,
@@ -43,6 +47,26 @@ import { cn } from "@/lib/utils";
 import { AppLogo, DeeixLogo } from "@/shared/components/app-logo";
 import { useBranding } from "@/shared/config/branding-provider";
 import { PoweredByDeeix } from "@/shared/components/powered-by-deeix";
+
+function ScrollToPendingUser({ scrollKey }: { scrollKey: string }) {
+  const { scrollToEnd } = useMessageScroller();
+  const handledScrollKeyRef = React.useRef("");
+
+  React.useLayoutEffect(() => {
+    if (!scrollKey) {
+      handledScrollKeyRef.current = "";
+      return;
+    }
+    if (handledScrollKeyRef.current === scrollKey) {
+      return;
+    }
+
+    handledScrollKeyRef.current = scrollKey;
+    scrollToEnd({ behavior: "auto" });
+  }, [scrollKey, scrollToEnd]);
+
+  return null;
+}
 
 function CompactDivider({ summaryPreview }: { summaryPreview: string }) {
   const t = useTranslations("chat.messages");
@@ -499,6 +523,10 @@ export function ChatArea({
     () => resolveLiveAnchorMessageKey(messages),
     [messages],
   );
+  const pendingUserScrollKey = React.useMemo(
+    () => resolvePendingUserScrollKey(messages),
+    [messages],
+  );
 
   return (
     <>
@@ -558,6 +586,7 @@ export function ChatArea({
       <div className="relative min-h-0 flex-1 overflow-hidden">
         <MessageScrollerProvider autoScroll defaultScrollPosition="end" scrollEdgeThreshold={16}>
           <MessageScroller>
+            <ScrollToPendingUser scrollKey={pendingUserScrollKey} />
             <MessageScrollerViewport
               ref={messageViewportBoundaryRef}
               className="px-3 pb-8 pt-2 [overflow-anchor:none] md:px-6"

--- a/frontend/features/chat/components/sections/chat-area.tsx
+++ b/frontend/features/chat/components/sections/chat-area.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/features/chat/components/message/message-bot";
 import { areChatAreaMessagesRenderEqual } from "@/features/chat/model/chat-message-render";
 import {
+  PENDING_USER_SCROLL_OPTIONS,
   resolveLiveAnchorMessageKey,
   resolvePendingUserScrollKey,
 } from "@/features/chat/model/chat-scroll";
@@ -62,7 +63,7 @@ function ScrollToPendingUser({ scrollKey }: { scrollKey: string }) {
     }
 
     handledScrollKeyRef.current = scrollKey;
-    scrollToEnd({ behavior: "auto" });
+    scrollToEnd(PENDING_USER_SCROLL_OPTIONS);
   }, [scrollKey, scrollToEnd]);
 
   return null;

--- a/frontend/features/chat/components/sections/chat-area.tsx
+++ b/frontend/features/chat/components/sections/chat-area.tsx
@@ -16,6 +16,7 @@ import {
   PENDING_USER_SCROLL_OPTIONS,
   resolveLiveAnchorMessageKey,
   resolvePendingUserScrollKey,
+  schedulePendingUserScroll,
 } from "@/features/chat/model/chat-scroll";
 import { type AssistantReaction } from "@/features/chat/components/message/message-meta";
 import type { ChatAreaMessage, MessageAttachment } from "@/features/chat/types/messages";
@@ -63,7 +64,11 @@ function ScrollToPendingUser({ scrollKey }: { scrollKey: string }) {
     }
 
     handledScrollKeyRef.current = scrollKey;
-    scrollToEnd(PENDING_USER_SCROLL_OPTIONS);
+    return schedulePendingUserScroll(
+      (callback) => window.requestAnimationFrame(callback),
+      (frameID) => window.cancelAnimationFrame(frameID),
+      () => scrollToEnd(PENDING_USER_SCROLL_OPTIONS),
+    );
   }, [scrollKey, scrollToEnd]);
 
   return null;

--- a/frontend/features/chat/model/chat-scroll.test.mjs
+++ b/frontend/features/chat/model/chat-scroll.test.mjs
@@ -17,8 +17,33 @@ test("keeps the previous user as the stream resize anchor", () => {
   );
 });
 
-test("uses smooth motion when following a newly submitted user turn", () => {
-  assert.deepEqual(chatScroll.PENDING_USER_SCROLL_OPTIONS, { behavior: "smooth" });
+test("animates submitted messages to the bottom over a controlled duration", () => {
+  assert.equal(chatScroll.CHAT_SEND_SCROLL_DURATION_MS, 700);
+  assert.equal(typeof chatScroll.animateChatScrollToBottom, "function");
+
+  const viewport = { scrollTop: 100, scrollHeight: 1100, clientHeight: 100 };
+  const frames = [];
+  let nextFrameID = 0;
+  const cancelled = [];
+  const cancel = chatScroll.animateChatScrollToBottom(
+    viewport,
+    (callback) => {
+      frames.push(callback);
+      nextFrameID += 1;
+      return nextFrameID;
+    },
+    (frameID) => cancelled.push(frameID),
+  );
+
+  frames.shift()(0);
+  assert.equal(viewport.scrollTop, 100);
+  frames.shift()(350);
+  assert.equal(viewport.scrollTop, 550);
+  frames.shift()(700);
+  assert.equal(viewport.scrollTop, 1000);
+
+  cancel();
+  assert.deepEqual(cancelled, [3]);
 });
 
 test("starts smooth scrolling after pending-message layout observers settle", () => {

--- a/frontend/features/chat/model/chat-scroll.test.mjs
+++ b/frontend/features/chat/model/chat-scroll.test.mjs
@@ -21,6 +21,35 @@ test("uses smooth motion when following a newly submitted user turn", () => {
   assert.deepEqual(chatScroll.PENDING_USER_SCROLL_OPTIONS, { behavior: "smooth" });
 });
 
+test("starts smooth scrolling after pending-message layout observers settle", () => {
+  assert.equal(typeof chatScroll.schedulePendingUserScroll, "function");
+
+  const frames = [];
+  const cancelled = [];
+  let nextFrameID = 0;
+  let scrollCount = 0;
+  const cancel = chatScroll.schedulePendingUserScroll(
+    (callback) => {
+      frames.push(callback);
+      nextFrameID += 1;
+      return nextFrameID;
+    },
+    (frameID) => cancelled.push(frameID),
+    () => {
+      scrollCount += 1;
+    },
+  );
+
+  assert.equal(scrollCount, 0);
+  frames.shift()(0);
+  assert.equal(scrollCount, 0);
+  frames.shift()(16);
+  assert.equal(scrollCount, 1);
+
+  cancel();
+  assert.deepEqual(cancelled, [1, 2]);
+});
+
 test("uses a newly pending user turn as the explicit scroll-to-bottom trigger", () => {
   assert.equal(typeof chatScroll.resolvePendingUserScrollKey, "function");
   assert.equal(

--- a/frontend/features/chat/model/chat-scroll.test.mjs
+++ b/frontend/features/chat/model/chat-scroll.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveLiveAnchorMessageKey } from "./chat-scroll.ts";
+
+test("anchors a newly pending user message so sending returns to the live turn", () => {
+  assert.equal(
+    resolveLiveAnchorMessageKey([
+      { key: "previous-user", role: "user" },
+      { key: "previous-assistant", role: "assistant" },
+      { key: "pending-user", role: "user", isPending: true },
+      { key: "pending-assistant", role: "assistant", isPending: true },
+    ]),
+    "pending-user",
+  );
+});
+
+test("anchors an assistant-only live run to its parent user message", () => {
+  assert.equal(
+    resolveLiveAnchorMessageKey([
+      { key: "parent-user", role: "user" },
+      { key: "pending-assistant", role: "assistant", isStreaming: true },
+    ]),
+    "parent-user",
+  );
+});
+
+test("returns no anchor when the conversation has no live message", () => {
+  assert.equal(
+    resolveLiveAnchorMessageKey([
+      { key: "user", role: "user" },
+      { key: "assistant", role: "assistant" },
+    ]),
+    "",
+  );
+});

--- a/frontend/features/chat/model/chat-scroll.test.mjs
+++ b/frontend/features/chat/model/chat-scroll.test.mjs
@@ -1,11 +1,26 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { resolveLiveAnchorMessageKey } from "./chat-scroll.ts";
+import * as chatScroll from "./chat-scroll.ts";
 
-test("anchors a newly pending user message so sending returns to the live turn", () => {
+const { resolveLiveAnchorMessageKey } = chatScroll;
+
+test("keeps the previous user as the stream resize anchor", () => {
   assert.equal(
     resolveLiveAnchorMessageKey([
+      { key: "previous-user", role: "user" },
+      { key: "previous-assistant", role: "assistant" },
+      { key: "pending-user", role: "user", isPending: true },
+      { key: "pending-assistant", role: "assistant", isPending: true },
+    ]),
+    "previous-user",
+  );
+});
+
+test("uses a newly pending user turn as the explicit scroll-to-bottom trigger", () => {
+  assert.equal(typeof chatScroll.resolvePendingUserScrollKey, "function");
+  assert.equal(
+    chatScroll.resolvePendingUserScrollKey([
       { key: "previous-user", role: "user" },
       { key: "previous-assistant", role: "assistant" },
       { key: "pending-user", role: "user", isPending: true },
@@ -25,12 +40,13 @@ test("anchors an assistant-only live run to its parent user message", () => {
   );
 });
 
-test("returns no anchor when the conversation has no live message", () => {
-  assert.equal(
-    resolveLiveAnchorMessageKey([
-      { key: "user", role: "user" },
-      { key: "assistant", role: "assistant" },
-    ]),
-    "",
-  );
+test("returns no live anchor or submit trigger when the conversation has no live message", () => {
+  const messages = [
+    { key: "user", role: "user" },
+    { key: "assistant", role: "assistant" },
+  ];
+
+  assert.equal(resolveLiveAnchorMessageKey(messages), "");
+  assert.equal(typeof chatScroll.resolvePendingUserScrollKey, "function");
+  assert.equal(chatScroll.resolvePendingUserScrollKey(messages), "");
 });

--- a/frontend/features/chat/model/chat-scroll.test.mjs
+++ b/frontend/features/chat/model/chat-scroll.test.mjs
@@ -17,6 +17,10 @@ test("keeps the previous user as the stream resize anchor", () => {
   );
 });
 
+test("uses smooth motion when following a newly submitted user turn", () => {
+  assert.deepEqual(chatScroll.PENDING_USER_SCROLL_OPTIONS, { behavior: "smooth" });
+});
+
 test("uses a newly pending user turn as the explicit scroll-to-bottom trigger", () => {
   assert.equal(typeof chatScroll.resolvePendingUserScrollKey, "function");
   assert.equal(

--- a/frontend/features/chat/model/chat-scroll.ts
+++ b/frontend/features/chat/model/chat-scroll.ts
@@ -1,0 +1,19 @@
+import type { ChatAreaMessage } from "@/features/chat/types/messages";
+
+type ScrollAnchorMessage = Pick<ChatAreaMessage, "key" | "role" | "isPending" | "isStreaming">;
+
+export function resolveLiveAnchorMessageKey(messages: ScrollAnchorMessage[]) {
+  const liveMessageIndex = messages.findIndex((item) => item.isPending || item.isStreaming);
+  if (liveMessageIndex < 0) {
+    return "";
+  }
+
+  for (let index = liveMessageIndex; index >= 0; index -= 1) {
+    const item = messages[index];
+    if (item?.role === "user") {
+      return item.key;
+    }
+  }
+
+  return "";
+}

--- a/frontend/features/chat/model/chat-scroll.ts
+++ b/frontend/features/chat/model/chat-scroll.ts
@@ -4,6 +4,29 @@ type ScrollAnchorMessage = Pick<ChatAreaMessage, "key" | "role" | "isPending" | 
 
 export const PENDING_USER_SCROLL_OPTIONS = { behavior: "smooth" } as const;
 
+type RequestAnimationFrame = (callback: (timestamp: number) => void) => number;
+type CancelAnimationFrame = (frameID: number) => void;
+
+export function schedulePendingUserScroll(
+  requestFrame: RequestAnimationFrame,
+  cancelFrame: CancelAnimationFrame,
+  scroll: () => void,
+) {
+  let secondFrameID: number | null = null;
+  const firstFrameID = requestFrame(() => {
+    secondFrameID = requestFrame(() => {
+      scroll();
+    });
+  });
+
+  return () => {
+    cancelFrame(firstFrameID);
+    if (secondFrameID !== null) {
+      cancelFrame(secondFrameID);
+    }
+  };
+}
+
 export function resolveLiveAnchorMessageKey(messages: ScrollAnchorMessage[]) {
   const liveMessageIndex = messages.findIndex((item) => item.isPending || item.isStreaming);
   if (liveMessageIndex < 0) {

--- a/frontend/features/chat/model/chat-scroll.ts
+++ b/frontend/features/chat/model/chat-scroll.ts
@@ -2,6 +2,8 @@ import type { ChatAreaMessage } from "@/features/chat/types/messages";
 
 type ScrollAnchorMessage = Pick<ChatAreaMessage, "key" | "role" | "isPending" | "isStreaming">;
 
+export const PENDING_USER_SCROLL_OPTIONS = { behavior: "smooth" } as const;
+
 export function resolveLiveAnchorMessageKey(messages: ScrollAnchorMessage[]) {
   const liveMessageIndex = messages.findIndex((item) => item.isPending || item.isStreaming);
   if (liveMessageIndex < 0) {

--- a/frontend/features/chat/model/chat-scroll.ts
+++ b/frontend/features/chat/model/chat-scroll.ts
@@ -8,9 +8,20 @@ export function resolveLiveAnchorMessageKey(messages: ScrollAnchorMessage[]) {
     return "";
   }
 
-  for (let index = liveMessageIndex; index >= 0; index -= 1) {
+  for (let index = liveMessageIndex - 1; index >= 0; index -= 1) {
     const item = messages[index];
     if (item?.role === "user") {
+      return item.key;
+    }
+  }
+
+  return "";
+}
+
+export function resolvePendingUserScrollKey(messages: ScrollAnchorMessage[]) {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const item = messages[index];
+    if (item?.role === "user" && item.isPending) {
       return item.key;
     }
   }

--- a/frontend/features/chat/model/chat-scroll.ts
+++ b/frontend/features/chat/model/chat-scroll.ts
@@ -2,10 +2,58 @@ import type { ChatAreaMessage } from "@/features/chat/types/messages";
 
 type ScrollAnchorMessage = Pick<ChatAreaMessage, "key" | "role" | "isPending" | "isStreaming">;
 
-export const PENDING_USER_SCROLL_OPTIONS = { behavior: "smooth" } as const;
+export const CHAT_SEND_SCROLL_DURATION_MS = 700;
 
 type RequestAnimationFrame = (callback: (timestamp: number) => void) => number;
 type CancelAnimationFrame = (frameID: number) => void;
+type ChatScrollViewport = Pick<HTMLElement, "scrollTop" | "scrollHeight" | "clientHeight">;
+
+function easeInOutCubic(progress: number) {
+  return progress < 0.5
+    ? 4 * progress * progress * progress
+    : 1 - (-2 * progress + 2) ** 3 / 2;
+}
+
+export function animateChatScrollToBottom(
+  viewport: ChatScrollViewport,
+  requestFrame: RequestAnimationFrame,
+  cancelFrame: CancelAnimationFrame,
+  durationMS = CHAT_SEND_SCROLL_DURATION_MS,
+) {
+  const startTop = viewport.scrollTop;
+  const initialTargetTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+  if (initialTargetTop <= startTop) {
+    viewport.scrollTop = initialTargetTop;
+    return () => undefined;
+  }
+
+  let animationFrameID = 0;
+  let startTimestamp: number | null = null;
+  let cancelled = false;
+  const step = (timestamp: number) => {
+    if (cancelled) {
+      return;
+    }
+    if (startTimestamp === null) {
+      startTimestamp = timestamp;
+    }
+
+    const progress = Math.min(1, Math.max(0, (timestamp - startTimestamp) / durationMS));
+    const targetTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+    viewport.scrollTop = startTop + (targetTop - startTop) * easeInOutCubic(progress);
+    if (progress < 1) {
+      animationFrameID = requestFrame(step);
+    }
+  };
+
+  animationFrameID = requestFrame(step);
+  return () => {
+    cancelled = true;
+    if (animationFrameID > 0) {
+      cancelFrame(animationFrameID);
+    }
+  };
+}
 
 export function schedulePendingUserScroll(
   requestFrame: RequestAnimationFrame,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "analyze:output": "next experimental-analyze --output",
     "start": "next start",
     "typecheck": "tsc --noEmit --pretty false",
-    "test": "node --no-warnings --test features/chat/components/sections/chat-model-picker-layout.test.mjs",
+    "test": "node --no-warnings --test features/chat/components/sections/chat-model-picker-layout.test.mjs features/chat/model/chat-scroll.test.mjs",
     "check": "pnpm lint && pnpm typecheck",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",


### PR DESCRIPTION
## Summary
- anchor newly pending user messages so sending from a scrolled-up conversation returns to the active turn
- preserve the existing parent-user anchor behavior for assistant-only retries and continuations
- add focused regression coverage for live-message anchor selection

## Root cause
Pending user messages are marked `isPending`, but the live-anchor lookup started one item before the first live message. As a result, the newly appended user item was skipped and the message scroller could not find a new `scrollAnchor` to jump to when the viewport was away from the bottom.

## Testing
- `pnpm --filter @deeix/web test`
- `pnpm --filter @deeix/web typecheck`
- `pnpm --filter @deeix/web lint`
- `pnpm --filter @deeix/web build`