### PR TITLE
fix: preserve negative balances in account displays

### DIFF
--- a/backend/internal/transport/http/billing/dto.go
+++ b/backend/internal/transport/http/billing/dto.go
@@ -816,7 +816,7 @@ func toBillingAccountResponse(item *domainbilling.BillingAccount) BillingAccount
 		UserID:         item.UserID,
 		Currency:       item.Currency,
 		BalanceNanousd: item.BalanceNanousd,
-		BalanceUSD:     nanousdToUSD(item.BalanceNanousd),
+		BalanceUSD:     signedNanousdToUSD(item.BalanceNanousd),
 		Status:         item.Status,
 		UpdatedAt:      item.UpdatedAt,
 	}
@@ -830,7 +830,7 @@ func toBillingAccountViewResponse(item *appbilling.BillingAccountView) *BillingA
 		UserID:         item.UserID,
 		Currency:       item.Currency,
 		BalanceNanousd: item.BalanceNanousd,
-		BalanceUSD:     nanousdToUSD(item.BalanceNanousd),
+		BalanceUSD:     signedNanousdToUSD(item.BalanceNanousd),
 		Status:         item.Status,
 		UpdatedAt:      item.UpdatedAt,
 	}
@@ -1181,5 +1181,9 @@ func nanousdToUSD(value int64) float64 {
 	if value <= 0 {
 		return 0
 	}
+	return float64(value) / 1000000000
+}
+
+func signedNanousdToUSD(value int64) float64 {
 	return float64(value) / 1000000000
 }

--- a/backend/internal/transport/http/billing/dto_test.go
+++ b/backend/internal/transport/http/billing/dto_test.go
@@ -3,6 +3,8 @@ package billing
 import (
 	"testing"
 
+	appbilling "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/billing"
+	domainbilling "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/billing"
 	"github.com/gin-gonic/gin/binding"
 )
 
@@ -106,5 +108,29 @@ func TestOptionalBillingCyclesUseServiceDefault(t *testing.T) {
 	}
 	if err := binding.Validator.ValidateStruct(CreateCheckoutRequest{Cycles: &zero}); err == nil {
 		t.Fatal("expected explicit zero checkout cycles to fail validation")
+	}
+}
+
+func TestBillingAccountResponsesPreserveNegativeBalance(t *testing.T) {
+	const balanceNanousd int64 = -1_250_000_000
+	const wantBalanceUSD = -1.25
+
+	account := toBillingAccountResponse(&domainbilling.BillingAccount{BalanceNanousd: balanceNanousd})
+	if account.BalanceUSD != wantBalanceUSD {
+		t.Fatalf("expected account balance %v, got %v", wantBalanceUSD, account.BalanceUSD)
+	}
+
+	accountView := toBillingAccountViewResponse(&appbilling.BillingAccountView{BalanceNanousd: balanceNanousd})
+	if accountView == nil {
+		t.Fatal("expected account view response")
+	}
+	if accountView.BalanceUSD != wantBalanceUSD {
+		t.Fatalf("expected account view balance %v, got %v", wantBalanceUSD, accountView.BalanceUSD)
+	}
+}
+
+func TestNanousdToUSDClampsNegativeNonBalanceAmount(t *testing.T) {
+	if got := nanousdToUSD(-1_250_000_000); got != 0 {
+		t.Fatalf("expected negative non-balance amount to be clamped, got %v", got)
 	}
 }

--- a/frontend/features/admin/components/sections/accounts/accounts-user-editor.tsx
+++ b/frontend/features/admin/components/sections/accounts/accounts-user-editor.tsx
@@ -59,6 +59,7 @@ import {
   type UserTier,
 } from "@/features/admin/types/accounts";
 import type { AdminBillingMode, AdminBillingPlanDTO } from "@/features/admin/api/billing.types";
+import type { BillingDisplayOptions } from "@/shared/lib/billing-display";
 import { formatBillingBalance, resolveDetailValue } from "@/features/admin/utils/account-display";
 
 const DIALOG_LAYOUT_TRANSITION = {
@@ -287,6 +288,7 @@ type EditUserSheetProps = {
   editPayload: EditUserPayload;
   setEditPayload: React.Dispatch<React.SetStateAction<EditUserPayload>>;
   billingMode: AdminBillingMode;
+  billingDisplay: BillingDisplayOptions;
   billingPlans: AdminBillingPlanDTO[];
   statusChanged: boolean;
   timeZoneOptions: string[];
@@ -353,6 +355,7 @@ export function EditUserSheet({
   editPayload,
   setEditPayload,
   billingMode,
+  billingDisplay,
   billingPlans,
   statusChanged,
   timeZoneOptions,
@@ -447,7 +450,7 @@ export function EditUserSheet({
                 ) : null}
                 {billingMode !== "self" ? (
                   <Badge variant="outline" className="text-muted-foreground">
-                    {formatBillingBalance(editDialogTarget?.billingBalanceUSD)}
+                    {formatBillingBalance(editDialogTarget?.billingBalanceUSD, billingDisplay)}
                   </Badge>
                 ) : null}
               </div>
@@ -633,7 +636,6 @@ export function EditUserSheet({
                   <Label className="text-xs font-normal text-muted-foreground">{t("editor.accountBalance")}</Label>
                   <Input
                     type="number"
-                    min="0"
                     step="0.000001"
                     value={editPayload.billingBalanceUSD}
                     onChange={(event) => setEditPayload((current) => ({ ...current, billingBalanceUSD: event.target.value }))}

--- a/frontend/features/admin/components/sections/accounts/accounts-users.tsx
+++ b/frontend/features/admin/components/sections/accounts/accounts-users.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import dynamic from "next/dynamic";
-import { Database, DollarSign, Globe, Plus, Settings, ShieldCheck, ShieldX, Trash2, Upload, UserCheck } from "lucide-react";
+import { Database, Globe, Plus, Settings, ShieldCheck, ShieldX, Trash2, Upload, UserCheck, WalletCards } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -51,6 +51,7 @@ import { useDialogSnapshot } from "@/shared/hooks/use-dialog-snapshot";
 import { TimeZoneSelect } from "@/shared/components/time-zone-select";
 import type { AdminUserDTO, AdminUserRole, AdminUserStatus } from "@/features/admin/api/admin.types";
 import type { AdminBillingMode } from "@/features/admin/api/billing.types";
+import type { BillingDisplayOptions } from "@/shared/lib/billing-display";
 
 import { AccountAvatarEditorDialog } from "./accounts-avatar-dialog";
 import { AccountConfirmationDialog } from "./accounts-confirm-dialog";
@@ -216,6 +217,7 @@ type UserTableRowProps = {
   item: AdminUserDTO;
   checked: boolean;
   billingMode: AdminBillingMode;
+  billingDisplay: BillingDisplayOptions;
   inlineRolePending: boolean;
   inlineStatusPending: boolean;
   pendingAction: string;
@@ -236,6 +238,7 @@ const UserTableRow = React.memo(function UserTableRow({
   item,
   checked,
   billingMode,
+  billingDisplay,
   inlineRolePending,
   inlineStatusPending,
   pendingAction,
@@ -368,7 +371,7 @@ const UserTableRow = React.memo(function UserTableRow({
       {billingMode !== "self" ? (
         <TableCell className="whitespace-nowrap text-foreground">
           <span title={resolveBillingAccountStatusLabel(item.billingAccountStatus || "active")}>
-            {formatBillingBalance(item.billingBalanceUSD)}
+            {formatBillingBalance(item.billingBalanceUSD, billingDisplay)}
           </span>
         </TableCell>
       ) : null}
@@ -473,6 +476,7 @@ export function AccountsUsers({
     resetPasswordDraft,
     setResetPasswordDraft,
     billingMode,
+    billingDisplay,
     billingPlans,
     createAvatarSource,
     avatarDialogPreviewSrc,
@@ -719,7 +723,7 @@ export function AccountsUsers({
 
               {showBalanceColumn ? (
                 <BulkActionControlRow
-                  icon={<DollarSign className="size-3 stroke-1" />}
+                  icon={<WalletCards className="size-3 stroke-1" />}
                   label={t("actions.apply")}
                   onApply={() => setBulkConfirmAction("balance")}
                   disabled={loading || Boolean(pendingAction) || selectedUserIDs.size === 0 || !batchBalance.trim()}
@@ -729,7 +733,7 @@ export function AccountsUsers({
                     min="0"
                     step="0.000001"
                     value={batchBalance}
-                    placeholder={t("fields.balance")}
+                    placeholder={t("fields.balanceUSDInput")}
                     onChange={(event) => setBatchBalance(event.target.value)}
                     disabled={loading || Boolean(pendingAction) || selectedUserIDs.size === 0}
                     className="h-7 px-2 text-[11px]"
@@ -828,6 +832,7 @@ export function AccountsUsers({
                       item={item}
                       checked={selectedUserIDs.has(item.id)}
                       billingMode={billingMode}
+                      billingDisplay={billingDisplay}
                       inlineRolePending={Boolean(inlinePending[resolveInlineKey(item.id, "role")])}
                       inlineStatusPending={Boolean(inlinePending[resolveInlineKey(item.id, "status")])}
                       pendingAction={pendingAction}
@@ -960,6 +965,7 @@ export function AccountsUsers({
           editPayload={editPayload}
           setEditPayload={setEditPayload}
           billingMode={billingMode}
+          billingDisplay={billingDisplay}
           billingPlans={billingPlans}
           statusChanged={editStatusChanged}
           timeZoneOptions={timeZoneOptions}

--- a/frontend/features/admin/hooks/use-admin-users-page.ts
+++ b/frontend/features/admin/hooks/use-admin-users-page.ts
@@ -11,7 +11,8 @@ import {
 import {
   createAdminUser,
   deleteAdminUser,
-  getAdminReferenceData,
+  getAdminBillingConfig,
+  listAdminBillingPlans,
   patchAdminUser,
   resetAdminUserPassword,
   resetAdminUserTwoFactor,
@@ -43,6 +44,10 @@ import { resolveAdminErrorMessage } from "@/features/admin/utils/admin-error";
 import { patchByID, removeByID, removeManyByID, replaceByID, restoreAt, restoreManyAt } from "@/shared/lib/optimistic-list";
 import { runBulkActionInChunks, runSettledBulkItems } from "@/shared/lib/bulk-action";
 import { resolveTimeZoneOptions } from "@/shared/lib/time-zone";
+import {
+  normalizeBillingDisplayCurrency,
+  type BillingDisplayOptions,
+} from "@/shared/lib/billing-display";
 import { useAdminUserFilters } from "./use-admin-user-filters";
 import { useAdminUserSelection } from "./use-admin-user-selection";
 
@@ -105,6 +110,7 @@ type UseAdminUsersPageState = {
   resetPasswordDraft: string;
   setResetPasswordDraft: (value: string) => void;
   billingMode: AdminBillingMode;
+  billingDisplay: BillingDisplayOptions;
   billingPlans: AdminBillingPlanDTO[];
   createAvatarSource: Pick<CreateUserPayload, "username" | "displayName">;
   avatarDialogPreviewSrc: string | undefined;
@@ -179,7 +185,7 @@ function hasPatchChanges(payload: AdminUserPatchPayload): boolean {
 }
 
 function roundBillingBalance(value: number): number {
-  return Math.round(Math.max(0, value) * 1_000_000) / 1_000_000;
+  return Math.round(value * 1_000_000) / 1_000_000;
 }
 
 function userFromUnknownResponse(response: unknown): AdminUserDTO | null {
@@ -267,6 +273,7 @@ export function useAdminUsersPage({
   });
   const [resetPasswordDraft, setResetPasswordDraft] = React.useState("");
   const [billingMode, setBillingMode] = React.useState<AdminBillingMode>("self");
+  const [billingDisplay, setBillingDisplay] = React.useState<BillingDisplayOptions>({ currency: "USD" });
   const [billingPlans, setBillingPlans] = React.useState<AdminBillingPlanDTO[]>([]);
 
   const createAvatarSource = React.useMemo(
@@ -299,13 +306,23 @@ export function useAdminUsersPage({
         if (!token) {
           return null;
         }
-        return getAdminReferenceData(token);
+        return Promise.allSettled([
+          getAdminBillingConfig(token),
+          listAdminBillingPlans(token),
+        ]);
       })
-      .then((billing) => {
-        if (!cancelled) {
-          if (billing) {
-            setBillingMode(billing.billingConfig.config.mode);
-            setBillingPlans(billing.billingPlans);
+      .then((results) => {
+        if (!cancelled && results) {
+          const [configResult, plansResult] = results;
+          if (configResult.status === "fulfilled") {
+            setBillingMode(configResult.value.config.mode);
+            setBillingDisplay({
+              currency: normalizeBillingDisplayCurrency(configResult.value.config.displayCurrency),
+              usdToCnyRate: configResult.value.config.usdToCNYRate,
+            });
+          }
+          if (plansResult.status === "fulfilled") {
+            setBillingPlans(plansResult.value);
           }
         }
       })
@@ -611,7 +628,11 @@ export function useAdminUsersPage({
       Number.isFinite(nextBillingBalance) &&
       roundBillingBalance(nextBillingBalance) !== roundBillingBalance(editDialogTarget.billingBalanceUSD ?? 0);
 
-    if (billingMode !== "self" && (!Number.isFinite(nextBillingBalance) || nextBillingBalance < 0)) {
+    if (billingMode !== "self" && !Number.isFinite(nextBillingBalance)) {
+      toast.error(t("toast.editFailed"), { description: t("validation.invalidUsageBalance") });
+      return;
+    }
+    if (billingBalanceChanged && nextBillingBalance < 0) {
       toast.error(t("toast.editFailed"), { description: t("validation.invalidUsageBalance") });
       return;
     }
@@ -1149,6 +1170,7 @@ export function useAdminUsersPage({
     resetPasswordDraft,
     setResetPasswordDraft,
     billingMode,
+    billingDisplay,
     billingPlans,
     createAvatarSource,
     avatarDialogPreviewSrc,

--- a/frontend/features/admin/utils/account-display.ts
+++ b/frontend/features/admin/utils/account-display.ts
@@ -1,4 +1,8 @@
 import type { AdminUserDTO } from "@/features/admin/api/admin.types";
+import {
+  formatBillingDisplayBalanceFromUSD,
+  type BillingDisplayOptions,
+} from "@/shared/lib/billing-display";
 
 const USER_STATUS_LABELS: Record<string, string> = {
   pending_activation: "Pending activation",
@@ -134,12 +138,9 @@ export function resolveDetailValue(value: string | number | null | undefined): s
   return String(value);
 }
 
-export function formatBillingBalance(value: number | null | undefined): string {
-  if (!Number.isFinite(value ?? NaN) || (value ?? 0) <= 0) {
-    return "$0.000000";
-  }
-  return `$${(value ?? 0).toLocaleString("en-US", {
-    minimumFractionDigits: 6,
-    maximumFractionDigits: 6,
-  })}`;
+export function formatBillingBalance(
+  value: number | null | undefined,
+  billingDisplay: BillingDisplayOptions = { currency: "USD" },
+): string {
+  return formatBillingDisplayBalanceFromUSD(value ?? 0, billingDisplay);
 }

--- a/frontend/features/settings/model/subscription-format.ts
+++ b/frontend/features/settings/model/subscription-format.ts
@@ -1,6 +1,7 @@
 import type { UserDTO } from "@/shared/api/auth.types";
 import type { BillingPlanDTO, BillingPlanPriceDTO } from "@/shared/api/billing.types";
 import {
+  formatBillingDisplayBalanceFromUSD,
   formatBillingDisplayAmountFromUSD,
   formatBillingDisplayCompactAmountFromUSD,
   formatBillingDisplayPreciseAmountFromUSD,
@@ -97,7 +98,7 @@ export function formatPlanCredit(value: number, billingDisplay: BillingDisplayOp
 }
 
 export function formatAccountBalance(value: number, billingDisplay: BillingDisplayOptions = DEFAULT_BILLING_DISPLAY): string {
-  return formatBillingDisplayPreciseAmountFromUSD(value, billingDisplay);
+  return formatBillingDisplayBalanceFromUSD(value, billingDisplay);
 }
 
 export function formatUsageCost(value: number, billingDisplay: BillingDisplayOptions = DEFAULT_BILLING_DISPLAY): string {

--- a/frontend/i18n/messages/en-US/admin-users.json
+++ b/frontend/i18n/messages/en-US/admin-users.json
@@ -95,6 +95,7 @@
     "status": "Status",
     "subscription": "Subscription",
     "balance": "Balance",
+    "balanceUSDInput": "Balance (USD)",
     "timezone": "Timezone",
     "lastLogin": "Last login",
     "lastActive": "Last active"
@@ -223,7 +224,7 @@
     "language": "Language",
     "reason": "Reason",
     "reasonPlaceholder": "Record the reason for this status change (optional)",
-    "accountBalance": "Account balance",
+    "accountBalance": "Account balance (USD)",
     "billingStatus": "Billing status",
     "twoFactor": "Two-factor authentication",
     "twoFactorEnabled": "Enabled (recovery codes {count})",

--- a/frontend/i18n/messages/zh-CN/admin-users.json
+++ b/frontend/i18n/messages/zh-CN/admin-users.json
@@ -95,6 +95,7 @@
     "status": "状态",
     "subscription": "订阅",
     "balance": "余额",
+    "balanceUSDInput": "余额（USD）",
     "timezone": "时区",
     "lastLogin": "最近登录",
     "lastActive": "最近活跃"
@@ -223,7 +224,7 @@
     "language": "语言",
     "reason": "原因",
     "reasonPlaceholder": "记录本次状态修改原因（可选）",
-    "accountBalance": "账号余额",
+    "accountBalance": "账号余额（USD）",
     "billingStatus": "计费状态",
     "twoFactor": "两步验证",
     "twoFactorEnabled": "已开启（恢复码 {count}）",

--- a/frontend/shared/lib/billing-display.ts
+++ b/frontend/shared/lib/billing-display.ts
@@ -56,6 +56,16 @@ function resolveDisplayAmountFromUSD(value: number, options: BillingDisplayOptio
   return value * Number(options.usdToCnyRate);
 }
 
+function resolveSignedDisplayAmountFromUSD(value: number, options: BillingDisplayOptions): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  if (resolveEffectiveBillingDisplayCurrency(options) !== "CNY") {
+    return value;
+  }
+  return value * Number(options.usdToCnyRate);
+}
+
 function resolveEffectiveBillingDisplayCurrency(options: BillingDisplayOptions): BillingDisplayCurrency {
   if (options.currency !== "CNY") {
     return "USD";
@@ -93,6 +103,16 @@ export function formatBillingDisplayPreciseAmountFromUSD(value: number, options:
     minimumFractionDigits: 6,
     maximumFractionDigits: 6,
   });
+}
+
+export function formatBillingDisplayBalanceFromUSD(value: number, options: BillingDisplayOptions): string {
+  const amount = resolveSignedDisplayAmountFromUSD(value, options);
+  const symbol = billingCurrencySymbol(resolveEffectiveBillingDisplayCurrency(options));
+  const sign = amount < 0 ? "-" : "";
+  return `${sign}${symbol}${Math.abs(amount).toLocaleString("en-US", {
+    minimumFractionDigits: 6,
+    maximumFractionDigits: 6,
+  })}`;
 }
 
 export function formatBillingDisplayCompactAmountFromUSD(


### PR DESCRIPTION
## Summary

修复负余额在订阅页面和后台账户管理中错误显示为 `0` 的问题。

后端账户余额响应现在保留负数；前端使用独立的余额格式化逻辑展示正负余额，并在后台账户列表中遵循管理员配置的 USD/CNY 展示货币。管理员仍不能主动设置负余额，但可以正常编辑已有负余额用户的其他资料。

同时精简账户页的计费配置请求，避免无关的模型或定价接口失败影响余额币种展示。

Fixes #518

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [x] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm typecheck`
- [x] `cd backend && go test ./internal/transport/http/billing`
- [x] `pnpm api:check`
- [x] `git diff --check`
- [ ] Not run; reason: `pnpm build` 未运行，本次已完成聚焦静态检查与后端测试。

## Screenshots, API examples, or logs

负余额现在会按照配置的展示货币正确呈现，例如：

```text
-$1.250000
-¥9.000000
```

## Configuration, migration, and compatibility notes

- 无数据库迁移或配置项变更。
- API 字段结构保持不变，仅修正 `balanceUSD` 将负余额错误归零的响应语义。
- 管理员余额写入接口仍以 USD 为单位，并继续拒绝设置负余额。
- 编辑和批量余额输入已明确标注为 USD，避免与 CNY 只读展示混淆。
- Swagger 与生成的 TypeScript API 契约无需更新。

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including billing balance reads and admin balance updates.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.