### PR TITLE
fix: isolate concurrent generations and queues by conversation branch

### DIFF
--- a/frontend/features/chat/components/app-chat-area.tsx
+++ b/frontend/features/chat/components/app-chat-area.tsx
@@ -603,7 +603,7 @@ export function AppChatArea() {
     failedGenerationRunsRef,
     resumingRunID,
   });
-  const generating = sending || Boolean(resumingRunID);
+  const generating = sending;
   const uploadDropDisabled = loading || uploading;
   const onStopActiveMessage = React.useCallback(() => {
     const visibleRunID = currentLeafMessage?.runID?.trim() || "";
@@ -614,7 +614,6 @@ export function AppChatArea() {
     if (onStopMessage()) {
       return;
     }
-    void cancelResumedGeneration();
   }, [
     cancelResumedGeneration,
     currentLeafMessage?.runID,

--- a/frontend/features/chat/hooks/use-chat-branch-state.ts
+++ b/frontend/features/chat/hooks/use-chat-branch-state.ts
@@ -17,11 +17,13 @@ import { useLocalizedErrorMessage } from "@/i18n/use-localized-error";
 
 function appendPendingExchangeMessages({
   conversationID,
+  conversationScopeKey,
   pendingExchange,
   messages,
   serverMessagePublicIDs,
 }: {
   conversationID: string | null;
+  conversationScopeKey: string;
   pendingExchange: PendingExchange;
   messages: ChatAreaMessage[];
   serverMessagePublicIDs: Set<string>;
@@ -29,6 +31,9 @@ function appendPendingExchangeMessages({
   const nextMessages = [...messages];
   const activePublicID = conversationID?.trim() || null;
   const pendingConversationPublicID = pendingExchange.conversationPublicID?.trim() || null;
+  if (pendingExchange.conversationScopeKey !== conversationScopeKey) {
+    return nextMessages;
+  }
   if (pendingConversationPublicID && pendingConversationPublicID !== activePublicID) {
     return nextMessages;
   }
@@ -123,11 +128,13 @@ function appendPendingExchangeMessages({
 
 function buildPendingMessages({
   conversationID,
+  conversationScopeKey,
   pendingExchanges,
   serverTreeMessages,
   serverMessagePublicIDs,
 }: {
   conversationID: string | null;
+  conversationScopeKey: string;
   pendingExchanges: PendingExchangeMap;
   serverTreeMessages: ChatAreaMessage[];
   serverMessagePublicIDs: Set<string>;
@@ -136,6 +143,7 @@ function buildPendingMessages({
     (messages, pendingExchange) =>
       appendPendingExchangeMessages({
         conversationID,
+        conversationScopeKey,
         pendingExchange,
         messages,
         serverMessagePublicIDs,
@@ -200,12 +208,14 @@ function mergePendingAssistantState(messages: ChatAreaMessage[], pendingExchange
 
 export function useChatBranchState({
   conversationID,
+  conversationScopeKey,
   resetToken,
   messages,
   pendingExchanges,
   liveRunIDs,
 }: {
   conversationID: string | null;
+  conversationScopeKey: string;
   resetToken: number;
   messages: MessageDTO[];
   pendingExchanges: PendingExchangeMap;
@@ -245,11 +255,12 @@ export function useChatBranchState({
     () =>
       buildPendingMessages({
         conversationID,
+        conversationScopeKey,
         pendingExchanges,
         serverTreeMessages,
         serverMessagePublicIDs,
       }),
-    [conversationID, pendingExchanges, serverMessagePublicIDs, serverTreeMessages],
+    [conversationID, conversationScopeKey, pendingExchanges, serverMessagePublicIDs, serverTreeMessages],
   );
   const combinedMessagesRef = React.useRef(combinedMessages);
   React.useEffect(() => {

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -13,6 +13,7 @@ import type {
 } from "@/features/chat/types/chat-runtime";
 import type { ChatSubmitBlockReason } from "@/features/chat/model/chat-task";
 import { resolveChatSubmitDecision } from "@/features/chat/model/chat-task";
+import { useHiddenQueuedParentRuns } from "@/features/chat/hooks/use-hidden-queued-parent-runs";
 import {
   resolveDefaultSubmissionParentMessage,
   resolvePersistedPublicID,
@@ -137,7 +138,13 @@ function resolveMediaStatusLabel(
   }
 }
 
-type ActiveStream = {
+type BranchScope = {
+  conversationScopeKey: string;
+  branchScopePath: string[];
+  branchScopeRunID: string;
+};
+
+type ActiveStream = BranchScope & {
   controller: AbortController;
   runID: string;
   accessToken: string | null;
@@ -186,8 +193,13 @@ function replaceCompletedBranchSelection(
   return changed ? next : previous;
 }
 
-type QueuedChatSubmission = {
+type QueuedChatSubmission = BranchScope & {
   id: string;
+  clientRunID: string;
+  parentRunID: string | null;
+  conversationPublicID: string | null;
+  conversation: ConversationDTO | null;
+  parentMessagePublicID: string | null;
   content: string;
   attachments: PendingAttachment[];
   platformModelName: string;
@@ -196,6 +208,125 @@ type QueuedChatSubmission = {
   selectedSkills: SkillSummaryDTO[];
   htmlVisualPromptEnabled: boolean;
 };
+
+function buildBranchScopePath(messages: ChatAreaMessage[]): string[] {
+  return messages.map((message) => message.publicID.trim()).filter(Boolean);
+}
+
+function buildSubmissionBranchScopePath(
+  messages: ChatAreaMessage[],
+  parentMessagePublicID: string | null | undefined,
+): string[] {
+  const visiblePath = buildBranchScopePath(messages);
+  const parentPublicID = parentMessagePublicID?.trim() || "";
+  if (!parentPublicID) {
+    return [];
+  }
+  const parentIndex = visiblePath.indexOf(parentPublicID);
+  return parentIndex >= 0 ? visiblePath.slice(0, parentIndex + 1) : visiblePath;
+}
+
+function branchScopePathsEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((publicID, index) => publicID === right[index]);
+}
+
+function branchScopesEqual(left: BranchScope, right: BranchScope): boolean {
+  return (
+    left.conversationScopeKey === right.conversationScopeKey &&
+    left.branchScopeRunID === right.branchScopeRunID &&
+    branchScopePathsEqual(left.branchScopePath, right.branchScopePath)
+  );
+}
+
+function branchScopeID(scope: BranchScope): string {
+  return JSON.stringify([
+    scope.conversationScopeKey,
+    scope.branchScopeRunID,
+    ...scope.branchScopePath,
+  ]);
+}
+
+function isSuccessfulBranchParentStatus(status: string | null | undefined): boolean {
+  const normalized = status?.trim().toLowerCase() || "";
+  return normalized === "success" || normalized === "interrupted";
+}
+
+function branchScopeIsVisible(
+  scope: BranchScope,
+  visibleConversationScopeKey: string,
+  visibleMessages: ChatAreaMessage[],
+): boolean {
+  return (
+    scope.conversationScopeKey === visibleConversationScopeKey &&
+    visibleMessages.some((message) => message.runID === scope.branchScopeRunID)
+  );
+}
+
+function findSuccessfulBranchParentMessage(
+  messages: ChatAreaMessage[],
+  runID: string | null | undefined,
+): ChatAreaMessage | undefined {
+  const normalizedRunID = runID?.trim() || "";
+  if (!normalizedRunID) {
+    return undefined;
+  }
+  return messages.find(
+    (message) =>
+      message.role === "assistant" &&
+      message.runID === normalizedRunID &&
+      Boolean(resolvePersistedPublicID(message.publicID)) &&
+      !message.isPending &&
+      !message.isStreaming &&
+      isSuccessfulBranchParentStatus(message.status),
+  );
+}
+
+function branchRunIsVisible(
+  scope: BranchScope,
+  runID: string | null | undefined,
+  visibleConversationScopeKey: string,
+  visibleBranchScopePath: readonly string[],
+  visibleMessages: ChatAreaMessage[],
+): boolean {
+  const normalizedRunID = runID?.trim() || "";
+  if (scope.conversationScopeKey !== visibleConversationScopeKey) {
+    return false;
+  }
+  if (normalizedRunID && visibleMessages.some((message) => message.runID === normalizedRunID)) {
+    return true;
+  }
+  return (
+    branchScopePathsEqual(scope.branchScopePath, visibleBranchScopePath) &&
+    (scope.branchScopeRunID === normalizedRunID ||
+      branchScopeIsVisible(scope, visibleConversationScopeKey, visibleMessages))
+  );
+}
+
+function rechainQueuedSubmissions(
+  submissions: QueuedChatSubmission[],
+  scope: BranchScope,
+  rootParentRunID: string | null,
+  rootParentMessagePublicID: string | null,
+): QueuedChatSubmission[] {
+  let parentRunID = rootParentRunID;
+  let firstSubmission = true;
+  return submissions.map((submission) => {
+    if (!branchScopesEqual(submission, scope)) {
+      return submission;
+    }
+    const parentMessagePublicID = firstSubmission
+      ? rootParentMessagePublicID
+      : submission.parentMessagePublicID;
+    const nextSubmission =
+      submission.parentRunID === parentRunID &&
+      submission.parentMessagePublicID === parentMessagePublicID
+        ? submission
+        : { ...submission, parentRunID, parentMessagePublicID };
+    parentRunID = submission.clientRunID;
+    firstSubmission = false;
+    return nextSubmission;
+  });
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -319,7 +450,7 @@ async function refreshGeneratedConversationMetadata(
 
 export function useChatMessageSubmit({
   conversationID,
-  resetToken,
+  conversationScopeKey,
   activeConversation,
   selectedPlatformModelName,
   modelOptions,
@@ -341,6 +472,7 @@ export function useChatMessageSubmit({
   setDraft,
   setAttachments,
   releaseAttachments,
+  getPendingExchanges,
   pendingExchanges,
   setPendingExchanges,
   setBranchSelections,
@@ -362,7 +494,7 @@ export function useChatMessageSubmit({
   resumeGenerationActive = false,
 }: {
   conversationID: string | null;
-  resetToken: number;
+  conversationScopeKey: string;
   activeConversation: ConversationDTO | null;
   selectedPlatformModelName: string;
   modelOptions: ChatModelOption[];
@@ -384,6 +516,7 @@ export function useChatMessageSubmit({
   setDraft: React.Dispatch<React.SetStateAction<string>>;
   setAttachments: React.Dispatch<React.SetStateAction<PendingAttachment[]>>;
   releaseAttachments: (items: PendingAttachment[]) => void;
+  getPendingExchanges: () => PendingExchangeMap;
   pendingExchanges: PendingExchangeMap;
   setPendingExchanges: React.Dispatch<React.SetStateAction<PendingExchangeMap>>;
   setBranchSelections: React.Dispatch<React.SetStateAction<Record<string, string>>>;
@@ -405,21 +538,52 @@ export function useChatMessageSubmit({
   resumeGenerationActive?: boolean;
 }) {
   const t = useTranslations("chat.submit");
-  const [activeRunCount, setActiveRunCount] = React.useState(0);
+  const [activeRunRevision, setActiveRunRevision] = React.useState(0);
   const activeStreamsRef = React.useRef(new Map<string, ActiveStream>());
-  const activeGenerationRunsRefRef = React.useRef(activeGenerationRunsRef);
-  const previousResetTokenRef = React.useRef(resetToken);
   const conversationIDRef = React.useRef(conversationID);
+  const conversationScopeKeyRef = React.useRef(conversationScopeKey);
   const activeConversationRef = React.useRef(activeConversation);
-  const nextModelRunSequenceRef = React.useRef(0);
-  const latestCompletedModelRunSequenceRef = React.useRef(0);
-  const sendQueuedAfterCurrentRef = React.useRef(false);
+  const nextModelRunSequenceRef = React.useRef(new Map<string, number>());
+  const latestCompletedModelRunSequenceRef = React.useRef(new Map<string, number>());
+  const optimisticMessageCountsRef = React.useRef(new Map<string, number>());
+  const sendQueuedAfterCurrentRef = React.useRef(new Set<string>());
+  const dispatchingQueuedSubmissionIDsRef = React.useRef(new Set<string>());
   const [queuedSubmissions, setQueuedSubmissions] = React.useState<QueuedChatSubmission[]>([]);
   const queuedSubmissionsRef = React.useRef<QueuedChatSubmission[]>([]);
-  const sending = activeRunCount > 0;
+  const isRunActive = React.useCallback((runID: string) => activeStreamsRef.current.has(runID), []);
+  const {
+    getStatus: getHiddenParentRunStatus,
+    revision: hiddenParentRunStatusRevision,
+  } = useHiddenQueuedParentRuns({
+    currentConversationScopeKey: conversationScopeKey,
+    queuedParents: queuedSubmissions,
+    getPendingExchanges,
+    isRunActive,
+  });
+  const visibleBranchScopePath = React.useMemo(
+    () => buildBranchScopePath(visibleMessages),
+    [visibleMessages],
+  );
+  const visibleBranchScopePathRef = React.useRef(visibleBranchScopePath);
+  const visibleMessagesRef = React.useRef(visibleMessages);
+  visibleBranchScopePathRef.current = visibleBranchScopePath;
+  visibleMessagesRef.current = visibleMessages;
+  const sending = React.useMemo(
+    () =>
+      Array.from(activeStreamsRef.current.values()).some((active) =>
+        branchRunIsVisible(
+          active,
+          active.runID,
+          conversationScopeKey,
+          visibleBranchScopePath,
+          visibleMessages,
+        ),
+      ),
+    [activeRunRevision, conversationScopeKey, visibleBranchScopePath, visibleMessages],
+  );
 
-  const syncActiveRunCount = React.useCallback(() => {
-    setActiveRunCount(activeStreamsRef.current.size);
+  const syncActiveRuns = React.useCallback(() => {
+    setActiveRunRevision((current) => current + 1);
   }, []);
 
   const updatePendingExchange = React.useCallback(
@@ -441,6 +605,10 @@ export function useChatMessageSubmit({
   }, [conversationID]);
 
   React.useEffect(() => {
+    conversationScopeKeyRef.current = conversationScopeKey;
+  }, [conversationScopeKey]);
+
+  React.useEffect(() => {
     activeConversationRef.current = activeConversation;
   }, [activeConversation]);
 
@@ -449,32 +617,26 @@ export function useChatMessageSubmit({
   }, [queuedSubmissions]);
 
   React.useEffect(() => {
-    activeGenerationRunsRefRef.current = activeGenerationRunsRef;
-  }, [activeGenerationRunsRef]);
-
-  React.useEffect(() => {
-    if (previousResetTokenRef.current === resetToken) {
-      return;
-    }
-    previousResetTokenRef.current = resetToken;
-
-    for (const active of activeStreamsRef.current.values()) {
-      // 会话切换只解除当前页面订阅，不取消服务端仍在执行的 run。
-      clearCancelSettlementTimer(active);
-      active.controller.abort();
-      activeGenerationRunsRefRef.current?.current.delete(active.runID);
-    }
-    activeStreamsRef.current.clear();
-
-    resetStreamBuffer();
-    setPendingExchanges({});
-    setActiveRunCount(0);
-    nextModelRunSequenceRef.current = 0;
-    latestCompletedModelRunSequenceRef.current = 0;
-    sendQueuedAfterCurrentRef.current = false;
-    releaseAttachments(queuedSubmissionsRef.current.flatMap((item) => item.attachments));
-    setQueuedSubmissions([]);
-  }, [releaseAttachments, resetStreamBuffer, resetToken, setPendingExchanges]);
+    setPendingExchanges((current) => {
+      const completedBackgroundKeys = Object.entries(current)
+        .filter(
+          ([, exchange]) =>
+            exchange.conversationScopeKey !== conversationScopeKey &&
+            Boolean(exchange.assistantPublicID) &&
+            !exchange.assistantPending &&
+            !exchange.assistantStreaming,
+        )
+        .map(([exchangeKey]) => exchangeKey);
+      if (completedBackgroundKeys.length === 0) {
+        return current;
+      }
+      const next = { ...current };
+      for (const exchangeKey of completedBackgroundKeys) {
+        delete next[exchangeKey];
+      }
+      return next;
+    });
+  }, [conversationScopeKey, setPendingExchanges]);
 
   React.useEffect(() => {
     const completedKeys: string[] = [];
@@ -540,7 +702,13 @@ export function useChatMessageSubmit({
         return next;
       });
     }
-  }, [combinedMessages, pendingExchanges, serverMessagePublicIDs, setBranchSelections, setPendingExchanges]);
+  }, [
+    combinedMessages,
+    pendingExchanges,
+    serverMessagePublicIDs,
+    setBranchSelections,
+    setPendingExchanges,
+  ]);
 
   const submitMessage = React.useCallback(
     async ({
@@ -566,14 +734,44 @@ export function useChatMessageSubmit({
       const requestSelectedToolIDs = queuedSubmission?.selectedToolIDs ?? selectedToolIDs;
       const requestSelectedSkills = queuedSubmission?.selectedSkills ?? selectedSkills;
       const requestHTMLVisualPromptEnabled = queuedSubmission?.htmlVisualPromptEnabled ?? htmlVisualPromptEnabled;
+      let targetConversationScopeKey = queuedSubmission?.conversationScopeKey ?? conversationScopeKeyRef.current;
+      const resolvedParentPublicID = resolvePersistedPublicID(parentMessagePublicID);
+      const targetBranchScopePath = queuedSubmission?.branchScopePath.slice() ??
+        buildSubmissionBranchScopePath(visibleMessagesRef.current, resolvedParentPublicID);
+      const clientRunID = queuedSubmission?.clientRunID ?? createClientRunID();
+      let targetBranchScope: BranchScope = {
+        conversationScopeKey: targetConversationScopeKey,
+        branchScopePath: targetBranchScopePath,
+        branchScopeRunID: queuedSubmission?.branchScopeRunID ?? clientRunID,
+      };
+      const shouldFollowSubmittedBranch =
+        !queuedSubmission ||
+        branchRunIsVisible(
+          targetBranchScope,
+          clientRunID,
+          conversationScopeKeyRef.current,
+          visibleBranchScopePathRef.current,
+          visibleMessagesRef.current,
+        );
       const selectedModel = modelOptions.find((item) => item.platformModelName === requestPlatformModelName) ?? null;
       const resolvedBranchReason = branchReason ?? "default";
       const concurrentBranchRun = resolvedBranchReason === "retry" || resolvedBranchReason === "edit";
+      const targetConversationHasActiveStream = Array.from(activeStreamsRef.current.values()).some(
+        (active) =>
+          queuedSubmission
+            ? branchScopesEqual(active, targetBranchScope)
+            : active.conversationScopeKey === targetConversationScopeKey &&
+              branchScopePathsEqual(active.branchScopePath, targetBranchScopePath),
+      );
       if (
         (!content && currentAttachments.length === 0) ||
-        uploading ||
-        (!concurrentBranchRun && activeStreamsRef.current.size > 0)
+        (!queuedSubmission && uploading) ||
+        (!concurrentBranchRun && targetConversationHasActiveStream)
       ) {
+        return false;
+      }
+      if (activeStreamsRef.current.size >= MAX_CONCURRENT_RUNS) {
+        toast.error(t("concurrentGenerationLimit", { count: MAX_CONCURRENT_RUNS }));
         return false;
       }
       if (concurrentBranchRun) {
@@ -617,9 +815,7 @@ export function useChatMessageSubmit({
       }
 
       const wasConversationMode = showConversationLayout || visibleMessageCount > 0;
-      const clientRunID = createClientRunID();
       const exchangeKey = `local-exchange-${clientRunID}`;
-      const resolvedParentPublicID = resolvePersistedPublicID(parentMessagePublicID);
       const resolvedSourcePublicID = resolvePersistedPublicID(sourceMessagePublicID);
       const assistantOnlyBranch =
         resolvedBranchReason === "retry" &&
@@ -646,21 +842,24 @@ export function useChatMessageSubmit({
           : undefined;
       const assistantContentType =
         submitTask === "chat" ? "markdown" : submitTask === "video_generation" ? "video" : "image";
-      let targetConversationID = conversationIDRef.current;
-      let targetConversation = activeConversationRef.current;
+      let targetConversationID = queuedSubmission?.conversationPublicID ?? conversationIDRef.current;
+      let targetConversation = queuedSubmission?.conversation ?? activeConversationRef.current;
       let metadataRefreshInFlight = false;
       let modelRunSequence = 0;
 
       activeGenerationRunsRef?.current.add(clientRunID);
-      setShowConversationLayout(true);
+      if (shouldFollowSubmittedBranch) {
+        setShowConversationLayout(true);
+      }
       activeStreamsRef.current.set(clientRunID, {
         controller: streamAbortController,
         runID: clientRunID,
+        ...targetBranchScope,
         accessToken: null,
         cancelRequested: false,
         cancelSettlementTimer: null,
       });
-      syncActiveRunCount();
+      syncActiveRuns();
       if (resetComposer) {
         setDraft("");
         setAttachments([]);
@@ -670,6 +869,7 @@ export function useChatMessageSubmit({
         ...current,
         [exchangeKey]: {
           key: exchangeKey,
+          ...targetBranchScope,
           conversationPublicID: targetConversationID?.trim() || null,
           userPublicID: assistantOnlyBranch ? pendingUserPublicID : undefined,
           tempUserPublicID,
@@ -693,11 +893,13 @@ export function useChatMessageSubmit({
           assistantProcessTrace: undefined,
         },
       }));
-      setBranchSelections((prev) => ({
-        ...prev,
-        ...(assistantOnlyBranch ? {} : { [toBranchKey(resolvedParentPublicID)]: pendingUserPublicID }),
-        [pendingUserPublicID]: tempAssistantPublicID,
-      }));
+      if (shouldFollowSubmittedBranch) {
+        setBranchSelections((prev) => ({
+          ...prev,
+          ...(assistantOnlyBranch ? {} : { [toBranchKey(resolvedParentPublicID)]: pendingUserPublicID }),
+          [pendingUserPublicID]: tempAssistantPublicID,
+        }));
+      }
 
       try {
         const token = await resolveAccessToken();
@@ -750,17 +952,69 @@ export function useChatMessageSubmit({
           if (!created?.publicID) {
             throw new Error(t("createConversationFailed"));
           }
+          const previousTargetBranchScope = targetBranchScope;
+          const previousConversationScopeKey = previousTargetBranchScope.conversationScopeKey;
+          targetConversationScopeKey = `conversation:${created.publicID}`;
+          targetBranchScope = {
+            ...previousTargetBranchScope,
+            conversationScopeKey: targetConversationScopeKey,
+          };
           targetConversationID = created.publicID;
           targetConversation = created;
-          conversationIDRef.current = created.publicID;
-          activeConversationRef.current = created;
+          const createdActiveStream = activeStreamsRef.current.get(clientRunID);
+          if (createdActiveStream) {
+            createdActiveStream.conversationScopeKey = targetConversationScopeKey;
+          }
+          const migratedBranchScopes: BranchScope[] = [
+            previousTargetBranchScope,
+            ...queuedSubmissionsRef.current
+              .filter((item) => item.conversationScopeKey === previousConversationScopeKey)
+              .map((item) => item),
+          ];
+          for (const branchScope of migratedBranchScopes) {
+            if (sendQueuedAfterCurrentRef.current.delete(branchScopeID(branchScope))) {
+              sendQueuedAfterCurrentRef.current.add(
+                branchScopeID({
+                  ...branchScope,
+                  conversationScopeKey: targetConversationScopeKey,
+                }),
+              );
+            }
+          }
+          setQueuedSubmissions((current) =>
+            current.map((item) =>
+              item.conversationScopeKey === previousConversationScopeKey
+                ? {
+                    ...item,
+                    conversationScopeKey: targetConversationScopeKey,
+                    conversationPublicID: created.publicID,
+                    conversation: created,
+                  }
+                : item,
+            ),
+          );
           updatePendingExchange(exchangeKey, (current) => ({
             ...current,
+            conversationScopeKey: targetConversationScopeKey,
             conversationPublicID: created.publicID,
           }));
-          // Update the URL without triggering Next.js RSC navigation, which can interrupt an active stream.
-          window.history.replaceState(null, "", `/chat?conversation_id=${created.publicID}`);
-          onConversationCreated?.(created.publicID);
+          if (
+            branchRunIsVisible(
+              previousTargetBranchScope,
+              clientRunID,
+              conversationScopeKeyRef.current,
+              visibleBranchScopePathRef.current,
+              visibleMessagesRef.current,
+            )
+          ) {
+            conversationIDRef.current = created.publicID;
+            conversationScopeKeyRef.current = targetConversationScopeKey;
+            activeConversationRef.current = created;
+            // Update the URL without triggering Next.js RSC navigation, which can interrupt an active stream.
+            window.history.replaceState(null, "", `/chat?conversation_id=${created.publicID}`);
+            onConversationCreated?.(created.publicID);
+          }
+          syncActiveRuns();
         }
         metadataFallbackTitle = conversationTitleFromFirstUserMessage(payloadContent);
         const optimisticTitle = metadataFallbackTitle;
@@ -774,7 +1028,9 @@ export function useChatMessageSubmit({
               ...targetConversation,
               title: optimisticTitle,
             };
-            activeConversationRef.current = targetConversation;
+            if (conversationScopeKeyRef.current === targetConversationScopeKey) {
+              activeConversationRef.current = targetConversation;
+            }
           }
           touchByPublicID(targetConversationID, { title: optimisticTitle });
         }
@@ -869,8 +1125,8 @@ export function useChatMessageSubmit({
             }));
           },
         };
-        modelRunSequence = nextModelRunSequenceRef.current + 1;
-        nextModelRunSequenceRef.current = modelRunSequence;
+        modelRunSequence = (nextModelRunSequenceRef.current.get(targetConversationScopeKey) ?? 0) + 1;
+        nextModelRunSequenceRef.current.set(targetConversationScopeKey, modelRunSequence);
         let completed: SendMessageResult;
         if (submitTask === "chat") {
           const chatPayload: SendMessageRequest = {
@@ -981,35 +1237,98 @@ export function useChatMessageSubmit({
                 : completed.assistantMessage.content,
           };
         });
-        setBranchSelections((current) =>
-          replaceCompletedBranchSelection(
-            current,
-            {
-              parentPublicID: resolvedParentPublicID,
-              tempUserPublicID,
-              tempAssistantPublicID,
-              reuseUserMessage: assistantOnlyBranch,
-            },
-            completed.userMessage.publicID,
-            completed.assistantMessage.publicID,
-          ),
-        );
+        const completedBranchScope: BranchScope = {
+          conversationScopeKey: targetConversationScopeKey,
+          branchScopePath: assistantOnlyBranch
+            ? [...targetBranchScope.branchScopePath, completed.assistantMessage.publicID]
+            : [
+                ...targetBranchScope.branchScopePath,
+                completed.userMessage.publicID,
+                completed.assistantMessage.publicID,
+              ],
+          branchScopeRunID: clientRunID,
+        };
+        if (conversationScopeKeyRef.current === targetConversationScopeKey) {
+          setBranchSelections((current) =>
+            replaceCompletedBranchSelection(
+              current,
+              {
+                parentPublicID: resolvedParentPublicID,
+                tempUserPublicID,
+                tempAssistantPublicID,
+                reuseUserMessage: assistantOnlyBranch,
+              },
+              completed.userMessage.publicID,
+              completed.assistantMessage.publicID,
+            ),
+          );
+        }
         const currentConversation =
           activeConversationRef.current?.publicID === targetConversationID
             ? activeConversationRef.current
             : targetConversation;
         const shouldUpdateConversationModel =
-          modelRunSequence > latestCompletedModelRunSequenceRef.current;
+          modelRunSequence > (latestCompletedModelRunSequenceRef.current.get(targetConversationScopeKey) ?? 0);
         if (shouldUpdateConversationModel) {
-          latestCompletedModelRunSequenceRef.current = modelRunSequence;
+          latestCompletedModelRunSequenceRef.current.set(targetConversationScopeKey, modelRunSequence);
         }
+        const optimisticMessageCount =
+          Math.max(
+            currentConversation?.messageCount ?? 0,
+            optimisticMessageCountsRef.current.get(targetConversationScopeKey) ?? 0,
+          ) + (assistantOnlyBranch ? 1 : 2);
+        optimisticMessageCountsRef.current.set(targetConversationScopeKey, optimisticMessageCount);
         const conversationPatch: Partial<ConversationDTO> = {
           ...(shouldUpdateConversationModel ? { model: requestPlatformModelName } : {}),
           updatedAt: new Date().toISOString(),
-          messageCount: (currentConversation?.messageCount ?? 0) + (assistantOnlyBranch ? 1 : 2),
+          messageCount: optimisticMessageCount,
         };
-        if (currentConversation) {
-          activeConversationRef.current = { ...currentConversation, ...conversationPatch };
+        const updatedConversation = currentConversation
+          ? { ...currentConversation, ...conversationPatch }
+          : null;
+        if (updatedConversation && conversationScopeKeyRef.current === targetConversationScopeKey) {
+          activeConversationRef.current = updatedConversation;
+        }
+        if (sendQueuedAfterCurrentRef.current.delete(branchScopeID(targetBranchScope))) {
+          sendQueuedAfterCurrentRef.current.add(branchScopeID(completedBranchScope));
+        }
+        setQueuedSubmissions((current) => {
+          if (!current.some((item) => item.conversationScopeKey === targetConversationScopeKey)) {
+            return current;
+          }
+          return current.map((item) => {
+            if (item.conversationScopeKey !== targetConversationScopeKey) {
+              return item;
+            }
+            const sameBranch = branchScopesEqual(item, targetBranchScope);
+            const isDirectChild = item.parentRunID === clientRunID;
+            return {
+              ...item,
+              ...(updatedConversation ? { conversation: updatedConversation } : {}),
+              ...(sameBranch
+                ? {
+                    branchScopePath: completedBranchScope.branchScopePath,
+                    branchScopeRunID: completedBranchScope.branchScopeRunID,
+                  }
+                : {}),
+              ...(isDirectChild
+                ? {
+                    parentRunID: null,
+                    parentMessagePublicID: completed.assistantMessage.publicID,
+                  }
+                : {}),
+            };
+          });
+        });
+        if (conversationScopeKeyRef.current !== targetConversationScopeKey) {
+          setPendingExchanges((current) => {
+            if (!current[exchangeKey]) {
+              return current;
+            }
+            const next = { ...current };
+            delete next[exchangeKey];
+            return next;
+          });
         }
         touchByPublicID(targetConversationID, conversationPatch);
         if (assistantMessageSucceeded || completed.metadataRefreshHint?.trim() === "pending") {
@@ -1023,7 +1342,9 @@ export function useChatMessageSubmit({
             conversationTitle: targetConversation?.title,
           });
         }
-        reload();
+        if (conversationScopeKeyRef.current === targetConversationScopeKey) {
+          reload();
+        }
       } catch (error) {
         flushStreamTextNow(exchangeKey);
         flushUpstreamThinkNow(exchangeKey);
@@ -1047,7 +1368,17 @@ export function useChatMessageSubmit({
         const errorSummary = resolveErrorSummary(error, t("retryLater"));
         failedGenerationRunsRef?.current.add(clientRunID);
         shouldKeepConversationLayout = true;
-        if (resetComposer && restoreDraftOnFailure) {
+        if (
+          resetComposer &&
+          restoreDraftOnFailure &&
+          branchRunIsVisible(
+            targetBranchScope,
+            clientRunID,
+            conversationScopeKeyRef.current,
+            visibleBranchScopePathRef.current,
+            visibleMessagesRef.current,
+          )
+        ) {
           setDraft(content);
           setAttachments(currentAttachments);
         }
@@ -1067,7 +1398,7 @@ export function useChatMessageSubmit({
           },
         }));
         toast.error(t("sendFailed"), { description: errorSummary });
-        if (targetConversationID) {
+        if (targetConversationID && conversationScopeKeyRef.current === targetConversationScopeKey) {
           reload();
         }
         return false;
@@ -1078,10 +1409,21 @@ export function useChatMessageSubmit({
           activeStreamsRef.current.delete(clientRunID);
         }
         activeGenerationRunsRef?.current.delete(clientRunID);
-        if (!sentSuccessfully && !wasConversationMode && !shouldKeepConversationLayout) {
+        if (
+          branchRunIsVisible(
+            targetBranchScope,
+            clientRunID,
+            conversationScopeKeyRef.current,
+            visibleBranchScopePathRef.current,
+            visibleMessagesRef.current,
+          ) &&
+          !sentSuccessfully &&
+          !wasConversationMode &&
+          !shouldKeepConversationLayout
+        ) {
           setShowConversationLayout(false);
         }
-        syncActiveRunCount();
+        syncActiveRuns();
       }
       return true;
     },
@@ -1116,7 +1458,7 @@ export function useChatMessageSubmit({
       uploading,
       maxFilesPerMessage,
       t,
-      syncActiveRunCount,
+      syncActiveRuns,
       updatePendingExchange,
       visibleMessageCount,
       combinedMessages,
@@ -1129,24 +1471,91 @@ export function useChatMessageSubmit({
     if ((!content && currentAttachments.length === 0) || uploading) {
       return false;
     }
-    setQueuedSubmissions((current) => [
-      ...current,
-      {
-        id: createClientRunID().replace("run_", "queue_"),
-        content,
-        attachments: currentAttachments,
-        platformModelName: selectedPlatformModelName,
-        options: sanitizeConversationOptions(options),
-        selectedToolIDs: selectedToolIDs.slice(),
-        selectedSkills: selectedSkills.slice(),
-        htmlVisualPromptEnabled,
-      },
-    ]);
+    const parentMessagePublicID =
+      resolvePersistedPublicID(currentLeafMessage?.publicID) ??
+      resolveDefaultSubmissionParentMessage(visibleMessages)?.publicID ??
+      null;
+    const targetConversationScopeKey = conversationScopeKeyRef.current;
+    const targetConversationPublicID = conversationIDRef.current;
+    const targetConversation = activeConversationRef.current;
+    const currentBranchScopePath = visibleBranchScopePathRef.current;
+    const visibleRunID = currentLeafMessage?.runID?.trim() || "";
+    const visibleRunPending = Boolean(
+      visibleRunID &&
+        (currentLeafMessage?.isPending ||
+          currentLeafMessage?.isStreaming ||
+          currentLeafMessage?.status?.trim().toLowerCase() === "pending"),
+    );
+    const visibleActiveCandidate = visibleRunID ? activeStreamsRef.current.get(visibleRunID) : undefined;
+    const visibleActive =
+      visibleActiveCandidate &&
+      branchRunIsVisible(
+        visibleActiveCandidate,
+        visibleActiveCandidate.runID,
+        targetConversationScopeKey,
+        currentBranchScopePath,
+        visibleMessagesRef.current,
+      )
+        ? visibleActiveCandidate
+        : Array.from(activeStreamsRef.current.values())
+            .filter((item) =>
+              branchRunIsVisible(
+                item,
+                item.runID,
+                targetConversationScopeKey,
+                currentBranchScopePath,
+                visibleMessagesRef.current,
+              ),
+            )
+            .at(-1);
+    const targetBranchScopePath = visibleActive?.branchScopePath.slice() ?? currentBranchScopePath.slice();
+    const targetBranchScopeRunID = visibleActive?.branchScopeRunID ?? visibleRunID;
+    if (!targetBranchScopeRunID) {
+      return false;
+    }
+    const targetBranchScope: BranchScope = {
+      conversationScopeKey: targetConversationScopeKey,
+      branchScopePath: targetBranchScopePath,
+      branchScopeRunID: targetBranchScopeRunID,
+    };
+    const clientRunID = createClientRunID();
+    setQueuedSubmissions((current) => {
+      const previousQueuedSubmission = current
+        .filter((item) => branchScopesEqual(item, targetBranchScope))
+        .at(-1);
+      return [
+        ...current,
+        {
+          id: clientRunID.replace("run_", "queue_"),
+          clientRunID,
+          parentRunID:
+            previousQueuedSubmission?.clientRunID ??
+            (visibleRunPending ? visibleRunID : visibleActive?.runID) ??
+            null,
+          ...targetBranchScope,
+          conversationPublicID: targetConversationPublicID,
+          conversation: targetConversation,
+          parentMessagePublicID,
+          content,
+          attachments: currentAttachments,
+          platformModelName: selectedPlatformModelName,
+          options: sanitizeConversationOptions(options),
+          selectedToolIDs: selectedToolIDs.slice(),
+          selectedSkills: selectedSkills.slice(),
+          htmlVisualPromptEnabled,
+        },
+      ];
+    });
     setDraft("");
     setAttachments([]);
     return true;
   }, [
     attachments,
+    currentLeafMessage?.publicID,
+    currentLeafMessage?.isPending,
+    currentLeafMessage?.isStreaming,
+    currentLeafMessage?.runID,
+    currentLeafMessage?.status,
     draft,
     htmlVisualPromptEnabled,
     options,
@@ -1156,6 +1565,7 @@ export function useChatMessageSubmit({
     setAttachments,
     setDraft,
     uploading,
+    visibleMessages,
   ]);
 
   const onStopMessage = React.useCallback(() => {
@@ -1166,7 +1576,18 @@ export function useChatMessageSubmit({
           currentLeafMessage?.isStreaming ||
           currentLeafMessage?.status?.trim().toLowerCase() === "pending"),
     );
-    const visibleActive = visibleRunID ? activeStreamsRef.current.get(visibleRunID) : undefined;
+    const visibleActiveCandidate = visibleRunID ? activeStreamsRef.current.get(visibleRunID) : undefined;
+    const visibleActive =
+      visibleActiveCandidate &&
+      branchRunIsVisible(
+        visibleActiveCandidate,
+        visibleActiveCandidate.runID,
+        conversationScopeKeyRef.current,
+        visibleBranchScopePathRef.current,
+        visibleMessagesRef.current,
+      )
+        ? visibleActiveCandidate
+        : undefined;
     if (!visibleActive && visibleRunPending) {
       void resolveAccessToken().then(async (token) => {
         if (!token) {
@@ -1177,7 +1598,19 @@ export function useChatMessageSubmit({
       });
       return true;
     }
-    const active = visibleActive ?? Array.from(activeStreamsRef.current.values()).at(-1);
+    const active =
+      visibleActive ??
+      Array.from(activeStreamsRef.current.values())
+        .filter((item) =>
+          branchRunIsVisible(
+            item,
+            item.runID,
+            conversationScopeKeyRef.current,
+            visibleBranchScopePathRef.current,
+            visibleMessagesRef.current,
+          ),
+        )
+        .at(-1);
     if (!active) {
       return false;
     }
@@ -1195,7 +1628,17 @@ export function useChatMessageSubmit({
         return;
       }
       active.controller.abort();
-      reload();
+      if (
+        branchRunIsVisible(
+          active,
+          active.runID,
+          conversationScopeKeyRef.current,
+          visibleBranchScopePathRef.current,
+          visibleMessagesRef.current,
+        )
+      ) {
+        reload();
+      }
     }, GENERATION_CANCEL_SETTLEMENT_TIMEOUT_MS);
 
     // Keep the stream connected so its terminal payload can replace optimistic IDs
@@ -1206,7 +1649,17 @@ export function useChatMessageSubmit({
       }
       clearCancelSettlementTimer(active);
       active.controller.abort();
-      reload();
+      if (
+        branchRunIsVisible(
+          active,
+          active.runID,
+          conversationScopeKeyRef.current,
+          visibleBranchScopePathRef.current,
+          visibleMessagesRef.current,
+        )
+      ) {
+        reload();
+      }
     });
     return true;
   }, [
@@ -1222,7 +1675,21 @@ export function useChatMessageSubmit({
     if (target) {
       releaseAttachments(target.attachments);
     }
-    setQueuedSubmissions((current) => current.filter((item) => item.id !== id));
+    setQueuedSubmissions((current) => {
+      const currentTarget = current.find((item) => item.id === id);
+      if (!currentTarget) {
+        return current;
+      }
+      const firstScopeSubmission = current.find(
+        (item) => branchScopesEqual(item, currentTarget),
+      );
+      return rechainQueuedSubmissions(
+        current.filter((item) => item.id !== id),
+        currentTarget,
+        firstScopeSubmission?.parentRunID ?? null,
+        firstScopeSubmission?.parentMessagePublicID ?? null,
+      );
+    });
   }, [releaseAttachments]);
 
   const onEditQueuedMessage = React.useCallback((id: string, content: string) => {
@@ -1237,13 +1704,24 @@ export function useChatMessageSubmit({
       if (!target) {
         return current;
       }
-      return [target, ...current.filter((item) => item.id !== id)];
+      sendQueuedAfterCurrentRef.current.add(branchScopeID(target));
+      const firstScopeIndex = current.findIndex(
+        (item) => branchScopesEqual(item, target),
+      );
+      const firstScopeSubmission = firstScopeIndex >= 0 ? current[firstScopeIndex] : undefined;
+      const reordered = current.filter((item) => item.id !== id);
+      reordered.splice(Math.max(firstScopeIndex, 0), 0, target);
+      return rechainQueuedSubmissions(
+        reordered,
+        target,
+        firstScopeSubmission?.parentRunID ?? null,
+        firstScopeSubmission?.parentMessagePublicID ?? null,
+      );
     });
-    sendQueuedAfterCurrentRef.current = true;
   }, []);
 
   const onSendMessage = React.useCallback(async () => {
-    if (activeStreamsRef.current.size > 0 || sending || resumeGenerationActive) {
+    if (sending || resumeGenerationActive) {
       enqueueSubmission();
       return;
     }
@@ -1262,54 +1740,144 @@ export function useChatMessageSubmit({
   }, [attachments, currentLeafMessage?.publicID, draft, enqueueSubmission, resumeGenerationActive, sending, submitMessage, visibleMessages]);
 
   React.useEffect(() => {
-    const hasUnresolvedDefaultExchange = Object.values(pendingExchanges).some(
-      (exchange) => exchange.branchReason === "default" && !exchange.assistantPublicID,
-    );
-    const hasPendingServerGeneration = combinedMessages.some(
+    const currentBranchHasPendingServerGeneration = visibleMessages.some(
       (message) =>
         message.role === "assistant" &&
         (message.isPending ||
           message.isStreaming ||
           message.status?.trim().toLowerCase() === "pending"),
     );
-    if (
-      sending ||
-      resumeGenerationActive ||
-      activeStreamsRef.current.size > 0 ||
-      hasPendingServerGeneration ||
-      (hasUnresolvedDefaultExchange && !sendQueuedAfterCurrentRef.current) ||
-      queuedSubmissions.length === 0 ||
-      uploading
-    ) {
+    if (queuedSubmissions.length === 0) {
       return;
     }
-    const queuedSubmission = queuedSubmissions[0];
+    if (activeStreamsRef.current.size >= MAX_CONCURRENT_RUNS) {
+      return;
+    }
+    const allPendingExchanges = getPendingExchanges();
+    const queuedSubmission = queuedSubmissions.find((item) => {
+      if (dispatchingQueuedSubmissionIDsRef.current.has(item.id)) {
+        return false;
+      }
+      const hasActiveStream = Array.from(activeStreamsRef.current.values()).some(
+        (active) => branchScopesEqual(active, item),
+      );
+      if (hasActiveStream) {
+        return false;
+      }
+      const isCurrentBranch =
+        branchScopeIsVisible(item, conversationScopeKey, visibleMessages);
+      if (
+        isCurrentBranch &&
+        (resumeGenerationActive || currentBranchHasPendingServerGeneration)
+      ) {
+        return false;
+      }
+      const hasUnresolvedDefaultExchange = Object.values(allPendingExchanges).some(
+        (exchange) =>
+          branchScopesEqual(exchange, item) &&
+          exchange.branchReason === "default" &&
+          !exchange.assistantPublicID,
+      );
+      if (
+        hasUnresolvedDefaultExchange &&
+        !sendQueuedAfterCurrentRef.current.has(branchScopeID(item))
+      ) {
+        return false;
+      }
+      if (!item.parentRunID) {
+        return true;
+      }
+      const parentExchange = Object.values(allPendingExchanges).find(
+        (exchange) =>
+          exchange.runID === item.parentRunID &&
+          branchScopesEqual(exchange, item),
+      );
+      if (resolvePersistedPublicID(parentExchange?.assistantPublicID)) {
+        return true;
+      }
+      const serverParentMessage = findSuccessfulBranchParentMessage(combinedMessages, item.parentRunID);
+      if (serverParentMessage) {
+        return true;
+      }
+      if (isSuccessfulBranchParentStatus(getHiddenParentRunStatus(item.parentRunID))) {
+        return true;
+      }
+      return Boolean(
+        isCurrentBranch &&
+          currentLeafMessage?.runID === item.parentRunID &&
+          resolvePersistedPublicID(currentLeafMessage.publicID),
+      );
+    });
     if (!queuedSubmission) {
       return;
     }
-    sendQueuedAfterCurrentRef.current = false;
-    setQueuedSubmissions((current) => current.filter((item) => item.id !== queuedSubmission.id));
+    const dispatchedBranchScope: BranchScope = {
+      conversationScopeKey: queuedSubmission.conversationScopeKey,
+      branchScopePath: queuedSubmission.branchScopePath,
+      branchScopeRunID: queuedSubmission.clientRunID,
+    };
+    const dispatchedSubmission: QueuedChatSubmission = {
+      ...queuedSubmission,
+      ...dispatchedBranchScope,
+    };
+    dispatchingQueuedSubmissionIDsRef.current.add(queuedSubmission.id);
+    sendQueuedAfterCurrentRef.current.delete(branchScopeID(queuedSubmission));
+    setQueuedSubmissions((current) =>
+      current
+        .filter((item) => item.id !== queuedSubmission.id)
+        .map((item) =>
+          branchScopesEqual(item, queuedSubmission)
+            ? {
+                ...item,
+                ...dispatchedBranchScope,
+              }
+            : item,
+        ),
+    );
+    const parentExchange = queuedSubmission.parentRunID
+      ? Object.values(allPendingExchanges).find(
+          (exchange) =>
+            exchange.runID === queuedSubmission.parentRunID &&
+            branchScopesEqual(exchange, queuedSubmission),
+        )
+      : undefined;
+    const serverParentMessage = findSuccessfulBranchParentMessage(
+      combinedMessages,
+      queuedSubmission.parentRunID,
+    );
     const parentMessagePublicID =
-      resolvePersistedPublicID(currentLeafMessage?.publicID) ??
-      resolveDefaultSubmissionParentMessage(visibleMessages)?.publicID ??
-      null;
+      resolvePersistedPublicID(parentExchange?.assistantPublicID) ??
+      resolvePersistedPublicID(serverParentMessage?.publicID) ??
+      (branchScopeIsVisible(queuedSubmission, conversationScopeKey, visibleMessages) &&
+      currentLeafMessage?.runID === queuedSubmission.parentRunID
+        ? resolvePersistedPublicID(currentLeafMessage.publicID)
+        : null) ??
+      queuedSubmission.parentMessagePublicID;
     void submitMessage({
       content: queuedSubmission.content,
       currentAttachments: queuedSubmission.attachments,
       resetComposer: false,
       parentMessagePublicID,
       branchReason: "default",
-      queuedSubmission,
-    });
+      queuedSubmission: dispatchedSubmission,
+    })
+      .finally(() => {
+        dispatchingQueuedSubmissionIDsRef.current.delete(queuedSubmission.id);
+      });
   }, [
+    activeRunRevision,
     combinedMessages,
+    conversationScopeKey,
     currentLeafMessage?.publicID,
+    currentLeafMessage?.runID,
+    getPendingExchanges,
+    getHiddenParentRunStatus,
+    hiddenParentRunStatusRevision,
     pendingExchanges,
     queuedSubmissions,
     resumeGenerationActive,
-    sending,
     submitMessage,
-    uploading,
+    visibleBranchScopePath,
     visibleMessages,
   ]);
 
@@ -1459,11 +2027,16 @@ export function useChatMessageSubmit({
     onDeleteQueuedMessage,
     onEditQueuedMessage,
     onGuideQueuedMessage,
-    queuedMessages: queuedSubmissions.map((item) => ({
-      id: item.id,
-      content: item.content,
-      attachmentCount: item.attachments.length,
-    })),
+    queuedMessages: queuedSubmissions
+      .filter(
+        (item) =>
+          branchScopeIsVisible(item, conversationScopeKey, visibleMessages),
+      )
+      .map((item) => ({
+        id: item.id,
+        content: item.content,
+        attachmentCount: item.attachments.length,
+      })),
     sending,
   };
 }

--- a/frontend/features/chat/hooks/use-chat-runtime.ts
+++ b/frontend/features/chat/hooks/use-chat-runtime.ts
@@ -13,6 +13,79 @@ import type {
 } from "@/shared/api/conversation.types";
 import type { SkillSummaryDTO } from "@/shared/api/skills.types";
 
+function selectPendingExchangesByScope(
+  exchanges: PendingExchangeMap,
+  conversationScopeKey: string,
+): PendingExchangeMap {
+  const scopedEntries = Object.entries(exchanges).filter(
+    ([, exchange]) => exchange.conversationScopeKey === conversationScopeKey,
+  );
+  return Object.fromEntries(scopedEntries);
+}
+
+function pendingExchangeMapsEqual(previous: PendingExchangeMap, next: PendingExchangeMap): boolean {
+  const previousKeys = Object.keys(previous);
+  const nextKeys = Object.keys(next);
+  if (previousKeys.length !== nextKeys.length) {
+    return false;
+  }
+  return previousKeys.every((key) => previous[key] === next[key]);
+}
+
+function useScopedPendingExchanges(conversationScopeKey: string) {
+  const allPendingExchangesRef = React.useRef<PendingExchangeMap>({});
+  const conversationScopeKeyRef = React.useRef(conversationScopeKey);
+  conversationScopeKeyRef.current = conversationScopeKey;
+  const [pendingExchanges, setVisiblePendingExchanges] = React.useState<PendingExchangeMap>({});
+  const visiblePendingExchangesRef = React.useRef(pendingExchanges);
+  const visiblePendingScopeKeyRef = React.useRef(conversationScopeKey);
+
+  const publishVisiblePendingExchanges = React.useCallback((allPendingExchanges: PendingExchangeMap) => {
+    const currentScopeKey = conversationScopeKeyRef.current;
+    const nextVisible = selectPendingExchangesByScope(
+      allPendingExchanges,
+      currentScopeKey,
+    );
+    if (
+      visiblePendingScopeKeyRef.current === currentScopeKey &&
+      pendingExchangeMapsEqual(visiblePendingExchangesRef.current, nextVisible)
+    ) {
+      return;
+    }
+    visiblePendingScopeKeyRef.current = currentScopeKey;
+    visiblePendingExchangesRef.current = nextVisible;
+    setVisiblePendingExchanges(nextVisible);
+  }, []);
+
+  const setPendingExchanges = React.useCallback<
+    React.Dispatch<React.SetStateAction<PendingExchangeMap>>
+  >((update) => {
+    const current = allPendingExchangesRef.current;
+    const next = typeof update === "function" ? update(current) : update;
+    if (next === current) {
+      return;
+    }
+    allPendingExchangesRef.current = next;
+    publishVisiblePendingExchanges(next);
+  }, [publishVisiblePendingExchanges]);
+
+  React.useEffect(() => {
+    publishVisiblePendingExchanges(allPendingExchangesRef.current);
+  }, [conversationScopeKey, publishVisiblePendingExchanges]);
+
+  const getPendingExchanges = React.useCallback(() => allPendingExchangesRef.current, []);
+  const scopedPendingExchanges =
+    visiblePendingScopeKeyRef.current === conversationScopeKey
+      ? pendingExchanges
+      : selectPendingExchangesByScope(allPendingExchangesRef.current, conversationScopeKey);
+
+  return {
+    getPendingExchanges,
+    pendingExchanges: scopedPendingExchanges,
+    setPendingExchanges,
+  };
+}
+
 export function useChatRuntime({
   conversationID,
   resetToken,
@@ -71,8 +144,13 @@ export function useChatRuntime({
   resumingRunID?: string;
 }) {
   const [showConversationLayout, setShowConversationLayout] = React.useState(false);
-  const [pendingExchanges, setPendingExchanges] = React.useState<PendingExchangeMap>({});
   const previousResetTokenRef = React.useRef(resetToken);
+  const conversationScopeKey = React.useMemo(
+    () => conversationID?.trim() ? `conversation:${conversationID.trim()}` : `draft:${resetToken}`,
+    [conversationID, resetToken],
+  );
+  const { getPendingExchanges, pendingExchanges, setPendingExchanges } =
+    useScopedPendingExchanges(conversationScopeKey);
   const liveServerRunIDs = React.useMemo(() => {
     const normalized = resumingRunID.trim();
     return normalized ? new Set([normalized]) : undefined;
@@ -80,14 +158,30 @@ export function useChatRuntime({
 
   const branchState = useChatBranchState({
     conversationID,
+    conversationScopeKey,
     resetToken,
     messages,
     pendingExchanges,
     liveRunIDs: liveServerRunIDs,
   });
+  const visibleResumeGenerationActive = React.useMemo(() => {
+    const normalizedRunID = resumingRunID.trim();
+    if (!normalizedRunID) {
+      return false;
+    }
+    return branchState.visibleMessages.some(
+      (message) =>
+        message.role === "assistant" &&
+        message.runID === normalizedRunID &&
+        (message.isPending ||
+          message.isStreaming ||
+          message.status?.trim().toLowerCase() === "pending"),
+    );
+  }, [branchState.visibleMessages, resumingRunID]);
 
   const submitState = useChatSubmitStream({
     conversationID,
+    conversationScopeKey,
     activeConversation,
     selectedPlatformModelName,
     modelOptions,
@@ -109,6 +203,7 @@ export function useChatRuntime({
     setDraft,
     setAttachments,
     releaseAttachments,
+    getPendingExchanges,
     pendingExchanges,
     setPendingExchanges,
     setBranchSelections: branchState.setBranchSelections,
@@ -119,10 +214,9 @@ export function useChatRuntime({
     visibleMessages: branchState.visibleMessages,
     combinedMessages: branchState.combinedMessages,
     serverMessagePublicIDs: branchState.serverMessagePublicIDs,
-    resetToken,
     activeGenerationRunsRef,
     failedGenerationRunsRef,
-    resumeGenerationActive: Boolean(resumingRunID),
+    resumeGenerationActive: visibleResumeGenerationActive,
   });
 
   React.useEffect(() => {
@@ -157,7 +251,7 @@ export function useChatRuntime({
     onEditQueuedMessage: submitState.onEditQueuedMessage,
     onGuideQueuedMessage: submitState.onGuideQueuedMessage,
     queuedMessages: submitState.queuedMessages,
-    sending: submitState.sending,
+    sending: submitState.sending || visibleResumeGenerationActive,
     visibleMessageCount: branchState.visibleMessageCount,
     visibleMessages: branchState.visibleMessages,
     isConversationMode: showConversationLayout || branchState.visibleMessageCount > 0,

--- a/frontend/features/chat/hooks/use-chat-submit-stream.ts
+++ b/frontend/features/chat/hooks/use-chat-submit-stream.ts
@@ -19,7 +19,7 @@ import type { SkillSummaryDTO } from "@/shared/api/skills.types";
 
 export function useChatSubmitStream({
   conversationID,
-  resetToken,
+  conversationScopeKey,
   activeConversation,
   selectedPlatformModelName,
   modelOptions,
@@ -41,6 +41,7 @@ export function useChatSubmitStream({
   setDraft,
   setAttachments,
   releaseAttachments,
+  getPendingExchanges,
   pendingExchanges,
   setPendingExchanges,
   setBranchSelections,
@@ -56,7 +57,7 @@ export function useChatSubmitStream({
   resumeGenerationActive,
 }: {
   conversationID: string | null;
-  resetToken: number;
+  conversationScopeKey: string;
   activeConversation: ConversationDTO | null;
   selectedPlatformModelName: string;
   modelOptions: ChatModelOption[];
@@ -78,6 +79,7 @@ export function useChatSubmitStream({
   setDraft: React.Dispatch<React.SetStateAction<string>>;
   setAttachments: React.Dispatch<React.SetStateAction<PendingAttachment[]>>;
   releaseAttachments: (items: PendingAttachment[]) => void;
+  getPendingExchanges: () => PendingExchangeMap;
   pendingExchanges: PendingExchangeMap;
   setPendingExchanges: React.Dispatch<React.SetStateAction<PendingExchangeMap>>;
   setBranchSelections: React.Dispatch<React.SetStateAction<Record<string, string>>>;
@@ -98,6 +100,7 @@ export function useChatSubmitStream({
 
   const messageSubmit = useChatMessageSubmit({
     conversationID,
+    conversationScopeKey,
     activeConversation,
     selectedPlatformModelName,
     modelOptions,
@@ -119,6 +122,7 @@ export function useChatSubmitStream({
     setDraft,
     setAttachments,
     releaseAttachments,
+    getPendingExchanges,
     pendingExchanges,
     setPendingExchanges,
     setBranchSelections,
@@ -135,7 +139,6 @@ export function useChatSubmitStream({
     flushUpstreamThinkNow: streamBuffer.flushUpstreamThinkNow,
     resetStreamBuffer: streamBuffer.resetStreamBuffer,
     startStream: streamBuffer.startStream,
-    resetToken,
     activeGenerationRunsRef,
     failedGenerationRunsRef,
     resumeGenerationActive,

--- a/frontend/features/chat/hooks/use-hidden-queued-parent-runs.ts
+++ b/frontend/features/chat/hooks/use-hidden-queued-parent-runs.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import * as React from "react";
+
+import type { PendingExchangeMap } from "@/features/chat/types/chat-runtime";
+import { listConversationRuns } from "@/shared/api/conversation";
+import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
+
+const POLL_INTERVAL_MS = 1_500;
+
+type QueuedParentRun = {
+  conversationScopeKey: string;
+  conversationPublicID: string | null;
+  parentRunID: string | null;
+};
+
+function isTerminalRunStatus(status: string | null | undefined): boolean {
+  const normalized = status?.trim().toLowerCase() || "";
+  return ["success", "interrupted", "error", "canceled", "cancelled"].includes(normalized);
+}
+
+export function useHiddenQueuedParentRuns({
+  currentConversationScopeKey,
+  queuedParents,
+  getPendingExchanges,
+  isRunActive,
+}: {
+  currentConversationScopeKey: string;
+  queuedParents: QueuedParentRun[];
+  getPendingExchanges: () => PendingExchangeMap;
+  isRunActive: (runID: string) => boolean;
+}) {
+  const statusesRef = React.useRef(new Map<string, string>());
+  const [revision, setRevision] = React.useState(0);
+
+  React.useEffect(() => {
+    const locallyTrackedRunIDs = new Set(
+      Object.values(getPendingExchanges())
+        .map((exchange) => exchange.runID?.trim() || "")
+        .filter(Boolean),
+    );
+    const watchedRunIDs = new Set<string>();
+    const runsByConversation = new Map<string, Set<string>>();
+    for (const parent of queuedParents) {
+      const parentRunID = parent.parentRunID?.trim() || "";
+      const conversationPublicID = parent.conversationPublicID?.trim() || "";
+      if (!parentRunID || !conversationPublicID) {
+        continue;
+      }
+      watchedRunIDs.add(parentRunID);
+      if (
+        parent.conversationScopeKey === currentConversationScopeKey ||
+        isRunActive(parentRunID) ||
+        locallyTrackedRunIDs.has(parentRunID) ||
+        isTerminalRunStatus(statusesRef.current.get(parentRunID))
+      ) {
+        continue;
+      }
+      const runIDs = runsByConversation.get(conversationPublicID) ?? new Set<string>();
+      runIDs.add(parentRunID);
+      runsByConversation.set(conversationPublicID, runIDs);
+    }
+    for (const runID of statusesRef.current.keys()) {
+      if (!watchedRunIDs.has(runID)) {
+        statusesRef.current.delete(runID);
+      }
+    }
+    if (runsByConversation.size === 0) {
+      return;
+    }
+
+    let cancelled = false;
+    let pollTimer: number | null = null;
+    const poll = async () => {
+      const token = await resolveAccessToken();
+      if (!token || cancelled) {
+        return;
+      }
+      let changed = false;
+      let shouldPollAgain = false;
+      await Promise.all(
+        Array.from(runsByConversation.entries()).map(async ([conversationPublicID, runIDs]) => {
+          try {
+            const page = await listConversationRuns(token, conversationPublicID, {
+              page: 1,
+              pageSize: 20,
+            });
+            if (cancelled) {
+              return;
+            }
+            const statuses = new Map(
+              page.results.map((run) => [run.runID.trim(), run.status.trim().toLowerCase()]),
+            );
+            for (const runID of runIDs) {
+              const status = statuses.get(runID) || "";
+              if (!status || !isTerminalRunStatus(status)) {
+                shouldPollAgain = true;
+              }
+              if (status && statusesRef.current.get(runID) !== status) {
+                statusesRef.current.set(runID, status);
+                changed = true;
+              }
+            }
+          } catch {
+            shouldPollAgain = true;
+          }
+        }),
+      );
+      if (cancelled) {
+        return;
+      }
+      if (changed) {
+        setRevision((current) => current + 1);
+      }
+      if (shouldPollAgain) {
+        pollTimer = window.setTimeout(poll, POLL_INTERVAL_MS);
+      }
+    };
+
+    void poll();
+    return () => {
+      cancelled = true;
+      if (pollTimer !== null) {
+        window.clearTimeout(pollTimer);
+      }
+    };
+  }, [currentConversationScopeKey, getPendingExchanges, isRunActive, queuedParents]);
+
+  const getStatus = React.useCallback((runID: string) => statusesRef.current.get(runID.trim()) || "", []);
+
+  return {
+    getStatus,
+    revision,
+  };
+}

--- a/frontend/features/chat/types/chat-runtime.ts
+++ b/frontend/features/chat/types/chat-runtime.ts
@@ -67,6 +67,9 @@ export type UploadingAttachment = {
 
 export type PendingExchange = {
   key: string;
+  conversationScopeKey: string;
+  branchScopePath: string[];
+  branchScopeRunID: string;
   conversationPublicID: string | null;
   tempUserPublicID: string;
   tempAssistantPublicID: string;


### PR DESCRIPTION
## Summary

修复并发对话与分支切换时的生成、排队和分支选择问题。

- 支持不同会话以及同一会话不同分支并发生成。
- 按会话、分支路径和 run ID 隔离排队消息，避免消息发送至错误会话或分支。
- 编辑或重试消息后立即切换至新分支，并安全完成临时消息 ID 替换。
- 切换页面、会话或分支后，后台生成及其队列继续归属于原始分支。
- 为隐藏会话中的恢复流增加按需、低频终态查询，使后续队列能够自动派发。
- 修复并发任务完成时侧边栏消息数量被旧快照覆盖的问题。
- 停止生成仅影响当前可见分支，不会取消其他后台任务。

Fixes #524

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm --filter @deeix/web check`
- [x] `git diff --check`
- [ ] Frontend build not run; requires explicit elevation and was not requested.
- [ ] Manual browser verification was not run.

## Screenshots, API examples, or logs

No API changes. No additional screenshots.

## Configuration, migration, and compatibility notes

- No database migration or configuration changes.
- No backend or public API contract changes.
- Hidden resumed runs are queried only while a dependent queue exists outside the current conversation.
- Existing conversations and queued-message behavior remain compatible.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.