### PR TITLE
fix: preserve conversation title after failed first generation

### DIFF
--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -376,6 +376,7 @@ func (s *Service) sendMessageInternal(
 		userMessage.SourcePublicID = branchState.SourcePublicID
 		assistantMessage.ParentPublicID = userMessage.PublicID
 	}
+	s.persistInitialConversationFallbackTitle(ctx, *conversation, *userMessage)
 	traceRecorder = newMessageTraceRecorder(s, ctx, assistantMessage, input.OnEvent)
 
 	if s.routeResolver == nil || s.llmClient == nil {

--- a/backend/internal/application/conversation/service_metadata.go
+++ b/backend/internal/application/conversation/service_metadata.go
@@ -434,6 +434,40 @@ func (s *Service) persistConversationFallbackTitle(
 	}
 }
 
+func (s *Service) persistInitialConversationFallbackTitle(
+	ctx context.Context,
+	conversation model.Conversation,
+	currentUserMessage model.Message,
+) {
+	if !shouldAutoReplaceConversationTitle(conversation.Title) {
+		return
+	}
+	candidate := currentUserMessage
+	messages, err := s.repo.ListAllMessages(ctx, conversation.ID)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("conversation_initial_title_message_load_failed",
+				zap.Uint("conversation_id", conversation.ID),
+				zap.Error(err),
+			)
+		}
+		return
+	}
+	if firstUserMessage, ok := firstTitleableConversationUserMessage(messages); ok {
+		candidate = firstUserMessage
+	}
+	s.persistConversationFallbackTitle(ctx, conversation, candidate)
+}
+
+func firstTitleableConversationUserMessage(messages []model.Message) (model.Message, bool) {
+	for _, message := range messages {
+		if message.Role == "user" && strings.TrimSpace(message.Content) != "" {
+			return message, true
+		}
+	}
+	return model.Message{}, false
+}
+
 func renderConversationMetadataPrompt(raw string, fallback string, messages string) string {
 	prompt := strings.TrimSpace(raw)
 	if prompt == "" {

--- a/backend/internal/application/conversation/service_metadata_test.go
+++ b/backend/internal/application/conversation/service_metadata_test.go
@@ -1,12 +1,35 @@
 package conversation
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
 
 	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
 )
+
+type initialFallbackTitleRepositoryStub struct {
+	repository.ConversationRepository
+	messages  []model.Message
+	patch     repository.ConversationMetadataPatch
+	listCalls int
+}
+
+func (s *initialFallbackTitleRepositoryStub) ListAllMessages(context.Context, uint) ([]model.Message, error) {
+	s.listCalls++
+	return append([]model.Message(nil), s.messages...), nil
+}
+
+func (s *initialFallbackTitleRepositoryStub) UpdateConversationMetadata(
+	_ context.Context,
+	conversationID uint,
+	patch repository.ConversationMetadataPatch,
+) (*model.Conversation, error) {
+	s.patch = patch
+	return &model.Conversation{ID: conversationID, Title: patch.Title}, nil
+}
 
 func TestBuildConversationMetadataMessagesTruncatesToBudget(t *testing.T) {
 	userMsg := model.Message{Content: strings.Repeat("用户输入内容", 6000)}
@@ -133,6 +156,46 @@ func TestConversationFallbackTitlePatchOnlyReplacesPlaceholder(t *testing.T) {
 	}
 	if _, ok = conversationFallbackTitlePatch(model.Conversation{Title: "新对话"}, model.Message{}); ok {
 		t.Fatal("expected empty user content not to receive a fallback patch")
+	}
+}
+
+func TestPersistInitialConversationFallbackTitleUsesFirstStoredUserMessage(t *testing.T) {
+	repo := &initialFallbackTitleRepositoryStub{messages: []model.Message{
+		{ID: 1, Role: "user", Content: "第一条失败消息", Status: "error"},
+		{ID: 2, Role: "assistant", Status: "error"},
+		{ID: 3, Role: "user", Content: "第二条成功消息", Status: "pending"},
+	}}
+	service := &Service{repo: repo}
+	service.persistInitialConversationFallbackTitle(
+		t.Context(),
+		model.Conversation{ID: 1, Title: "新对话", MessageCount: 2},
+		model.Message{ID: 3, Role: "user", Content: "第二条成功消息"},
+	)
+
+	if repo.patch.Title != "第一条失败消息" {
+		t.Fatalf("expected the first failed user message to remain the fallback title, got %q", repo.patch.Title)
+	}
+	if repo.listCalls != 1 {
+		t.Fatalf("expected existing conversation history to be loaded once, got %d", repo.listCalls)
+	}
+}
+
+func TestPersistInitialConversationFallbackTitleUsesCurrentFirstMessage(t *testing.T) {
+	repo := &initialFallbackTitleRepositoryStub{messages: []model.Message{{
+		ID: 1, Role: "user", Content: "第一条消息", Status: "pending",
+	}}}
+	service := &Service{repo: repo}
+	service.persistInitialConversationFallbackTitle(
+		t.Context(),
+		model.Conversation{ID: 1, Title: "新对话", MessageCount: 0},
+		model.Message{ID: 1, Role: "user", Content: "第一条消息"},
+	)
+
+	if repo.patch.Title != "第一条消息" {
+		t.Fatalf("expected current first user message as fallback title, got %q", repo.patch.Title)
+	}
+	if repo.listCalls != 1 {
+		t.Fatalf("expected the persisted first message to be loaded once, got %d calls", repo.listCalls)
 	}
 }
 

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -1398,6 +1398,21 @@ export function useChatMessageSubmit({
           },
         }));
         toast.error(t("sendFailed"), { description: errorSummary });
+        if (targetConversationID) {
+          const failedConversationID = targetConversationID;
+          void resolveAccessToken()
+            .then((latestToken) =>
+              latestToken ? getConversation(latestToken, failedConversationID) : null,
+            )
+            .then((latestConversation) => {
+              if (latestConversation) {
+                touchByPublicID(failedConversationID, latestConversation);
+              }
+            })
+            .catch(() => {
+              // The next conversation list load will reconcile a failed refresh.
+            });
+        }
         if (targetConversationID && conversationScopeKeyRef.current === targetConversationScopeKey) {
           reload();
         }


### PR DESCRIPTION
## Summary

Fix conversation titles being reset to `新对话` when the first model generation fails while automatic title generation is disabled.

The initial user message now persists the fallback title immediately after being saved. Failed, cancelled, and incomplete generations no longer prevent title creation, and later messages cannot overwrite the initial title. The frontend also refreshes conversation metadata after a generation failure so the sidebar stays synchronized.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm lint`
- [x] `cd backend && go test ./...`
- [x] Targeted conversation metadata tests
- [x] `git diff --check`
- [ ] Not run; reason:

## Screenshots, API examples, or logs

Not applicable. This change does not alter user-facing layout or API response formats.

## Configuration, migration, and compatibility notes

No configuration, database migration, API contract, or deployment changes are required.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.