### PR TITLE
fix: preserve chat scroll position after streaming completes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
-    "@shadcn/react": "^0.1.0",
+    "@shadcn/react": "^0.2.1",
     "@streamdown/cjk": "^1.0.3",
     "@streamdown/code": "^1.1.1",
     "@streamdown/math": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^1.2.2
         version: 1.2.3(@types/react@19.2.17)(react@19.2.5)
       '@shadcn/react':
-        specifier: ^0.1.0
-        version: 0.1.0(@types/react@19.2.17)(react@19.2.5)
+        specifier: ^0.2.1
+        version: 0.2.1(@types/react@19.2.17)(react@19.2.5)
       '@streamdown/cjk':
         specifier: ^1.0.3
         version: 1.0.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(react@19.2.5)(unified@11.0.5)
@@ -1643,8 +1643,8 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
-  '@shadcn/react@0.1.0':
-    resolution: {integrity: sha512-6i67TEnqValsZY7e4exJ4rkHo2OdHXmDH152YulwSpuEUnTQYumHkXzFsaje7HB7GbMTWuI9x1Jn6sSduCYdeA==}
+  '@shadcn/react@0.2.1':
+    resolution: {integrity: sha512-5krgi3dRMKb5jH6a+qPzVJUy/54s0kKE4Rw4LjDfLqOdVQTWKUgxWf1kW8r912I0jX/Lzxqc+pgjkjWxUIK5BQ==}
     peerDependencies:
       '@types/react': '>=19'
       react: '>=19'
@@ -6096,7 +6096,7 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@shadcn/react@0.1.0(@types/react@19.2.17)(react@19.2.5)':
+  '@shadcn/react@0.2.1(@types/react@19.2.17)(react@19.2.5)':
     optionalDependencies:
       '@types/react': 19.2.17
       react: 19.2.5


### PR DESCRIPTION
## Summary

升级 `@shadcn/react` 至 `0.2.1`，修复 MessageScroller 在高速流式输出、消息锚点切换及 ResizeObserver 更新期间错误恢复自动追底的问题。

用户主动离开底部后，模型输出完成及终态消息替换不再将页面自动滚动到底部。现有发送消息平滑滚动动画保持不变。

Fixes #536

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm --filter @deeix/web lint`
- [x] `pnpm --filter @deeix/web typecheck`
- [x] `git diff --check`
- [ ] Production build not run; the privilege approval service returned `model_not_found` before the build started.

## Screenshots, API examples, or logs

Not applicable. This change updates the underlying message scrolling state machine without changing the UI layout.

## Configuration, migration, and compatibility notes

- No configuration or database migration is required.
- No frontend or backend API contract changes.
- The MessageScroller public TypeScript API remains unchanged.
- The existing smooth scrolling animation after sending a message is preserved.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.