### PR TITLE
fix: improve mobile markdown table rendering

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1097,11 +1097,9 @@ html[data-branding-pending] body {
   }
 
   .markdown-table-shell {
-    position: relative;
     width: 100%;
     max-width: 100%;
     margin-block: 1rem;
-    isolation: isolate;
   }
 
   .markdown-table-scroll {
@@ -1109,11 +1107,7 @@ html[data-branding-pending] body {
     max-width: 100%;
     overflow-x: auto;
     overflow-y: hidden;
-    border: 1px solid color-mix(in oklch, var(--border) 78%, transparent);
-    border-radius: 0.75rem;
-    background: color-mix(in oklch, var(--background) 94%, var(--muted));
     overscroll-behavior-inline: contain;
-    scrollbar-width: thin;
     touch-action: pan-x pan-y;
     -webkit-overflow-scrolling: touch;
   }
@@ -1123,34 +1117,11 @@ html[data-branding-pending] body {
     outline-offset: 2px;
   }
 
-  .markdown-table-shell::after {
-    position: absolute;
-    z-index: 2;
-    inset-block: 1px;
-    inset-inline-end: 1px;
-    width: 1.5rem;
-    border-start-end-radius: 0.7rem;
-    border-end-end-radius: 0.7rem;
-    background: linear-gradient(to left, color-mix(in oklch, var(--foreground) 9%, transparent), transparent);
-    content: "";
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 160ms ease;
-  }
-
-  :dir(rtl) .markdown-table-shell::after {
-    background: linear-gradient(to right, color-mix(in oklch, var(--foreground) 9%, transparent), transparent);
-  }
-
-  .markdown-table-shell[data-overflow-hint="visible"]::after {
-    opacity: 1;
-  }
-
   .markdown-table {
     width: max-content !important;
     min-width: 100% !important;
     max-width: none !important;
-    margin: 0 !important;
+    margin: 0.5rem 0 !important;
     table-layout: auto !important;
     border-collapse: collapse;
     background: transparent;
@@ -1158,23 +1129,41 @@ html[data-branding-pending] body {
 
   .markdown-table th,
   .markdown-table td {
-    padding: 0.625rem 0.75rem !important;
+    padding: 0 !important;
     border: 0 !important;
-    border-block-end: 1px solid color-mix(in oklch, var(--border) 64%, transparent) !important;
-    line-height: 1.55 !important;
-    vertical-align: top;
+    line-height: inherit !important;
     text-align: start;
     overflow-wrap: normal;
     word-break: normal;
   }
 
+  .markdown-table th,
+  .markdown-table td {
+    border-block-end: 1px solid color-mix(in oklch, var(--border) 54%, transparent) !important;
+  }
+
+  .markdown-table thead,
+  .markdown-table tbody,
+  .markdown-table tfoot,
+  .markdown-table tr {
+    border: 0 !important;
+    background: transparent !important;
+  }
+
   .markdown-table th {
-    background: color-mix(in oklch, var(--muted) 68%, var(--background));
-    color: var(--foreground);
+    padding: 0.5rem 2rem 0.5rem 0 !important;
+    vertical-align: bottom;
     font-weight: 600;
   }
 
-  .markdown-table tbody tr:last-child td {
+  .markdown-table td {
+    padding: 0.25rem 2rem 0.25rem 0 !important;
+    vertical-align: middle;
+    line-height: 2rem !important;
+  }
+
+  .markdown-table tbody tr:last-child td,
+  .markdown-table tfoot tr:last-child td {
     border-block-end: 0 !important;
   }
 
@@ -1216,14 +1205,9 @@ html[data-branding-pending] body {
     max-width: 30rem;
   }
 
-  .markdown-table-col--normal {
-    min-width: 6.25rem;
-    max-width: 13.75rem;
-  }
-
-  .markdown-table-col--content {
-    min-width: 17rem;
-    max-width: 30rem;
+  .markdown-table-cell--normal {
+    white-space: normal;
+    overflow-wrap: anywhere;
   }
 
   .markdown-table-shell[data-content-columns="2"] .markdown-table-col--content,
@@ -1266,11 +1250,6 @@ html[data-branding-pending] body {
   }
 
   @media (max-width: 30rem) {
-    .markdown-table th,
-    .markdown-table td {
-      padding: 0.5rem 0.625rem !important;
-    }
-
     .markdown-table-col--content,
     .markdown-table-cell--content {
       min-width: 16rem;
@@ -1287,11 +1266,6 @@ html[data-branding-pending] body {
     }
   }
 
-  @media (prefers-reduced-motion: reduce) {
-    .markdown-table-shell::after {
-      transition: none;
-    }
-  }
 }
 
 :root[data-chat-font="default"] {

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1095,6 +1095,203 @@ html[data-branding-pending] body {
       transition: none;
     }
   }
+
+  .markdown-table-shell {
+    position: relative;
+    width: 100%;
+    max-width: 100%;
+    margin-block: 1rem;
+    isolation: isolate;
+  }
+
+  .markdown-table-scroll {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border: 1px solid color-mix(in oklch, var(--border) 78%, transparent);
+    border-radius: 0.75rem;
+    background: color-mix(in oklch, var(--background) 94%, var(--muted));
+    overscroll-behavior-inline: contain;
+    scrollbar-width: thin;
+    touch-action: pan-x pan-y;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .markdown-table-scroll:focus-visible {
+    outline: 2px solid color-mix(in oklch, var(--ring) 55%, transparent);
+    outline-offset: 2px;
+  }
+
+  .markdown-table-shell::after {
+    position: absolute;
+    z-index: 2;
+    inset-block: 1px;
+    inset-inline-end: 1px;
+    width: 1.5rem;
+    border-start-end-radius: 0.7rem;
+    border-end-end-radius: 0.7rem;
+    background: linear-gradient(to left, color-mix(in oklch, var(--foreground) 9%, transparent), transparent);
+    content: "";
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 160ms ease;
+  }
+
+  :dir(rtl) .markdown-table-shell::after {
+    background: linear-gradient(to right, color-mix(in oklch, var(--foreground) 9%, transparent), transparent);
+  }
+
+  .markdown-table-shell[data-overflow-hint="visible"]::after {
+    opacity: 1;
+  }
+
+  .markdown-table {
+    width: max-content !important;
+    min-width: 100% !important;
+    max-width: none !important;
+    margin: 0 !important;
+    table-layout: auto !important;
+    border-collapse: collapse;
+    background: transparent;
+  }
+
+  .markdown-table th,
+  .markdown-table td {
+    padding: 0.625rem 0.75rem !important;
+    border: 0 !important;
+    border-block-end: 1px solid color-mix(in oklch, var(--border) 64%, transparent) !important;
+    line-height: 1.55 !important;
+    vertical-align: top;
+    text-align: start;
+    overflow-wrap: normal;
+    word-break: normal;
+  }
+
+  .markdown-table th {
+    background: color-mix(in oklch, var(--muted) 68%, var(--background));
+    color: var(--foreground);
+    font-weight: 600;
+  }
+
+  .markdown-table tbody tr:last-child td {
+    border-block-end: 0 !important;
+  }
+
+  /* Width hints on <col> are weak (per CSS spec only `width` applies to table
+   * columns). The real min/max constraints must live on the cells, otherwise
+   * Chromium ignores them in `width: max-content` tables and long text renders
+   * unwrapped on a single line.
+   */
+  .markdown-table-col--compact,
+  .markdown-table-col--numeric,
+  .markdown-table-col--date {
+    width: 1%;
+  }
+
+  .markdown-table-col--compact,
+  .markdown-table-cell--compact {
+    min-width: 3rem;
+  }
+
+  .markdown-table-col--numeric,
+  .markdown-table-cell--numeric {
+    min-width: 4.5rem;
+  }
+
+  .markdown-table-col--date,
+  .markdown-table-cell--date {
+    min-width: 6.75rem;
+  }
+
+  .markdown-table-col--normal,
+  .markdown-table-cell--normal {
+    min-width: 6.25rem;
+    max-width: 13.75rem;
+  }
+
+  .markdown-table-col--content,
+  .markdown-table-cell--content {
+    min-width: 17rem;
+    max-width: 30rem;
+  }
+
+  .markdown-table-col--normal {
+    min-width: 6.25rem;
+    max-width: 13.75rem;
+  }
+
+  .markdown-table-col--content {
+    min-width: 17rem;
+    max-width: 30rem;
+  }
+
+  .markdown-table-shell[data-content-columns="2"] .markdown-table-col--content,
+  .markdown-table-shell[data-content-columns="2"] .markdown-table-cell--content {
+    min-width: 14.5rem;
+  }
+
+  .markdown-table-shell[data-content-columns="many"] .markdown-table-col--content,
+  .markdown-table-shell[data-content-columns="many"] .markdown-table-cell--content {
+    min-width: 12rem;
+  }
+
+  .markdown-table-col--code,
+  .markdown-table-cell--code {
+    min-width: 12.5rem;
+    max-width: 26rem;
+  }
+
+  .markdown-table-cell--compact,
+  .markdown-table-cell--numeric,
+  .markdown-table-cell--date {
+    white-space: nowrap;
+  }
+
+  .markdown-table-cell--numeric {
+    text-align: end !important;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .markdown-table-cell--content {
+    white-space: normal;
+    overflow-wrap: break-word;
+    word-break: normal;
+  }
+
+  .markdown-table-cell--code {
+    font-family: var(--font-mono);
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  @media (max-width: 30rem) {
+    .markdown-table th,
+    .markdown-table td {
+      padding: 0.5rem 0.625rem !important;
+    }
+
+    .markdown-table-col--content,
+    .markdown-table-cell--content {
+      min-width: 16rem;
+    }
+
+    .markdown-table-shell[data-content-columns="2"] .markdown-table-col--content,
+    .markdown-table-shell[data-content-columns="2"] .markdown-table-cell--content {
+      min-width: 14rem;
+    }
+
+    .markdown-table-shell[data-content-columns="many"] .markdown-table-col--content,
+    .markdown-table-shell[data-content-columns="many"] .markdown-table-cell--content {
+      min-width: 11.5rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .markdown-table-shell::after {
+      transition: none;
+    }
+  }
 }
 
 :root[data-chat-font="default"] {

--- a/frontend/i18n/messages/en-US/chat.json
+++ b/frontend/i18n/messages/en-US/chat.json
@@ -122,6 +122,8 @@
     "previewImage": "Preview image",
     "editImage": "Edit image",
     "downloadImage": "Download image",
+    "scrollableTable": "Scrollable data table",
+    "scrollableTableHint": "Scroll horizontally to view more columns.",
     "copyLatex": "Copy formula source",
     "latexCopied": "Formula source copied",
     "latexCopyFailed": "Could not copy formula source",

--- a/frontend/i18n/messages/zh-CN/chat.json
+++ b/frontend/i18n/messages/zh-CN/chat.json
@@ -122,6 +122,8 @@
     "previewImage": "放大图片",
     "editImage": "编辑图片",
     "downloadImage": "下载图片",
+    "scrollableTable": "可横向滚动的数据表格",
+    "scrollableTableHint": "横向滚动可查看更多列。",
     "copyLatex": "复制公式源码",
     "latexCopied": "已复制公式源码",
     "latexCopyFailed": "公式源码复制失败",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "check": "pnpm lint && pnpm typecheck",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",
-    "clean": "rm -rf .next out"
+    "clean": "rm -rf .next out",
+    "test": "node --no-warnings --test shared/components/markdown/markdown-table-analyzer.test.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/frontend/shared/components/markdown/adaptive-markdown-table.tsx
+++ b/frontend/shared/components/markdown/adaptive-markdown-table.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import * as React from "react";
+import { useTranslations } from "next-intl";
+
+import { cn } from "@/lib/utils";
+import {
+  classifyTableColumns,
+  type ColumnAnalyzerOptions,
+  type ColumnType,
+  mergeColumnType,
+} from "./markdown-table-analyzer";
+
+const INITIAL_STREAMING_ROWS = 3;
+const INITIAL_ANALYSIS_DELAY_MS = 120;
+const REANALYSIS_DEBOUNCE_MS = 420;
+
+export const MarkdownTableStreamingContext = React.createContext(false);
+export const MarkdownTableAnalyzerOptionsContext = React.createContext<ColumnAnalyzerOptions | undefined>(undefined);
+
+type MarkdownTableProps = React.TableHTMLAttributes<HTMLTableElement> & {
+  children?: React.ReactNode;
+  node?: unknown;
+};
+
+type TableSnapshot = {
+  headers: string[];
+  rows: string[][];
+  columnCount: number;
+};
+
+type ElementWithChildren = React.ReactElement<{
+  children?: React.ReactNode;
+  className?: string;
+  node?: unknown;
+  scope?: string;
+}>;
+
+export function AdaptiveMarkdownTable({ children, className, node: _node, ...props }: MarkdownTableProps) {
+  const t = useTranslations("chat.markdown");
+  const streaming = React.useContext(MarkdownTableStreamingContext);
+  const analyzerOptions = React.useContext(MarkdownTableAnalyzerOptionsContext);
+  const snapshot = React.useMemo(() => getTableSnapshot(children), [children]);
+  const candidateTypes = React.useMemo(
+    () => classifyTableColumns(snapshot.headers, snapshot.rows, analyzerOptions),
+    [analyzerOptions, snapshot],
+  );
+  const columnTypes = useStableColumnTypes(candidateTypes, snapshot.rows.length, streaming);
+  const contentColumnCount = columnTypes.filter((type) => type === "content").length;
+  const contentColumnBucket = contentColumnCount >= 3 ? "many" : String(contentColumnCount);
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+  const hintID = React.useId();
+  const [hasHorizontalOverflow, setHasHorizontalOverflow] = React.useState(false);
+  const [showOverflowHint, setShowOverflowHint] = React.useState(false);
+
+  const updateOverflowHint = React.useCallback(() => {
+    const scrollElement = scrollRef.current;
+    if (!scrollElement) {
+      return;
+    }
+    const hasHiddenContent = scrollElement.scrollWidth - scrollElement.clientWidth > 2;
+    const direction = window.getComputedStyle(scrollElement).direction;
+    const inlineProgress = direction === "rtl" ? Math.abs(scrollElement.scrollLeft) : scrollElement.scrollLeft;
+    const isAtInlineEnd = inlineProgress + scrollElement.clientWidth >= scrollElement.scrollWidth - 2;
+    setHasHorizontalOverflow(hasHiddenContent);
+    setShowOverflowHint(hasHiddenContent && !isAtInlineEnd);
+  }, []);
+
+  React.useLayoutEffect(() => {
+    updateOverflowHint();
+    const scrollElement = scrollRef.current;
+    if (!scrollElement || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver(updateOverflowHint);
+    observer.observe(scrollElement);
+    const table = scrollElement.querySelector("table");
+    if (table) {
+      observer.observe(table);
+    }
+    return () => observer.disconnect();
+  }, [columnTypes, updateOverflowHint]);
+
+  const decoratedChildren = React.useMemo(
+    () => decorateTableChildren(children, columnTypes),
+    [children, columnTypes],
+  );
+
+  return (
+    <div
+      className="markdown-table-shell"
+      data-content-columns={contentColumnBucket}
+      data-overflow-hint={showOverflowHint ? "visible" : "hidden"}
+    >
+      {/* Keyboard users need to focus the horizontal scroll region itself. */}
+      <div
+        ref={scrollRef}
+        aria-describedby={hasHorizontalOverflow ? hintID : undefined}
+        aria-label={t("scrollableTable")}
+        className="markdown-table-scroll"
+        role="region"
+        tabIndex={hasHorizontalOverflow ? 0 : undefined}
+        onScroll={updateOverflowHint}
+      >
+        <table {...props} className={cn("markdown-table", className)} data-streamdown="table">
+          <colgroup>
+            {columnTypes.map((type, index) => (
+              <col
+                // Column order is dynamic; this key only identifies the current rendered column.
+                key={`${index}-${type}`}
+                className={`markdown-table-col markdown-table-col--${type}`}
+                data-markdown-column-type={type}
+              />
+            ))}
+          </colgroup>
+          {decoratedChildren}
+        </table>
+      </div>
+      <span id={hintID} className="sr-only">
+        {t("scrollableTableHint")}
+      </span>
+    </div>
+  );
+}
+
+function useStableColumnTypes(
+  candidateTypes: readonly ColumnType[],
+  rowCount: number,
+  streaming: boolean,
+): ColumnType[] {
+  const [streamingTypes, setStreamingTypes] = React.useState<ColumnType[]>(() =>
+    Array.from({ length: candidateTypes.length }, () => "normal"),
+  );
+  const classifiedRef = React.useRef(false);
+  const hasStreamedRef = React.useRef(streaming);
+  React.useEffect(() => {
+    if (!streaming) {
+      if (hasStreamedRef.current) {
+        setStreamingTypes((previousTypes) =>
+          candidateTypes.map((nextType, index) =>
+            mergeColumnType(previousTypes[index] ?? "normal", nextType),
+          ),
+        );
+      }
+      return;
+    }
+
+    if (candidateTypes.length !== streamingTypes.length) {
+      classifiedRef.current = false;
+      setStreamingTypes(Array.from({ length: candidateTypes.length }, () => "normal"));
+    }
+    if (rowCount < INITIAL_STREAMING_ROWS) {
+      return;
+    }
+
+    const delay = classifiedRef.current ? REANALYSIS_DEBOUNCE_MS : INITIAL_ANALYSIS_DELAY_MS;
+    const timeout = window.setTimeout(() => {
+      setStreamingTypes((previousTypes) => {
+        if (!classifiedRef.current || previousTypes.length !== candidateTypes.length) {
+          return [...candidateTypes];
+        }
+        return candidateTypes.map((nextType, index) =>
+          mergeColumnType(previousTypes[index] ?? "normal", nextType),
+        );
+      });
+      classifiedRef.current = true;
+    }, delay);
+
+    return () => window.clearTimeout(timeout);
+  }, [candidateTypes, rowCount, streaming, streamingTypes.length]);
+
+  if (!streaming) {
+    if (!hasStreamedRef.current) {
+      return [...candidateTypes];
+    }
+    return candidateTypes.map((nextType, index) =>
+      mergeColumnType(streamingTypes[index] ?? "normal", nextType),
+    );
+  }
+  return streamingTypes.length === candidateTypes.length
+    ? streamingTypes
+    : Array.from({ length: candidateTypes.length }, () => "normal");
+}
+
+function getTableSnapshot(children: React.ReactNode): TableSnapshot {
+  const sections = React.Children.toArray(children).filter(React.isValidElement) as ElementWithChildren[];
+  let headers: string[] = [];
+  const rows: string[][] = [];
+
+  for (const section of sections) {
+    const sectionRows = getChildElements(section.props.children);
+    const tagName = getElementTagName(section);
+    for (const row of sectionRows) {
+      const values = getChildElements(row.props.children).map((cell) => getReactNodeText(cell.props.children));
+      if (tagName === "thead" && headers.length === 0) {
+        headers = values;
+      } else {
+        rows.push(values);
+      }
+    }
+  }
+
+  const columnCount = Math.max(headers.length, ...rows.map((row) => row.length), 0);
+  if (headers.length < columnCount) {
+    headers = [...headers, ...Array.from({ length: columnCount - headers.length }, () => "")];
+  }
+  return { headers, rows, columnCount };
+}
+
+function decorateTableChildren(children: React.ReactNode, columnTypes: readonly ColumnType[]): React.ReactNode {
+  return React.Children.map(children, (sectionNode) => {
+    if (!React.isValidElement(sectionNode)) {
+      return sectionNode;
+    }
+    const section = sectionNode as ElementWithChildren;
+    const headerSection = getElementTagName(section) === "thead";
+    const rows = React.Children.map(section.props.children, (rowNode) => {
+      if (!React.isValidElement(rowNode)) {
+        return rowNode;
+      }
+      const row = rowNode as ElementWithChildren;
+      const cells = React.Children.map(row.props.children, (cellNode, columnIndex) => {
+        if (!React.isValidElement(cellNode)) {
+          return cellNode;
+        }
+        const cell = cellNode as ElementWithChildren;
+        const type = columnTypes[columnIndex] ?? "normal";
+        return React.cloneElement(cell, {
+          className: cn(cell.props.className, "markdown-table-cell", `markdown-table-cell--${type}`),
+          "data-markdown-column-type": type,
+          ...(headerSection ? { scope: "col" } : {}),
+        } as React.HTMLAttributes<HTMLTableCellElement>);
+      });
+      return React.cloneElement(row, undefined, cells);
+    });
+    return React.cloneElement(section, undefined, rows);
+  });
+}
+
+function getChildElements(children: React.ReactNode): ElementWithChildren[] {
+  return React.Children.toArray(children).filter(React.isValidElement) as ElementWithChildren[];
+}
+
+function getElementTagName(element: ElementWithChildren): string {
+  const node = element.props.node as { tagName?: string } | undefined;
+  if (node?.tagName) {
+    return node.tagName.toLowerCase();
+  }
+  if (typeof element.type === "string") {
+    return element.type.toLowerCase();
+  }
+  const displayName = (element.type as React.ComponentType).displayName ?? (element.type as React.ComponentType).name ?? "";
+  return displayName.toLowerCase().replace(/^markdown/, "");
+}
+
+function getReactNodeText(node: React.ReactNode): string {
+  return React.Children.toArray(node)
+    .map((child) => {
+      if (typeof child === "string" || typeof child === "number") {
+        return String(child);
+      }
+      if (React.isValidElement<{ children?: React.ReactNode }>(child)) {
+        return getReactNodeText(child.props.children);
+      }
+      return "";
+    })
+    .join("")
+    .trim();
+}

--- a/frontend/shared/components/markdown/adaptive-markdown-table.tsx
+++ b/frontend/shared/components/markdown/adaptive-markdown-table.tsx
@@ -26,7 +26,6 @@ type MarkdownTableProps = React.TableHTMLAttributes<HTMLTableElement> & {
 type TableSnapshot = {
   headers: string[];
   rows: string[][];
-  columnCount: number;
 };
 
 type ElementWithChildren = React.ReactElement<{
@@ -40,46 +39,36 @@ export function AdaptiveMarkdownTable({ children, className, node: _node, ...pro
   const t = useTranslations("chat.markdown");
   const streaming = React.useContext(MarkdownTableStreamingContext);
   const analyzerOptions = React.useContext(MarkdownTableAnalyzerOptionsContext);
-  const snapshot = React.useMemo(() => getTableSnapshot(children), [children]);
-  const candidateTypes = React.useMemo(
-    () => classifyTableColumns(snapshot.headers, snapshot.rows, analyzerOptions),
-    [analyzerOptions, snapshot],
-  );
-  const columnTypes = useStableColumnTypes(candidateTypes, snapshot.rows.length, streaming);
+  const columnTypes = useStableColumnTypes(children, analyzerOptions, streaming);
   const contentColumnCount = columnTypes.filter((type) => type === "content").length;
   const contentColumnBucket = contentColumnCount >= 3 ? "many" : String(contentColumnCount);
   const scrollRef = React.useRef<HTMLDivElement>(null);
   const hintID = React.useId();
   const [hasHorizontalOverflow, setHasHorizontalOverflow] = React.useState(false);
-  const [showOverflowHint, setShowOverflowHint] = React.useState(false);
 
-  const updateOverflowHint = React.useCallback(() => {
+  const updateOverflowState = React.useCallback(() => {
     const scrollElement = scrollRef.current;
     if (!scrollElement) {
       return;
     }
     const hasHiddenContent = scrollElement.scrollWidth - scrollElement.clientWidth > 2;
-    const direction = window.getComputedStyle(scrollElement).direction;
-    const inlineProgress = direction === "rtl" ? Math.abs(scrollElement.scrollLeft) : scrollElement.scrollLeft;
-    const isAtInlineEnd = inlineProgress + scrollElement.clientWidth >= scrollElement.scrollWidth - 2;
     setHasHorizontalOverflow(hasHiddenContent);
-    setShowOverflowHint(hasHiddenContent && !isAtInlineEnd);
   }, []);
 
   React.useLayoutEffect(() => {
-    updateOverflowHint();
+    updateOverflowState();
     const scrollElement = scrollRef.current;
     if (!scrollElement || typeof ResizeObserver === "undefined") {
       return;
     }
-    const observer = new ResizeObserver(updateOverflowHint);
+    const observer = new ResizeObserver(updateOverflowState);
     observer.observe(scrollElement);
     const table = scrollElement.querySelector("table");
     if (table) {
       observer.observe(table);
     }
     return () => observer.disconnect();
-  }, [columnTypes, updateOverflowHint]);
+  }, [columnTypes, updateOverflowState]);
 
   const decoratedChildren = React.useMemo(
     () => decorateTableChildren(children, columnTypes),
@@ -90,17 +79,15 @@ export function AdaptiveMarkdownTable({ children, className, node: _node, ...pro
     <div
       className="markdown-table-shell"
       data-content-columns={contentColumnBucket}
-      data-overflow-hint={showOverflowHint ? "visible" : "hidden"}
     >
       {/* Keyboard users need to focus the horizontal scroll region itself. */}
       <div
         ref={scrollRef}
         aria-describedby={hasHorizontalOverflow ? hintID : undefined}
         aria-label={t("scrollableTable")}
-        className="markdown-table-scroll"
+        className="markdown-table-scroll scroll-fade-x scroll-fade-12"
         role="region"
         tabIndex={hasHorizontalOverflow ? 0 : undefined}
-        onScroll={updateOverflowHint}
       >
         <table {...props} className={cn("markdown-table", className)} data-streamdown="table">
           <colgroup>
@@ -124,62 +111,113 @@ export function AdaptiveMarkdownTable({ children, className, node: _node, ...pro
 }
 
 function useStableColumnTypes(
-  candidateTypes: readonly ColumnType[],
-  rowCount: number,
+  children: React.ReactNode,
+  analyzerOptions: ColumnAnalyzerOptions | undefined,
   streaming: boolean,
 ): ColumnType[] {
-  const [streamingTypes, setStreamingTypes] = React.useState<ColumnType[]>(() =>
-    Array.from({ length: candidateTypes.length }, () => "normal"),
-  );
-  const classifiedRef = React.useRef(false);
+  const latestChildrenRef = React.useRef(children);
+  const latestAnalyzerOptionsRef = React.useRef(analyzerOptions);
+  const streamingRef = React.useRef(streaming);
+  const analysisTimeoutRef = React.useRef<number | null>(null);
+  const analyzedCurrentStreamRef = React.useRef(false);
   const hasStreamedRef = React.useRef(streaming);
+  const [streamingTypes, setStreamingTypes] = React.useState<ColumnType[]>([]);
+
+  latestChildrenRef.current = children;
+  latestAnalyzerOptionsRef.current = analyzerOptions;
+  streamingRef.current = streaming;
+
+  const staticTypes = React.useMemo(() => {
+    if (streaming) {
+      return null;
+    }
+    const snapshot = getTableSnapshot(children);
+    return classifyTableColumns(snapshot.headers, snapshot.rows, analyzerOptions);
+  }, [analyzerOptions, children, streaming]);
+
+  const resolvedStaticTypes = React.useMemo(
+    () => staticTypes === null
+      ? null
+      : hasStreamedRef.current
+        ? mergeColumnTypes(streamingTypes, staticTypes)
+        : staticTypes,
+    [staticTypes, streamingTypes],
+  );
+
   React.useEffect(() => {
     if (!streaming) {
-      if (hasStreamedRef.current) {
+      if (analysisTimeoutRef.current !== null) {
+        window.clearTimeout(analysisTimeoutRef.current);
+        analysisTimeoutRef.current = null;
+      }
+      analyzedCurrentStreamRef.current = false;
+      if (resolvedStaticTypes !== null) {
         setStreamingTypes((previousTypes) =>
-          candidateTypes.map((nextType, index) =>
-            mergeColumnType(previousTypes[index] ?? "normal", nextType),
-          ),
+          areColumnTypesEqual(previousTypes, resolvedStaticTypes)
+            ? previousTypes
+            : resolvedStaticTypes,
         );
       }
       return;
     }
 
-    if (candidateTypes.length !== streamingTypes.length) {
-      classifiedRef.current = false;
-      setStreamingTypes(Array.from({ length: candidateTypes.length }, () => "normal"));
-    }
-    if (rowCount < INITIAL_STREAMING_ROWS) {
+    hasStreamedRef.current = true;
+    if (analysisTimeoutRef.current !== null) {
       return;
     }
 
-    const delay = classifiedRef.current ? REANALYSIS_DEBOUNCE_MS : INITIAL_ANALYSIS_DELAY_MS;
-    const timeout = window.setTimeout(() => {
+    const delay = analyzedCurrentStreamRef.current
+      ? REANALYSIS_DEBOUNCE_MS
+      : INITIAL_ANALYSIS_DELAY_MS;
+    analysisTimeoutRef.current = window.setTimeout(() => {
+      analysisTimeoutRef.current = null;
+      if (!streamingRef.current) {
+        return;
+      }
+      const snapshot = getTableSnapshot(latestChildrenRef.current);
+      if (snapshot.rows.length < INITIAL_STREAMING_ROWS) {
+        return;
+      }
+      const candidateTypes = classifyTableColumns(
+        snapshot.headers,
+        snapshot.rows,
+        latestAnalyzerOptionsRef.current,
+      );
       setStreamingTypes((previousTypes) => {
-        if (!classifiedRef.current || previousTypes.length !== candidateTypes.length) {
-          return [...candidateTypes];
-        }
-        return candidateTypes.map((nextType, index) =>
-          mergeColumnType(previousTypes[index] ?? "normal", nextType),
-        );
+        const mergedTypes = mergeColumnTypes(previousTypes, candidateTypes);
+        return areColumnTypesEqual(previousTypes, mergedTypes) ? previousTypes : mergedTypes;
       });
-      classifiedRef.current = true;
+      analyzedCurrentStreamRef.current = true;
     }, delay);
+  }, [analyzerOptions, children, resolvedStaticTypes, streaming]);
 
-    return () => window.clearTimeout(timeout);
-  }, [candidateTypes, rowCount, streaming, streamingTypes.length]);
-
-  if (!streaming) {
-    if (!hasStreamedRef.current) {
-      return [...candidateTypes];
+  React.useEffect(() => () => {
+    if (analysisTimeoutRef.current !== null) {
+      window.clearTimeout(analysisTimeoutRef.current);
     }
-    return candidateTypes.map((nextType, index) =>
-      mergeColumnType(streamingTypes[index] ?? "normal", nextType),
-    );
-  }
-  return streamingTypes.length === candidateTypes.length
-    ? streamingTypes
-    : Array.from({ length: candidateTypes.length }, () => "normal");
+  }, []);
+
+  return streaming ? streamingTypes : (resolvedStaticTypes ?? []);
+}
+
+function mergeColumnTypes(
+  previousTypes: readonly ColumnType[],
+  candidateTypes: readonly ColumnType[],
+): ColumnType[] {
+  return candidateTypes.map((nextType, index) => {
+    const previousType = previousTypes[index];
+    return previousType === undefined
+      ? nextType
+      : mergeColumnType(previousType, nextType);
+  });
+}
+
+function areColumnTypesEqual(
+  leftTypes: readonly ColumnType[],
+  rightTypes: readonly ColumnType[],
+): boolean {
+  return leftTypes.length === rightTypes.length
+    && leftTypes.every((type, index) => type === rightTypes[index]);
 }
 
 function getTableSnapshot(children: React.ReactNode): TableSnapshot {
@@ -204,7 +242,7 @@ function getTableSnapshot(children: React.ReactNode): TableSnapshot {
   if (headers.length < columnCount) {
     headers = [...headers, ...Array.from({ length: columnCount - headers.length }, () => "")];
   }
-  return { headers, rows, columnCount };
+  return { headers, rows };
 }
 
 function decorateTableChildren(children: React.ReactNode, columnTypes: readonly ColumnType[]): React.ReactNode {

--- a/frontend/shared/components/markdown/markdown-table-analyzer.test.mjs
+++ b/frontend/shared/components/markdown/markdown-table-analyzer.test.mjs
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyColumn,
+  classifyTableColumns,
+  createColumnAnalyzerConfig,
+  DEFAULT_COLUMN_ANALYZER_PATTERNS,
+  getVisualLength,
+  mergeColumnType,
+} from "./markdown-table-analyzer.ts";
+
+test("classifies a mixed table from values rather than column position", () => {
+  const headers = ["编号", "Name", "説明", "Date"];
+  const rows = [
+    ["1", "Alpha", "这是一个较长的中文说明，用于解释问题发生的原因以及推荐的处理方式。", "2026-03-20"],
+    ["2", "ベータ", "This description contains enough natural-language detail to remain readable on a phone.", "2026-03-21"],
+    ["3", "Gamma", "複数の言語を含む長い説明で、列が狭くなりすぎないことを確認します。", "2026-03-22"],
+  ];
+
+  assert.deepEqual(classifyTableColumns(headers, rows), ["numeric", "normal", "content", "date"]);
+});
+
+test("counts CJK and other wide characters as two visual units", () => {
+  assert.equal(getVisualLength("ab中文"), 6);
+  assert.equal(getVisualLength("テスト"), 6);
+});
+
+test("classifies multiple long natural-language columns as content", () => {
+  const types = classifyTableColumns(
+    ["原因", "Recommendation", "詳細"],
+    [
+      [
+        "因为移动端将所有列压缩到屏幕内，长文本被拆成了大量短行。",
+        "Allow the table to grow naturally and keep horizontal scrolling inside its container.",
+        "ユーザーが内容を読みやすいように、長文列には十分な最小幅を確保します。",
+      ],
+      [
+        "第二个原因字段继续包含完整的自然语言句子，以提供稳定的统计样本。",
+        "Use column-level metadata instead of fixed child indexes for unknown generated schemas.",
+        "ストリーミング中は狭い列から広い列へのアップグレードだけを許可します。",
+      ],
+    ],
+  );
+
+  assert.deepEqual(types, ["content", "content", "content"]);
+});
+
+test("recognizes all-numeric values including money and percentages", () => {
+  assert.deepEqual(
+    classifyTableColumns(
+      ["Count", "金额", "Ratio"],
+      [
+        ["1,200", "￥99.50", "12%"],
+        ["3,400", "￥125.00", "8.5%"],
+        ["5,600", "￥1,020.25", "100%"],
+      ],
+    ),
+    ["numeric", "numeric", "numeric"],
+  );
+});
+
+test("classifies URLs and long unbroken identifiers as code", () => {
+  assert.deepEqual(
+    classifyTableColumns(
+      ["未知字段", "Token"],
+      [
+        ["https://example.com/a/very/long/path?query=mobile-table", "customer_session_identifier_01HZX4RTN8Q3YJ7K9MP2W6CVBX"],
+        ["/srv/app/releases/2026-03-20/config.json", "customer_session_identifier_01HZX4RTN8Q3YJ7K9MP2W6CVBY"],
+      ],
+    ),
+    ["code", "code"],
+  );
+});
+
+test("supports multilingual and unknown headers without relying on hints", () => {
+  assert.deepEqual(
+    classifyTableColumns(
+      ["名称", "Category", "更新日時", "Champ inconnu"],
+      [
+        ["Alpha", "Tool", "2026-03-20 09:30", "Medium value"],
+        ["ベータ", "Library", "2026-03-21 10:45", "Another value"],
+        ["Gamma", "Service", "2026-03-22 11:15", "Third value"],
+      ],
+      { headerRules: false },
+    ),
+    ["normal", "normal", "date", "normal"],
+  );
+});
+
+test("ignores empty and missing cells while preserving uneven columns", () => {
+  assert.deepEqual(
+    classifyTableColumns(
+      ["ID", "Name", "Notes"],
+      [
+        ["1", "Alpha Product"],
+        ["2", "", ""],
+        ["3", "Gamma Service", "This populated note is long enough to be handled as readable natural-language content."],
+        [],
+      ],
+    ),
+    ["numeric", "normal", "content"],
+  );
+});
+
+test("header rules remain weak, replaceable hints", () => {
+  const shortDescription = ["ok", "new", "done", "hold"];
+  assert.notEqual(classifyColumn("Description", shortDescription), "content");
+  assert.equal(
+    classifyColumn("Arbitrary", ["x", "y", "z"], {
+      headerRules: [{ pattern: /^Arbitrary$/, type: "date", weight: 0.2 }],
+    }),
+    "compact",
+  );
+});
+test("normalizes complete pattern overrides with partial thresholds", () => {
+  const patterns = Object.fromEntries(
+    Object.entries(DEFAULT_COLUMN_ANALYZER_PATTERNS).map(([name, pattern]) => [name, new RegExp(pattern.source, pattern.flags)]),
+  );
+  assert.equal(
+    classifyColumn("Value", ["1", "2", "3"], {
+      patterns,
+      thresholds: { numericRatio: 0.5 },
+    }),
+    "numeric",
+  );
+  assert.equal(classifyColumn("Value", ["1", "2", "3"], createColumnAnalyzerConfig()), "numeric");
+});
+
+test("treats whitespace-free CJK prose as natural language rather than code", () => {
+  assert.equal(
+    classifyColumn("未知", [
+      "这是没有空格但依然属于自然语言的中文长文本内容",
+      "これは空白がなくても自然言語として扱うべき日本語の長文です",
+    ]),
+    "content",
+  );
+});
+
+test("upgrades columns without shrinking a previous streaming type", () => {
+  const initial = classifyColumn("Value", ["Alpha Product", "Beta Service", "Gamma Library"]);
+  const expanded = classifyColumn("Value", [
+    "Alpha now includes a complete explanation with substantially more natural-language detail.",
+    "Beta now includes a second detailed sentence because the streamed answer continued growing.",
+    "Gamma now also contains enough descriptive prose to need a readable content-column width.",
+  ]);
+
+  assert.equal(initial, "normal");
+  assert.equal(expanded, "content");
+  assert.equal(mergeColumnType(initial, expanded), "content");
+  assert.equal(mergeColumnType("content", "normal"), "content");
+});

--- a/frontend/shared/components/markdown/markdown-table-analyzer.test.mjs
+++ b/frontend/shared/components/markdown/markdown-table-analyzer.test.mjs
@@ -60,6 +60,28 @@ test("recognizes all-numeric values including money and percentages", () => {
   );
 });
 
+test("keeps long structured-column fallback text wrap-safe", () => {
+  assert.equal(
+    classifyColumn("Amount", [
+      "1",
+      "2",
+      "3",
+      "This value could not be calculated because the upstream response omitted pricing metadata.",
+    ]),
+    "normal",
+  );
+  assert.equal(
+    classifyColumn("Date", [
+      "2026-03-20",
+      "2026-03-21",
+      "2026-03-22",
+      "The date is unavailable because this record predates the migration.",
+    ]),
+    "normal",
+  );
+  assert.equal(classifyColumn("Amount", ["1", "2", "3", "N/A"]), "numeric");
+});
+
 test("classifies URLs and long unbroken identifiers as code", () => {
   assert.deepEqual(
     classifyTableColumns(

--- a/frontend/shared/components/markdown/markdown-table-analyzer.ts
+++ b/frontend/shared/components/markdown/markdown-table-analyzer.ts
@@ -18,6 +18,7 @@ export type ColumnAnalyzerThresholds = {
   contentMaximumLength: number;
   strongContentAverageLength: number;
   longUnbrokenLength: number;
+  structuredOutlierMaximumLength: number;
 };
 
 export type ColumnAnalyzerPatterns = {
@@ -55,7 +56,9 @@ export type ColumnMetrics = {
   maximumVisualLength: number;
   compactRatio: number;
   numericRatio: number;
+  numericOutlierMaximumVisualLength: number;
   dateRatio: number;
+  dateOutlierMaximumVisualLength: number;
   codeRatio: number;
   sentenceRatio: number;
   longUnbrokenRatio: number;
@@ -78,6 +81,7 @@ export const DEFAULT_COLUMN_ANALYZER_THRESHOLDS: Readonly<ColumnAnalyzerThreshol
   contentMaximumLength: 44,
   strongContentAverageLength: 38,
   longUnbrokenLength: 22,
+  structuredOutlierMaximumLength: 16,
 };
 
 export const DEFAULT_COLUMN_ANALYZER_PATTERNS: Readonly<ColumnAnalyzerPatterns> = {
@@ -142,6 +146,11 @@ export function analyzeColumnValues(
   const lengths = nonEmpty.map(getVisualLength);
   const countMatches = (predicate: (value: string) => boolean) =>
     nonEmpty.reduce((count, value) => count + (predicate(value) ? 1 : 0), 0);
+  const maximumNonMatchingVisualLength = (predicate: (value: string) => boolean) =>
+    nonEmpty.reduce(
+      (maximum, value) => predicate(value) ? maximum : Math.max(maximum, getVisualLength(value)),
+      0,
+    );
   const ratio = (matches: number) => (nonEmpty.length > 0 ? matches / nonEmpty.length : 0);
   const isCode = (value: string) =>
     config.patterns.url.test(value) ||
@@ -164,7 +173,13 @@ export function analyzeColumnValues(
       ),
     ),
     numericRatio: ratio(countMatches((value) => config.patterns.numeric.test(value))),
+    numericOutlierMaximumVisualLength: maximumNonMatchingVisualLength(
+      (value) => config.patterns.numeric.test(value),
+    ),
     dateRatio: ratio(countMatches((value) => config.patterns.date.test(value))),
+    dateOutlierMaximumVisualLength: maximumNonMatchingVisualLength(
+      (value) => config.patterns.date.test(value),
+    ),
     codeRatio: ratio(countMatches(isCode)),
     sentenceRatio: ratio(countMatches((value) => config.patterns.sentence.test(value))),
     longUnbrokenRatio: ratio(
@@ -222,10 +237,16 @@ export function classifyColumn(
   ) {
     return "code";
   }
-  if (metrics.dateRatio + hintBoost("date") >= thresholds.dateRatio) {
+  if (
+    metrics.dateRatio + hintBoost("date") >= thresholds.dateRatio
+    && metrics.dateOutlierMaximumVisualLength <= thresholds.structuredOutlierMaximumLength
+  ) {
     return "date";
   }
-  if (metrics.numericRatio + hintBoost("numeric") >= thresholds.numericRatio) {
+  if (
+    metrics.numericRatio + hintBoost("numeric") >= thresholds.numericRatio
+    && metrics.numericOutlierMaximumVisualLength <= thresholds.structuredOutlierMaximumLength
+  ) {
     return "numeric";
   }
 

--- a/frontend/shared/components/markdown/markdown-table-analyzer.ts
+++ b/frontend/shared/components/markdown/markdown-table-analyzer.ts
@@ -1,0 +1,292 @@
+export type ColumnType = "compact" | "numeric" | "date" | "normal" | "content" | "code";
+
+export type HeaderRule = {
+  pattern: RegExp;
+  type: ColumnType;
+  weight?: number;
+};
+
+export type ColumnAnalyzerThresholds = {
+  compactAverageLength: number;
+  compactMaximumLength: number;
+  compactRatio: number;
+  numericRatio: number;
+  dateRatio: number;
+  codeRatio: number;
+  sentenceRatio: number;
+  contentAverageLength: number;
+  contentMaximumLength: number;
+  strongContentAverageLength: number;
+  longUnbrokenLength: number;
+};
+
+export type ColumnAnalyzerPatterns = {
+  numeric: RegExp;
+  date: RegExp;
+  boolean: RegExp;
+  url: RegExp;
+  path: RegExp;
+  hash: RegExp;
+  commandOrCode: RegExp;
+  sentence: RegExp;
+  unbroken: RegExp;
+};
+
+export type ColumnAnalyzerConfig = {
+  thresholds: ColumnAnalyzerThresholds;
+  patterns: ColumnAnalyzerPatterns;
+  headerRules: readonly HeaderRule[] | false;
+};
+
+export type ColumnAnalyzerOptions = {
+  thresholds?: Partial<ColumnAnalyzerThresholds>;
+  patterns?: Partial<ColumnAnalyzerPatterns>;
+  /** `false` disables hints; an array replaces the built-in rules. */
+  headerRules?: readonly HeaderRule[] | false;
+  /** Appended after the configured or built-in rules. */
+  additionalHeaderRules?: readonly HeaderRule[];
+};
+
+export type ColumnMetrics = {
+  totalCount: number;
+  nonEmptyCount: number;
+  distinctCount: number;
+  averageVisualLength: number;
+  maximumVisualLength: number;
+  compactRatio: number;
+  numericRatio: number;
+  dateRatio: number;
+  codeRatio: number;
+  sentenceRatio: number;
+  longUnbrokenRatio: number;
+};
+
+export type HeaderHint = {
+  type: ColumnType;
+  confidence: number;
+} | null;
+
+export const DEFAULT_COLUMN_ANALYZER_THRESHOLDS: Readonly<ColumnAnalyzerThresholds> = {
+  compactAverageLength: 5,
+  compactMaximumLength: 12,
+  compactRatio: 0.75,
+  numericRatio: 0.72,
+  dateRatio: 0.6,
+  codeRatio: 0.45,
+  sentenceRatio: 0.34,
+  contentAverageLength: 26,
+  contentMaximumLength: 44,
+  strongContentAverageLength: 38,
+  longUnbrokenLength: 22,
+};
+
+export const DEFAULT_COLUMN_ANALYZER_PATTERNS: Readonly<ColumnAnalyzerPatterns> = {
+  numeric: /^[+\-−]?(?:[$€£¥￥]\s*)?(?:\d{1,3}(?:[,， ]\d{3})+|\d+)(?:[.．]\d+)?(?:\s*(?:%|％|‰|[a-zA-Z]{3}))?$/u,
+  date: /^(?:\d{4}[-/.年]\d{1,2}(?:[-/.月]\d{1,2}日?)?|\d{1,2}[-/.]\d{1,2}[-/.]\d{2,4})(?:[T\s]+\d{1,2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:\s*(?:Z|[+-]\d{2}:?\d{2}|[AP]M))?)?$/iu,
+  boolean: /^(?:true|false|yes|no|on|off|null|n\/?a|是|否|有|无|启用|禁用|成功|失败|正常|异常|はい|いいえ|真|偽)$/iu,
+  url: /^(?:(?:https?|ftp):\/\/|www\.)\S+$/iu,
+  path: /^(?:[a-zA-Z]:[\\/]|\.{0,2}\/|~\/|\/)[^\s]+$/u,
+  hash: /^(?:[a-f\d]{20,}|[A-Za-z\d_-]{28,})$/u,
+  commandOrCode: /^(?:[$#>]\s+.+|--?[a-z][\w-]*(?:=\S+)?|[\w.-]+\([^)]*\)|[a-z_$][\w$]*(?:(?:::|\.|\/)[\w.$-]+){2,})$/iu,
+  sentence: /(?:[。！？.!?]\s*$|[,，、;；:]|\s+(?:and|or|but|because|with|from|that|this|the|to|of|is|are)\s+)/iu,
+  unbroken: /[^\s\u3000]{22,}/u,
+};
+
+export const DEFAULT_HEADER_RULES: readonly HeaderRule[] = [
+  { pattern: /^(?:id|no\.?|number|index|编号|序号|索引|識別子|番号)$/iu, type: "compact", weight: 0.12 },
+  { pattern: /(?:amount|price|cost|rate|ratio|percent|total|count|金额|价格|比例|百分比|数量|金額|比率|件数)/iu, type: "numeric", weight: 0.12 },
+  { pattern: /(?:date|time|created|updated|日期|时间|日時|日付|時刻)/iu, type: "date", weight: 0.14 },
+  { pattern: /(?:description|detail|reason|note|advice|summary|说明|详情|原因|建议|备注|描述|説明|詳細|理由|提案)/iu, type: "content", weight: 0.14 },
+  { pattern: /(?:url|uri|link|path|file|hash|command|code|链接|路径|文件|哈希|命令|代码|リンク|パス|コマンド)/iu, type: "code", weight: 0.14 },
+];
+
+const WIDE_CHARACTER_RE = /[\u1100-\u115f\u2329\u232a\u2e80-\u303e\u3040-\ua4cf\uac00-\ud7a3\uf900-\ufaff\ufe10-\ufe19\ufe30-\ufe6f\uff01-\uff60\uffe0-\uffe6\u{1f300}-\u{1faff}\u{20000}-\u{3fffd}]/u;
+const TYPE_WIDTH_RANK: Readonly<Record<ColumnType, number>> = {
+  compact: 0,
+  numeric: 1,
+  date: 2,
+  normal: 3,
+  code: 4,
+  content: 5,
+};
+const RESOLVED_CONFIGS = new WeakSet<ColumnAnalyzerConfig>();
+
+export function createColumnAnalyzerConfig(options: ColumnAnalyzerOptions = {}): ColumnAnalyzerConfig {
+  const baseRules = options.headerRules === undefined ? DEFAULT_HEADER_RULES : options.headerRules;
+  const config: ColumnAnalyzerConfig = {
+    thresholds: { ...DEFAULT_COLUMN_ANALYZER_THRESHOLDS, ...options.thresholds },
+    patterns: { ...DEFAULT_COLUMN_ANALYZER_PATTERNS, ...options.patterns },
+    headerRules:
+      baseRules === false ? false : [...baseRules, ...(options.additionalHeaderRules ?? [])],
+  };
+  RESOLVED_CONFIGS.add(config);
+  return config;
+}
+
+export function getVisualLength(value: unknown): number {
+  const text = normalizeValue(value);
+  let length = 0;
+  for (const character of text) {
+    length += WIDE_CHARACTER_RE.test(character) ? 2 : 1;
+  }
+  return length;
+}
+
+export function analyzeColumnValues(
+  values: readonly unknown[],
+  options: ColumnAnalyzerOptions | ColumnAnalyzerConfig = {},
+): ColumnMetrics {
+  const config = resolveConfig(options);
+  const normalized = values.map(normalizeValue);
+  const nonEmpty = normalized.filter(Boolean);
+  const lengths = nonEmpty.map(getVisualLength);
+  const countMatches = (predicate: (value: string) => boolean) =>
+    nonEmpty.reduce((count, value) => count + (predicate(value) ? 1 : 0), 0);
+  const ratio = (matches: number) => (nonEmpty.length > 0 ? matches / nonEmpty.length : 0);
+  const isCode = (value: string) =>
+    config.patterns.url.test(value) ||
+    config.patterns.path.test(value) ||
+    config.patterns.hash.test(value) ||
+    config.patterns.commandOrCode.test(value);
+
+  return {
+    totalCount: normalized.length,
+    nonEmptyCount: nonEmpty.length,
+    distinctCount: new Set(nonEmpty.map((value) => value.toLocaleLowerCase())).size,
+    averageVisualLength:
+      lengths.length > 0 ? lengths.reduce((sum, length) => sum + length, 0) / lengths.length : 0,
+    maximumVisualLength: lengths.length > 0 ? Math.max(...lengths) : 0,
+    compactRatio: ratio(
+      countMatches(
+        (value) =>
+          config.patterns.boolean.test(value) ||
+          getVisualLength(value) <= config.thresholds.compactAverageLength,
+      ),
+    ),
+    numericRatio: ratio(countMatches((value) => config.patterns.numeric.test(value))),
+    dateRatio: ratio(countMatches((value) => config.patterns.date.test(value))),
+    codeRatio: ratio(countMatches(isCode)),
+    sentenceRatio: ratio(countMatches((value) => config.patterns.sentence.test(value))),
+    longUnbrokenRatio: ratio(
+      countMatches(
+        (value) =>
+          isASCIIIdentifierLike(value) &&
+          config.patterns.unbroken.test(value) &&
+          !config.patterns.sentence.test(value),
+      ),
+    ),
+  };
+}
+
+export function getHeaderHint(
+  header: unknown,
+  options: ColumnAnalyzerOptions | ColumnAnalyzerConfig = {},
+): HeaderHint {
+  const config = resolveConfig(options);
+  const normalizedHeader = normalizeValue(header);
+  if (!normalizedHeader || config.headerRules === false) {
+    return null;
+  }
+
+  let best: HeaderHint = null;
+  for (const rule of config.headerRules) {
+    if (rule.pattern.test(normalizedHeader)) {
+      const confidence = Math.min(0.2, Math.max(0, rule.weight ?? 0.1));
+      if (!best || confidence > best.confidence) {
+        best = { type: rule.type, confidence };
+      }
+    }
+  }
+  return best;
+}
+
+export function classifyColumn(
+  header: unknown,
+  values: readonly unknown[],
+  options: ColumnAnalyzerOptions | ColumnAnalyzerConfig = {},
+): ColumnType {
+  const config = resolveConfig(options);
+  const metrics = analyzeColumnValues(values, config);
+  const hint = getHeaderHint(header, config);
+  const hintBoost = (type: ColumnType) => (hint?.type === type ? hint.confidence : 0);
+  const { thresholds } = config;
+
+  // Empty and header-only streaming tables intentionally start at the stable default.
+  if (metrics.nonEmptyCount === 0) {
+    return "normal";
+  }
+
+  if (
+    metrics.codeRatio + hintBoost("code") >= thresholds.codeRatio ||
+    (metrics.longUnbrokenRatio >= 0.34 && metrics.maximumVisualLength >= thresholds.longUnbrokenLength)
+  ) {
+    return "code";
+  }
+  if (metrics.dateRatio + hintBoost("date") >= thresholds.dateRatio) {
+    return "date";
+  }
+  if (metrics.numericRatio + hintBoost("numeric") >= thresholds.numericRatio) {
+    return "numeric";
+  }
+
+  const contentEvidence =
+    metrics.averageVisualLength >= thresholds.strongContentAverageLength ||
+    (metrics.averageVisualLength >= thresholds.contentAverageLength &&
+      metrics.sentenceRatio + hintBoost("content") >= thresholds.sentenceRatio) ||
+    (metrics.maximumVisualLength >= thresholds.contentMaximumLength &&
+      metrics.sentenceRatio + hintBoost("content") >= thresholds.sentenceRatio);
+  if (contentEvidence) {
+    return "content";
+  }
+
+  const isVeryShort =
+    metrics.averageVisualLength <= thresholds.compactAverageLength &&
+    metrics.maximumVisualLength <= thresholds.compactMaximumLength;
+  const compactEvidence =
+    isVeryShort &&
+    (metrics.compactRatio + hintBoost("compact") >= thresholds.compactRatio ||
+      (metrics.averageVisualLength <= 3 && metrics.distinctCount <= 5));
+  if (compactEvidence) {
+    return "compact";
+  }
+
+  return "normal";
+}
+
+export function classifyTableColumns(
+  headers: readonly unknown[],
+  rows: readonly (readonly unknown[])[],
+  options: ColumnAnalyzerOptions | ColumnAnalyzerConfig = {},
+): ColumnType[] {
+  const columnCount = Math.max(headers.length, ...rows.map((row) => row.length), 0);
+  return Array.from({ length: columnCount }, (_, columnIndex) =>
+    classifyColumn(
+      headers[columnIndex],
+      rows.map((row) => row[columnIndex]),
+      options,
+    ),
+  );
+}
+
+/** Keeps width evolution monotonic during streaming while retaining the wider cell behavior. */
+export function mergeColumnType(previousType: ColumnType, nextType: ColumnType): ColumnType {
+  return TYPE_WIDTH_RANK[nextType] > TYPE_WIDTH_RANK[previousType] ? nextType : previousType;
+}
+
+function isASCIIIdentifierLike(value: string): boolean {
+  const asciiCharacters = Array.from(value).filter((character) => character.codePointAt(0)! <= 0x7f).length;
+  return asciiCharacters / Math.max(Array.from(value).length, 1) >= 0.8;
+}
+
+function normalizeValue(value: unknown): string {
+  if (value == null) {
+    return "";
+  }
+  return String(value).replace(/\s+/gu, " ").trim();
+}
+
+function resolveConfig(options: ColumnAnalyzerOptions | ColumnAnalyzerConfig): ColumnAnalyzerConfig {
+  return RESOLVED_CONFIGS.has(options as ColumnAnalyzerConfig)
+    ? (options as ColumnAnalyzerConfig)
+    : createColumnAnalyzerConfig(options);
+}

--- a/frontend/shared/components/markdown/streamdown-render.tsx
+++ b/frontend/shared/components/markdown/streamdown-render.tsx
@@ -22,6 +22,10 @@ import {
 } from "@/components/ui/accordion";
 import { Marker, MarkerContent } from "@/components/ui/marker";
 import { cn } from "@/lib/utils";
+import {
+  AdaptiveMarkdownTable,
+  MarkdownTableStreamingContext,
+} from "./adaptive-markdown-table";
 import { useMarkdownCopy } from "./use-markdown-copy";
 
 import {
@@ -215,19 +219,6 @@ const BASE_MARKDOWN_CLASSNAME = cn(
   "[&_[data-streamdown='mermaid-block-actions']_button]:border-0 [&_[data-streamdown='mermaid-block-actions']_button]:bg-transparent [&_[data-streamdown='mermaid-block-actions']_button]:shadow-none [&_[data-streamdown='mermaid-block-actions']_button:hover]:bg-foreground/[0.04] [&_[data-streamdown='mermaid-block-actions']_button:hover]:text-foreground",
   "[&_[data-streamdown='mermaid-block-actions']_svg]:size-3",
   "[&_[data-streamdown='mermaid-block']_button>svg]:size-3",
-  "[&_[data-streamdown='table-wrapper']]:my-4 [&_[data-streamdown='table-wrapper']]:!w-full [&_[data-streamdown='table-wrapper']]:min-w-0 [&_[data-streamdown='table-wrapper']]:gap-0 [&_[data-streamdown='table-wrapper']]:border-0 [&_[data-streamdown='table-wrapper']]:rounded-none [&_[data-streamdown='table-wrapper']]:bg-transparent [&_[data-streamdown='table-wrapper']]:p-0 [&_[data-streamdown='table-wrapper']]:shadow-none [&_[data-streamdown='table-wrapper']]:outline-none [&_[data-streamdown='table-wrapper']]:ring-0",
-  "[&_[data-streamdown='table-wrapper']>div:last-child]:!w-full [&_[data-streamdown='table-wrapper']>div:last-child]:min-w-0 [&_[data-streamdown='table-wrapper']>div:last-child]:overflow-x-auto [&_[data-streamdown='table-wrapper']>div:last-child]:overflow-y-hidden [&_[data-streamdown='table-wrapper']>div:last-child]:border-0 [&_[data-streamdown='table-wrapper']>div:last-child]:rounded-none [&_[data-streamdown='table-wrapper']>div:last-child]:bg-transparent [&_[data-streamdown='table-wrapper']>div:last-child]:p-0 [&_[data-streamdown='table-wrapper']>div:last-child]:shadow-none [&_[data-streamdown='table-wrapper']>div:last-child]:outline-none [&_[data-streamdown='table-wrapper']>div:last-child]:ring-0",
-  "[&_table]:my-2 [&_table]:!min-w-full [&_table]:!w-full [&_table]:border-collapse [&_table]:table-auto [&_table]:border-0 [&_table]:outline-none [&_table]:shadow-none [&_table]:ring-0 [&_table]:bg-transparent",
-  "[&_table]:max-w-none [&_table]:rounded-none",
-  "[&_thead]:border-table-border [&_tbody]:border-table-border [&_tfoot]:border-table-border",
-  "[&_tr]:border-table-border/50 [&_thead_tr]:border-table-border/50 [&_tbody_tr]:border-table-border/50",
-  "[&_th]:px-0 [&_th]:py-2 [&_th]:pr-8 [&_th]:text-left [&_th]:align-bottom [&_th]:font-semibold [&_th]:tracking-[-0.01em] [&_th]:text-foreground",
-  "[&_td]:px-0 [&_td]:py-1 [&_td]:pr-8 [&_td]:align-middle [&_td]:leading-8 [&_td]:text-foreground/90",
-  "[&_th]:border-0 [&_td]:border-0",
-  "[&_th:last-child]:pr-0 [&_td:last-child]:pr-0",
-  "[&_thead]:bg-transparent [&_tbody]:bg-transparent [&_tr]:bg-transparent",
-  "[&_div:has(>table)]:border-0 [&_div:has(>table)]:outline-none [&_div:has(>table)]:ring-0 [&_div:has(>table)]:rounded-none [&_div:has(>table)]:bg-transparent [&_div:has(>table)]:shadow-none",
-  "[&_table_*]:outline-none [&_table_*]:ring-0",
   "[&_code:not(pre_code)]:rounded-md [&_code:not(pre_code)]:bg-foreground/[0.05] [&_code:not(pre_code)]:px-1.5 [&_code:not(pre_code)]:py-0.5 [&_code:not(pre_code)]:font-mono [&_code:not(pre_code)]:text-[0.85em] [&_code:not(pre_code)]:text-primary [&_code:not(pre_code)]:whitespace-pre-wrap [&_code:not(pre_code)]:break-words [&_code:not(pre_code)]:[overflow-wrap:anywhere]",
   "[&_[data-streamdown='code-block']]:my-4 [&_[data-streamdown='code-block']]:!w-full [&_[data-streamdown='code-block']]:min-w-0 [&_[data-streamdown='code-block']]:gap-0 [&_[data-streamdown='code-block']]:border-0 [&_[data-streamdown='code-block']]:rounded-none [&_[data-streamdown='code-block']]:bg-transparent [&_[data-streamdown='code-block']]:p-0 [&_[data-streamdown='code-block']]:shadow-none [&_[data-streamdown='code-block']]:outline-none [&_[data-streamdown='code-block']]:ring-0",
   "[&_[data-streamdown='code-block']>div:first-child]:min-h-0 [&_[data-streamdown='code-block']>div:first-child]:justify-between [&_[data-streamdown='code-block']>div:first-child]:gap-2 [&_[data-streamdown='code-block']>div:first-child]:border-0 [&_[data-streamdown='code-block']>div:first-child]:bg-transparent [&_[data-streamdown='code-block']>div:first-child]:mt-2 [&_[data-streamdown='code-block']>div:first-child]:pb-6 [&_[data-streamdown='code-block']>div:first-child]:text-[11px] [&_[data-streamdown='code-block']>div:first-child]:font-medium [&_[data-streamdown='code-block']>div:first-child]:tracking-[0.06em] [&_[data-streamdown='code-block']>div:first-child]:text-muted-foreground/85 [&_[data-streamdown='code-block']>div:first-child]:shadow-none",
@@ -309,6 +300,7 @@ const DEFAULT_STREAMDOWN_COMPONENTS = {
   span: MarkdownHTMLSpan,
   strong: MarkdownStrong,
   summary: MarkdownHTMLSummary,
+  table: AdaptiveMarkdownTable,
 } as const;
 
 const THINKING_STREAMDOWN_COMPONENTS = {
@@ -659,14 +651,15 @@ export const StreamdownRender = React.memo(function StreamdownRender({
       onKeyDownCapture={handleMarkdownCopyKeyDownCapture}
       onPointerDownCapture={handleMarkdownCopyPointerDownCapture}
     >
-      {mergedThinkingContent ? (
-        <ThinkingSegmentBlock
-          content={mergedThinkingContent}
-          incomplete={hasIncompleteThinking}
-          plugins={plugins}
-          streaming={streaming}
-        />
-      ) : null}
+      <MarkdownTableStreamingContext.Provider value={streaming}>
+        {mergedThinkingContent ? (
+          <ThinkingSegmentBlock
+            content={mergedThinkingContent}
+            incomplete={hasIncompleteThinking}
+            plugins={plugins}
+            streaming={streaming}
+          />
+        ) : null}
       {markdownSegments.map((segment, index) => (
         <MarkdownArtifactActionsContext.Provider key={`markdown-${index}`} value={artifactActions ?? null}>
           <MarkdownImageActionsContext.Provider value={imageActions ?? null}>
@@ -696,7 +689,8 @@ export const StreamdownRender = React.memo(function StreamdownRender({
             </HTMLMarkdownRenderProvider>
           </MarkdownImageActionsContext.Provider>
         </MarkdownArtifactActionsContext.Provider>
-      ))}
+        ))}
+      </MarkdownTableStreamingContext.Provider>
     </div>
   );
 });


### PR DESCRIPTION
## Summary

修改前，Markdown 表格的列宽主要由表头和表格的 intrinsic layout 决定，且最大宽度被限制在屏幕内。当某个较窄的列包含较长内容时，移动端会将该列压缩成很少的字符宽度，导致文本被拆成大量行，表格高度异常，阅读体验较差。

本次修改通过分析单元格实际内容，为不同列分配有限的视觉宽度类型，并允许表格在必要时超过消息容器宽度，在表格内部进行横向滚动。

- Add content-aware column classification for unknown LLM-generated table schemas.
- Keep standard table semantics while allowing internal horizontal scrolling.
- Move effective width constraints to table cells so long content can wrap normally.
- Stabilize column type upgrades during streamed responses.
- Add configurable thresholds, header hints, multilingual handling, accessibility support, and mobile scrolling behavior.

当前默认列宽上限如下，具体数值仍需要结合实际移动端消息容器宽度和真实 LLM 表格样本继续**探讨是否合适**：

- `compact`：无固定上限，最小宽度约 `48px`
- `numeric`：无固定上限，最小宽度约 `72px`
- `date`：无固定上限，最小宽度约 `108px`
- `normal`：最大约 `220px`
- `content`：默认最大约 `480px`
- `code`：最大约 `416px`
- 存在多个 `content` 列时：
  - 2 个：最小宽度约 `232px`
  - 3 个及以上：最小宽度约 `192px`
  - 移动端会进一步调整为约 `224px` 和 `184px`

上述宽度主要用于避免长文本列被压缩得过窄；表格仍然允许超过屏幕宽度，并通过内部横向滚动访问完整内容。

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm typecheck`
- [x] `cd frontend && pnpm test`
- [x] `cd frontend && pnpm build`

Test result:

- 11 Markdown table analyzer tests passed.
- Biome checked 550 files.
- TypeScript typecheck passed.
- Next.js production build passed.
- Static pages generated successfully.

A Chromium layout check at a 390px viewport also confirmed:

- The table scroll container overflows internally instead of the page.
- The description cell is capped at approximately `500px` including cell spacing.
- Long description text wraps to multiple lines.
- The cell uses `white-space: normal`.

## Screenshots, API examples, or logs

A local Chromium layout check confirmed that the description column no longer expands to its full single-line width. Before the fix, it expanded to approximately `1081px`; after the fix, it is approximately `500px` and wraps normally.

The validation screenshot was generated locally and is not committed to the repository.

## Configuration, migration, and compatibility notes

- No backend or API changes.
- No database migration.
- No environment variable changes.
- No version number update.
- No public URL changes.
- Standard Markdown table semantics are preserved.
- Existing non-table Markdown rendering remains unchanged.
- No generated API artifacts are required.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed; this change does not affect security-sensitive paths.

## Checklist

- [ ] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior is documented above.
- [x] Generated artifacts are included only when required.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.
