### PR TITLE
fix: prevent file payloads from bloating conversation traces

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1462,6 +1462,112 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/conversation-events/cleanup": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "物理删除指定运行的全部对话事件；保留消息、附件、调用与计费记录",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "管理员按运行清理对话事件",
+                "parameters": [
+                    {
+                        "description": "运行轨迹清理参数",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CleanupConversationRunsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/CleanupConversationRunsResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/conversation-events/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "管理员按事件 ID 查看单条对话运行事件详情；超大历史负载会被安全省略",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "管理员查询对话事件详情",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "事件 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ConversationEventDetailResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/conversations/export": {
             "get": {
                 "security": [
@@ -13211,6 +13317,52 @@ const docTemplate = `{
                 }
             }
         },
+        "CleanupConversationRunsRequest": {
+            "type": "object",
+            "required": [
+                "runIDs"
+            ],
+            "properties": {
+                "runIDs": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "CleanupConversationRunsResponse": {
+            "type": "object",
+            "required": [
+                "deletedCount",
+                "runCount"
+            ],
+            "properties": {
+                "deletedCount": {
+                    "type": "integer"
+                },
+                "runCount": {
+                    "type": "integer"
+                }
+            }
+        },
+        "CleanupConversationRunsResponseDoc": {
+            "type": "object",
+            "required": [
+                "data",
+                "errorMsg"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/CleanupConversationRunsResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
         "CleanupLogsRequest": {
             "type": "object",
             "required": [
@@ -13436,6 +13588,21 @@ const docTemplate = `{
                 }
             }
         },
+        "ConversationEventDetailResponseDoc": {
+            "type": "object",
+            "required": [
+                "data",
+                "errorMsg"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/ConversationEventResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
         "ConversationEventListResponseDoc": {
             "type": "object",
             "required": [
@@ -13484,6 +13651,8 @@ const docTemplate = `{
                 "outputJSON",
                 "parentEventID",
                 "payloadJSON",
+                "payloadOmitted",
+                "payloadSizeBytes",
                 "phase",
                 "platformModelName",
                 "providerProtocol",
@@ -13553,6 +13722,12 @@ const docTemplate = `{
                 },
                 "payloadJSON": {
                     "type": "string"
+                },
+                "payloadOmitted": {
+                    "type": "boolean"
+                },
+                "payloadSizeBytes": {
+                    "type": "integer"
                 },
                 "phase": {
                     "type": "string"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1455,6 +1455,112 @@
                 }
             }
         },
+        "/admin/conversation-events/cleanup": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "物理删除指定运行的全部对话事件；保留消息、附件、调用与计费记录",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "管理员按运行清理对话事件",
+                "parameters": [
+                    {
+                        "description": "运行轨迹清理参数",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CleanupConversationRunsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/CleanupConversationRunsResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/conversation-events/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "管理员按事件 ID 查看单条对话运行事件详情；超大历史负载会被安全省略",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "管理员查询对话事件详情",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "事件 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ConversationEventDetailResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/conversations/export": {
             "get": {
                 "security": [
@@ -13204,6 +13310,52 @@
                 }
             }
         },
+        "CleanupConversationRunsRequest": {
+            "type": "object",
+            "required": [
+                "runIDs"
+            ],
+            "properties": {
+                "runIDs": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "CleanupConversationRunsResponse": {
+            "type": "object",
+            "required": [
+                "deletedCount",
+                "runCount"
+            ],
+            "properties": {
+                "deletedCount": {
+                    "type": "integer"
+                },
+                "runCount": {
+                    "type": "integer"
+                }
+            }
+        },
+        "CleanupConversationRunsResponseDoc": {
+            "type": "object",
+            "required": [
+                "data",
+                "errorMsg"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/CleanupConversationRunsResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
         "CleanupLogsRequest": {
             "type": "object",
             "required": [
@@ -13429,6 +13581,21 @@
                 }
             }
         },
+        "ConversationEventDetailResponseDoc": {
+            "type": "object",
+            "required": [
+                "data",
+                "errorMsg"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/ConversationEventResponse"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
         "ConversationEventListResponseDoc": {
             "type": "object",
             "required": [
@@ -13477,6 +13644,8 @@
                 "outputJSON",
                 "parentEventID",
                 "payloadJSON",
+                "payloadOmitted",
+                "payloadSizeBytes",
                 "phase",
                 "platformModelName",
                 "providerProtocol",
@@ -13546,6 +13715,12 @@
                 },
                 "payloadJSON": {
                     "type": "string"
+                },
+                "payloadOmitted": {
+                    "type": "boolean"
+                },
+                "payloadSizeBytes": {
+                    "type": "integer"
                 },
                 "phase": {
                     "type": "string"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1372,6 +1372,37 @@ definitions:
     required:
     - reset
     type: object
+  CleanupConversationRunsRequest:
+    properties:
+      runIDs:
+        items:
+          type: string
+        maxItems: 100
+        minItems: 1
+        type: array
+    required:
+    - runIDs
+    type: object
+  CleanupConversationRunsResponse:
+    properties:
+      deletedCount:
+        type: integer
+      runCount:
+        type: integer
+    required:
+    - deletedCount
+    - runCount
+    type: object
+  CleanupConversationRunsResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/CleanupConversationRunsResponse'
+      errorMsg:
+        type: string
+    required:
+    - data
+    - errorMsg
+    type: object
   CleanupLogsRequest:
     properties:
       before:
@@ -1527,6 +1558,16 @@ definitions:
     - data
     - errorMsg
     type: object
+  ConversationEventDetailResponseDoc:
+    properties:
+      data:
+        $ref: '#/definitions/ConversationEventResponse'
+      errorMsg:
+        type: string
+    required:
+    - data
+    - errorMsg
+    type: object
   ConversationEventListResponseDoc:
     properties:
       data:
@@ -1581,6 +1622,10 @@ definitions:
         type: string
       payloadJSON:
         type: string
+      payloadOmitted:
+        type: boolean
+      payloadSizeBytes:
+        type: integer
       phase:
         type: string
       platformModelName:
@@ -1639,6 +1684,8 @@ definitions:
     - outputJSON
     - parentEventID
     - payloadJSON
+    - payloadOmitted
+    - payloadSizeBytes
     - phase
     - platformModelName
     - providerProtocol
@@ -8816,6 +8863,73 @@ paths:
       security:
       - BearerAuth: []
       summary: 管理员查询对话事件
+      tags:
+      - admin
+  /admin/conversation-events/{id}:
+    get:
+      consumes:
+      - application/json
+      description: 管理员按事件 ID 查看单条对话运行事件详情；超大历史负载会被安全省略
+      parameters:
+      - description: 事件 ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/ConversationEventDetailResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/AdminErrorDoc'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/AdminErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/AdminErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 管理员查询对话事件详情
+      tags:
+      - admin
+  /admin/conversation-events/cleanup:
+    post:
+      consumes:
+      - application/json
+      description: 物理删除指定运行的全部对话事件；保留消息、附件、调用与计费记录
+      parameters:
+      - description: 运行轨迹清理参数
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/CleanupConversationRunsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/CleanupConversationRunsResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/AdminErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/AdminErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 管理员按运行清理对话事件
       tags:
       - admin
   /admin/conversations/export:

--- a/backend/internal/application/admin/service.go
+++ b/backend/internal/application/admin/service.go
@@ -106,10 +106,12 @@ type orderLogService interface {
 
 type conversationEventService interface {
 	ListConversationEventLogs(ctx context.Context, page int, pageSize int, filter appconversation.EventLogListFilter) ([]domainconversation.EventLog, int64, error)
+	GetConversationEventLog(ctx context.Context, eventID uint) (*domainconversation.EventLog, error)
 }
 
 type logCleanupService interface {
 	Cleanup(ctx context.Context, input applogcleanup.Input) (*applogcleanup.Result, error)
+	CleanupConversationRuns(ctx context.Context, input applogcleanup.ConversationRunInput) (*applogcleanup.ConversationRunResult, error)
 }
 
 type authSecurityService interface {

--- a/backend/internal/application/admin/service_logs.go
+++ b/backend/internal/application/admin/service_logs.go
@@ -63,6 +63,14 @@ func (s *Service) ListConversationEventLogs(ctx context.Context, page int, pageS
 	return s.conversationEventSvc.ListConversationEventLogs(ctx, page, pageSize, filter)
 }
 
+// GetConversationEventLog 查询管理员对话事件详情。
+func (s *Service) GetConversationEventLog(ctx context.Context, eventID uint) (*domainconversation.EventLog, error) {
+	if s.conversationEventSvc == nil {
+		return nil, appconversation.ErrConversationEventNotFound
+	}
+	return s.conversationEventSvc.GetConversationEventLog(ctx, eventID)
+}
+
 // ListSystemEvents 查询系统事件分页列表。
 func (s *Service) ListSystemEvents(ctx context.Context, page int, pageSize int, filter systemeventapp.ListFilter) ([]domainsystemevent.Event, int64, error) {
 	if s.systemEventService == nil {
@@ -77,4 +85,12 @@ func (s *Service) CleanupLogs(ctx context.Context, input applogcleanup.Input) (*
 		return nil, errors.New("log cleanup service unavailable")
 	}
 	return s.logCleanupService.Cleanup(ctx, input)
+}
+
+// CleanupConversationRuns 清理指定运行的全部对话事件。
+func (s *Service) CleanupConversationRuns(ctx context.Context, input applogcleanup.ConversationRunInput) (*applogcleanup.ConversationRunResult, error) {
+	if s.logCleanupService == nil {
+		return nil, errors.New("log cleanup service unavailable")
+	}
+	return s.logCleanupService.CleanupConversationRuns(ctx, input)
 }

--- a/backend/internal/application/conversation/errs.go
+++ b/backend/internal/application/conversation/errs.go
@@ -5,6 +5,8 @@ import "errors"
 var (
 	// ErrConversationNotFound 会话不存在或无权限。
 	ErrConversationNotFound = errors.New("conversation not found")
+	// ErrConversationEventNotFound 对话事件日志不存在。
+	ErrConversationEventNotFound = errors.New("conversation event not found")
 	// ErrConversationShareNotFound 会话分享不存在、已关闭或原会话已删除。
 	ErrConversationShareNotFound = errors.New("conversation share not found")
 	// ErrInvalidConversationShare 会话分享请求不合法。

--- a/backend/internal/application/conversation/service_conversation.go
+++ b/backend/internal/application/conversation/service_conversation.go
@@ -553,6 +553,21 @@ func (s *Service) ListConversationEventLogs(ctx context.Context, page int, pageS
 	}, offset, limit)
 }
 
+// GetConversationEventLog 查询单条管理员对话事件详情。
+func (s *Service) GetConversationEventLog(ctx context.Context, eventID uint) (*model.EventLog, error) {
+	if eventID == 0 {
+		return nil, ErrConversationEventNotFound
+	}
+	item, err := s.repo.GetConversationEventLog(ctx, eventID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrConversationEventNotFound
+		}
+		return nil, err
+	}
+	return item, nil
+}
+
 // ListConversationRunsByRunIDs 批量查询消息对应的运行快照。
 func (s *Service) ListConversationRunsByRunIDs(
 	ctx context.Context,

--- a/backend/internal/application/conversation/service_message_context.go
+++ b/backend/internal/application/conversation/service_message_context.go
@@ -279,13 +279,19 @@ func sanitizeUpstreamDebugSnapshot(debug *llm.UpstreamDebugSnapshot) *llm.Upstre
 	}
 	return &llm.UpstreamDebugSnapshot{
 		Request: llm.UpstreamDebugRequest{
-			Method: debug.Request.Method,
-			Path:   debug.Request.Path,
-			Body:   sanitizeUpstreamNameJSON(debug.Request.Body),
+			Method:        debug.Request.Method,
+			Path:          debug.Request.Path,
+			Body:          sanitizeUpstreamNameJSON(llm.SanitizeUpstreamDebugBody(debug.Request.Body)),
+			BodyBytes:     debug.Request.BodyBytes,
+			BodyTruncated: debug.Request.BodyTruncated,
+			RedactedParts: debug.Request.RedactedParts,
 		},
 		Response: llm.UpstreamDebugResponse{
-			StatusCode: debug.Response.StatusCode,
-			Body:       sanitizeUpstreamNameJSON(debug.Response.Body),
+			StatusCode:    debug.Response.StatusCode,
+			Body:          sanitizeUpstreamNameJSON(llm.SanitizeUpstreamDebugBody(debug.Response.Body)),
+			BodyBytes:     debug.Response.BodyBytes,
+			BodyTruncated: debug.Response.BodyTruncated,
+			RedactedParts: debug.Response.RedactedParts,
 		},
 	}
 }

--- a/backend/internal/application/conversation/service_stream_fallback_test.go
+++ b/backend/internal/application/conversation/service_stream_fallback_test.go
@@ -88,6 +88,25 @@ func TestMessageErrorSummaryIncludesUpstreamBody(t *testing.T) {
 	}
 }
 
+func TestMessageErrorDebugSanitizesRawBinarySnapshot(t *testing.T) {
+	err := wrapUpstreamRequestError(&llm.UpstreamError{
+		StatusCode: 400,
+		Message:    "unsupported image",
+		Debug: &llm.UpstreamDebugSnapshot{
+			Request: llm.UpstreamDebugRequest{
+				Method: "POST",
+				Path:   "/v1/chat/completions",
+				Body:   `{"messages":[{"content":[{"image_url":{"url":"data:image/png;base64,eA=="}}]}]}`,
+			},
+		},
+	})
+
+	debug := MessageErrorDebug(err)
+	if debug == nil || strings.Contains(debug.Request.Body, "data:image/png;base64,eA==") {
+		t.Fatalf("expected raw binary snapshot to be sanitized, got %#v", debug)
+	}
+}
+
 func TestMessageErrorSummaryHidesRawSSEForSuccessfulHTTPStatus(t *testing.T) {
 	err := wrapUpstreamRequestError(&llm.UpstreamError{
 		StatusCode: 200,

--- a/backend/internal/application/conversation/service_trace.go
+++ b/backend/internal/application/conversation/service_trace.go
@@ -46,6 +46,7 @@ const (
 const (
 	toolTracePreviewMaxChars = 260
 	toolTraceDetailMaxChars  = 4096
+	maxTracePayloadBytes     = 1024 * 1024
 )
 
 const (
@@ -842,6 +843,23 @@ func tracePayloadJSON(payload map[string]interface{}) string {
 	if err != nil {
 		return "{}"
 	}
+	if len(raw) > maxTracePayloadBytes {
+		return tracePayloadOmittedJSON(len(raw))
+	}
+	return string(raw)
+}
+
+func tracePayloadOmittedJSON(originalBytes int) string {
+	raw, err := json.Marshal(map[string]interface{}{
+		"_trace": map[string]interface{}{
+			"payloadOmitted": true,
+			"originalBytes":  originalBytes,
+			"reason":         "payload_too_large",
+		},
+	})
+	if err != nil {
+		return "{}"
+	}
 	return string(raw)
 }
 
@@ -962,11 +980,9 @@ func traceDraftToBlock(draft *messageTraceDraft) *model.MessageTraceBlock {
 	if draft.endedAt != nil {
 		updatedAt = *draft.endedAt
 	}
-	var payloadJSON string
+	payloadJSON := ""
 	if len(draft.payload) > 0 {
-		if raw, err := json.Marshal(draft.payload); err == nil {
-			payloadJSON = string(raw)
-		}
+		payloadJSON = tracePayloadJSON(draft.payload)
 	}
 	return &model.MessageTraceBlock{
 		Title:           draft.title,

--- a/backend/internal/application/conversation/service_trace_tool_test.go
+++ b/backend/internal/application/conversation/service_trace_tool_test.go
@@ -147,6 +147,20 @@ func TestBuildMessageProcessTraceDTOIncludesOrderedEvents(t *testing.T) {
 	}
 }
 
+func TestTracePayloadJSONBoundsOversizedPayload(t *testing.T) {
+	secret := strings.Repeat("x", maxTracePayloadBytes+1)
+	serialized := tracePayloadJSON(map[string]interface{}{"upstream_debug": secret})
+	if len(serialized) >= maxTracePayloadBytes {
+		t.Fatalf("expected bounded trace payload, got %d bytes", len(serialized))
+	}
+	if strings.Contains(serialized, secret[:1024]) {
+		t.Fatal("oversized trace payload must not retain original content")
+	}
+	if !strings.Contains(serialized, `"payloadOmitted":true`) {
+		t.Fatalf("expected payload omission marker, got %s", serialized)
+	}
+}
+
 func TestProcessTraceStaysStreamingUntilNextVisiblePhase(t *testing.T) {
 	recorder := &messageTraceRecorder{
 		cfg: config.Config{

--- a/backend/internal/application/logcleanup/service.go
+++ b/backend/internal/application/logcleanup/service.go
@@ -18,10 +18,13 @@ const (
 	TypeSystem       = repository.LogCleanupTypeSystem
 )
 
+const maxConversationRunCleanupCount = 100
+
 var (
 	ErrInvalidType   = errors.New("invalid log cleanup type")
 	ErrInvalidBefore = errors.New("invalid log cleanup before")
 	ErrFutureBefore  = errors.New("log cleanup before must not be in the future")
+	ErrInvalidRunIDs = errors.New("invalid conversation run ids")
 )
 
 type auditWriter interface {
@@ -52,6 +55,21 @@ type Input struct {
 type Result struct {
 	Type         string
 	Before       time.Time
+	DeletedCount int64
+}
+
+// ConversationRunInput 描述一次管理员按运行清理对话事件的请求。
+type ConversationRunInput struct {
+	RunIDs      []string
+	RequestID   string
+	ActorUserID uint
+	IP          string
+	UserAgent   string
+}
+
+// ConversationRunResult 描述按运行清理对话事件的结果。
+type ConversationRunResult struct {
+	RunCount     int
 	DeletedCount int64
 }
 
@@ -107,6 +125,59 @@ func (s *Service) Cleanup(ctx context.Context, input Input) (*Result, error) {
 		Before:       input.Before,
 		DeletedCount: deletedCount,
 	}, nil
+}
+
+// CleanupConversationRuns 物理删除指定运行的对话事件，并记录管理员操作审计。
+func (s *Service) CleanupConversationRuns(ctx context.Context, input ConversationRunInput) (*ConversationRunResult, error) {
+	runIDs, err := normalizeConversationRunIDs(input.RunIDs)
+	if err != nil {
+		return nil, err
+	}
+	deletedCount, err := s.repo.DeleteConversationRuns(ctx, runIDs)
+	if err != nil {
+		return nil, err
+	}
+	if s.auditWriter != nil {
+		s.auditWriter.Write(
+			ctx,
+			input.RequestID,
+			input.ActorUserID,
+			"admin_cleanup_conversation_runs",
+			"conversation_events",
+			"batch",
+			input.IP,
+			input.UserAgent,
+			map[string]interface{}{
+				"run_ids":       runIDs,
+				"run_count":     len(runIDs),
+				"deleted_count": deletedCount,
+			},
+		)
+	}
+	return &ConversationRunResult{RunCount: len(runIDs), DeletedCount: deletedCount}, nil
+}
+
+func normalizeConversationRunIDs(values []string) ([]string, error) {
+	if len(values) == 0 || len(values) > maxConversationRunCleanupCount {
+		return nil, ErrInvalidRunIDs
+	}
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		runID := strings.TrimSpace(value)
+		if runID == "" || len(runID) > 64 {
+			return nil, ErrInvalidRunIDs
+		}
+		if _, exists := seen[runID]; exists {
+			continue
+		}
+		seen[runID] = struct{}{}
+		result = append(result, runID)
+	}
+	if len(result) == 0 {
+		return nil, ErrInvalidRunIDs
+	}
+	return result, nil
 }
 
 func validType(value string) bool {

--- a/backend/internal/application/logcleanup/service_test.go
+++ b/backend/internal/application/logcleanup/service_test.go
@@ -1,0 +1,61 @@
+package logcleanup
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type cleanupTestRepository struct {
+	runIDs []string
+}
+
+func (r *cleanupTestRepository) DeleteBefore(context.Context, string, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (r *cleanupTestRepository) DeleteConversationRuns(_ context.Context, runIDs []string) (int64, error) {
+	r.runIDs = append([]string(nil), runIDs...)
+	return 4, nil
+}
+
+type cleanupTestAuditWriter struct {
+	action string
+	detail interface{}
+}
+
+func (w *cleanupTestAuditWriter) Write(_ context.Context, _ string, _ uint, action string, _ string, _ string, _ string, _ string, detail interface{}) {
+	w.action = action
+	w.detail = detail
+}
+
+func TestCleanupConversationRunsNormalizesAndAudits(t *testing.T) {
+	repo := &cleanupTestRepository{}
+	auditWriter := &cleanupTestAuditWriter{}
+	service := NewService(repo, auditWriter)
+
+	result, err := service.CleanupConversationRuns(context.Background(), ConversationRunInput{
+		RunIDs: []string{" run_1 ", "run_2", "run_1"},
+	})
+	if err != nil {
+		t.Fatalf("cleanup conversation runs: %v", err)
+	}
+	if result.RunCount != 2 || result.DeletedCount != 4 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if len(repo.runIDs) != 2 || repo.runIDs[0] != "run_1" || repo.runIDs[1] != "run_2" {
+		t.Fatalf("unexpected normalized run ids: %#v", repo.runIDs)
+	}
+	if auditWriter.action != "admin_cleanup_conversation_runs" || auditWriter.detail == nil {
+		t.Fatalf("expected cleanup audit record, got action=%q detail=%#v", auditWriter.action, auditWriter.detail)
+	}
+}
+
+func TestCleanupConversationRunsRejectsInvalidInput(t *testing.T) {
+	service := NewService(&cleanupTestRepository{}, nil)
+	for _, runIDs := range [][]string{nil, {""}, {string(make([]byte, 65))}} {
+		if _, err := service.CleanupConversationRuns(context.Background(), ConversationRunInput{RunIDs: runIDs}); err != ErrInvalidRunIDs {
+			t.Fatalf("run ids %#v: expected ErrInvalidRunIDs, got %v", runIDs, err)
+		}
+	}
+}

--- a/backend/internal/domain/conversation/types.go
+++ b/backend/internal/domain/conversation/types.go
@@ -443,6 +443,8 @@ type EventLog struct {
 	Summary           string
 	ContentMarkdown   string
 	PayloadJSON       string
+	PayloadSizeBytes  int64
+	PayloadOmitted    bool
 	Seq               int
 	ToolCallID        string
 	ToolName          string

--- a/backend/internal/infra/llm/client.go
+++ b/backend/internal/infra/llm/client.go
@@ -774,17 +774,23 @@ type UpstreamDebugSnapshot struct {
 
 // UpstreamDebugRequest 表示上游请求侧的调试信息。
 type UpstreamDebugRequest struct {
-	Method  string            `json:"method"`
-	Path    string            `json:"path"`
-	Headers map[string]string `json:"headers,omitempty"`
-	Body    string            `json:"body"`
+	Method        string            `json:"method"`
+	Path          string            `json:"path"`
+	Headers       map[string]string `json:"headers,omitempty"`
+	Body          string            `json:"body"`
+	BodyBytes     int               `json:"bodyBytes,omitempty"`
+	BodyTruncated bool              `json:"bodyTruncated,omitempty"`
+	RedactedParts int               `json:"redactedParts,omitempty"`
 }
 
 // UpstreamDebugResponse 表示上游响应侧的调试信息。
 type UpstreamDebugResponse struct {
-	StatusCode int               `json:"statusCode"`
-	Headers    map[string]string `json:"headers,omitempty"`
-	Body       string            `json:"body"`
+	StatusCode    int               `json:"statusCode"`
+	Headers       map[string]string `json:"headers,omitempty"`
+	Body          string            `json:"body"`
+	BodyBytes     int               `json:"bodyBytes,omitempty"`
+	BodyTruncated bool              `json:"bodyTruncated,omitempty"`
+	RedactedParts int               `json:"redactedParts,omitempty"`
 }
 
 func (e *UpstreamError) Error() string {
@@ -1193,17 +1199,25 @@ func upstreamDebugSnapshot(req *http.Request, requestBody []byte, resp *http.Res
 			path += "?" + req.URL.RawQuery
 		}
 	}
+	requestDebugBody := sanitizeUpstreamDebugBody(requestBody)
+	responseDebugBody := sanitizeUpstreamDebugBody(responseBody)
 	return &UpstreamDebugSnapshot{
 		Request: UpstreamDebugRequest{
-			Method:  req.Method,
-			Path:    path,
-			Headers: redactHeaders(req.Header),
-			Body:    string(requestBody),
+			Method:        req.Method,
+			Path:          path,
+			Headers:       redactHeaders(req.Header),
+			Body:          requestDebugBody.Body,
+			BodyBytes:     requestDebugBody.OriginalBytes,
+			BodyTruncated: requestDebugBody.Truncated,
+			RedactedParts: requestDebugBody.RedactedParts,
 		},
 		Response: UpstreamDebugResponse{
-			StatusCode: responseStatusCode(resp),
-			Headers:    responseHeaders(resp),
-			Body:       string(responseBody),
+			StatusCode:    responseStatusCode(resp),
+			Headers:       responseHeaders(resp),
+			Body:          responseDebugBody.Body,
+			BodyBytes:     responseDebugBody.OriginalBytes,
+			BodyTruncated: responseDebugBody.Truncated,
+			RedactedParts: responseDebugBody.RedactedParts,
 		},
 	}
 }

--- a/backend/internal/infra/llm/debug_snapshot.go
+++ b/backend/internal/infra/llm/debug_snapshot.go
@@ -1,0 +1,303 @@
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+const maxUpstreamDebugBodyBytes = 128 * 1024
+
+type sanitizedUpstreamDebugBody struct {
+	Body          string
+	OriginalBytes int
+	Truncated     bool
+	RedactedParts int
+}
+
+// SanitizeUpstreamDebugBody removes inline binary data and bounds a debug body
+// before it crosses into application-level errors or trace payloads.
+func SanitizeUpstreamDebugBody(raw string) string {
+	return sanitizeUpstreamDebugBody([]byte(raw)).Body
+}
+
+func sanitizeUpstreamDebugBody(raw []byte) sanitizedUpstreamDebugBody {
+	result := sanitizedUpstreamDebugBody{OriginalBytes: len(raw)}
+	if len(raw) == 0 {
+		return result
+	}
+	if len(raw) > maxUpstreamDebugBodyBytes {
+		result.Body = upstreamDebugBodySummary(result.OriginalBytes, 0, "body_too_large")
+		result.Truncated = true
+		return result
+	}
+
+	var payload interface{}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&payload); err == nil {
+		payload = sanitizeUpstreamDebugValue(payload, "", nil, &result.RedactedParts)
+		encoded, marshalErr := json.Marshal(payload)
+		if marshalErr == nil && len(encoded) <= maxUpstreamDebugBodyBytes {
+			result.Body = string(encoded)
+			return result
+		}
+		result.Body = upstreamDebugBodySummary(result.OriginalBytes, result.RedactedParts, "body_too_large")
+		result.Truncated = true
+		return result
+	}
+
+	if !utf8.Valid(raw) {
+		result.Body = upstreamDebugBodySummary(result.OriginalBytes, 1, "binary_body")
+		result.RedactedParts = 1
+		result.Truncated = true
+		return result
+	}
+
+	if sanitized, redacted, ok := sanitizeUpstreamDebugSSE(string(raw)); ok {
+		result.RedactedParts = redacted
+		if len(sanitized) <= maxUpstreamDebugBodyBytes {
+			result.Body = sanitized
+			return result
+		}
+	}
+	result.Body = redactDebugDataURLs(string(raw), &result.RedactedParts)
+	return result
+}
+
+func sanitizeUpstreamDebugValue(value interface{}, parentKey string, parent map[string]interface{}, redactedParts *int) interface{} {
+	switch current := value.(type) {
+	case map[string]interface{}:
+		result := make(map[string]interface{}, len(current))
+		for key, child := range current {
+			if text, ok := child.(string); ok && shouldRedactDebugString(key, parentKey, current, text) {
+				result[key] = upstreamDebugBinaryPlaceholder(key, text)
+				(*redactedParts)++
+				continue
+			}
+			result[key] = sanitizeUpstreamDebugValue(child, key, current, redactedParts)
+		}
+		return result
+	case []interface{}:
+		result := make([]interface{}, len(current))
+		for index, child := range current {
+			result[index] = sanitizeUpstreamDebugValue(child, parentKey, parent, redactedParts)
+		}
+		return result
+	case string:
+		if isDebugDataURL(current) {
+			(*redactedParts)++
+			return upstreamDebugBinaryPlaceholder(parentKey, current)
+		}
+		if sanitized, ok := sanitizeNestedDebugJSONString(current, redactedParts); ok {
+			return sanitized
+		}
+	}
+	return value
+}
+
+func sanitizeNestedDebugJSONString(value string, redactedParts *int) (string, bool) {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) < 2 || (trimmed[0] != '{' && trimmed[0] != '[') {
+		return value, false
+	}
+	var payload interface{}
+	decoder := json.NewDecoder(strings.NewReader(trimmed))
+	decoder.UseNumber()
+	if err := decoder.Decode(&payload); err != nil {
+		return value, false
+	}
+	switch payload.(type) {
+	case map[string]interface{}, []interface{}:
+	default:
+		return value, false
+	}
+	before := *redactedParts
+	sanitized := sanitizeUpstreamDebugValue(payload, "", nil, redactedParts)
+	if *redactedParts == before {
+		return value, true
+	}
+	encoded, err := json.Marshal(sanitized)
+	if err != nil {
+		return value, false
+	}
+	return string(encoded), true
+}
+
+func shouldRedactDebugString(key string, parentKey string, parent map[string]interface{}, value string) bool {
+	if isDebugDataURL(value) {
+		return true
+	}
+	normalizedKey := normalizeDebugFieldName(key)
+	switch normalizedKey {
+	case "b64json", "base64", "imagebase64", "audiobase64", "filebase64", "filedata":
+		return strings.TrimSpace(value) != ""
+	case "data":
+		normalizedParent := normalizeDebugFieldName(parentKey)
+		if normalizedParent == "inlinedata" || normalizedParent == "inlineimage" || normalizedParent == "inputaudio" || normalizedParent == "source" {
+			return strings.TrimSpace(value) != ""
+		}
+		if debugMapDeclaresBase64(parent) {
+			return strings.TrimSpace(value) != ""
+		}
+		return looksLikeBase64Payload(value)
+	default:
+		return false
+	}
+}
+
+func normalizeDebugFieldName(value string) string {
+	replacer := strings.NewReplacer("_", "", "-", "", ".", "")
+	return strings.ToLower(replacer.Replace(strings.TrimSpace(value)))
+}
+
+func debugMapDeclaresBase64(value map[string]interface{}) bool {
+	for _, key := range []string{"type", "encoding", "format"} {
+		if text, ok := value[key].(string); ok && strings.EqualFold(strings.TrimSpace(text), "base64") {
+			return true
+		}
+	}
+	for _, key := range []string{"media_type", "mediaType", "mime_type", "mimeType"} {
+		if text, ok := value[key].(string); ok && strings.HasPrefix(strings.ToLower(strings.TrimSpace(text)), "image/") {
+			return true
+		}
+	}
+	return false
+}
+
+func isDebugDataURL(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	return strings.HasPrefix(normalized, "data:") && strings.Contains(normalized[:min(len(normalized), 256)], ";base64,")
+}
+
+func looksLikeBase64Payload(value string) bool {
+	normalized := strings.TrimSpace(value)
+	if len(normalized) < 256 || len(normalized)%4 != 0 {
+		return false
+	}
+	for _, current := range normalized {
+		if (current >= 'a' && current <= 'z') || (current >= 'A' && current <= 'Z') || (current >= '0' && current <= '9') || current == '+' || current == '/' || current == '=' || current == '\r' || current == '\n' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func upstreamDebugBinaryPlaceholder(key string, value string) string {
+	mimeType := "application/octet-stream"
+	encodedBytes := len(strings.TrimSpace(value))
+	if isDebugDataURL(value) {
+		normalized := strings.TrimSpace(value)
+		if separator := strings.Index(normalized, ";"); separator > len("data:") {
+			mimeType = normalized[len("data:"):separator]
+		}
+		if comma := strings.Index(normalized, ","); comma >= 0 {
+			encodedBytes = len(normalized) - comma - 1
+		}
+	} else if strings.Contains(strings.ToLower(key), "image") {
+		mimeType = "image/*"
+	} else if strings.Contains(strings.ToLower(key), "audio") {
+		mimeType = "audio/*"
+	}
+	return fmt.Sprintf("[binary omitted; mime=%s; encoded_bytes=%d]", mimeType, encodedBytes)
+}
+
+func upstreamDebugBodySummary(originalBytes int, redactedParts int, reason string) string {
+	payload := map[string]interface{}{
+		"_debug": map[string]interface{}{
+			"bodyOmitted":   true,
+			"originalBytes": originalBytes,
+			"reason":        reason,
+			"redactedParts": redactedParts,
+		},
+	}
+	encoded, _ := json.Marshal(payload)
+	return string(encoded)
+}
+
+func sanitizeUpstreamDebugSSE(raw string) (string, int, bool) {
+	lines := strings.SplitAfter(raw, "\n")
+	redactedParts := 0
+	parsed := false
+	for index, line := range lines {
+		content := strings.TrimSuffix(line, "\n")
+		lineEnding := strings.TrimPrefix(line, content)
+		trimmed := strings.TrimSpace(content)
+		if !strings.HasPrefix(trimmed, "data:") {
+			continue
+		}
+		body := strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
+		if body == "" || body == "[DONE]" {
+			continue
+		}
+		var payload interface{}
+		decoder := json.NewDecoder(strings.NewReader(body))
+		decoder.UseNumber()
+		if err := decoder.Decode(&payload); err != nil {
+			continue
+		}
+		parsed = true
+		previousRedactedParts := redactedParts
+		payload = sanitizeUpstreamDebugValue(payload, "", nil, &redactedParts)
+		if redactedParts == previousRedactedParts {
+			continue
+		}
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			continue
+		}
+		prefixIndex := strings.Index(content, "data:")
+		lines[index] = content[:prefixIndex] + "data: " + string(encoded) + lineEnding
+	}
+	return strings.Join(lines, ""), redactedParts, parsed
+}
+
+func redactDebugDataURLs(value string, redactedParts *int) string {
+	result := value
+	searchOffset := 0
+	for {
+		lower := strings.ToLower(result)
+		relativeStart := strings.Index(lower[searchOffset:], "data:")
+		if relativeStart < 0 {
+			return result
+		}
+		start := searchOffset + relativeStart
+		candidateEnd := min(len(lower), start+256)
+		for index := start; index < candidateEnd; index++ {
+			if isDebugDataURLBoundary(result[index]) {
+				candidateEnd = index
+				break
+			}
+		}
+		markerOffset := strings.Index(lower[start:candidateEnd], ";base64,")
+		if markerOffset < 0 {
+			searchOffset = candidateEnd
+			continue
+		}
+		marker := start + markerOffset
+		payloadStart := marker + len(";base64,")
+		end := payloadStart
+		for end < len(result) {
+			if isDebugDataURLBoundary(result[end]) {
+				break
+			}
+			end++
+		}
+		placeholder := upstreamDebugBinaryPlaceholder("", result[start:end])
+		result = result[:start] + placeholder + result[end:]
+		(*redactedParts)++
+		searchOffset = start + len(placeholder)
+	}
+}
+
+func isDebugDataURLBoundary(value byte) bool {
+	switch value {
+	case '"', '\'', ' ', '\r', '\n', '\t', '}', ']':
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/infra/llm/debug_snapshot_test.go
+++ b/backend/internal/infra/llm/debug_snapshot_test.go
@@ -1,0 +1,103 @@
+package llm
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestUpstreamDebugSnapshotRedactsInlineBinaryPayloads(t *testing.T) {
+	base64Data := strings.Repeat("a", 4096)
+	requestBody := []byte(`{"model":"vision-model","messages":[{"content":[{"type":"image_url","image_url":{"url":"data:image/webp;base64,` + base64Data + `"}}]}],"inlineData":{"mimeType":"image/png","data":"` + base64Data + `"},"source":{"type":"base64","media_type":"image/jpeg","data":"` + base64Data + `"}}`)
+	responseBody := []byte(`{"data":[{"b64_json":"` + base64Data + `"}],"error":{"message":"unsupported image"}}`)
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	debug := upstreamDebugSnapshot(req, requestBody, &http.Response{StatusCode: http.StatusBadRequest}, responseBody)
+	if debug == nil {
+		t.Fatal("expected debug snapshot")
+	}
+	for _, body := range []string{debug.Request.Body, debug.Response.Body} {
+		if strings.Contains(body, base64Data) || strings.Contains(body, ";base64,") {
+			t.Fatalf("expected binary payload to be redacted, got %s", body)
+		}
+		if !json.Valid([]byte(body)) {
+			t.Fatalf("expected valid JSON debug body, got %s", body)
+		}
+	}
+	if debug.Request.RedactedParts != 3 || debug.Response.RedactedParts != 1 {
+		t.Fatalf("unexpected redaction counts: request=%d response=%d", debug.Request.RedactedParts, debug.Response.RedactedParts)
+	}
+	if debug.Request.BodyBytes != len(requestBody) || debug.Response.BodyBytes != len(responseBody) {
+		t.Fatalf("unexpected original body sizes: request=%d response=%d", debug.Request.BodyBytes, debug.Response.BodyBytes)
+	}
+}
+
+func TestUpstreamDebugSnapshotBoundsOversizedTextBody(t *testing.T) {
+	requestBody := []byte(`{"model":"text-model","input":"` + strings.Repeat("x", maxUpstreamDebugBodyBytes) + `"}`)
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/responses", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	debug := upstreamDebugSnapshot(req, requestBody, nil, nil)
+	if !debug.Request.BodyTruncated {
+		t.Fatal("expected oversized request body to be omitted")
+	}
+	if len(debug.Request.Body) > maxUpstreamDebugBodyBytes || !json.Valid([]byte(debug.Request.Body)) {
+		t.Fatalf("expected bounded valid JSON summary, got %q", debug.Request.Body)
+	}
+	if strings.Contains(debug.Request.Body, strings.Repeat("x", 1024)) {
+		t.Fatal("expected oversized text not to remain in debug body")
+	}
+}
+
+func TestUpstreamDebugSnapshotPreservesAndSanitizesSSE(t *testing.T) {
+	base64Data := strings.Repeat("Y", 4096)
+	raw := "event: response.error\n" +
+		`data: {"type":"response.error","image":{"b64_json":"` + base64Data + `"},"error":{"message":"bad request"}}` + "\n\n"
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/responses", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	debug := upstreamDebugSnapshot(req, []byte(`{"model":"gpt"}`), &http.Response{StatusCode: http.StatusBadRequest}, []byte(raw))
+	if strings.Contains(debug.Response.Body, base64Data) || !strings.Contains(debug.Response.Body, "bad request") {
+		t.Fatalf("expected SSE error preserved without binary data, got %q", debug.Response.Body)
+	}
+	if debug.Response.RedactedParts != 1 {
+		t.Fatalf("expected one SSE redaction, got %d", debug.Response.RedactedParts)
+	}
+}
+
+func TestUpstreamDebugSnapshotRedactsSmallAndMultipleDataURLs(t *testing.T) {
+	raw := []byte(`plain data:text/plain,hello data:image/png;base64,eA==`)
+	result := sanitizeUpstreamDebugBody(raw)
+	if !strings.Contains(result.Body, "data:text/plain,hello") {
+		t.Fatalf("expected non-base64 data URI to remain, got %q", result.Body)
+	}
+	if strings.Contains(result.Body, "data:image/png;base64,eA==") || !strings.Contains(result.Body, "binary omitted") {
+		t.Fatalf("expected second data URI to be redacted, got %q", result.Body)
+	}
+	if result.RedactedParts != 1 {
+		t.Fatalf("redacted parts = %d, want 1", result.RedactedParts)
+	}
+
+	knownField := sanitizeUpstreamDebugBody([]byte(`{"source":{"type":"base64","data":"eA=="},"b64_json":"eA=="}`))
+	if strings.Contains(knownField.Body, "eA==") || knownField.RedactedParts != 2 {
+		t.Fatalf("expected small known binary fields to be redacted, got %q (%d parts)", knownField.Body, knownField.RedactedParts)
+	}
+
+	nested := sanitizeUpstreamDebugBody([]byte(`{"body":"{\"messages\":[{\"content\":[{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,eA==\"}}]}]}"}`))
+	if strings.Contains(nested.Body, "data:image/png;base64,eA==") || nested.RedactedParts != 1 {
+		t.Fatalf("expected nested JSON string binary to be redacted, got %q (%d parts)", nested.Body, nested.RedactedParts)
+	}
+
+	ordinary := sanitizeUpstreamDebugBody([]byte(`{"data":"test"}`))
+	if strings.Contains(ordinary.Body, "binary omitted") || ordinary.RedactedParts != 0 {
+		t.Fatalf("ordinary data field should remain unchanged, got %q (%d parts)", ordinary.Body, ordinary.RedactedParts)
+	}
+}

--- a/backend/internal/infra/persistence/models/chat.go
+++ b/backend/internal/infra/persistence/models/chat.go
@@ -297,31 +297,33 @@ func (ConversationRun) TableName() string {
 // ChatRunEvent 存储运行轨迹、事件流和工具调用明细。
 type ChatRunEvent struct {
 	BaseModel
-	MessageID       uint       `gorm:"not null;default:0;index:idx_chat_run_events_message_id;comment:消息ID"`
-	ConversationID  uint       `gorm:"not null;default:0;index:idx_chat_run_events_conversation_id;comment:会话ID"`
-	UserID          uint       `gorm:"not null;default:0;index:idx_chat_run_events_user_id;comment:用户ID"`
-	RunID           string     `gorm:"size:64;not null;default:'';index:idx_chat_run_events_run_id;uniqueIndex:uk_chat_run_events_run_scope_event,priority:1;comment:运行ID"`
-	EventScope      string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_scope;uniqueIndex:uk_chat_run_events_run_scope_event,priority:2;comment:事件范围(trace_block/trace_event/tool_call)"`
-	EventID         string     `gorm:"size:255;not null;default:'';uniqueIndex:uk_chat_run_events_run_scope_event,priority:3;comment:事件ID"`
-	EventType       string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_type;comment:事件类型"`
-	Phase           string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_phase;comment:阶段(process/tools/upstream_think)"`
-	Stage           string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_stage;comment:链路阶段(process/think/tool/answer)"`
-	RoundID         string     `gorm:"size:64;not null;default:'';index:idx_chat_run_events_round_id;comment:链路轮次ID"`
-	ParentEventID   string     `gorm:"size:255;not null;default:'';index:idx_chat_run_events_parent_event_id;comment:父事件ID"`
-	Status          string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_status;comment:事件状态(streaming/completed/error)"`
-	Title           string     `gorm:"size:255;not null;default:'';comment:轨迹标题"`
-	Summary         string     `gorm:"size:255;not null;default:'';comment:轨迹摘要"`
-	ContentMarkdown string     `gorm:"type:text;not null;default:'';comment:轨迹Markdown内容"`
-	PayloadJSON     string     `gorm:"type:text;not null;default:'';comment:轨迹负载JSON"`
-	Seq             int        `gorm:"not null;default:0;index:idx_chat_run_events_seq;comment:事件顺序"`
-	ToolCallID      string     `gorm:"size:255;not null;default:'';index:idx_chat_run_events_tool_call_id;comment:工具调用ID"`
-	ToolName        string     `gorm:"size:128;not null;default:'';index:idx_chat_run_events_tool_name;comment:工具名称"`
-	LatencyMS       int64      `gorm:"not null;default:0;comment:调用时长毫秒"`
-	InputJSON       string     `gorm:"type:text;not null;default:'';comment:输入JSON"`
-	OutputJSON      string     `gorm:"type:text;not null;default:'';comment:输出JSON"`
-	ErrorJSON       string     `gorm:"type:text;not null;default:'';comment:错误JSON"`
-	StartedAt       time.Time  `gorm:"not null;comment:开始时间"`
-	EndedAt         *time.Time `gorm:"comment:结束时间"`
+	MessageID        uint       `gorm:"not null;default:0;index:idx_chat_run_events_message_id;comment:消息ID"`
+	ConversationID   uint       `gorm:"not null;default:0;index:idx_chat_run_events_conversation_id;comment:会话ID"`
+	UserID           uint       `gorm:"not null;default:0;index:idx_chat_run_events_user_id;comment:用户ID"`
+	RunID            string     `gorm:"size:64;not null;default:'';index:idx_chat_run_events_run_id;uniqueIndex:uk_chat_run_events_run_scope_event,priority:1;comment:运行ID"`
+	EventScope       string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_scope;uniqueIndex:uk_chat_run_events_run_scope_event,priority:2;comment:事件范围(trace_block/trace_event/tool_call)"`
+	EventID          string     `gorm:"size:255;not null;default:'';uniqueIndex:uk_chat_run_events_run_scope_event,priority:3;comment:事件ID"`
+	EventType        string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_type;comment:事件类型"`
+	Phase            string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_phase;comment:阶段(process/tools/upstream_think)"`
+	Stage            string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_stage;comment:链路阶段(process/think/tool/answer)"`
+	RoundID          string     `gorm:"size:64;not null;default:'';index:idx_chat_run_events_round_id;comment:链路轮次ID"`
+	ParentEventID    string     `gorm:"size:255;not null;default:'';index:idx_chat_run_events_parent_event_id;comment:父事件ID"`
+	Status           string     `gorm:"size:32;not null;default:'';index:idx_chat_run_events_status;comment:事件状态(streaming/completed/error)"`
+	Title            string     `gorm:"size:255;not null;default:'';comment:轨迹标题"`
+	Summary          string     `gorm:"size:255;not null;default:'';comment:轨迹摘要"`
+	ContentMarkdown  string     `gorm:"type:text;not null;default:'';comment:轨迹Markdown内容"`
+	PayloadJSON      string     `gorm:"type:text;not null;default:'';comment:轨迹负载JSON"`
+	PayloadSizeBytes int64      `gorm:"->;-:migration;column:payload_size_bytes"`
+	PayloadOmitted   bool       `gorm:"->;-:migration;column:payload_omitted"`
+	Seq              int        `gorm:"not null;default:0;index:idx_chat_run_events_seq;comment:事件顺序"`
+	ToolCallID       string     `gorm:"size:255;not null;default:'';index:idx_chat_run_events_tool_call_id;comment:工具调用ID"`
+	ToolName         string     `gorm:"size:128;not null;default:'';index:idx_chat_run_events_tool_name;comment:工具名称"`
+	LatencyMS        int64      `gorm:"not null;default:0;comment:调用时长毫秒"`
+	InputJSON        string     `gorm:"type:text;not null;default:'';comment:输入JSON"`
+	OutputJSON       string     `gorm:"type:text;not null;default:'';comment:输出JSON"`
+	ErrorJSON        string     `gorm:"type:text;not null;default:'';comment:错误JSON"`
+	StartedAt        time.Time  `gorm:"not null;comment:开始时间"`
+	EndedAt          *time.Time `gorm:"comment:结束时间"`
 }
 
 func (ChatRunEvent) TableName() string {

--- a/backend/internal/infra/persistence/postgres/conversation/repository.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository.go
@@ -1630,6 +1630,63 @@ const (
 	chatContextRecordArtifact   = "artifact"
 )
 
+const maxConversationEventDetailPayloadBytes = 1024 * 1024
+
+func conversationEventPayloadSizeExpression(db *gorm.DB) string {
+	if db != nil && db.Dialector != nil {
+		switch db.Dialector.Name() {
+		case "postgres":
+			return "OCTET_LENGTH(payload_json)"
+		case "sqlite":
+			return "LENGTH(CAST(payload_json AS BLOB))"
+		}
+	}
+	return "LENGTH(payload_json)"
+}
+
+func conversationEventSummarySelectColumns(db *gorm.DB) []string {
+	payloadSize := conversationEventPayloadSizeExpression(db)
+	return []string{
+		"id",
+		"message_id",
+		"conversation_id",
+		"user_id",
+		"run_id",
+		"event_scope",
+		"event_id",
+		"event_type",
+		"phase",
+		"stage",
+		"round_id",
+		"parent_event_id",
+		"status",
+		"title",
+		"summary",
+		"seq",
+		"tool_call_id",
+		"tool_name",
+		"latency_ms",
+		"started_at",
+		"ended_at",
+		"created_at",
+		"updated_at",
+		payloadSize + " AS payload_size_bytes",
+		fmt.Sprintf("CASE WHEN %s > %d THEN TRUE ELSE FALSE END AS payload_omitted", payloadSize, maxConversationEventDetailPayloadBytes),
+	}
+}
+
+func conversationEventDetailSelectColumns(db *gorm.DB) []string {
+	payloadSize := conversationEventPayloadSizeExpression(db)
+	return append(
+		conversationEventSummarySelectColumns(db),
+		"content_markdown",
+		fmt.Sprintf("CASE WHEN %s <= %d THEN payload_json ELSE '' END AS payload_json", payloadSize, maxConversationEventDetailPayloadBytes),
+		"input_json",
+		"output_json",
+		"error_json",
+	)
+}
+
 // CreateConversationRun 写入会话运行日志。
 func (r *Repo) CreateConversationRun(ctx context.Context, item *domainconversation.Run) error {
 	entity := toConversationRunModel(item)
@@ -1683,6 +1740,7 @@ func (r *Repo) ListConversationMessageTracesByMessageIDs(ctx context.Context, me
 		return []domainconversation.MessageTrace{}, nil
 	}
 	if err := r.db.WithContext(ctx).
+		Select(conversationEventDetailSelectColumns(r.db)).
 		Where("message_id IN ? AND event_scope = ?", messageIDs, chatRunEventScopeTraceBlock).
 		Order("message_id ASC, seq ASC, id ASC").
 		Find(&items).Error; err != nil {
@@ -1734,6 +1792,7 @@ func (r *Repo) ListConversationMessageTraceEventsByMessageIDs(ctx context.Contex
 		return []domainconversation.MessageTraceEventRow{}, nil
 	}
 	if err := r.db.WithContext(ctx).
+		Select(conversationEventDetailSelectColumns(r.db)).
 		Where("message_id IN ? AND event_scope = ?", messageIDs, chatRunEventScopeTraceEvent).
 		Order("message_id ASC, seq ASC, id ASC").
 		Find(&items).Error; err != nil {
@@ -1863,6 +1922,7 @@ func (r *Repo) ListConversationEventLogs(
 		order = "run_id ASC, seq ASC, id ASC"
 	}
 	if err := query.
+		Select(conversationEventSummarySelectColumns(r.db)).
 		Order(order).
 		Offset(offset).
 		Limit(limit).
@@ -1870,6 +1930,32 @@ func (r *Repo) ListConversationEventLogs(
 		return nil, 0, translateError(err)
 	}
 	results := toConversationEventLogDomains(items)
+	if err := r.hydrateConversationEventRunMetadata(ctx, results); err != nil {
+		return nil, 0, err
+	}
+	return results, total, nil
+}
+
+// GetConversationEventLog 查询单条管理员对话事件日志详情。
+func (r *Repo) GetConversationEventLog(ctx context.Context, eventID uint) (*domainconversation.EventLog, error) {
+	var item models.ChatRunEvent
+	if err := r.db.WithContext(ctx).
+		Select(conversationEventDetailSelectColumns(r.db)).
+		Where("id = ?", eventID).
+		First(&item).Error; err != nil {
+		return nil, translateError(err)
+	}
+	results := toConversationEventLogDomains([]models.ChatRunEvent{item})
+	if err := r.hydrateConversationEventRunMetadata(ctx, results); err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, repository.ErrNotFound
+	}
+	return &results[0], nil
+}
+
+func (r *Repo) hydrateConversationEventRunMetadata(ctx context.Context, results []domainconversation.EventLog) error {
 	runIDs := make([]string, 0, len(results))
 	seenRunIDs := make(map[string]struct{}, len(results))
 	for _, item := range results {
@@ -1884,7 +1970,7 @@ func (r *Repo) ListConversationEventLogs(
 		runIDs = append(runIDs, runID)
 	}
 	if len(runIDs) == 0 {
-		return results, total, nil
+		return nil
 	}
 
 	runs := make([]models.ConversationRun, 0, len(runIDs))
@@ -1892,7 +1978,7 @@ func (r *Repo) ListConversationEventLogs(
 		Select("run_id", "provider_protocol", "upstream_name", "platform_model_name", "routed_binding_code", "upstream_model_name").
 		Where("run_id IN ?", runIDs).
 		Find(&runs).Error; err != nil {
-		return nil, 0, translateError(err)
+		return translateError(err)
 	}
 	runsByID := make(map[string]models.ConversationRun, len(runs))
 	for _, run := range runs {
@@ -1909,7 +1995,7 @@ func (r *Repo) ListConversationEventLogs(
 		results[index].RoutedBindingCode = run.RoutedBindingCode
 		results[index].UpstreamModelName = run.UpstreamModelName
 	}
-	return results, total, nil
+	return nil
 }
 
 // ListConversationRunsByRunIDs 按运行 ID 查询会话运行快照。
@@ -3632,34 +3718,36 @@ func toConversationEventLogDomains(items []models.ChatRunEvent) []domainconversa
 	results := make([]domainconversation.EventLog, 0, len(items))
 	for _, item := range items {
 		results = append(results, domainconversation.EventLog{
-			ID:              item.ID,
-			MessageID:       item.MessageID,
-			ConversationID:  item.ConversationID,
-			UserID:          item.UserID,
-			RunID:           item.RunID,
-			EventScope:      item.EventScope,
-			EventID:         item.EventID,
-			EventType:       item.EventType,
-			Phase:           item.Phase,
-			Stage:           item.Stage,
-			RoundID:         item.RoundID,
-			ParentEventID:   item.ParentEventID,
-			Status:          item.Status,
-			Title:           item.Title,
-			Summary:         item.Summary,
-			ContentMarkdown: item.ContentMarkdown,
-			PayloadJSON:     item.PayloadJSON,
-			Seq:             item.Seq,
-			ToolCallID:      item.ToolCallID,
-			ToolName:        item.ToolName,
-			LatencyMS:       item.LatencyMS,
-			InputJSON:       item.InputJSON,
-			OutputJSON:      item.OutputJSON,
-			ErrorJSON:       item.ErrorJSON,
-			StartedAt:       item.StartedAt,
-			EndedAt:         item.EndedAt,
-			CreatedAt:       item.CreatedAt,
-			UpdatedAt:       item.UpdatedAt,
+			ID:               item.ID,
+			MessageID:        item.MessageID,
+			ConversationID:   item.ConversationID,
+			UserID:           item.UserID,
+			RunID:            item.RunID,
+			EventScope:       item.EventScope,
+			EventID:          item.EventID,
+			EventType:        item.EventType,
+			Phase:            item.Phase,
+			Stage:            item.Stage,
+			RoundID:          item.RoundID,
+			ParentEventID:    item.ParentEventID,
+			Status:           item.Status,
+			Title:            item.Title,
+			Summary:          item.Summary,
+			ContentMarkdown:  item.ContentMarkdown,
+			PayloadJSON:      item.PayloadJSON,
+			PayloadSizeBytes: item.PayloadSizeBytes,
+			PayloadOmitted:   item.PayloadOmitted,
+			Seq:              item.Seq,
+			ToolCallID:       item.ToolCallID,
+			ToolName:         item.ToolName,
+			LatencyMS:        item.LatencyMS,
+			InputJSON:        item.InputJSON,
+			OutputJSON:       item.OutputJSON,
+			ErrorJSON:        item.ErrorJSON,
+			StartedAt:        item.StartedAt,
+			EndedAt:          item.EndedAt,
+			CreatedAt:        item.CreatedAt,
+			UpdatedAt:        item.UpdatedAt,
 		})
 	}
 	return results

--- a/backend/internal/infra/persistence/postgres/conversation/repository_test.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository_test.go
@@ -158,6 +158,144 @@ func TestListConversationEventLogsHydratesRunRouteSnapshot(t *testing.T) {
 	}
 }
 
+func TestConversationEventLogListAndDetailBoundPayloads(t *testing.T) {
+	db := openConversationRepositoryTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+	now := time.Now()
+	largePayload := strings.Repeat("x", maxConversationEventDetailPayloadBytes+1)
+	events := []model.ChatRunEvent{
+		{
+			ConversationID:  1,
+			UserID:          1,
+			RunID:           "run_normal_payload",
+			EventScope:      "trace_event",
+			EventID:         "event_normal_payload",
+			EventType:       "error",
+			Status:          "error",
+			ContentMarkdown: "request failed after upload",
+			PayloadJSON:     `{"error":"上游不可用"}`,
+			InputJSON:       `{"input":true}`,
+			OutputJSON:      `{"output":true}`,
+			ErrorJSON:       `{"code":"upstream_unavailable"}`,
+			StartedAt:       now,
+		},
+		{
+			ConversationID: 1,
+			UserID:         1,
+			RunID:          "run_large_payload",
+			EventScope:     "trace_event",
+			EventID:        "event_large_payload",
+			EventType:      "error",
+			Status:         "error",
+			PayloadJSON:    largePayload,
+			StartedAt:      now,
+		},
+	}
+	if err := db.Create(&events).Error; err != nil {
+		t.Fatalf("create conversation events: %v", err)
+	}
+
+	items, total, err := repo.ListConversationEventLogs(ctx, repository.ConversationEventLogListFilter{}, 0, 10)
+	if err != nil {
+		t.Fatalf("ListConversationEventLogs() error = %v", err)
+	}
+	if total != 2 || len(items) != 2 {
+		t.Fatalf("got total=%d len=%d, want 2", total, len(items))
+	}
+	itemsByRunID := make(map[string]domainconversation.EventLog, len(items))
+	for _, item := range items {
+		itemsByRunID[item.RunID] = item
+		if item.ContentMarkdown != "" || item.PayloadJSON != "" || item.InputJSON != "" || item.OutputJSON != "" || item.ErrorJSON != "" {
+			t.Fatalf("list item contains detail payloads: %#v", item)
+		}
+	}
+	if got := itemsByRunID["run_normal_payload"].PayloadSizeBytes; got != int64(len(events[0].PayloadJSON)) {
+		t.Fatalf("normal payload size = %d, want %d", got, len(events[0].PayloadJSON))
+	}
+	if itemsByRunID["run_normal_payload"].PayloadOmitted {
+		t.Fatal("normal list payload should not be marked omitted")
+	}
+	if got := itemsByRunID["run_large_payload"].PayloadSizeBytes; got != int64(len(largePayload)) {
+		t.Fatalf("large payload size = %d, want %d", got, len(largePayload))
+	}
+	if !itemsByRunID["run_large_payload"].PayloadOmitted {
+		t.Fatal("large list payload should be marked omitted")
+	}
+
+	normalDetail, err := repo.GetConversationEventLog(ctx, events[0].ID)
+	if err != nil {
+		t.Fatalf("GetConversationEventLog(normal) error = %v", err)
+	}
+	if normalDetail.ContentMarkdown != events[0].ContentMarkdown ||
+		normalDetail.PayloadJSON != events[0].PayloadJSON ||
+		normalDetail.InputJSON != events[0].InputJSON ||
+		normalDetail.OutputJSON != events[0].OutputJSON ||
+		normalDetail.ErrorJSON != events[0].ErrorJSON ||
+		normalDetail.PayloadOmitted {
+		t.Fatalf("normal detail = %#v", normalDetail)
+	}
+
+	largeDetail, err := repo.GetConversationEventLog(ctx, events[1].ID)
+	if err != nil {
+		t.Fatalf("GetConversationEventLog(large) error = %v", err)
+	}
+	if largeDetail.PayloadJSON != "" || !largeDetail.PayloadOmitted {
+		t.Fatalf("large detail should omit payload, got %#v", largeDetail)
+	}
+	if largeDetail.PayloadSizeBytes != int64(len(largePayload)) {
+		t.Fatalf("large detail payload size = %d, want %d", largeDetail.PayloadSizeBytes, len(largePayload))
+	}
+}
+
+func TestConversationMessageTraceReadsBoundPayloads(t *testing.T) {
+	db := openConversationRepositoryTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+	now := time.Now()
+	largePayload := strings.Repeat("x", maxConversationEventDetailPayloadBytes+1)
+	items := []model.ChatRunEvent{
+		{
+			MessageID:       11,
+			RunID:           "run_trace_block_large",
+			EventScope:      "trace_block",
+			EventID:         "trace_block_large",
+			EventType:       "process",
+			ContentMarkdown: "处理失败",
+			PayloadJSON:     largePayload,
+			StartedAt:       now,
+		},
+		{
+			MessageID:   11,
+			RunID:       "run_trace_event_large",
+			EventScope:  "trace_event",
+			EventID:     "trace_event_large",
+			EventType:   "error",
+			PayloadJSON: largePayload,
+			StartedAt:   now,
+		},
+	}
+	if err := db.Create(&items).Error; err != nil {
+		t.Fatalf("create trace events: %v", err)
+	}
+
+	blocks, err := repo.ListConversationMessageTracesByMessageIDs(ctx, []uint{11})
+	if err != nil {
+		t.Fatalf("list message traces: %v", err)
+	}
+	if len(blocks) != 1 || blocks[0].PayloadJSON != "" || blocks[0].ContentMarkdown != "处理失败" {
+		t.Fatalf("large trace block was not safely loaded: %#v", blocks)
+	}
+
+	events, err := repo.ListConversationMessageTraceEventsByMessageIDs(ctx, []uint{11})
+	if err != nil {
+		t.Fatalf("list trace events: %v", err)
+	}
+	if len(events) != 1 || events[0].PayloadJSON != "" {
+		t.Fatalf("large trace event was not safely loaded: %#v", events)
+	}
+}
+
 func TestListMessagesBeforeIDReturnsPreviousWindowAscending(t *testing.T) {
 	db := openConversationRepositoryTestDB(t)
 	repo := NewRepo(db)

--- a/backend/internal/infra/persistence/postgres/logcleanup/repository.go
+++ b/backend/internal/infra/persistence/postgres/logcleanup/repository.go
@@ -47,3 +47,20 @@ func (r *Repo) DeleteBefore(ctx context.Context, logType string, before time.Tim
 	}
 	return result.RowsAffected, nil
 }
+
+// DeleteConversationRuns 物理删除指定运行的全部对话事件。
+func (r *Repo) DeleteConversationRuns(ctx context.Context, runIDs []string) (int64, error) {
+	if len(runIDs) == 0 {
+		return 0, nil
+	}
+	var deletedCount int64
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		result := tx.Unscoped().Where("run_id IN ?", runIDs).Delete(&model.ChatRunEvent{})
+		if result.Error != nil {
+			return result.Error
+		}
+		deletedCount = result.RowsAffected
+		return nil
+	})
+	return deletedCount, err
+}

--- a/backend/internal/infra/persistence/postgres/logcleanup/repository_test.go
+++ b/backend/internal/infra/persistence/postgres/logcleanup/repository_test.go
@@ -1,0 +1,48 @@
+package logcleanup
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestDeleteConversationRunsDeletesOnlySelectedRunEvents(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:cleanup_conversation_runs?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err = db.AutoMigrate(&model.ChatRunEvent{}); err != nil {
+		t.Fatalf("migrate chat run events: %v", err)
+	}
+
+	now := time.Now()
+	events := []model.ChatRunEvent{
+		{RunID: "run_delete", EventScope: "trace_block", EventID: "block", StartedAt: now},
+		{RunID: "run_delete", EventScope: "trace_event", EventID: "event", StartedAt: now},
+		{RunID: "run_keep", EventScope: "trace_event", EventID: "keep", StartedAt: now},
+	}
+	if err = db.Create(&events).Error; err != nil {
+		t.Fatalf("create events: %v", err)
+	}
+
+	deletedCount, err := NewRepo(db).DeleteConversationRuns(context.Background(), []string{"run_delete"})
+	if err != nil {
+		t.Fatalf("DeleteConversationRuns() error = %v", err)
+	}
+	if deletedCount != 2 {
+		t.Fatalf("deleted count = %d, want 2", deletedCount)
+	}
+
+	var remaining []model.ChatRunEvent
+	if err = db.Order("id ASC").Find(&remaining).Error; err != nil {
+		t.Fatalf("list remaining events: %v", err)
+	}
+	if len(remaining) != 1 || strings.TrimSpace(remaining[0].RunID) != "run_keep" {
+		t.Fatalf("remaining events = %#v, want only run_keep", remaining)
+	}
+}

--- a/backend/internal/repository/conversation_core.go
+++ b/backend/internal/repository/conversation_core.go
@@ -127,6 +127,7 @@ type ConversationTraceRepository interface {
 	ListConversationRuns(ctx context.Context, userID uint, conversationID uint, offset int, limit int) ([]domainconversation.Run, int64, error)
 	ListConversationRunsByRunIDs(ctx context.Context, userID uint, conversationID uint, runIDs []string) ([]domainconversation.Run, error)
 	ListConversationEventLogs(ctx context.Context, filter ConversationEventLogListFilter, offset int, limit int) ([]domainconversation.EventLog, int64, error)
+	GetConversationEventLog(ctx context.Context, eventID uint) (*domainconversation.EventLog, error)
 }
 
 // ConversationEventLogListFilter 描述管理员对话事件列表筛选和排序条件。

--- a/backend/internal/repository/log_cleanup.go
+++ b/backend/internal/repository/log_cleanup.go
@@ -17,4 +17,5 @@ const (
 // LogCleanupRepository 定义管理员日志物理清理能力。
 type LogCleanupRepository interface {
 	DeleteBefore(ctx context.Context, logType string, before time.Time) (int64, error)
+	DeleteConversationRuns(ctx context.Context, runIDs []string) (int64, error)
 }

--- a/backend/internal/transport/http/admin/dto.go
+++ b/backend/internal/transport/http/admin/dto.go
@@ -70,6 +70,11 @@ type CleanupLogsRequest struct {
 	Before string `json:"before" binding:"required"`
 }
 
+// CleanupConversationRunsRequest 管理员按运行清理对话事件请求。
+type CleanupConversationRunsRequest struct {
+	RunIDs []string `json:"runIDs" binding:"required,min=1,max=100,dive,required,max=64"`
+}
+
 // CreatePermissionGroupRequest 创建权限组请求。
 type CreatePermissionGroupRequest struct {
 	Name                  string `json:"name" binding:"required,max=128"`
@@ -183,6 +188,12 @@ type CleanupLogsResponse struct {
 	Type         string    `json:"type"`
 	Before       time.Time `json:"before"`
 	DeletedCount int64     `json:"deletedCount"`
+}
+
+// CleanupConversationRunsResponse 管理员按运行清理对话事件响应。
+type CleanupConversationRunsResponse struct {
+	RunCount     int   `json:"runCount"`
+	DeletedCount int64 `json:"deletedCount"`
 }
 
 // ImportOpenWebUIUsersResponse 从 OpenWebUI 导入用户响应。
@@ -399,6 +410,8 @@ type ConversationEventResponse struct {
 	Summary           string     `json:"summary"`
 	ContentMarkdown   string     `json:"contentMarkdown"`
 	PayloadJSON       string     `json:"payloadJSON"`
+	PayloadSizeBytes  int64      `json:"payloadSizeBytes"`
+	PayloadOmitted    bool       `json:"payloadOmitted"`
 	Seq               int        `json:"seq"`
 	ToolCallID        string     `json:"toolCallID"`
 	ToolName          string     `json:"toolName"`
@@ -561,6 +574,12 @@ type CleanupLogsResponseDoc struct {
 	Data     CleanupLogsResponse `json:"data"`
 }
 
+// CleanupConversationRunsResponseDoc 管理员按运行清理对话事件响应。
+type CleanupConversationRunsResponseDoc struct {
+	ErrorMsg string                          `json:"errorMsg"`
+	Data     CleanupConversationRunsResponse `json:"data"`
+}
+
 // ImportOpenWebUIUsersResponseDoc 从 OpenWebUI 导入用户响应。
 type ImportOpenWebUIUsersResponseDoc struct {
 	ErrorMsg string                       `json:"errorMsg"`
@@ -625,6 +644,12 @@ type ConversationEventListResponseDoc struct {
 		Total   int64                       `json:"total"`
 		Results []ConversationEventResponse `json:"results"`
 	} `json:"data"`
+}
+
+// ConversationEventDetailResponseDoc 对话事件详情响应。
+type ConversationEventDetailResponseDoc struct {
+	ErrorMsg string                    `json:"errorMsg"`
+	Data     ConversationEventResponse `json:"data"`
 }
 
 // ErrorDoc 错误响应。
@@ -936,6 +961,8 @@ func toConversationEventResponse(item domainconversation.EventLog, label appadmi
 		Summary:           item.Summary,
 		ContentMarkdown:   item.ContentMarkdown,
 		PayloadJSON:       item.PayloadJSON,
+		PayloadSizeBytes:  item.PayloadSizeBytes,
+		PayloadOmitted:    item.PayloadOmitted,
 		Seq:               item.Seq,
 		ToolCallID:        item.ToolCallID,
 		ToolName:          item.ToolName,

--- a/backend/internal/transport/http/admin/handler.go
+++ b/backend/internal/transport/http/admin/handler.go
@@ -425,6 +425,46 @@ func (h *Handler) CleanupLogs(c *gin.Context) {
 	})
 }
 
+// CleanupConversationRuns godoc
+// @Summary 管理员按运行清理对话事件
+// @Description 物理删除指定运行的全部对话事件；保留消息、附件、调用与计费记录
+// @Tags admin
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param body body CleanupConversationRunsRequest true "运行轨迹清理参数"
+// @Success 200 {object} CleanupConversationRunsResponseDoc
+// @Failure 400 {object} ErrorDoc
+// @Failure 500 {object} ErrorDoc
+// @Router /admin/conversation-events/cleanup [post]
+// CleanupConversationRuns 清理指定运行的全部对话事件。
+func (h *Handler) CleanupConversationRuns(c *gin.Context) {
+	var req CleanupConversationRunsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.InvalidRequestBody(c, err)
+		return
+	}
+	result, err := h.service.CleanupConversationRuns(c.Request.Context(), applogcleanup.ConversationRunInput{
+		RunIDs:      req.RunIDs,
+		RequestID:   middleware.MustRequestID(c),
+		ActorUserID: middleware.MustUserID(c),
+		IP:          c.ClientIP(),
+		UserAgent:   c.Request.UserAgent(),
+	})
+	if err != nil {
+		if errors.Is(err, applogcleanup.ErrInvalidRunIDs) {
+			response.ErrorFrom(c, http.StatusBadRequest, err)
+			return
+		}
+		response.Error(c, http.StatusInternalServerError, "cleanup conversation runs failed")
+		return
+	}
+	response.Success(c, CleanupConversationRunsResponse{
+		RunCount:     result.RunCount,
+		DeletedCount: result.DeletedCount,
+	})
+}
+
 // ListUsageLogs godoc
 // @Summary 管理员查询模型调用日志
 // @Description 管理员分页查看全量模型调用与计费用量账本
@@ -732,6 +772,39 @@ func (h *Handler) ListConversationEvents(c *gin.Context) {
 		events = append(events, toConversationEventResponse(item, userLabels[item.UserID]))
 	}
 	response.SuccessPage(c, total, events)
+}
+
+// GetConversationEvent godoc
+// @Summary 管理员查询对话事件详情
+// @Description 管理员按事件 ID 查看单条对话运行事件详情；超大历史负载会被安全省略
+// @Tags admin
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param id path int true "事件 ID"
+// @Success 200 {object} ConversationEventDetailResponseDoc
+// @Failure 400 {object} ErrorDoc
+// @Failure 404 {object} ErrorDoc
+// @Failure 500 {object} ErrorDoc
+// @Router /admin/conversation-events/{id} [get]
+// GetConversationEvent 查询单条对话事件详情。
+func (h *Handler) GetConversationEvent(c *gin.Context) {
+	parsedID, err := strconv.ParseUint(c.Param("id"), 10, strconv.IntSize)
+	if err != nil || parsedID == 0 {
+		response.Error(c, http.StatusBadRequest, "invalid conversation event id")
+		return
+	}
+	item, err := h.service.GetConversationEventLog(c.Request.Context(), uint(parsedID))
+	if err != nil {
+		if errors.Is(err, appconversation.ErrConversationEventNotFound) {
+			response.ErrorFrom(c, http.StatusNotFound, err)
+			return
+		}
+		response.Error(c, http.StatusInternalServerError, "get conversation event failed")
+		return
+	}
+	label := h.service.ResolveUserLabels(c.Request.Context(), []uint{item.UserID})[item.UserID]
+	response.Success(c, toConversationEventResponse(*item, label))
 }
 
 // ListSystemEvents godoc

--- a/backend/internal/transport/http/admin/router.go
+++ b/backend/internal/transport/http/admin/router.go
@@ -19,6 +19,8 @@ func (m *Module) RegisterRoutes(adminGroup *gin.RouterGroup) {
 	adminGroup.GET("/call-logs", m.Handler.ListUsageLogs)
 	adminGroup.GET("/payment-orders", m.Handler.ListPaymentOrders)
 	adminGroup.GET("/conversation-events", m.Handler.ListConversationEvents)
+	adminGroup.GET("/conversation-events/:id", m.Handler.GetConversationEvent)
+	adminGroup.POST("/conversation-events/cleanup", m.Handler.CleanupConversationRuns)
 	adminGroup.GET("/system-events", m.Handler.ListSystemEvents)
 	adminGroup.POST("/logs/cleanup", m.Handler.CleanupLogs)
 	adminGroup.GET("/conversations/export", m.Handler.ExportConversations)

--- a/frontend/features/admin/api/audit.ts
+++ b/frontend/features/admin/api/audit.ts
@@ -1,4 +1,9 @@
-import type { CleanupLogsRequest, CleanupLogsResponse } from "@deeix/api-contract";
+import type {
+  CleanupConversationRunsRequest,
+  CleanupConversationRunsResponse,
+  CleanupLogsRequest,
+  CleanupLogsResponse,
+} from "@deeix/api-contract";
 import { authedRequest } from "@/shared/api/authed-client";
 import type {
   AdminAuditLogDTO,
@@ -265,4 +270,30 @@ export async function listAdminConversationEvents(
   );
 
   return normalizeAdminPagePayload(data);
+}
+
+export async function getAdminConversationEvent(
+  accessToken: string,
+  eventID: number,
+): Promise<AdminConversationEventDTO> {
+  return authedRequest<AdminConversationEventDTO>(
+    `/api/v1/admin/conversation-events/${eventID}`,
+    { accessToken },
+    true,
+  );
+}
+
+export async function cleanupAdminConversationRuns(
+  accessToken: string,
+  input: CleanupConversationRunsRequest,
+): Promise<CleanupConversationRunsResponse> {
+  return authedRequest<CleanupConversationRunsResponse>(
+    "/api/v1/admin/conversation-events/cleanup",
+    {
+      accessToken,
+      method: "POST",
+      body: input,
+    },
+    true,
+  );
 }

--- a/frontend/features/admin/components/sections/logs/admin-logs.tsx
+++ b/frontend/features/admin/components/sections/logs/admin-logs.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -26,7 +27,7 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { SpinnerLabel } from "@/components/ui/spinner";
+import { Spinner, SpinnerLabel } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Tooltip,
@@ -59,7 +60,9 @@ import type {
 } from "@/features/admin/api/admin.types";
 import { getAdminBillingConfig } from "@/features/admin/api/billing";
 import {
+  cleanupAdminConversationRuns,
   cleanupAdminLogs,
+  getAdminConversationEvent,
   type AdminLogCleanupType,
 } from "@/features/admin/api/audit";
 import {
@@ -95,6 +98,7 @@ import {
   type BillingDisplayOptions,
 } from "@/shared/lib/billing-display";
 import { ModelSelect, type ModelSelectOption } from "@/shared/components/model-select";
+import { formatBytes } from "@/shared/lib/file-display";
 
 type LogDetail =
   | { kind: "audit"; item: AdminAuditLogDTO }
@@ -702,10 +706,12 @@ function DetailBlock({ title, children }: { title: string; children: React.React
 function LogDetailSheet({
   detail: rawDetail,
   billingDisplay,
+  conversationDetailLoading,
   onClose,
 }: {
   detail: LogDetail | null;
   billingDisplay: BillingDisplayOptions;
+  conversationDetailLoading: boolean;
   onClose: () => void;
 }) {
   const locale = useLocale();
@@ -948,6 +954,7 @@ function LogDetailSheet({
                 <DetailRow label={t("fields.latency")} value={`${formatCount(detail.item.latencyMS, locale)} ms`} mono />
                 <DetailRow label={t("fields.title")} value={detail.item.title || "-"} />
                 <DetailRow label={t("fields.summary")} value={detail.item.summary || "-"} />
+                <DetailRow label={t("fields.payloadSize")} value={formatBytes(detail.item.payloadSizeBytes)} mono />
               </DetailBlock>
             </>
           ) : null}
@@ -975,6 +982,7 @@ function LogDetailSheet({
                   size="sm"
                   className="h-7 px-2 text-xs shadow-none"
                   value={formattedJSON}
+                  disabled={conversationDetailLoading || (detail?.kind === "conversation" && detail.item.payloadOmitted)}
                   messages={copyMessages}
                   copyOptions={{ copied: t("copied", { label: t("jsonTitle") }) }}
                 >
@@ -982,9 +990,22 @@ function LogDetailSheet({
                 </CopyActionButton>
               </div>
             </div>
-            <pre className="max-h-[320px] overflow-auto rounded-lg border border-border/60 bg-muted/35 p-3 text-xs leading-5 text-foreground/86">
-              <code>{formattedJSON}</code>
-            </pre>
+            {conversationDetailLoading ? (
+              <div className="flex h-28 items-center justify-center rounded-lg border border-border/60 bg-muted/20">
+                <Spinner label={t("loading")} className="size-4 text-muted-foreground" />
+              </div>
+            ) : (
+              <>
+                {detail?.kind === "conversation" && detail.item.payloadOmitted ? (
+                  <p className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2 text-xs leading-5 text-muted-foreground">
+                    {t("payloadOmitted", { size: formatBytes(detail.item.payloadSizeBytes) })}
+                  </p>
+                ) : null}
+                <pre className="max-h-[320px] overflow-auto rounded-lg border border-border/60 bg-muted/35 p-3 text-xs leading-5 text-foreground/86">
+                  <code>{formattedJSON}</code>
+                </pre>
+              </>
+            )}
           </section>
         </div>
       </SheetContent>
@@ -1503,11 +1524,78 @@ function PaymentOrderTable({ onOpenDetail }: { onOpenDetail: (item: AdminPayment
 function ConversationEventTable({ onOpenDetail }: { onOpenDetail: (item: AdminConversationEventDTO) => void }) {
   const locale = useLocale();
   const t = useTranslations("adminLogs");
+  const commonT = useTranslations("common.actions");
   const logs = useAdminConversationEvents();
+  const [selectedRunIDs, setSelectedRunIDs] = React.useState<Set<string>>(new Set());
+  const [cleanupOpen, setCleanupOpen] = React.useState(false);
+  const [cleanupPending, setCleanupPending] = React.useState(false);
   const virtualRows = useVirtualTableRows(logs.events, {
     enabled: logs.events.length > 100,
     estimateSize: 40,
   });
+  const visibleRunIDs = React.useMemo(
+    () => [...new Set(logs.events.map((item) => item.runID.trim()).filter(Boolean))],
+    [logs.events],
+  );
+  const allVisibleSelected = visibleRunIDs.length > 0 && visibleRunIDs.every((runID) => selectedRunIDs.has(runID));
+  const someVisibleSelected = visibleRunIDs.some((runID) => selectedRunIDs.has(runID));
+
+  React.useEffect(() => {
+    setSelectedRunIDs(new Set());
+  }, [logs.events]);
+
+  const toggleRun = React.useCallback((runID: string, selected: boolean) => {
+    if (!runID) return;
+    setSelectedRunIDs((current) => {
+      const next = new Set(current);
+      if (selected) {
+        if (next.size >= 100 && !next.has(runID)) {
+          toast.error(t("conversation.cleanup.maxSelection"));
+          return current;
+        }
+        next.add(runID);
+      } else {
+        next.delete(runID);
+      }
+      return next;
+    });
+  }, [t]);
+
+  const toggleVisibleRuns = React.useCallback((selected: boolean) => {
+    if (!selected) {
+      setSelectedRunIDs(new Set());
+      return;
+    }
+    if (visibleRunIDs.length > 100) {
+      toast.error(t("conversation.cleanup.maxSelection"));
+    }
+    setSelectedRunIDs(new Set(visibleRunIDs.slice(0, 100)));
+  }, [t, visibleRunIDs]);
+
+  const cleanupSelectedRuns = React.useCallback(async () => {
+    const runIDs = [...selectedRunIDs];
+    if (runIDs.length === 0) return;
+    setCleanupPending(true);
+    try {
+      const token = await resolveAccessToken();
+      if (!token) {
+        toast.error(t("toast.sessionExpired"), { description: t("toast.signInAgain") });
+        return;
+      }
+      const result = await cleanupAdminConversationRuns(token, { runIDs });
+      toast.success(t("conversation.cleanup.success", {
+        runs: result.runCount,
+        events: result.deletedCount,
+      }));
+      setCleanupOpen(false);
+      setSelectedRunIDs(new Set());
+      await logs.loadConversationEvents(logs.page, logs.pageSize);
+    } catch (error) {
+      toast.error(t("conversation.cleanup.failed"), { description: resolveAdminErrorMessage(error) });
+    } finally {
+      setCleanupPending(false);
+    }
+  }, [logs, selectedRunIDs, t]);
   const scopeLabel = React.useCallback((value: string) => {
     switch (value) {
       case "trace_block":
@@ -1591,6 +1679,15 @@ function ConversationEventTable({ onOpenDetail }: { onOpenDetail: (item: AdminCo
           onValueChange: (value) => logs.setSortValue(value as ConversationEventSortValue),
           options: CONVERSATION_EVENT_SORT_OPTIONS.map((item) => ({ label: t(item.labelKey), value: item.value })),
         }}
+        selectedCount={selectedRunIDs.size}
+        bulkActions={[
+          {
+            key: "delete-runs",
+            label: t("conversation.cleanup.action"),
+            icon: <Trash2 />,
+            onClick: () => setCleanupOpen(true),
+          },
+        ]}
         loading={logs.loading}
         onRefresh={() => void logs.loadConversationEvents(logs.page, logs.pageSize)}
       />
@@ -1602,6 +1699,16 @@ function ConversationEventTable({ onOpenDetail }: { onOpenDetail: (item: AdminCo
       >
         <TableHeader>
           <TableRow className="hover:bg-transparent">
+            <TableHead className="w-[44px] py-1.5 text-center">
+              <div className="flex h-7 items-center justify-center">
+                <Checkbox
+                  checked={allVisibleSelected ? true : someVisibleSelected ? "indeterminate" : false}
+                  disabled={visibleRunIDs.length === 0}
+                  onCheckedChange={(checked) => toggleVisibleRuns(checked === true)}
+                  aria-label={t("conversation.cleanup.selectAll")}
+                />
+              </div>
+            </TableHead>
             <TableHead className="w-[72px]">ID</TableHead>
             <TableHead>{t("columns.user")}</TableHead>
             <TableHead>{t("columns.scope")}</TableHead>
@@ -1614,33 +1721,52 @@ function ConversationEventTable({ onOpenDetail }: { onOpenDetail: (item: AdminCo
           </TableRow>
         </TableHeader>
         <TableBody>
-          {logs.loading && logs.events.length === 0 ? <TableLoadingRow colSpan={9} /> : null}
-          {logs.events.length > 0 ? <VirtualTablePaddingRow colSpan={9} height={virtualRows.paddingTop} /> : null}
-          {logs.events.length > 0 ? virtualRows.rows.map(({ item }) => (
-            <TableRow key={item.id} className="cursor-pointer" onClick={() => onOpenDetail(item)}>
-              <TableCell className="font-mono text-xs text-foreground">{item.id}</TableCell>
-              <TableCell className="whitespace-nowrap text-muted-foreground">
-                {resolveUserDisplayName(item.userLabel, item.username, item.userID)}
-              </TableCell>
-              <TableCell className="whitespace-nowrap text-muted-foreground">{scopeLabel(item.eventScope)}</TableCell>
-              <TableCell>
-                <div className="max-w-[12rem] truncate" title={item.eventType || item.title || "-"}>{item.eventType || item.title || "-"}</div>
-              </TableCell>
-              <TableCell className="whitespace-nowrap">{eventStatusLabel(item.status)}</TableCell>
-              <TableCell>
-                <div className="max-w-[12rem] truncate text-muted-foreground" title={item.upstreamName || "-"}>{item.upstreamName || "-"}</div>
-              </TableCell>
-              <TableCell>
-                <div className="max-w-[10rem] truncate text-muted-foreground" title={item.toolName || "-"}>{item.toolName || "-"}</div>
-              </TableCell>
-              <TableCell className="font-mono text-xs text-muted-foreground">
-                <div className="max-w-[13rem] truncate" title={item.runID || "-"}>{item.runID || "-"}</div>
-              </TableCell>
-              <TableCell className="whitespace-nowrap text-muted-foreground">{formatDateTime(item.createdAt, locale)}</TableCell>
-            </TableRow>
-          )) : null}
-          {logs.events.length > 0 ? <VirtualTablePaddingRow colSpan={9} height={virtualRows.paddingBottom} /> : null}
-          {!logs.loading && logs.events.length === 0 ? <TableEmptyRow colSpan={9}>{t("conversation.empty")}</TableEmptyRow> : null}
+          {logs.loading && logs.events.length === 0 ? <TableLoadingRow colSpan={10} /> : null}
+          {logs.events.length > 0 ? <VirtualTablePaddingRow colSpan={10} height={virtualRows.paddingTop} /> : null}
+          {logs.events.length > 0 ? virtualRows.rows.map(({ item }) => {
+            const runID = item.runID.trim();
+            return (
+              <TableRow
+                key={item.id}
+                className="cursor-pointer"
+                selected={selectedRunIDs.has(runID)}
+                onClick={() => onOpenDetail(item)}
+              >
+                <TableCell className="w-[44px] py-1.5 text-center">
+                  <div className="flex h-7 items-center justify-center">
+                    <Checkbox
+                      checked={selectedRunIDs.has(runID)}
+                      disabled={!runID}
+                      onClick={(event) => event.stopPropagation()}
+                      onCheckedChange={(checked) => toggleRun(runID, checked === true)}
+                      aria-label={t("conversation.cleanup.selectRun", { runID: runID || "-" })}
+                    />
+                  </div>
+                </TableCell>
+                <TableCell className="font-mono text-xs text-foreground">{item.id}</TableCell>
+                <TableCell className="whitespace-nowrap text-muted-foreground">
+                  {resolveUserDisplayName(item.userLabel, item.username, item.userID)}
+                </TableCell>
+                <TableCell className="whitespace-nowrap text-muted-foreground">{scopeLabel(item.eventScope)}</TableCell>
+                <TableCell>
+                  <div className="max-w-[12rem] truncate" title={item.eventType || item.title || "-"}>{item.eventType || item.title || "-"}</div>
+                </TableCell>
+                <TableCell className="whitespace-nowrap">{eventStatusLabel(item.status)}</TableCell>
+                <TableCell>
+                  <div className="max-w-[12rem] truncate text-muted-foreground" title={item.upstreamName || "-"}>{item.upstreamName || "-"}</div>
+                </TableCell>
+                <TableCell>
+                  <div className="max-w-[10rem] truncate text-muted-foreground" title={item.toolName || "-"}>{item.toolName || "-"}</div>
+                </TableCell>
+                <TableCell className="font-mono text-xs text-muted-foreground">
+                  <div className="max-w-[13rem] truncate" title={runID || "-"}>{runID || "-"}</div>
+                </TableCell>
+                <TableCell className="whitespace-nowrap text-muted-foreground">{formatDateTime(item.createdAt, locale)}</TableCell>
+              </TableRow>
+            );
+          }) : null}
+          {logs.events.length > 0 ? <VirtualTablePaddingRow colSpan={10} height={virtualRows.paddingBottom} /> : null}
+          {!logs.loading && logs.events.length === 0 ? <TableEmptyRow colSpan={10}>{t("conversation.empty")}</TableEmptyRow> : null}
         </TableBody>
       </Table>
 
@@ -1653,6 +1779,30 @@ function ConversationEventTable({ onOpenDetail }: { onOpenDetail: (item: AdminCo
         onPageChange={(nextPage) => void logs.loadConversationEvents(nextPage, logs.pageSize)}
         onPageSizeChange={(nextPageSize) => void logs.loadConversationEvents(1, nextPageSize)}
       />
+
+      <AlertDialog open={cleanupOpen} onOpenChange={(open) => !cleanupPending && setCleanupOpen(open)}>
+        <AlertDialogContent className="sm:max-w-[440px]">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("conversation.cleanup.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("conversation.cleanup.description", { count: selectedRunIDs.size })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={cleanupPending}>{commonT("cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={cleanupPending || selectedRunIDs.size === 0}
+              onClick={(event) => {
+                event.preventDefault();
+                void cleanupSelectedRuns();
+              }}
+            >
+              {cleanupPending ? <SpinnerLabel>{t("conversation.cleanup.deleting")}</SpinnerLabel> : t("conversation.cleanup.confirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }
@@ -1822,6 +1972,8 @@ function LogCleanupDialog({
 export function AdminLogsPage() {
   const t = useTranslations("adminLogs");
   const [detail, setDetail] = React.useState<LogDetail | null>(null);
+  const [conversationDetailLoading, setConversationDetailLoading] = React.useState(false);
+  const detailRequestRef = React.useRef(0);
   const [cleanupOpen, setCleanupOpen] = React.useState(false);
   const [billingDisplay, setBillingDisplay] = React.useState<BillingDisplayOptions>({
     currency: "USD",
@@ -1864,6 +2016,38 @@ export function AdminLogsPage() {
       ...current,
       [type]: current[type] + 1,
     }));
+  }, []);
+
+  const openConversationDetail = React.useCallback(async (item: AdminConversationEventDTO) => {
+    const requestID = detailRequestRef.current + 1;
+    detailRequestRef.current = requestID;
+    setDetail({ kind: "conversation", item });
+    setConversationDetailLoading(true);
+    try {
+      const token = await resolveAccessToken();
+      if (!token) {
+        toast.error(t("toast.sessionExpired"), { description: t("toast.signInAgain") });
+        return;
+      }
+      const loaded = await getAdminConversationEvent(token, item.id);
+      if (detailRequestRef.current === requestID) {
+        setDetail({ kind: "conversation", item: loaded });
+      }
+    } catch (error) {
+      if (detailRequestRef.current === requestID) {
+        toast.error(t("toast.conversationEventDetailLoadFailed"), { description: resolveAdminErrorMessage(error) });
+      }
+    } finally {
+      if (detailRequestRef.current === requestID) {
+        setConversationDetailLoading(false);
+      }
+    }
+  }, [t]);
+
+  const closeDetail = React.useCallback(() => {
+    detailRequestRef.current += 1;
+    setConversationDetailLoading(false);
+    setDetail(null);
   }, []);
 
   return (
@@ -1909,11 +2093,16 @@ export function AdminLogsPage() {
           <PaymentOrderTable key={cleanupRevisions.orders} onOpenDetail={(item) => setDetail({ kind: "order", item })} />
         </TabsContent>
         <TabsContent value="conversation">
-          <ConversationEventTable key={cleanupRevisions.conversation} onOpenDetail={(item) => setDetail({ kind: "conversation", item })} />
+          <ConversationEventTable key={cleanupRevisions.conversation} onOpenDetail={(item) => void openConversationDetail(item)} />
         </TabsContent>
       </Tabs>
 
-      <LogDetailSheet detail={detail} billingDisplay={billingDisplay} onClose={() => setDetail(null)} />
+      <LogDetailSheet
+        detail={detail}
+        billingDisplay={billingDisplay}
+        conversationDetailLoading={conversationDetailLoading}
+        onClose={closeDetail}
+      />
       <LogCleanupDialog
         open={cleanupOpen}
         onOpenChange={setCleanupOpen}

--- a/frontend/features/chat/hooks/use-chat-attachments.ts
+++ b/frontend/features/chat/hooks/use-chat-attachments.ts
@@ -181,8 +181,8 @@ export function useChatAttachments({
       let overflowCount = 0;
       const policyLabels = {
         mimeNotAllowed: t("policy.mimeNotAllowed"),
-        fullContextLimitExceeded: (limitKB: number) => t("policy.fullContextLimitExceeded", { limit: limitKB }),
-        sizeLimitExceeded: (limitKB: number) => t("policy.sizeLimitExceeded", { limit: limitKB }),
+        fullContextLimitExceeded: (limit: string) => t("policy.fullContextLimitExceeded", { limit }),
+        sizeLimitExceeded: (limit: string) => t("policy.sizeLimitExceeded", { limit }),
       };
       for (const file of files) {
         const rejection = resolveUploadPolicyRejection(file, chatFilePolicy, policyLabels);

--- a/frontend/features/chat/utils/attachments.ts
+++ b/frontend/features/chat/utils/attachments.ts
@@ -1,4 +1,5 @@
 import type { ChatFilePolicyDTO } from "@/shared/api/file.types";
+import { formatBytes } from "@/shared/lib/file-display";
 
 export type UploadCategory = "image" | "pdf" | "word" | "excel" | "text" | "unknown";
 
@@ -168,14 +169,14 @@ export function resolveEffectiveUploadLimit(policy: ChatFilePolicyDTO | null, ca
 
 type UploadPolicyRejectionLabels = {
   mimeNotAllowed: string;
-  fullContextLimitExceeded: (limitKB: number) => string;
-  sizeLimitExceeded: (limitKB: number) => string;
+  fullContextLimitExceeded: (limit: string) => string;
+  sizeLimitExceeded: (limit: string) => string;
 };
 
 const DEFAULT_UPLOAD_POLICY_REJECTION_LABELS: UploadPolicyRejectionLabels = {
   mimeNotAllowed: "This file type is not included in the admin MIME allowlist.",
-  fullContextLimitExceeded: (limitKB) => `Vector retrieval is disabled. Only small files that fit full-context injection can be uploaded, and this file exceeds the ${limitKB} KB limit.`,
-  sizeLimitExceeded: (limitKB) => `This file exceeds the ${limitKB} KB limit.`,
+  fullContextLimitExceeded: (limit) => `Vector retrieval is disabled. Only small files that fit full-context injection can be uploaded, and this file exceeds the ${limit} limit.`,
+  sizeLimitExceeded: (limit) => `This file exceeds the ${limit} limit.`,
 };
 
 export function resolveUploadPolicyRejection(
@@ -195,11 +196,11 @@ export function resolveUploadPolicyRejection(
 
   const limit = resolveEffectiveUploadLimit(policy, category);
   if (limit > 0 && file.size > limit) {
-    const limitKB = Math.round(limit / 1024);
+    const formattedLimit = formatBytes(limit);
     if (policy.capabilityMode === "full_context_only" && category !== "image") {
-      return labels.fullContextLimitExceeded(limitKB);
+      return labels.fullContextLimitExceeded(formattedLimit);
     }
-    return labels.sizeLimitExceeded(limitKB);
+    return labels.sizeLimitExceeded(formattedLimit);
   }
 
   return null;

--- a/frontend/i18n/messages/en-US/admin-logs.json
+++ b/frontend/i18n/messages/en-US/admin-logs.json
@@ -56,6 +56,7 @@
     "usageLoadFailed": "Failed to load usage logs",
     "ordersLoadFailed": "Failed to load order records",
     "conversationEventsLoadFailed": "Failed to load conversation events",
+    "conversationEventDetailLoadFailed": "Failed to load conversation event details",
     "modelFilterLoadFailed": "Failed to load model filters"
   },
   "sort": {
@@ -165,7 +166,8 @@
       "admin_reset_user_password": "Admin reset password",
       "admin_reset_user_2fa": "Admin reset two-factor auth",
       "admin_delete_user": "Admin delete user",
-      "admin_cleanup_logs": "Admin clean up logs"
+      "admin_cleanup_logs": "Admin clean up logs",
+      "admin_cleanup_conversation_runs": "Admin delete conversation run traces"
     }
   },
   "auth": {
@@ -273,6 +275,18 @@
       "streaming": "Streaming",
       "completed": "Completed",
       "error": "Error"
+    },
+    "cleanup": {
+      "action": "Delete run traces",
+      "title": "Delete run traces",
+      "description": "Permanently deletes all trace events for the selected {count} runs. Conversations, messages, attachments, calls, and billing records are preserved.",
+      "confirm": "Delete",
+      "deleting": "Deleting",
+      "success": "Deleted {events} trace events from {runs} runs",
+      "failed": "Failed to delete run traces",
+      "maxSelection": "You can select up to 100 runs at a time",
+      "selectAll": "Select runs on this page",
+      "selectRun": "Select run {runID}"
     }
   },
   "detail": {
@@ -353,7 +367,8 @@
       "toolName": "Tool name",
       "toolCallID": "Tool call ID",
       "title": "Title",
-      "summary": "Summary"
+      "summary": "Summary",
+      "payloadSize": "Payload size"
     },
     "result": {
       "success": "Success",
@@ -362,6 +377,8 @@
     },
     "rawUsageJsonTitle": "Raw Usage JSON",
     "jsonTitle": "Detail JSON",
+    "loading": "Loading details",
+    "payloadOmitted": "This historical payload is {size}, above the safe viewing limit, so its content was omitted. Delete the associated run traces to remove this abnormal historical data.",
     "copied": "{label} copied",
     "copyFailed": "Copy failed"
   }

--- a/frontend/i18n/messages/en-US/chat.json
+++ b/frontend/i18n/messages/en-US/chat.json
@@ -247,8 +247,8 @@
     "retry": "Please try again.",
     "policy": {
       "mimeNotAllowed": "This file type is not included in the admin MIME allowlist.",
-      "fullContextLimitExceeded": "Vector retrieval is disabled. Only small files that fit full-context injection can be uploaded, and this file exceeds the {limit} KB limit.",
-      "sizeLimitExceeded": "This file exceeds the {limit} KB limit."
+      "fullContextLimitExceeded": "Vector retrieval is disabled. Only small files that fit full-context injection can be uploaded, and this file exceeds the {limit} limit.",
+      "sizeLimitExceeded": "This file exceeds the {limit} limit."
     }
   },
   "submit": {

--- a/frontend/i18n/messages/zh-CN/admin-logs.json
+++ b/frontend/i18n/messages/zh-CN/admin-logs.json
@@ -56,6 +56,7 @@
     "usageLoadFailed": "调用日志加载失败",
     "ordersLoadFailed": "订单记录加载失败",
     "conversationEventsLoadFailed": "对话事件加载失败",
+    "conversationEventDetailLoadFailed": "对话事件详情加载失败",
     "modelFilterLoadFailed": "模型筛选加载失败"
   },
   "sort": {
@@ -165,7 +166,8 @@
       "admin_reset_user_password": "管理员重置密码",
       "admin_reset_user_2fa": "管理员重置二步验证",
       "admin_delete_user": "管理员删除用户",
-      "admin_cleanup_logs": "管理员清理日志"
+      "admin_cleanup_logs": "管理员清理日志",
+      "admin_cleanup_conversation_runs": "管理员清理对话运行轨迹"
     }
   },
   "auth": {
@@ -273,6 +275,18 @@
       "streaming": "生成中",
       "completed": "已完成",
       "error": "异常"
+    },
+    "cleanup": {
+      "action": "删除运行轨迹",
+      "title": "删除运行轨迹",
+      "description": "将永久删除所选 {count} 个运行的全部处理轨迹。会话、消息、附件、调用记录和计费数据不受影响。",
+      "confirm": "删除",
+      "deleting": "正在删除",
+      "success": "已删除 {runs} 个运行的 {events} 条轨迹记录",
+      "failed": "运行轨迹删除失败",
+      "maxSelection": "单次最多选择 100 个运行",
+      "selectAll": "选择当前页运行",
+      "selectRun": "选择运行 {runID}"
     }
   },
   "detail": {
@@ -353,7 +367,8 @@
       "toolName": "工具名",
       "toolCallID": "工具调用 ID",
       "title": "标题",
-      "summary": "摘要"
+      "summary": "摘要",
+      "payloadSize": "负载大小"
     },
     "result": {
       "success": "成功",
@@ -362,6 +377,8 @@
     },
     "rawUsageJsonTitle": "原始 Usage JSON",
     "jsonTitle": "详情 JSON",
+    "loading": "正在加载详情",
+    "payloadOmitted": "该历史负载大小为 {size}，超过安全查看上限，内容已省略。可删除对应运行轨迹以移除这条异常历史数据。",
     "copied": "{label}已复制",
     "copyFailed": "复制失败"
   }

--- a/frontend/i18n/messages/zh-CN/chat.json
+++ b/frontend/i18n/messages/zh-CN/chat.json
@@ -247,8 +247,8 @@
     "retry": "请重试。",
     "policy": {
       "mimeNotAllowed": "当前文件类型不在后台允许的 MIME 白名单内。",
-      "fullContextLimitExceeded": "当前未启用向量检索，只允许上传可走全文注入的小文件。当前文件超过 {limit} KB 上限。",
-      "sizeLimitExceeded": "当前文件超过 {limit} KB 上限。"
+      "fullContextLimitExceeded": "当前未启用向量检索，只允许上传可走全文注入的小文件。当前文件超过 {limit} 上限。",
+      "sizeLimitExceeded": "当前文件超过 {limit} 上限。"
     }
   },
   "submit": {

--- a/packages/api-contract/src/types.generated.ts
+++ b/packages/api-contract/src/types.generated.ts
@@ -554,6 +554,24 @@ export interface CircuitResetResponse {
   reset: boolean;
 }
 
+export interface CleanupConversationRunsRequest {
+  /**
+   * @maxItems 100
+   * @minItems 1
+   */
+  runIDs: string[];
+}
+
+export interface CleanupConversationRunsResponse {
+  deletedCount: number;
+  runCount: number;
+}
+
+export interface CleanupConversationRunsResponseDoc {
+  data: CleanupConversationRunsResponse;
+  errorMsg: string;
+}
+
 export interface CleanupLogsRequest {
   before: string;
   type: string;
@@ -626,6 +644,11 @@ export interface ConversationErrorDoc {
   requestId?: string;
 }
 
+export interface ConversationEventDetailResponseDoc {
+  data: ConversationEventResponse;
+  errorMsg: string;
+}
+
 export interface ConversationEventListResponseDoc {
   data: {
     results: ConversationEventResponse[];
@@ -650,6 +673,8 @@ export interface ConversationEventResponse {
   outputJSON: string;
   parentEventID: string;
   payloadJSON: string;
+  payloadOmitted: boolean;
+  payloadSizeBytes: number;
   phase: string;
   platformModelName: string;
   providerProtocol: string;
@@ -4006,6 +4031,41 @@ export namespace Admin {
     export type RequestBody = never;
     export type RequestHeaders = {};
     export type ResponseBody = ConversationEventListResponseDoc;
+  }
+
+  /**
+   * @description 物理删除指定运行的全部对话事件；保留消息、附件、调用与计费记录
+   * @tags admin
+   * @name ConversationEventsCleanupCreate
+   * @summary 管理员按运行清理对话事件
+   * @request POST:/admin/conversation-events/cleanup
+   * @secure
+   */
+  export namespace ConversationEventsCleanupCreate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = CleanupConversationRunsRequest;
+    export type RequestHeaders = {};
+    export type ResponseBody = CleanupConversationRunsResponseDoc;
+  }
+
+  /**
+   * @description 管理员按事件 ID 查看单条对话运行事件详情；超大历史负载会被安全省略
+   * @tags admin
+   * @name ConversationEventsDetail
+   * @summary 管理员查询对话事件详情
+   * @request GET:/admin/conversation-events/{id}
+   * @secure
+   */
+  export namespace ConversationEventsDetail {
+    export type RequestParams = {
+      /** 事件 ID */
+      id: number;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ConversationEventDetailResponseDoc;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #540.

模型调用失败时，上游调试快照可能将图片或文件的 Base64 内容完整写入 `chat_run_events.payload_json`。同一次失败还可能同时生成 `trace_block` 和 `trace_event`，导致数据库在短时间内快速增长。

本次修改：

- 脱敏上游请求与响应中的 data URI、Base64 和常见内联二进制字段。
- 将单个调试正文限制为 128 KiB，并保留原始大小和脱敏状态。
- 为最终写入的轨迹负载增加 1 MiB 硬限制，防止其他异常路径写入超大数据。
- 在数据库查询层省略历史超大负载，避免管理端和会话接口读取几十 MB 的历史数据。
- 管理端改为按需加载对话事件详情，并支持按运行删除异常轨迹。
- 文件大小超限提示改用可读的 KB/MB 单位。
- 同步更新 Swagger 文档和前端 API contract。

实际发送给模型的文件和图片不受影响；脱敏仅作用于调试日志和轨迹存储。

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [x] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./...`
- [x] `cd backend && go vet ./...`
- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm typecheck`
- [x] `git diff --check`

## Screenshots, API examples, or logs

脱敏后的调试负载示例：

```json
{
  "url": "[binary omitted; mime=image/png; encoded_bytes=35651584]"
}
```

超过轨迹存储上限时：

```json
{
  "_trace": {
    "payloadOmitted": true,
    "originalBytes": 12582912,
    "reason": "payload_too_large"
  }
}
```

## Configuration, migration, and compatibility notes

- 不需要数据库迁移或新增配置。
- 不改变实际发送给上游模型的请求内容。
- 正常大小的轨迹内容和展示保持不变。
- 已有超大历史负载不会自动删除，但查询时不再完整加载，可在管理端按运行清理。
- PostgreSQL 删除历史记录后会将空间标记为可复用；如需立即缩小磁盘文件，需要由管理员单独执行 `VACUUM FULL` 或 `pg_repack`。
- 新增管理端事件详情和按运行清理接口，Swagger 与 API contract 已同步。

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including upstream debug data, file payload handling, administrator authorization, and cleanup scope.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.