### PR TITLE
fix: preserve failed turns when balance is insufficient

### DIFF
--- a/backend/internal/application/conversation/service_billing.go
+++ b/backend/internal/application/conversation/service_billing.go
@@ -20,6 +20,8 @@ const (
 	usageReconciliationSettlement  = "settle_usage_ledger_failed"
 	usageBillingRetryAttempts      = 3
 	usageBillingRetryBaseDelay     = 100 * time.Millisecond
+	messageUsageBalanceErrorCode   = "billing.insufficient_funds"
+	messageUsageBalanceErrorText   = "insufficient balance"
 )
 
 // SendMessageBillingInput 描述一次消息发送对应的计费上下文。
@@ -75,6 +77,28 @@ func (s *Service) AuthorizeSendMessageUsage(ctx context.Context, input SendMessa
 		return &domainbilling.UsageAuthorization{Mode: "self"}, nil
 	}
 	return s.billingSvc.AuthorizeUsage(ctx, input.UserID, sendMessageBillingPlatformModelName(input), strings.TrimSpace(input.ClientRunID))
+}
+
+// PersistMessageUsageRejection 将需要进入对话历史的终态业务拒绝持久化。
+// 可重试的预算预约失败不产生消息，保证客户端可以安全重试。
+func (s *Service) PersistMessageUsageRejection(
+	ctx context.Context,
+	input SendMessageInput,
+	authorizationErr error,
+) error {
+	if !shouldPersistMessageUsageRejection(authorizationErr) {
+		return nil
+	}
+	return s.persistRejectedMessageSend(
+		ctx,
+		input,
+		messageUsageBalanceErrorCode,
+		messageUsageBalanceErrorText,
+	)
+}
+
+func shouldPersistMessageUsageRejection(err error) bool {
+	return errors.Is(err, appbilling.ErrUsageBalanceInsufficient)
 }
 
 // ReleaseSendMessageUsageAuthorization 在调用未产生可计费用量时释放预留预算。

--- a/backend/internal/application/conversation/service_message_preparation.go
+++ b/backend/internal/application/conversation/service_message_preparation.go
@@ -1,0 +1,223 @@
+package conversation
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
+	"github.com/google/uuid"
+)
+
+type messageSendBranchPreparation struct {
+	branchState            *messageBranchState
+	normalizedBranchReason string
+	reuseUserMessage       bool
+}
+
+type rejectedMessageState struct {
+	errorCode    string
+	errorMessage string
+}
+
+// prepareMessageSendBranch 在消息落库前解析并规范化分支。
+// 正常生成与发送拒绝共用该准备过程，保证重试和编辑的祖先关系一致。
+func (s *Service) prepareMessageSendBranch(ctx context.Context, input *SendMessageInput) (*messageSendBranchPreparation, error) {
+	if input == nil {
+		return nil, ErrInvalidMessageContent
+	}
+
+	normalizedBranchReason := normalizeBranchReason(input.BranchReason)
+	branchState, err := s.resolveMessageBranch(
+		ctx,
+		input.ConversationID,
+		input.UserID,
+		input.ParentMessagePublicID,
+		input.SourceMessagePublicID,
+		normalizedBranchReason,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	reuseUserMessage := branchState.ReuseUserMessage != nil
+	if reuseUserMessage {
+		input.Content = branchState.ReuseUserMessage.Content
+		input.FileIDs = parseAttachmentSnapshotFileIDs(branchState.ReuseUserMessage.Attachments)
+	}
+	maxFiles := s.cfg.Snapshot().MaxMessageFiles
+	if maxFiles <= 0 {
+		maxFiles = 10
+	}
+	if len(input.FileIDs) > maxFiles {
+		return nil, ErrTooManyMessageFiles
+	}
+
+	return &messageSendBranchPreparation{
+		branchState:            branchState,
+		normalizedBranchReason: normalizedBranchReason,
+		reuseUserMessage:       reuseUserMessage,
+	}, nil
+}
+
+type messagePair struct {
+	user      *model.Message
+	assistant *model.Message
+}
+
+// createMessagePair 为已准备的分支原子写入用户消息、助手占位消息与附件引用。
+func (s *Service) createMessagePair(
+	ctx context.Context,
+	input SendMessageInput,
+	runID string,
+	preparation *messageSendBranchPreparation,
+	resolvedAttachments []AttachmentInput,
+	rejected *rejectedMessageState,
+) (*messagePair, error) {
+	if preparation == nil || preparation.branchState == nil {
+		return nil, ErrInvalidMessageBranch
+	}
+
+	userStatus := "pending"
+	assistantStatus := "pending"
+	messageErrorCode := ""
+	messageErrorMessage := ""
+	if rejected != nil {
+		userStatus = "error"
+		assistantStatus = "error"
+		messageErrorCode = strings.TrimSpace(rejected.errorCode)
+		messageErrorMessage = truncateError(strings.TrimSpace(rejected.errorMessage), 255)
+	}
+
+	userContentEstimatedInputTokens := estimateTokens(input.Content)
+	if rejected != nil {
+		userContentEstimatedInputTokens = 0
+	}
+	assistantMessage := &model.Message{
+		ConversationID:   input.ConversationID,
+		UserID:           input.UserID,
+		PublicID:         normalizePublicID(uuid.NewString()),
+		RunID:            runID,
+		Role:             "assistant",
+		ContentType:      "text",
+		Content:          "",
+		BranchReason:     preparation.normalizedBranchReason,
+		TokenUsage:       0,
+		InputTokens:      0,
+		OutputTokens:     0,
+		CacheReadTokens:  0,
+		CacheWriteTokens: 0,
+		ReasoningTokens:  0,
+		LatencyMS:        0,
+		Status:           assistantStatus,
+		ErrorCode:        messageErrorCode,
+		ErrorMessage:     messageErrorMessage,
+		Attachments:      "[]",
+	}
+
+	if preparation.reuseUserMessage {
+		reused := *preparation.branchState.ReuseUserMessage
+		userMessage := &reused
+		assistantMessage.ParentMessageID = &userMessage.ID
+		assistantMessage.SourceMessageID = preparation.branchState.SourceMessageID
+		if err := s.repo.CreateAssistantBranchMessage(ctx, assistantMessage); err != nil {
+			return nil, err
+		}
+		assistantMessage.ParentPublicID = userMessage.PublicID
+		assistantMessage.SourcePublicID = preparation.branchState.SourcePublicID
+		return &messagePair{user: userMessage, assistant: assistantMessage}, nil
+	}
+
+	attachmentsJSON := []byte(marshalAttachmentSnapshots(resolvedAttachments))
+	userMessage := &model.Message{
+		ConversationID:  input.ConversationID,
+		UserID:          input.UserID,
+		PublicID:        normalizePublicID(uuid.NewString()),
+		ParentMessageID: preparation.branchState.ParentMessageID,
+		RunID:           runID,
+		Role:            "user",
+		ContentType:     fallbackContentType(input.ContentType),
+		Content:         input.Content,
+		BranchReason:    preparation.normalizedBranchReason,
+		SourceMessageID: preparation.branchState.SourceMessageID,
+		TokenUsage:      userContentEstimatedInputTokens,
+		InputTokens:     userContentEstimatedInputTokens,
+		Attachments:     string(attachmentsJSON),
+		Status:          userStatus,
+		ErrorCode:       messageErrorCode,
+		ErrorMessage:    messageErrorMessage,
+	}
+	attachmentRows := make([]model.Attachment, 0, len(resolvedAttachments))
+	now := time.Now()
+	for _, item := range resolvedAttachments {
+		attachmentRows = append(attachmentRows, model.Attachment{
+			ConversationID: input.ConversationID,
+			UserID:         input.UserID,
+			FileID:         strings.TrimSpace(item.FileID),
+			Kind:           normalizeAttachmentKind(item.Kind, item.MimeType),
+			FileName:       strings.TrimSpace(item.FileName),
+			MimeType:       strings.TrimSpace(item.MimeType),
+			FileSize:       item.FileSize,
+			SHA256:         strings.TrimSpace(item.SHA256),
+			StoragePath:    strings.TrimSpace(item.StoragePath),
+			Status:         "active",
+			MetaJSON:       strings.TrimSpace(item.MetaJSON),
+			UploadedAt:     now,
+		})
+	}
+
+	if err := s.repo.CreateMessagePairWithUserAttachments(ctx, userMessage, assistantMessage, attachmentRows); err != nil {
+		return nil, err
+	}
+	userMessage.ParentPublicID = preparation.branchState.ParentPublicID
+	userMessage.SourcePublicID = preparation.branchState.SourcePublicID
+	assistantMessage.ParentPublicID = userMessage.PublicID
+	return &messagePair{user: userMessage, assistant: assistantMessage}, nil
+}
+
+// persistRejectedMessageSend 在上游请求开始前保存被业务规则拒绝的对话回合。
+// 消息创建和最终错误状态位于同一事务，刷新时不会出现半个回合或永久 pending 消息。
+func (s *Service) persistRejectedMessageSend(
+	ctx context.Context,
+	input SendMessageInput,
+	errorCode string,
+	errorMessage string,
+) error {
+	if err := s.ValidateSelectedToolIDs(input.SelectedToolIDs); err != nil {
+		return err
+	}
+
+	conversation, err := s.repo.GetConversationByUser(ctx, input.ConversationID, input.UserID)
+	if err != nil {
+		return ErrConversationNotFound
+	}
+	preparation, err := s.prepareMessageSendBranch(ctx, &input)
+	if err != nil {
+		return err
+	}
+	resolvedAttachments, err := s.resolveAttachments(ctx, input.UserID, input.FileIDs)
+	if err != nil {
+		return err
+	}
+
+	runID := normalizeRunID(input.ClientRunID)
+	if runID == "" {
+		runID = "run_" + normalizePublicID(uuid.NewString())
+	}
+	pair, err := s.createMessagePair(
+		ctx,
+		input,
+		runID,
+		preparation,
+		resolvedAttachments,
+		&rejectedMessageState{
+			errorCode:    errorCode,
+			errorMessage: errorMessage,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	s.persistInitialConversationFallbackTitle(ctx, *conversation, *pair.user)
+	return nil
+}

--- a/backend/internal/application/conversation/service_message_preparation_test.go
+++ b/backend/internal/application/conversation/service_message_preparation_test.go
@@ -1,0 +1,229 @@
+package conversation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	appbilling "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/billing"
+	appcompact "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/compact"
+	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
+	"go.uber.org/zap"
+)
+
+type rejectedMessageRepositoryStub struct {
+	repository.ConversationRepository
+	conversation      model.Conversation
+	userMessage       *model.Message
+	assistantMessage  *model.Message
+	attachments       []model.Attachment
+	metadataPatch     repository.ConversationMetadataPatch
+	pairCreateCalls   int
+	branchCreateCalls int
+}
+
+func (r *rejectedMessageRepositoryStub) GetConversationByUser(_ context.Context, conversationID uint, userID uint) (*model.Conversation, error) {
+	if r.conversation.ID != conversationID || r.conversation.UserID != userID {
+		return nil, repository.ErrNotFound
+	}
+	item := r.conversation
+	return &item, nil
+}
+
+func (r *rejectedMessageRepositoryStub) ListRecentMessages(context.Context, uint, int) ([]model.Message, int64, error) {
+	return nil, 0, nil
+}
+
+func (r *rejectedMessageRepositoryStub) CreateMessagePairWithUserAttachments(
+	_ context.Context,
+	userMessage *model.Message,
+	assistantMessage *model.Message,
+	attachments []model.Attachment,
+) error {
+	r.pairCreateCalls++
+	userMessage.ID = 11
+	assistantMessage.ID = 12
+	parentID := userMessage.ID
+	assistantMessage.ParentMessageID = &parentID
+	r.userMessage = userMessage
+	r.assistantMessage = assistantMessage
+	r.attachments = append([]model.Attachment(nil), attachments...)
+	return nil
+}
+
+func (r *rejectedMessageRepositoryStub) CreateAssistantBranchMessage(
+	_ context.Context,
+	assistantMessage *model.Message,
+) error {
+	r.branchCreateCalls++
+	assistantMessage.ID = 13
+	r.assistantMessage = assistantMessage
+	return nil
+}
+
+func (r *rejectedMessageRepositoryStub) ListAllMessages(context.Context, uint) ([]model.Message, error) {
+	return []model.Message{*r.userMessage, *r.assistantMessage}, nil
+}
+
+func (r *rejectedMessageRepositoryStub) UpdateConversationMetadata(
+	_ context.Context,
+	_ uint,
+	patch repository.ConversationMetadataPatch,
+) (*model.Conversation, error) {
+	r.metadataPatch = patch
+	item := r.conversation
+	item.Title = patch.Title
+	return &item, nil
+}
+
+func TestPersistMessageUsageRejectionStoresStableFailedTurn(t *testing.T) {
+	runtimeCfg := config.NewRuntime(config.Config{MaxMessageFiles: 10})
+	repo := &rejectedMessageRepositoryStub{
+		conversation: model.Conversation{
+			ID:       7,
+			UserID:   9,
+			PublicID: "conversation-7",
+			Title:    "New chat",
+			Model:    "gpt-test",
+		},
+	}
+	logger := zap.NewNop()
+	service := &Service{
+		cfg:    runtimeCfg,
+		repo:   repo,
+		logger: logger,
+	}
+	service.compactSvc = appcompact.NewServiceWithRuntime(runtimeCfg, repo, logger)
+
+	err := service.PersistMessageUsageRejection(
+		context.Background(),
+		SendMessageInput{
+			UserID:            9,
+			ConversationID:    7,
+			ContentType:       "text",
+			Content:           "keep this failed message",
+			PlatformModelName: "gpt-test",
+			ClientRunID:       "run_issue_544",
+			BranchReason:      "default",
+		},
+		appbilling.ErrUsageBalanceInsufficient,
+	)
+	if err != nil {
+		t.Fatalf("PersistMessageUsageRejection() error = %v", err)
+	}
+	if repo.userMessage == nil || repo.assistantMessage == nil {
+		t.Fatal("rejected turn did not persist both messages")
+	}
+	if repo.userMessage.Status != "error" || repo.assistantMessage.Status != "error" {
+		t.Fatalf("message statuses = (%q, %q), want both error", repo.userMessage.Status, repo.assistantMessage.Status)
+	}
+	if repo.userMessage.Content != "keep this failed message" {
+		t.Fatalf("user content = %q", repo.userMessage.Content)
+	}
+	if repo.userMessage.ErrorCode != messageUsageBalanceErrorCode || repo.assistantMessage.ErrorCode != messageUsageBalanceErrorCode {
+		t.Fatalf("message error codes = (%q, %q)", repo.userMessage.ErrorCode, repo.assistantMessage.ErrorCode)
+	}
+	if repo.assistantMessage.ErrorMessage != messageUsageBalanceErrorText {
+		t.Fatalf("assistant error message = %q", repo.assistantMessage.ErrorMessage)
+	}
+	if repo.assistantMessage.ParentMessageID == nil || *repo.assistantMessage.ParentMessageID != repo.userMessage.ID {
+		t.Fatal("assistant message is not attached to the rejected user message")
+	}
+	if repo.pairCreateCalls != 1 || repo.branchCreateCalls != 0 {
+		t.Fatalf("repository create calls = pair:%d branch:%d", repo.pairCreateCalls, repo.branchCreateCalls)
+	}
+	wantTitle := conversationTitleFromFirstUserMessage("keep this failed message")
+	if repo.metadataPatch.Title != wantTitle {
+		t.Fatalf("fallback title = %q", repo.metadataPatch.Title)
+	}
+}
+
+func TestShouldPersistMessageUsageRejection(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "insufficient balance", err: appbilling.ErrUsageBalanceInsufficient, want: true},
+		{name: "wrapped insufficient balance", err: errors.Join(errors.New("authorize usage"), appbilling.ErrUsageBalanceInsufficient), want: true},
+		{name: "concurrency limit", err: appbilling.ErrUsageConcurrencyLimitExceeded, want: false},
+		{name: "reservation conflict", err: appbilling.ErrUsageReservationConflict, want: false},
+		{name: "pricing missing", err: appbilling.ErrModelPricingRequired, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldPersistMessageUsageRejection(tt.err); got != tt.want {
+				t.Fatalf("shouldPersistMessageUsageRejection() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPersistMessageUsageRejectionLeavesRetryableFailuresSideEffectFree(t *testing.T) {
+	service := &Service{}
+	for _, err := range []error{
+		appbilling.ErrUsageConcurrencyLimitExceeded,
+		appbilling.ErrUsageReservationConflict,
+		appbilling.ErrModelPricingRequired,
+	} {
+		if persistErr := service.PersistMessageUsageRejection(context.Background(), SendMessageInput{}, err); persistErr != nil {
+			t.Fatalf("PersistMessageUsageRejection(%v) error = %v", err, persistErr)
+		}
+	}
+}
+
+func TestCreateRejectedAssistantRetryReusesExistingUserMessage(t *testing.T) {
+	repo := &rejectedMessageRepositoryStub{}
+	service := &Service{repo: repo}
+	existingUser := &model.Message{
+		ID:             21,
+		ConversationID: 7,
+		UserID:         9,
+		PublicID:       "msg_existing_user",
+		Role:           "user",
+		ContentType:    "text",
+		Content:        "retry this message",
+		Status:         "error",
+	}
+	sourceAssistantID := uint(22)
+
+	pair, err := service.createMessagePair(
+		context.Background(),
+		SendMessageInput{UserID: 9, ConversationID: 7, Content: existingUser.Content},
+		"run_retry_issue_544",
+		&messageSendBranchPreparation{
+			branchState: &messageBranchState{
+				SourceMessageID:  &sourceAssistantID,
+				SourcePublicID:   "msg_failed_assistant",
+				ReuseUserMessage: existingUser,
+			},
+			normalizedBranchReason: "retry",
+			reuseUserMessage:       true,
+		},
+		nil,
+		&rejectedMessageState{
+			errorCode:    messageUsageBalanceErrorCode,
+			errorMessage: messageUsageBalanceErrorText,
+		},
+	)
+	if err != nil {
+		t.Fatalf("createMessagePair() error = %v", err)
+	}
+	if pair.user.ID != existingUser.ID {
+		t.Fatalf("user message ID = %d, want reused ID %d", pair.user.ID, existingUser.ID)
+	}
+	if repo.pairCreateCalls != 0 || repo.branchCreateCalls != 1 {
+		t.Fatalf("repository create calls = pair:%d branch:%d", repo.pairCreateCalls, repo.branchCreateCalls)
+	}
+	if pair.assistant.Status != "error" || pair.assistant.ErrorCode != messageUsageBalanceErrorCode {
+		t.Fatalf("assistant rejection state = status:%q code:%q", pair.assistant.Status, pair.assistant.ErrorCode)
+	}
+	if pair.assistant.ParentMessageID == nil || *pair.assistant.ParentMessageID != existingUser.ID {
+		t.Fatal("retry assistant is not attached to the reused user message")
+	}
+	if pair.assistant.SourceMessageID == nil || *pair.assistant.SourceMessageID != sourceAssistantID {
+		t.Fatal("retry assistant does not reference the failed source assistant")
+	}
+}

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -182,10 +182,6 @@ func (s *Service) sendMessageInternal(
 		sendSpan.End()
 	}()
 
-	maxFiles := s.cfg.Snapshot().MaxMessageFiles
-	if maxFiles <= 0 {
-		maxFiles = 10
-	}
 	// application 层保留兜底校验，保证非 HTTP 调用路径也遵守同一 MCP 工具数量策略。
 	if err := s.ValidateSelectedToolIDs(input.SelectedToolIDs); err != nil {
 		return nil, err
@@ -202,20 +198,14 @@ func (s *Service) sendMessageInternal(
 		return nil, ErrConversationNotFound
 	}
 
-	normalizedBranchReason := normalizeBranchReason(input.BranchReason)
-	branchState, err := s.resolveMessageBranch(ctx, input.ConversationID, input.UserID, input.ParentMessagePublicID, input.SourceMessagePublicID, normalizedBranchReason)
+	branchPreparation, err := s.prepareMessageSendBranch(ctx, &input)
 	if err != nil {
 		retErr = err
 		return nil, err
 	}
-	reuseUserMessage := branchState.ReuseUserMessage != nil
-	if reuseUserMessage {
-		input.Content = branchState.ReuseUserMessage.Content
-		input.FileIDs = parseAttachmentSnapshotFileIDs(branchState.ReuseUserMessage.Attachments)
-	}
-	if len(input.FileIDs) > maxFiles {
-		return nil, ErrTooManyMessageFiles
-	}
+	branchState := branchPreparation.branchState
+	normalizedBranchReason := branchPreparation.normalizedBranchReason
+	reuseUserMessage := branchPreparation.reuseUserMessage
 	if input.Cancelable {
 		cancelCtx, cancel := context.WithCancel(ctx)
 		ctx = cancelCtx
@@ -246,7 +236,6 @@ func (s *Service) sendMessageInternal(
 	var responsesBackgroundRouteConfig llm.RouteConfig
 	var responsesBackgroundRecovery openAIResponsesBackgroundRecoveryState
 	responsesBackgroundUsageRecovered := false
-	userContentEstimatedInputTokens := int64(0)
 	usageAccumulator := &messageUsageAccumulator{}
 	upstreamCallStarted := false
 	runState := newMessageSendRunState(s, input, conversation, startedAt, runID)
@@ -318,92 +307,13 @@ func (s *Service) sendMessageInternal(
 		return nil, err
 	}
 
-	userContentEstimatedInputTokens = estimateTokens(input.Content)
-	assistantMessage = &model.Message{
-		ConversationID:   input.ConversationID,
-		UserID:           input.UserID,
-		PublicID:         normalizePublicID(uuid.NewString()),
-		RunID:            runID,
-		Role:             "assistant",
-		ContentType:      "text",
-		Content:          "",
-		BranchReason:     normalizedBranchReason,
-		TokenUsage:       0,
-		InputTokens:      0,
-		OutputTokens:     0,
-		CacheReadTokens:  0,
-		CacheWriteTokens: 0,
-		ReasoningTokens:  0,
-		LatencyMS:        0,
-		Status:           "pending",
-		ErrorCode:        "",
-		ErrorMessage:     "",
-		Attachments:      "[]",
+	pair, err := s.createMessagePair(ctx, input, runID, branchPreparation, resolvedAttachments, nil)
+	if err != nil {
+		retErr = err
+		return nil, err
 	}
-	if reuseUserMessage {
-		reused := *branchState.ReuseUserMessage
-		userMessage = &reused
-		assistantMessage.ParentMessageID = &userMessage.ID
-		assistantMessage.SourceMessageID = branchState.SourceMessageID
-		if err = s.repo.CreateAssistantBranchMessage(ctx, assistantMessage); err != nil {
-			retErr = err
-			return nil, err
-		}
-		assistantMessage.ParentPublicID = userMessage.PublicID
-		assistantMessage.SourcePublicID = branchState.SourcePublicID
-	} else {
-		attachmentsJSON := []byte(marshalAttachmentSnapshots(resolvedAttachments))
-		userMessage = &model.Message{
-			ConversationID:   input.ConversationID,
-			UserID:           input.UserID,
-			PublicID:         normalizePublicID(uuid.NewString()),
-			ParentMessageID:  branchState.ParentMessageID,
-			RunID:            runID,
-			Role:             "user",
-			ContentType:      fallbackContentType(input.ContentType),
-			Content:          input.Content,
-			BranchReason:     normalizedBranchReason,
-			SourceMessageID:  branchState.SourceMessageID,
-			TokenUsage:       userContentEstimatedInputTokens,
-			InputTokens:      userContentEstimatedInputTokens,
-			OutputTokens:     0,
-			CacheReadTokens:  0,
-			CacheWriteTokens: 0,
-			ReasoningTokens:  0,
-			LatencyMS:        0,
-			Status:           "pending",
-			ErrorCode:        "",
-			ErrorMessage:     "",
-			Attachments:      string(attachmentsJSON),
-		}
-		attachmentRows := make([]model.Attachment, 0, len(resolvedAttachments))
-		now := time.Now()
-		for _, item := range resolvedAttachments {
-			attachmentRows = append(attachmentRows, model.Attachment{
-				ConversationID: input.ConversationID,
-				UserID:         input.UserID,
-				FileID:         strings.TrimSpace(item.FileID),
-				Kind:           normalizeAttachmentKind(item.Kind, item.MimeType),
-				FileName:       strings.TrimSpace(item.FileName),
-				MimeType:       strings.TrimSpace(item.MimeType),
-				FileSize:       item.FileSize,
-				SHA256:         strings.TrimSpace(item.SHA256),
-				StoragePath:    strings.TrimSpace(item.StoragePath),
-				Status:         "active",
-				MetaJSON:       strings.TrimSpace(item.MetaJSON),
-				UploadedAt:     now,
-			})
-		}
-
-		// 用户消息、助手占位、用户附件与消息计数必须一起提交，避免失败时留下半个回合。
-		if err = s.repo.CreateMessagePairWithUserAttachments(ctx, userMessage, assistantMessage, attachmentRows); err != nil {
-			retErr = err
-			return nil, err
-		}
-		userMessage.ParentPublicID = branchState.ParentPublicID
-		userMessage.SourcePublicID = branchState.SourcePublicID
-		assistantMessage.ParentPublicID = userMessage.PublicID
-	}
+	userMessage = pair.user
+	assistantMessage = pair.assistant
 	s.persistInitialConversationFallbackTitle(ctx, *conversation, *userMessage)
 	traceRecorder = newMessageTraceRecorder(s, ctx, assistantMessage, input.OnEvent)
 

--- a/backend/internal/transport/http/conversation/handler_message_send.go
+++ b/backend/internal/transport/http/conversation/handler_message_send.go
@@ -126,33 +126,39 @@ func sendMessageBillingInput(
 	return input
 }
 
-// authorizeUsage 在写入流式响应头前完成请求级计费授权。
-func (h *Handler) authorizeUsage(c *gin.Context, input appconversation.SendMessageBillingInput) (*domainbilling.UsageAuthorization, error) {
-	authorization, err := h.service.AuthorizeSendMessageUsage(
+func (h *Handler) reserveUsage(c *gin.Context, input appconversation.SendMessageBillingInput) (*domainbilling.UsageAuthorization, error) {
+	return h.service.AuthorizeSendMessageUsage(
 		c.Request.Context(),
 		input,
 	)
+}
+
+// authorizeUsage 在写入流式响应头前完成请求级计费授权。
+func (h *Handler) authorizeUsage(c *gin.Context, input appconversation.SendMessageBillingInput) (*domainbilling.UsageAuthorization, error) {
+	authorization, err := h.reserveUsage(c, input)
 	if err != nil {
-		if errors.Is(err, billing.ErrUsageConcurrencyLimitExceeded) {
-			response.Error(c, http.StatusTooManyRequests, "usage concurrency limit exceeded")
-			return nil, err
-		}
-		if errors.Is(err, billing.ErrUsageReservationConflict) {
-			response.Error(c, http.StatusConflict, "usage reservation already exists")
-			return nil, err
-		}
-		if errors.Is(err, billing.ErrUsageBalanceInsufficient) {
-			response.Error(c, http.StatusPaymentRequired, "usage balance is insufficient")
-			return nil, err
-		}
-		if errors.Is(err, billing.ErrModelPricingRequired) {
-			response.Error(c, http.StatusPaymentRequired, "model pricing is required")
-			return nil, err
-		}
-		response.Error(c, http.StatusInternalServerError, "usage balance reservation failed")
+		handleUsageAuthorizationError(c, err)
 		return nil, err
 	}
 	return authorization, nil
+}
+
+// authorizeMessageUsage 将终态拒绝的持久化委托给应用层，再把授权结果转换为 HTTP 响应。
+func (h *Handler) authorizeMessageUsage(
+	c *gin.Context,
+	input appconversation.SendMessageInput,
+	billingInput appconversation.SendMessageBillingInput,
+) (*domainbilling.UsageAuthorization, error) {
+	authorization, err := h.reserveUsage(c, billingInput)
+	if err == nil {
+		return authorization, nil
+	}
+	if persistErr := h.service.PersistMessageUsageRejection(c.Request.Context(), input, err); persistErr != nil {
+		handleSendMessageError(c, persistErr)
+		return nil, persistErr
+	}
+	handleUsageAuthorizationError(c, err)
+	return nil, err
 }
 
 // releaseSendMessageUsageAuthorization 使用独立短上下文释放未消费的预算。
@@ -291,6 +297,26 @@ func handleSendMessageBillingError(c *gin.Context, err error) {
 	response.Error(c, http.StatusInternalServerError, "record billing failed")
 }
 
+func handleUsageAuthorizationError(c *gin.Context, err error) {
+	if errors.Is(err, billing.ErrUsageConcurrencyLimitExceeded) {
+		response.Error(c, http.StatusTooManyRequests, "usage concurrency limit exceeded")
+		return
+	}
+	if errors.Is(err, billing.ErrUsageReservationConflict) {
+		response.Error(c, http.StatusConflict, "usage reservation already exists")
+		return
+	}
+	if errors.Is(err, billing.ErrUsageBalanceInsufficient) {
+		response.Error(c, http.StatusPaymentRequired, "usage balance is insufficient")
+		return
+	}
+	if errors.Is(err, billing.ErrModelPricingRequired) {
+		response.Error(c, http.StatusPaymentRequired, "model pricing is required")
+		return
+	}
+	response.Error(c, http.StatusInternalServerError, "usage balance reservation failed")
+}
+
 func mapBillingStreamError(err error) streamError {
 	status := http.StatusInternalServerError
 	message := "record billing failed"
@@ -391,7 +417,7 @@ func (h *Handler) SendMessage(c *gin.Context) {
 	if err != nil {
 		return
 	}
-	authorization, err := h.authorizeUsage(c, sendMessageBillingInput(middleware.MustUserID(c), conversation, req, nil))
+	authorization, err := h.authorizeMessageUsage(c, input, sendMessageBillingInput(middleware.MustUserID(c), conversation, req, nil))
 	if err != nil {
 		return
 	}
@@ -452,7 +478,7 @@ func (h *Handler) StreamMessage(c *gin.Context) {
 	if err != nil {
 		return
 	}
-	authorization, err := h.authorizeUsage(c, sendMessageBillingInput(middleware.MustUserID(c), conversation, req, nil))
+	authorization, err := h.authorizeMessageUsage(c, input, sendMessageBillingInput(middleware.MustUserID(c), conversation, req, nil))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary

When a user has insufficient balance, billing authorization returns before the conversation messages are persisted. The frontend only had optimistic messages, so refreshing the page showed an empty conversation.

This change persists the user message and a terminal assistant error message atomically before returning the billing error. Existing conversation branching and retry behavior remain intact.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [x] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm check`
- [x] `env GOCACHE=/Users/project/DEEIX-Chat/.gocache go test ./...`
- [x] `env GOCACHE=/Users/project/DEEIX-Chat/.gocache go vet ./...`
- [x] `git diff --check`

Additional coverage includes insufficient-balance persistence, retry branch behavior, stable error codes, and side-effect-free retryable billing failures.

## Screenshots, API examples, or logs

No screenshots or logs are required. This is a backend persistence and conversation-state fix.

## Configuration, migration, and compatibility notes

No configuration changes, database migrations, generated API contract changes, or deployment changes are required.

The persisted failure uses the stable error code `billing.insufficient_funds`, which is already supported by the frontend localization and message rendering path.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including billing and conversation persistence.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior and compatibility impact are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.