### PR TITLE
feat: standardize admin file size settings in MB

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -223,7 +223,7 @@ MinerU 可在设置中选择处理的文件类型；云端 MinerU 支持 `.doc/.
 
 OCR 引擎配置由后台文件设置管理，当前支持 RapidOCR、Tesseract OCR、Paddle OCR、腾讯云 OCR、阿里云 OCR 与 LLM OCR。服务地址、鉴权密钥和超时时间按具体引擎配置。
 
-用户文件存储配额由运行时设置 `storage:user_storage_quota_bytes` 管理，单位为字节。值为 `0` 表示不限制；非零时，上传、分享克隆和文件复用链路都会按用户维度校验并同步最新配额。前端 `/files` 页支持单个删除和批量删除，后端会在删除后释放对应配额。
+用户文件存储配额由运行时设置 `storage:user_storage_quota_bytes` 管理。后台 `/admin/chat-files` 页面中的 `storage:max_upload_file_bytes`、`storage:user_storage_quota_bytes`、`file:image_max_bytes`、`file:doc_max_bytes` 和 `file:file_full_context_max_bytes` 统一按 MB 输入，设置值在 API、数据库和运行时内部统一按字节保存与计算；值为 `0` 表示不限制。非零时，上传、分享克隆和文件复用链路都会按用户维度校验并同步最新配额。前端 `/files` 页支持单个删除和批量删除，后端会在删除后释放对应配额。
 
 ## 模型能力与官方原生工具
 

--- a/backend/internal/application/settings/seed.go
+++ b/backend/internal/application/settings/seed.go
@@ -1,6 +1,8 @@
 package settings
 
 import (
+	"strconv"
+
 	domainsettings "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/settings"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/shared/nativetool"
@@ -76,17 +78,17 @@ func defaultSettings() []domainsettings.SystemSetting {
 		{Namespace: "chat", Key: "model_option_denied_paths", Value: config.DefaultModelOptionDeniedPathsJSON(), ValueType: "json", Description: "模型 options 黑名单路径 JSON，default 对所有协议生效"},
 
 		// 存储配置
-		{Namespace: "storage", Key: "user_storage_quota_bytes", Value: "104857600", ValueType: "int", Description: "用户总存储配额(字节)，0表示不限制"},
-		{Namespace: "storage", Key: "max_upload_file_bytes", Value: "20971520", ValueType: "int", Description: "默认附件大小上限(字节)"},
+		{Namespace: "storage", Key: "user_storage_quota_bytes", Value: "104857600", ValueType: "int", Description: "用户总存储配额（管理页面按 MB 输入，内部以字节保存），0表示不限制"},
+		{Namespace: "storage", Key: "max_upload_file_bytes", Value: "20971520", ValueType: "int", Description: "默认附件大小上限（管理页面按 MB 输入，内部以字节保存）"},
 		{Namespace: "storage", Key: "max_message_files", Value: "10", ValueType: "int", Description: "单消息附件数"},
 
 		// 文件处理配置
 		{Namespace: "file", Key: "image_max_dimension", Value: "1024", ValueType: "int", Description: "图片发送前缩放最大边长(px)，0=不缩放"},
 		{Namespace: "file", Key: "full_context_limit_enabled", Value: "true", ValueType: "bool", Description: "是否启用全文注入大小、Token、PDF页数限制"},
-		{Namespace: "file", Key: "file_full_context_max_bytes", Value: "65536", ValueType: "int", Description: "文本文件全文注入最大字节数(64KB)，留空或0表示不限制"},
+		{Namespace: "file", Key: "file_full_context_max_bytes", Value: strconv.FormatInt(config.DefaultFileFullContextMaxBytes, 10), ValueType: "int", Description: "文本文件全文注入最大大小（管理页面按 MB 输入，内部以字节保存，默认2MB），留空或0表示不限制"},
 		{Namespace: "file", Key: "full_context_max_tokens", Value: "65536", ValueType: "int", Description: "全文注入最大token预算，留空或0表示不限制"},
-		{Namespace: "file", Key: "image_max_bytes", Value: "", ValueType: "int", Description: "图片单文件大小上限(字节)，留空则回退默认附件大小上限"},
-		{Namespace: "file", Key: "doc_max_bytes", Value: "", ValueType: "int", Description: "文档单文件大小上限(字节)，留空则回退默认附件大小上限"},
+		{Namespace: "file", Key: "image_max_bytes", Value: "", ValueType: "int", Description: "图片单文件大小上限（管理页面按 MB 输入，内部以字节保存），留空则回退默认附件大小上限"},
+		{Namespace: "file", Key: "doc_max_bytes", Value: "", ValueType: "int", Description: "文档单文件大小上限（管理页面按 MB 输入，内部以字节保存），留空则回退默认附件大小上限"},
 		{Namespace: "file", Key: "full_context_pdf_max_pages", Value: "20", ValueType: "int", Description: "PDF Full Context最大页数，留空或0表示不限制"},
 		{Namespace: "file", Key: "allowed_mime_types", Value: defaultAllowedMIMETypes, ValueType: "string", Description: "白名单MIME类型(逗号分隔)"},
 		{Namespace: "extract", Key: "engine", Value: "builtin", ValueType: "string", Description: "提取主引擎枚举(builtin/tika/docling/mineru)"},

--- a/backend/internal/application/settings/service_seed_test.go
+++ b/backend/internal/application/settings/service_seed_test.go
@@ -3,6 +3,7 @@ package settings
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	domainsettings "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/settings"
@@ -95,6 +96,37 @@ func TestSeedKeepsCustomAllowedMIMETypes(t *testing.T) {
 	got := repo.items["file:allowed_mime_types"].Value
 	if got != custom {
 		t.Fatalf("expected custom MIME defaults to stay unchanged, got %q", got)
+	}
+}
+
+func TestSeedUsesDefaultFullContextMaxBytesForMissingSetting(t *testing.T) {
+	repo := newSettingsSeedRepo()
+	service := NewService(repo, "")
+
+	if err := service.Seed(context.Background(), config.Config{}); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+	want := strconv.FormatInt(config.DefaultFileFullContextMaxBytes, 10)
+	if got := repo.items["file:file_full_context_max_bytes"].Value; got != want {
+		t.Fatalf("expected default full-context size %q, got %q", want, got)
+	}
+}
+
+func TestSeedKeepsExistingFullContextMaxBytes(t *testing.T) {
+	const existingValue = "65536"
+	repo := newSettingsSeedRepo(domainsettings.SystemSetting{
+		Namespace: "file",
+		Key:       "file_full_context_max_bytes",
+		Value:     existingValue,
+		ValueType: "int",
+	})
+	service := NewService(repo, "")
+
+	if err := service.Seed(context.Background(), config.Config{}); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+	if got := repo.items["file:file_full_context_max_bytes"].Value; got != existingValue {
+		t.Fatalf("expected existing full-context size to remain %q, got %q", existingValue, got)
 	}
 }
 

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -32,6 +32,8 @@ const (
 	defaultHTTPReadTimeoutSeconds       = 120
 	defaultHTTPIdleTimeoutSeconds       = 120
 	defaultHTTPMaxHeaderBytes           = 1 << 20
+	// DefaultFileFullContextMaxBytes 是全文注入的默认提取文本大小上限（2 MiB）。
+	DefaultFileFullContextMaxBytes int64 = 2 * 1024 * 1024
 )
 
 const (
@@ -646,7 +648,7 @@ func Load() Config {
 		MaxMessageFiles:                   10,
 		ImageMaxDimension:                 1024,
 		FileFullContextLimitEnabled:       true,
-		FileFullContextMaxBytes:           65536, // 64KB
+		FileFullContextMaxBytes:           DefaultFileFullContextMaxBytes,
 		FileFullContextMaxTokens:          65536,
 		FileImageMaxBytes:                 0,
 		FileDocMaxBytes:                   0,

--- a/backend/internal/infra/config/config_test.go
+++ b/backend/internal/infra/config/config_test.go
@@ -20,6 +20,9 @@ func TestLoadDefaultsUseBootstrapAdmin(t *testing.T) {
 	if cfg.AdminDisplayName != defaultAdminDisplayName {
 		t.Fatalf("expected default admin display name %q, got %q", defaultAdminDisplayName, cfg.AdminDisplayName)
 	}
+	if cfg.FileFullContextMaxBytes != DefaultFileFullContextMaxBytes {
+		t.Fatalf("expected default full-context size %d, got %d", DefaultFileFullContextMaxBytes, cfg.FileFullContextMaxBytes)
+	}
 }
 
 func TestLoadTreatsBlankAPPEnvAsUnset(t *testing.T) {

--- a/frontend/features/admin/model/files-settings.ts
+++ b/frontend/features/admin/model/files-settings.ts
@@ -234,7 +234,7 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
         namespace: "file",
         key: "image_max_bytes",
         label: "Image size limit",
-        description: "Override the size limit for image attachments. Falls back to the default attachment limit when empty.",
+        description: "Override the size limit for image attachments. The UI uses MB; leave empty to use the default attachment limit.",
         type: "int",
         placeholder: "Leave empty to use the default attachment limit",
         valueUnit: "mb",
@@ -244,7 +244,7 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
         namespace: "file",
         key: "doc_max_bytes",
         label: "Document size limit",
-        description: "Override the size limit for document attachments. Falls back to the default attachment limit when empty.",
+        description: "Override the size limit for document attachments. The UI uses MB; leave empty to use the default attachment limit.",
         type: "int",
         placeholder: "Leave empty to use the default attachment limit",
         valueUnit: "mb",
@@ -680,10 +680,11 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
       {
         namespace: "file",
         key: "file_full_context_max_bytes",
-        label: "Full-text byte limit",
-        description: "Maximum extracted text bytes allowed for full-context injection. Leave empty or use 0 for no byte limit.",
+        label: "Full-text size limit",
+        description: "Maximum extracted text size allowed for full-context injection. The UI uses MB; leave empty or use 0 for no size limit.",
         type: "int",
-        placeholder: "Empty or 0 means unlimited",
+        valueUnit: "mb",
+        placeholder: "Size limit (MB); empty or 0 means unlimited",
         visibleWhen: { field: "file.full_context_limit_enabled", equals: FULL_CONTEXT_LIMIT_MODES.ON },
       },
       {
@@ -1055,7 +1056,16 @@ export function normalizeMBValue(raw: string): string {
     return trimmed;
   }
   const mb = bytes / BYTES_PER_MB;
-  return Number.isInteger(mb) ? String(mb) : String(Number(mb.toFixed(2)));
+  if (Number.isInteger(mb)) {
+    return String(mb);
+  }
+
+  // Keep normal values compact while retaining enough precision for sub-MB limits.
+  const compact = Number(mb.toFixed(6));
+  if (Number.isSafeInteger(bytes) && Math.round(compact * BYTES_PER_MB) === bytes) {
+    return String(compact);
+  }
+  return String(mb);
 }
 
 export function denormalizeMBValue(raw: string): string {

--- a/frontend/i18n/messages/en-US/admin-files.json
+++ b/frontend/i18n/messages/en-US/admin-files.json
@@ -104,22 +104,22 @@
       },
       "image_max_bytes": {
         "label": "Image size limit",
-        "description": "Override the size limit for image attachments. Falls back to the default attachment limit when empty.",
+        "description": "Override the size limit for image attachments. The UI uses MB; leave empty to use the default attachment limit.",
         "placeholder": "Leave empty to use the default attachment limit"
       },
       "doc_max_bytes": {
         "label": "Document size limit",
-        "description": "Override the size limit for document attachments. Falls back to the default attachment limit when empty.",
+        "description": "Override the size limit for document attachments. The UI uses MB; leave empty to use the default attachment limit.",
         "placeholder": "Leave empty to use the default attachment limit"
       },
       "full_context_limit_enabled": {
         "label": "Full-text injection limits",
-        "description": "When enabled, full-text injection is limited by byte size, token budget, and PDF pages. When disabled, these limits are ignored."
+        "description": "When enabled, full-text injection is limited by size in MB, token budget, and PDF pages. When disabled, these limits are ignored."
       },
       "file_full_context_max_bytes": {
-        "label": "Full-text byte limit",
-        "description": "Maximum extracted text bytes allowed for full-context injection. Leave empty or use 0 for no byte limit.",
-        "placeholder": "Empty or 0 means unlimited"
+        "label": "Full-text size limit",
+        "description": "Maximum extracted text size allowed for full-context injection. The UI uses MB; leave empty or use 0 for no size limit.",
+        "placeholder": "Size limit (MB); empty or 0 means unlimited"
       },
       "full_context_max_tokens": {
         "label": "Full-text token limit",

--- a/frontend/i18n/messages/zh-CN/admin-files.json
+++ b/frontend/i18n/messages/zh-CN/admin-files.json
@@ -118,8 +118,8 @@
       },
       "file_full_context_max_bytes": {
         "label": "全文大小上限",
-        "description": "用于限制全文注入允许的最大文本字节数；留空或填 0 表示不限制大小。",
-        "placeholder": "留空或 0 表示不限制"
+        "description": "用于限制全文注入允许的最大提取文本大小，页面单位为 MB；留空或填 0 表示不限制大小。",
+        "placeholder": "大小上限（MB）；留空或 0 表示不限制"
       },
       "full_context_max_tokens": {
         "label": "全文 Token 上限",

--- a/frontend/i18n/resolve-error-message.ts
+++ b/frontend/i18n/resolve-error-message.ts
@@ -132,7 +132,7 @@ const SETTINGS_FIELD_LABELS: Record<AppLocale, Record<string, string>> = {
     "chat:model_option_policy_mode": "Model option policy",
     "file:embedding_enabled": "Embedding",
     "file:full_context_limit_enabled": "Full-text injection limits",
-    "file:file_full_context_max_bytes": "Full-text byte limit",
+    "file:file_full_context_max_bytes": "Full-text size limit",
     "file:full_context_max_tokens": "Full-text token limit",
     "file:full_context_pdf_max_pages": "Full-text page limit",
     "mcp:mcp_enable": "MCP",


### PR DESCRIPTION
## Summary

Standardize all admin-configured file and storage size fields to use MB in the frontend while retaining byte-based storage and runtime calculation in the backend.

The new default for `file:file_full_context_max_bytes` is 2 MB. Existing database values are preserved and are not migrated or overwritten.

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Files / RAG / extraction
- [ ] Billing / payments
- [ ] Deployment / Docker / configuration
- [x] Documentation

## Verification

- [x] `pnpm --dir frontend lint`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir packages/api-contract check`
- [x] `go test ./internal/application/settings ./internal/infra/config ./internal/transport/http/settings`
- [x] `go vet ./internal/application/settings ./internal/infra/config ./internal/transport/http/settings`
- [x] `git diff --check`
- [ ] Not run: production frontend build stalled in the local environment during the Next.js/Turbopack build stage without producing an error.

## Screenshots, API examples, or logs

No API contract changes or operational logs. The admin UI now documents MB units through field descriptions and placeholders.

## Configuration, migration, and compatibility notes

- Admin file and storage size settings use MB for frontend input.
- Backend API, database, and runtime calculations continue using bytes as the internal unit.
- The new default full-context text limit is `2,097,152` bytes (2 MB).
- Existing `file:file_full_context_max_bytes` values are preserved without migration.
- Missing settings receive the new 2 MB default.
- PDF page and Token limits are unchanged.

## Documentation

- [x] Documentation was updated.
- [ ] Documentation is not needed for this change.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context.
- [x] No authentication, authorization, provider routing, or security-sensitive behavior was changed.

## Checklist

- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests and static verification were run.
- [x] User-facing behavior and configuration semantics are documented.
- [x] No database migration is required.
- [x] No generated artifacts, caches, build output, `.env` files, or local storage data are included.