### PR TITLE
fix: invalidate stale user settings cache

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -337,6 +337,7 @@ func NewApp() (*App, error) {
 	contentModerationHandler.SetUserLabelResolver(adminService)
 	userSettingsRepo := usersettingsrepo.NewRepo(db)
 	userSettingsService := usersettings.NewService(userSettingsRepo)
+	userSettingsService.SetCacheInvalidator(conversationService.InvalidateUserSettingCache)
 	userSettingsHandler := usersettingshttp.NewHandler(userSettingsService)
 	userSettingsModule := usersettingshttp.NewModule(userSettingsHandler)
 	announcementRepo := announcementrepo.NewRepo(db)

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -337,7 +337,7 @@ func NewApp() (*App, error) {
 	contentModerationHandler.SetUserLabelResolver(adminService)
 	userSettingsRepo := usersettingsrepo.NewRepo(db)
 	userSettingsService := usersettings.NewService(userSettingsRepo)
-	userSettingsService.SetCacheInvalidator(conversationService.InvalidateUserSettingCache)
+	userSettingsService.SetCacheRefresher(conversationService.RefreshUserSettingCache)
 	userSettingsHandler := usersettingshttp.NewHandler(userSettingsService)
 	userSettingsModule := usersettingshttp.NewModule(userSettingsHandler)
 	announcementRepo := announcementrepo.NewRepo(db)

--- a/backend/internal/application/conversation/service.go
+++ b/backend/internal/application/conversation/service.go
@@ -119,7 +119,6 @@ type Service struct {
 	generationStreams *generationStreamRegistry
 	snapshotCache     sync.Map // conversationID (uint) → *cachedSnapshot
 	userMemCache      sync.Map // userID (uint) → *cachedUserMemories
-	userSettingCache  sync.Map // "userID:key" (string) → *cachedUserSetting
 	imageContextCache *preparedConversationImageCache
 }
 

--- a/backend/internal/application/conversation/service_cache.go
+++ b/backend/internal/application/conversation/service_cache.go
@@ -2,13 +2,11 @@ package conversation
 
 import (
 	"context"
-	"fmt"
-	"hash/fnv"
-	"sync"
 	"time"
 
 	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
 	domainmemory "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/memory"
+	"go.uber.org/zap"
 )
 
 const (
@@ -20,15 +18,7 @@ const (
 	userSettingCacheTTL = 10 * time.Minute
 	// inMemoryCacheSweepInterval：主动清理过期内存缓存，避免冷 key 长期驻留。
 	inMemoryCacheSweepInterval = time.Minute
-	userSettingCacheLockShards = 64
 )
-
-type userSettingCacheShard struct {
-	mu    sync.Mutex
-	epoch uint64
-}
-
-var userSettingCacheShards [userSettingCacheLockShards]userSettingCacheShard
 
 type cachedSnapshot struct {
 	snapshot  *model.ContextSnapshot
@@ -37,12 +27,6 @@ type cachedSnapshot struct {
 
 type cachedUserMemories struct {
 	memories  []domainmemory.UserMemory
-	expiresAt time.Time
-}
-
-type cachedUserSetting struct {
-	value     string
-	valid     bool
 	expiresAt time.Time
 }
 
@@ -71,78 +55,63 @@ func (s *Service) invalidateSnapshotCache(conversationID uint) {
 	s.snapshotCache.Delete(conversationID)
 }
 
-// getUserSettingCached 从内存缓存读取用户设置，未命中时回退到 DB 查询。
+// getUserSettingCached 从共享缓存读取用户设置，未命中或缓存不可用时回退到 DB。
 func (s *Service) getUserSettingCached(ctx context.Context, userID uint, key string) (string, error) {
-	cacheKey := userSettingCacheKey(userID, key)
-	lockIndex := s.userSettingCacheLockIndex(cacheKey)
-	shard := &userSettingCacheShards[lockIndex]
-
-	shard.mu.Lock()
-	if value, ok := s.loadCachedUserSetting(cacheKey); ok {
-		shard.mu.Unlock()
-		return value.value, value.err
+	if s.cache == nil {
+		return s.repo.GetUserSettingValue(ctx, userID, key)
 	}
-	epoch := shard.epoch
-	shard.mu.Unlock()
-
+	version, versionErr := s.cache.GetUserSettingCacheVersion(ctx, userID, key, userSettingCacheTTL)
+	if versionErr == nil {
+		if value, ok, err := s.cache.GetUserSettingCache(ctx, userID, key, version); err == nil && ok {
+			return value, nil
+		} else if err != nil && s.logger != nil {
+			s.logger.Warn("user_setting_cache_read_failed", zap.Uint("user_id", userID), zap.String("key", key), zap.Error(err))
+		}
+	} else if s.logger != nil {
+		s.logger.Warn("user_setting_cache_version_read_failed", zap.Uint("user_id", userID), zap.String("key", key), zap.Error(versionErr))
+	}
 	value, err := s.repo.GetUserSettingValue(ctx, userID, key)
-
-	shard.mu.Lock()
-	if shard.epoch == epoch {
-		if err != nil {
-			s.userSettingCache.Store(cacheKey, &cachedUserSetting{valid: false, expiresAt: time.Now().Add(userSettingCacheTTL)})
-		} else {
-			s.userSettingCache.Store(cacheKey, &cachedUserSetting{value: value, valid: true, expiresAt: time.Now().Add(userSettingCacheTTL)})
+	if err != nil {
+		return "", err
+	}
+	if versionErr == nil {
+		if err := s.cache.SetUserSettingCache(ctx, userID, key, version, value, userSettingCacheTTL); err != nil && s.logger != nil {
+			s.logger.Warn("user_setting_cache_write_failed", zap.Uint("user_id", userID), zap.String("key", key), zap.Error(err))
 		}
 	}
-	shard.mu.Unlock()
-
-	return value, err
+	return value, nil
 }
 
-type cachedUserSettingResult struct {
-	value string
-	err   error
-}
-
-// loadCachedUserSetting must be called while holding the key's shard lock.
-func (s *Service) loadCachedUserSetting(cacheKey string) (cachedUserSettingResult, bool) {
-	value, ok := s.userSettingCache.Load(cacheKey)
-	if !ok {
-		return cachedUserSettingResult{}, false
+// RefreshUserSettingCache 推进指定设置的共享缓存版本，并用数据库中已提交的当前值回填新版本。
+// 版本化数据键保证了在途旧读取与并发更新都无法覆盖当前值。
+func (s *Service) RefreshUserSettingCache(ctx context.Context, userID uint, keys []string) {
+	if s.cache == nil {
+		return
 	}
-	entry := value.(*cachedUserSetting)
-	if !time.Now().Before(entry.expiresAt) {
-		s.userSettingCache.Delete(cacheKey)
-		return cachedUserSettingResult{}, false
-	}
-	if !entry.valid {
-		return cachedUserSettingResult{err: fmt.Errorf("not found")}, true
-	}
-	return cachedUserSettingResult{value: entry.value}, true
-}
-
-func userSettingCacheKey(userID uint, key string) string {
-	return fmt.Sprintf("%d:%s", userID, key)
-}
-
-func (s *Service) userSettingCacheLockIndex(cacheKey string) uint32 {
-	hasher := fnv.New32a()
-	_, _ = hasher.Write([]byte(cacheKey))
-	return hasher.Sum32() % userSettingCacheLockShards
-}
-
-// InvalidateUserSettingCache 清除指定用户指定 key 的用户设置缓存。
-// 由 usersettings 服务在写入成功后通过回调触发，避免循环依赖。
-func (s *Service) InvalidateUserSettingCache(userID uint, keys []string) {
+	versions := make(map[string]string, len(keys))
+	refreshKeys := make([]string, 0, len(keys))
 	for _, key := range keys {
-		cacheKey := userSettingCacheKey(userID, key)
-		lockIndex := s.userSettingCacheLockIndex(cacheKey)
-		shard := &userSettingCacheShards[lockIndex]
-		shard.mu.Lock()
-		shard.epoch++
-		s.userSettingCache.Delete(cacheKey)
-		shard.mu.Unlock()
+		version, err := s.cache.AdvanceUserSettingCacheVersion(ctx, userID, key, userSettingCacheTTL)
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Warn("user_setting_cache_version_advance_failed", zap.Uint("user_id", userID), zap.String("key", key), zap.Error(err))
+			}
+			continue
+		}
+		versions[key] = version
+		refreshKeys = append(refreshKeys, key)
+	}
+	values, err := s.repo.GetUserSettingValues(ctx, userID, refreshKeys)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("user_setting_cache_refresh_load_failed", zap.Uint("user_id", userID), zap.Error(err))
+		}
+		return
+	}
+	for _, key := range refreshKeys {
+		if err := s.cache.SetUserSettingCache(ctx, userID, key, versions[key], values[key], userSettingCacheTTL); err != nil && s.logger != nil {
+			s.logger.Warn("user_setting_cache_refresh_write_failed", zap.Uint("user_id", userID), zap.String("key", key), zap.Error(err))
+		}
 	}
 }
 
@@ -196,13 +165,6 @@ func (s *Service) cleanupExpiredInMemoryCaches(now time.Time) {
 		entry, ok := value.(*cachedUserMemories)
 		if !ok || !now.Before(entry.expiresAt) {
 			s.userMemCache.Delete(key)
-		}
-		return true
-	})
-	s.userSettingCache.Range(func(key, value interface{}) bool {
-		entry, ok := value.(*cachedUserSetting)
-		if !ok || !now.Before(entry.expiresAt) {
-			s.userSettingCache.Delete(key)
 		}
 		return true
 	})

--- a/backend/internal/application/conversation/service_cache.go
+++ b/backend/internal/application/conversation/service_cache.go
@@ -3,6 +3,8 @@ package conversation
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
+	"sync"
 	"time"
 
 	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
@@ -18,7 +20,15 @@ const (
 	userSettingCacheTTL = 10 * time.Minute
 	// inMemoryCacheSweepInterval：主动清理过期内存缓存，避免冷 key 长期驻留。
 	inMemoryCacheSweepInterval = time.Minute
+	userSettingCacheLockShards = 64
 )
+
+type userSettingCacheShard struct {
+	mu    sync.Mutex
+	epoch uint64
+}
+
+var userSettingCacheShards [userSettingCacheLockShards]userSettingCacheShard
 
 type cachedSnapshot struct {
 	snapshot  *model.ContextSnapshot
@@ -63,24 +73,77 @@ func (s *Service) invalidateSnapshotCache(conversationID uint) {
 
 // getUserSettingCached 从内存缓存读取用户设置，未命中时回退到 DB 查询。
 func (s *Service) getUserSettingCached(ctx context.Context, userID uint, key string) (string, error) {
-	cacheKey := fmt.Sprintf("%d:%s", userID, key)
-	if v, ok := s.userSettingCache.Load(cacheKey); ok {
-		entry := v.(*cachedUserSetting)
-		if time.Now().Before(entry.expiresAt) {
-			if !entry.valid {
-				return "", fmt.Errorf("not found")
-			}
-			return entry.value, nil
+	cacheKey := userSettingCacheKey(userID, key)
+	lockIndex := s.userSettingCacheLockIndex(cacheKey)
+	shard := &userSettingCacheShards[lockIndex]
+
+	shard.mu.Lock()
+	if value, ok := s.loadCachedUserSetting(cacheKey); ok {
+		shard.mu.Unlock()
+		return value.value, value.err
+	}
+	epoch := shard.epoch
+	shard.mu.Unlock()
+
+	value, err := s.repo.GetUserSettingValue(ctx, userID, key)
+
+	shard.mu.Lock()
+	if shard.epoch == epoch {
+		if err != nil {
+			s.userSettingCache.Store(cacheKey, &cachedUserSetting{valid: false, expiresAt: time.Now().Add(userSettingCacheTTL)})
+		} else {
+			s.userSettingCache.Store(cacheKey, &cachedUserSetting{value: value, valid: true, expiresAt: time.Now().Add(userSettingCacheTTL)})
 		}
+	}
+	shard.mu.Unlock()
+
+	return value, err
+}
+
+type cachedUserSettingResult struct {
+	value string
+	err   error
+}
+
+// loadCachedUserSetting must be called while holding the key's shard lock.
+func (s *Service) loadCachedUserSetting(cacheKey string) (cachedUserSettingResult, bool) {
+	value, ok := s.userSettingCache.Load(cacheKey)
+	if !ok {
+		return cachedUserSettingResult{}, false
+	}
+	entry := value.(*cachedUserSetting)
+	if !time.Now().Before(entry.expiresAt) {
 		s.userSettingCache.Delete(cacheKey)
+		return cachedUserSettingResult{}, false
 	}
-	val, err := s.repo.GetUserSettingValue(ctx, userID, key)
-	if err != nil {
-		s.userSettingCache.Store(cacheKey, &cachedUserSetting{valid: false, expiresAt: time.Now().Add(userSettingCacheTTL)})
-		return "", err
+	if !entry.valid {
+		return cachedUserSettingResult{err: fmt.Errorf("not found")}, true
 	}
-	s.userSettingCache.Store(cacheKey, &cachedUserSetting{value: val, valid: true, expiresAt: time.Now().Add(userSettingCacheTTL)})
-	return val, nil
+	return cachedUserSettingResult{value: entry.value}, true
+}
+
+func userSettingCacheKey(userID uint, key string) string {
+	return fmt.Sprintf("%d:%s", userID, key)
+}
+
+func (s *Service) userSettingCacheLockIndex(cacheKey string) uint32 {
+	hasher := fnv.New32a()
+	_, _ = hasher.Write([]byte(cacheKey))
+	return hasher.Sum32() % userSettingCacheLockShards
+}
+
+// InvalidateUserSettingCache 清除指定用户指定 key 的用户设置缓存。
+// 由 usersettings 服务在写入成功后通过回调触发，避免循环依赖。
+func (s *Service) InvalidateUserSettingCache(userID uint, keys []string) {
+	for _, key := range keys {
+		cacheKey := userSettingCacheKey(userID, key)
+		lockIndex := s.userSettingCacheLockIndex(cacheKey)
+		shard := &userSettingCacheShards[lockIndex]
+		shard.mu.Lock()
+		shard.epoch++
+		s.userSettingCache.Delete(cacheKey)
+		shard.mu.Unlock()
+	}
 }
 
 // getCachedUserMemories 从内存缓存读取用户长期记忆，未命中时回退到 DB 查询。

--- a/backend/internal/application/conversation/service_cache_test.go
+++ b/backend/internal/application/conversation/service_cache_test.go
@@ -13,8 +13,6 @@ func TestCleanupExpiredInMemoryCaches(t *testing.T) {
 	svc.snapshotCache.Store(uint(2), &cachedSnapshot{expiresAt: now.Add(time.Minute)})
 	svc.userMemCache.Store(uint(1), &cachedUserMemories{expiresAt: now.Add(-time.Second)})
 	svc.userMemCache.Store(uint(2), &cachedUserMemories{expiresAt: now.Add(time.Minute)})
-	svc.userSettingCache.Store("1:stale", &cachedUserSetting{expiresAt: now.Add(-time.Second)})
-	svc.userSettingCache.Store("1:fresh", &cachedUserSetting{expiresAt: now.Add(time.Minute)})
 
 	svc.cleanupExpiredInMemoryCaches(now)
 
@@ -29,11 +27,5 @@ func TestCleanupExpiredInMemoryCaches(t *testing.T) {
 	}
 	if _, ok := svc.userMemCache.Load(uint(2)); !ok {
 		t.Fatal("expected fresh user memory cache entry to remain")
-	}
-	if _, ok := svc.userSettingCache.Load("1:stale"); ok {
-		t.Fatal("expected expired user setting cache entry to be deleted")
-	}
-	if _, ok := svc.userSettingCache.Load("1:fresh"); !ok {
-		t.Fatal("expected fresh user setting cache entry to remain")
 	}
 }

--- a/backend/internal/application/conversation/service_user_settings_test.go
+++ b/backend/internal/application/conversation/service_user_settings_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/channel"
 	appusersettings "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/usersettings"
 	domainusersettings "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/usersettings"
+	memorycache "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/cache/memory"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
 )
@@ -28,6 +30,16 @@ func (r *mutableUserSettingsRepository) GetUserSettingValue(_ context.Context, u
 		r.beforeGet()
 	}
 	return value, nil
+}
+
+func (r *mutableUserSettingsRepository) GetUserSettingValues(_ context.Context, userID uint, keys []string) (map[string]string, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	values := make(map[string]string, len(keys))
+	for _, key := range keys {
+		values[key] = r.values[userID][key]
+	}
+	return values, nil
 }
 
 func (r *mutableUserSettingsRepository) ListByUserID(_ context.Context, userID uint) ([]domainusersettings.UserSetting, error) {
@@ -67,7 +79,21 @@ func (r *failingUpsertUserSettingsRepository) Upsert(_ context.Context, _ []doma
 	return errors.New("upsert failed")
 }
 
-func TestConversationSettingsReadPatchedValuesImmediately(t *testing.T) {
+type userSettingTestRepository interface {
+	repository.ConversationRepository
+	repository.UserSettingsRepository
+}
+
+func newUserSettingTestServices(repo userSettingTestRepository, runtimeCfg *config.Runtime) (*Service, *appusersettings.Service, repository.ConversationCacheRepository) {
+	cache := memorycache.NewConversationCache(memorycache.New())
+	conversationService := &Service{cfg: runtimeCfg, repo: repo, cache: cache}
+	settingsService := appusersettings.NewService(repo)
+	settingsService.SetCacheRefresher(conversationService.RefreshUserSettingCache)
+	return conversationService, settingsService, cache
+}
+
+// TestIssue589UserSettingChangesTakeEffectImmediately covers every setting reported in #589.
+func TestIssue589UserSettingChangesTakeEffectImmediately(t *testing.T) {
 	const userID uint = 17
 	ctx := context.Background()
 	runtimeCfg := config.NewRuntime(config.Config{ContextCompactEnabled: true})
@@ -80,38 +106,16 @@ func TestConversationSettingsReadPatchedValuesImmediately(t *testing.T) {
 			},
 		},
 	}
-	conversationService := &Service{
-		cfg:  runtimeCfg,
-		repo: repo,
-	}
-	settingsService := appusersettings.NewService(repo)
-	settingsService.SetCacheInvalidator(conversationService.InvalidateUserSettingCache)
+	conversationService, settingsService, cache := newUserSettingTestServices(repo, runtimeCfg)
 
-	// 初始读取走生产路径并填充内存缓存。
 	if !conversationService.reasoningContentPassbackEnabled(ctx, userID, &channel.ResolvedRoute{ReasoningContentPassback: true}) {
 		t.Fatal("expected initial reasoning passback to be enabled")
 	}
 	if !conversationService.resolveContextCompactionPolicy(ctx, runtimeCfg.Snapshot(), userID).EffectiveEnabled() {
 		t.Fatal("expected initial context compaction to be enabled")
 	}
-	initialFileMode, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode")
-	if err != nil {
-		t.Fatalf("initial file mode read: %v", err)
-	}
-	if initialFileMode != "auto" {
-		t.Fatalf("initial message file mode = %q, want auto", initialFileMode)
-	}
-
-	for key, want := range map[string]string{
-		"chat.reasoning_content_passback": "true",
-		"chat.context_compact_auto":       "true",
-		"chat.file_mode":                  "auto",
-	} {
-		if v, ok := conversationService.userSettingCache.Load(userSettingCacheKey(userID, key)); !ok {
-			t.Fatalf("expected user setting cache entry for %q to be populated", key)
-		} else if entry := v.(*cachedUserSetting); !entry.valid || entry.value != want {
-			t.Fatalf("cached user setting %q = %q (valid=%v), want %q", key, entry.value, entry.valid, want)
-		}
+	if value, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode"); err != nil || value != "auto" {
+		t.Fatalf("initial file mode = %q (err %v), want auto", value, err)
 	}
 
 	if _, err := settingsService.PatchSettings(ctx, userID, map[string]string{
@@ -122,14 +126,18 @@ func TestConversationSettingsReadPatchedValuesImmediately(t *testing.T) {
 		t.Fatalf("patch settings: %v", err)
 	}
 
-	// 写入成功后，生产失效回调应清除相关缓存条目。
-	for _, key := range []string{
-		"chat.reasoning_content_passback",
-		"chat.context_compact_auto",
-		"chat.file_mode",
+	for key, want := range map[string]string{
+		"chat.reasoning_content_passback": "false",
+		"chat.context_compact_auto":       "false",
+		"chat.file_mode":                  "rag",
 	} {
-		if _, ok := conversationService.userSettingCache.Load(userSettingCacheKey(userID, key)); ok {
-			t.Fatalf("expected user setting cache entry for %q to be invalidated after patch", key)
+		version, err := cache.GetUserSettingCacheVersion(ctx, userID, key, userSettingCacheTTL)
+		if err != nil || version == "" {
+			t.Fatalf("cache version for %q = %q (err %v), want a version", key, version, err)
+		}
+		value, ok, err := cache.GetUserSettingCache(ctx, userID, key, version)
+		if err != nil || !ok || value != want {
+			t.Fatalf("refreshed cache for %q = %q (ok %v, err %v), want %q", key, value, ok, err, want)
 		}
 	}
 
@@ -139,35 +147,30 @@ func TestConversationSettingsReadPatchedValuesImmediately(t *testing.T) {
 	if conversationService.resolveContextCompactionPolicy(ctx, runtimeCfg.Snapshot(), userID).EffectiveEnabled() {
 		t.Fatal("expected patched context compaction to be disabled")
 	}
-	updatedFileMode, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode")
-	if err != nil {
-		t.Fatalf("updated file mode read: %v", err)
-	}
-	if updatedFileMode != "rag" {
-		t.Fatalf("updated message file mode = %q, want rag", updatedFileMode)
+	if value, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode"); err != nil || value != "rag" {
+		t.Fatalf("updated file mode = %q (err %v), want rag", value, err)
 	}
 }
 
-func TestConversationSettingsCacheDoesNotRepopulateAfterInvalidation(t *testing.T) {
+func TestConversationSettingsCacheDoesNotRepopulateAfterRefresh(t *testing.T) {
 	const userID uint = 19
 	ctx := context.Background()
 	readStarted := make(chan struct{})
 	releaseRead := make(chan struct{})
-	var readOnce sync.Once
+	var blockFirstRead atomic.Bool
+	blockFirstRead.Store(true)
 	repo := &mutableUserSettingsRepository{
 		values: map[uint]map[string]string{
 			userID: {"chat.file_mode": "auto"},
 		},
 		beforeGet: func() {
-			readOnce.Do(func() {
+			if blockFirstRead.CompareAndSwap(true, false) {
 				close(readStarted)
 				<-releaseRead
-			})
+			}
 		},
 	}
-	conversationService := &Service{repo: repo}
-	settingsService := appusersettings.NewService(repo)
-	settingsService.SetCacheInvalidator(conversationService.InvalidateUserSettingCache)
+	conversationService, settingsService, cache := newUserSettingTestServices(repo, nil)
 
 	readDone := make(chan struct{})
 	go func() {
@@ -181,22 +184,44 @@ func TestConversationSettingsCacheDoesNotRepopulateAfterInvalidation(t *testing.
 	if _, err := settingsService.PatchSettings(ctx, userID, map[string]string{"chat.file_mode": "rag"}); err != nil {
 		t.Fatalf("patch settings: %v", err)
 	}
-	if _, ok := conversationService.userSettingCache.Load(userSettingCacheKey(userID, "chat.file_mode")); ok {
-		t.Fatal("expected cache entry to remain absent while stale read is blocked")
-	}
-
 	close(releaseRead)
 	<-readDone
-	if _, ok := conversationService.userSettingCache.Load(userSettingCacheKey(userID, "chat.file_mode")); ok {
-		t.Fatal("stale read must not repopulate cache after invalidation")
-	}
 
-	value, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode")
-	if err != nil {
-		t.Fatalf("updated setting read: %v", err)
+	version, err := cache.GetUserSettingCacheVersion(ctx, userID, "chat.file_mode", userSettingCacheTTL)
+	if err != nil || version == "" {
+		t.Fatalf("cache version = %q (err %v), want a version", version, err)
 	}
-	if value != "rag" {
-		t.Fatalf("updated file mode = %q, want rag", value)
+	value, ok, err := cache.GetUserSettingCache(ctx, userID, "chat.file_mode", version)
+	if err != nil || !ok || value != "rag" {
+		t.Fatalf("current cache = %q (ok %v, err %v), want rag", value, ok, err)
+	}
+	if value, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode"); err != nil || value != "rag" {
+		t.Fatalf("updated file mode = %q (err %v), want rag", value, err)
+	}
+}
+
+func TestConversationSettingsRefreshIsSharedAcrossServiceInstances(t *testing.T) {
+	const userID uint = 20
+	ctx := context.Background()
+	repo := &mutableUserSettingsRepository{
+		values: map[uint]map[string]string{
+			userID: {"chat.file_mode": "auto"},
+		},
+	}
+	sharedCache := memorycache.NewConversationCache(memorycache.New())
+	firstConversationService := &Service{repo: repo, cache: sharedCache}
+	secondConversationService := &Service{repo: repo, cache: sharedCache}
+	settingsService := appusersettings.NewService(repo)
+	settingsService.SetCacheRefresher(firstConversationService.RefreshUserSettingCache)
+
+	if value, err := secondConversationService.getUserSettingCached(ctx, userID, "chat.file_mode"); err != nil || value != "auto" {
+		t.Fatalf("initial second-instance read = %q (err %v), want auto", value, err)
+	}
+	if _, err := settingsService.PatchSettings(ctx, userID, map[string]string{"chat.file_mode": "full_context"}); err != nil {
+		t.Fatalf("patch settings: %v", err)
+	}
+	if value, err := secondConversationService.getUserSettingCached(ctx, userID, "chat.file_mode"); err != nil || value != "full_context" {
+		t.Fatalf("second-instance read after refresh = %q (err %v), want full_context", value, err)
 	}
 }
 
@@ -205,30 +230,29 @@ func TestConversationSettingsCacheSurvivesFailedUpsert(t *testing.T) {
 	ctx := context.Background()
 	base := &mutableUserSettingsRepository{
 		values: map[uint]map[string]string{
-			userID: {
-				"chat.file_mode": "auto",
-			},
+			userID: {"chat.file_mode": "auto"},
 		},
 	}
 	repo := &failingUpsertUserSettingsRepository{mutableUserSettingsRepository: base}
-	conversationService := &Service{repo: repo}
-	settingsService := appusersettings.NewService(repo)
-	settingsService.SetCacheInvalidator(conversationService.InvalidateUserSettingCache)
+	conversationService, settingsService, cache := newUserSettingTestServices(repo, nil)
 
-	if got, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode"); err != nil || got != "auto" {
-		t.Fatalf("initial cached file mode = %q (err %v), want auto", got, err)
+	if value, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode"); err != nil || value != "auto" {
+		t.Fatalf("initial cached file mode = %q (err %v), want auto", value, err)
 	}
-
-	// 模拟外部 DB 写入；若缓存被误失效则下一次读取会拿到新值。
+	versionBefore, err := cache.GetUserSettingCacheVersion(ctx, userID, "chat.file_mode", userSettingCacheTTL)
+	if err != nil {
+		t.Fatalf("cache version before failed upsert: %v", err)
+	}
 	base.setValue(userID, "chat.file_mode", "rag")
 
-	if _, err := settingsService.PatchSettings(ctx, userID, map[string]string{
-		"chat.file_mode": "full_context",
-	}); err == nil {
+	if _, err := settingsService.PatchSettings(ctx, userID, map[string]string{"chat.file_mode": "full_context"}); err == nil {
 		t.Fatal("expected patch settings to fail")
 	}
-
-	if got, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode"); err != nil || got != "auto" {
-		t.Fatalf("cached file mode after failed upsert = %q (err %v), want auto from cache", got, err)
+	versionAfter, err := cache.GetUserSettingCacheVersion(ctx, userID, "chat.file_mode", userSettingCacheTTL)
+	if err != nil || versionAfter != versionBefore {
+		t.Fatalf("cache version after failed upsert = %q (err %v), want unchanged %q", versionAfter, err, versionBefore)
+	}
+	if value, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode"); err != nil || value != "auto" {
+		t.Fatalf("cached file mode after failed upsert = %q (err %v), want auto", value, err)
 	}
 }

--- a/backend/internal/application/conversation/service_user_settings_test.go
+++ b/backend/internal/application/conversation/service_user_settings_test.go
@@ -1,0 +1,234 @@
+package conversation
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/channel"
+	appusersettings "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/usersettings"
+	domainusersettings "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/usersettings"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
+)
+
+type mutableUserSettingsRepository struct {
+	repository.ConversationRepository
+	mu        sync.RWMutex
+	values    map[uint]map[string]string
+	beforeGet func()
+}
+
+func (r *mutableUserSettingsRepository) GetUserSettingValue(_ context.Context, userID uint, key string) (string, error) {
+	r.mu.RLock()
+	value := r.values[userID][key]
+	r.mu.RUnlock()
+	if r.beforeGet != nil {
+		r.beforeGet()
+	}
+	return value, nil
+}
+
+func (r *mutableUserSettingsRepository) ListByUserID(_ context.Context, userID uint) ([]domainusersettings.UserSetting, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	values := r.values[userID]
+	items := make([]domainusersettings.UserSetting, 0, len(values))
+	for key, value := range values {
+		items = append(items, domainusersettings.UserSetting{UserID: userID, Key: key, Value: value})
+	}
+	return items, nil
+}
+
+func (r *mutableUserSettingsRepository) Upsert(_ context.Context, items []domainusersettings.UserSetting) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, item := range items {
+		if r.values[item.UserID] == nil {
+			r.values[item.UserID] = make(map[string]string)
+		}
+		r.values[item.UserID][item.Key] = item.Value
+	}
+	return nil
+}
+
+func (r *mutableUserSettingsRepository) setValue(userID uint, key, value string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.values[userID][key] = value
+}
+
+type failingUpsertUserSettingsRepository struct {
+	*mutableUserSettingsRepository
+}
+
+func (r *failingUpsertUserSettingsRepository) Upsert(_ context.Context, _ []domainusersettings.UserSetting) error {
+	return errors.New("upsert failed")
+}
+
+func TestConversationSettingsReadPatchedValuesImmediately(t *testing.T) {
+	const userID uint = 17
+	ctx := context.Background()
+	runtimeCfg := config.NewRuntime(config.Config{ContextCompactEnabled: true})
+	repo := &mutableUserSettingsRepository{
+		values: map[uint]map[string]string{
+			userID: {
+				"chat.reasoning_content_passback": "true",
+				"chat.context_compact_auto":       "true",
+				"chat.file_mode":                  "auto",
+			},
+		},
+	}
+	conversationService := &Service{
+		cfg:  runtimeCfg,
+		repo: repo,
+	}
+	settingsService := appusersettings.NewService(repo)
+	settingsService.SetCacheInvalidator(conversationService.InvalidateUserSettingCache)
+
+	// 初始读取走生产路径并填充内存缓存。
+	if !conversationService.reasoningContentPassbackEnabled(ctx, userID, &channel.ResolvedRoute{ReasoningContentPassback: true}) {
+		t.Fatal("expected initial reasoning passback to be enabled")
+	}
+	if !conversationService.resolveContextCompactionPolicy(ctx, runtimeCfg.Snapshot(), userID).EffectiveEnabled() {
+		t.Fatal("expected initial context compaction to be enabled")
+	}
+	initialFileMode, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode")
+	if err != nil {
+		t.Fatalf("initial file mode read: %v", err)
+	}
+	if initialFileMode != "auto" {
+		t.Fatalf("initial message file mode = %q, want auto", initialFileMode)
+	}
+
+	for key, want := range map[string]string{
+		"chat.reasoning_content_passback": "true",
+		"chat.context_compact_auto":       "true",
+		"chat.file_mode":                  "auto",
+	} {
+		if v, ok := conversationService.userSettingCache.Load(userSettingCacheKey(userID, key)); !ok {
+			t.Fatalf("expected user setting cache entry for %q to be populated", key)
+		} else if entry := v.(*cachedUserSetting); !entry.valid || entry.value != want {
+			t.Fatalf("cached user setting %q = %q (valid=%v), want %q", key, entry.value, entry.valid, want)
+		}
+	}
+
+	if _, err := settingsService.PatchSettings(ctx, userID, map[string]string{
+		"chat.reasoning_content_passback": "false",
+		"chat.context_compact_auto":       "false",
+		"chat.file_mode":                  "rag",
+	}); err != nil {
+		t.Fatalf("patch settings: %v", err)
+	}
+
+	// 写入成功后，生产失效回调应清除相关缓存条目。
+	for _, key := range []string{
+		"chat.reasoning_content_passback",
+		"chat.context_compact_auto",
+		"chat.file_mode",
+	} {
+		if _, ok := conversationService.userSettingCache.Load(userSettingCacheKey(userID, key)); ok {
+			t.Fatalf("expected user setting cache entry for %q to be invalidated after patch", key)
+		}
+	}
+
+	if conversationService.reasoningContentPassbackEnabled(ctx, userID, &channel.ResolvedRoute{ReasoningContentPassback: true}) {
+		t.Fatal("expected patched reasoning passback to be disabled")
+	}
+	if conversationService.resolveContextCompactionPolicy(ctx, runtimeCfg.Snapshot(), userID).EffectiveEnabled() {
+		t.Fatal("expected patched context compaction to be disabled")
+	}
+	updatedFileMode, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode")
+	if err != nil {
+		t.Fatalf("updated file mode read: %v", err)
+	}
+	if updatedFileMode != "rag" {
+		t.Fatalf("updated message file mode = %q, want rag", updatedFileMode)
+	}
+}
+
+func TestConversationSettingsCacheDoesNotRepopulateAfterInvalidation(t *testing.T) {
+	const userID uint = 19
+	ctx := context.Background()
+	readStarted := make(chan struct{})
+	releaseRead := make(chan struct{})
+	var readOnce sync.Once
+	repo := &mutableUserSettingsRepository{
+		values: map[uint]map[string]string{
+			userID: {"chat.file_mode": "auto"},
+		},
+		beforeGet: func() {
+			readOnce.Do(func() {
+				close(readStarted)
+				<-releaseRead
+			})
+		},
+	}
+	conversationService := &Service{repo: repo}
+	settingsService := appusersettings.NewService(repo)
+	settingsService.SetCacheInvalidator(conversationService.InvalidateUserSettingCache)
+
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		if value, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode"); err != nil || value != "auto" {
+			t.Errorf("initial concurrent read = %q (err %v), want auto", value, err)
+		}
+	}()
+
+	<-readStarted
+	if _, err := settingsService.PatchSettings(ctx, userID, map[string]string{"chat.file_mode": "rag"}); err != nil {
+		t.Fatalf("patch settings: %v", err)
+	}
+	if _, ok := conversationService.userSettingCache.Load(userSettingCacheKey(userID, "chat.file_mode")); ok {
+		t.Fatal("expected cache entry to remain absent while stale read is blocked")
+	}
+
+	close(releaseRead)
+	<-readDone
+	if _, ok := conversationService.userSettingCache.Load(userSettingCacheKey(userID, "chat.file_mode")); ok {
+		t.Fatal("stale read must not repopulate cache after invalidation")
+	}
+
+	value, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode")
+	if err != nil {
+		t.Fatalf("updated setting read: %v", err)
+	}
+	if value != "rag" {
+		t.Fatalf("updated file mode = %q, want rag", value)
+	}
+}
+
+func TestConversationSettingsCacheSurvivesFailedUpsert(t *testing.T) {
+	const userID uint = 18
+	ctx := context.Background()
+	base := &mutableUserSettingsRepository{
+		values: map[uint]map[string]string{
+			userID: {
+				"chat.file_mode": "auto",
+			},
+		},
+	}
+	repo := &failingUpsertUserSettingsRepository{mutableUserSettingsRepository: base}
+	conversationService := &Service{repo: repo}
+	settingsService := appusersettings.NewService(repo)
+	settingsService.SetCacheInvalidator(conversationService.InvalidateUserSettingCache)
+
+	if got, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode"); err != nil || got != "auto" {
+		t.Fatalf("initial cached file mode = %q (err %v), want auto", got, err)
+	}
+
+	// 模拟外部 DB 写入；若缓存被误失效则下一次读取会拿到新值。
+	base.setValue(userID, "chat.file_mode", "rag")
+
+	if _, err := settingsService.PatchSettings(ctx, userID, map[string]string{
+		"chat.file_mode": "full_context",
+	}); err == nil {
+		t.Fatal("expected patch settings to fail")
+	}
+
+	if got, err := conversationService.getUserSettingCached(ctx, userID, "chat.file_mode"); err != nil || got != "auto" {
+		t.Fatalf("cached file mode after failed upsert = %q (err %v), want auto from cache", got, err)
+	}
+}

--- a/backend/internal/application/usersettings/service.go
+++ b/backend/internal/application/usersettings/service.go
@@ -113,12 +113,18 @@ func IsValidationError(err error) bool {
 
 // Service 封装用户配置业务逻辑。
 type Service struct {
-	repo repository.UserSettingsRepository
+	repo             repository.UserSettingsRepository
+	cacheInvalidator func(userID uint, keys []string)
 }
 
 // NewService 创建服务。
 func NewService(repo repository.UserSettingsRepository) *Service {
 	return &Service{repo: repo}
+}
+
+// SetCacheInvalidator 注入缓存失效回调。每当用户设置写入成功后调用，通知上层清除本地缓存。
+func (s *Service) SetCacheInvalidator(fn func(userID uint, keys []string)) {
+	s.cacheInvalidator = fn
 }
 
 // ListSettings 返回指定用户的全部配置，缺失的 key 用默认值填充。
@@ -162,6 +168,13 @@ func (s *Service) PatchSettings(ctx context.Context, userID uint, patches map[st
 	}
 	if err := s.repo.Upsert(ctx, items); err != nil {
 		return nil, err
+	}
+	if s.cacheInvalidator != nil {
+		keys := make([]string, 0, len(items))
+		for _, item := range items {
+			keys = append(keys, item.Key)
+		}
+		s.cacheInvalidator(userID, keys)
 	}
 	return s.ListSettings(ctx, userID)
 }

--- a/backend/internal/application/usersettings/service.go
+++ b/backend/internal/application/usersettings/service.go
@@ -113,8 +113,8 @@ func IsValidationError(err error) bool {
 
 // Service 封装用户配置业务逻辑。
 type Service struct {
-	repo             repository.UserSettingsRepository
-	cacheInvalidator func(userID uint, keys []string)
+	repo           repository.UserSettingsRepository
+	cacheRefresher func(ctx context.Context, userID uint, keys []string)
 }
 
 // NewService 创建服务。
@@ -122,9 +122,9 @@ func NewService(repo repository.UserSettingsRepository) *Service {
 	return &Service{repo: repo}
 }
 
-// SetCacheInvalidator 注入缓存失效回调。每当用户设置写入成功后调用，通知上层清除本地缓存。
-func (s *Service) SetCacheInvalidator(fn func(userID uint, keys []string)) {
-	s.cacheInvalidator = fn
+// SetCacheRefresher 注入缓存刷新回调。用户设置写入成功后，以数据库已提交值刷新相关缓存。
+func (s *Service) SetCacheRefresher(fn func(ctx context.Context, userID uint, keys []string)) {
+	s.cacheRefresher = fn
 }
 
 // ListSettings 返回指定用户的全部配置，缺失的 key 用默认值填充。
@@ -169,12 +169,12 @@ func (s *Service) PatchSettings(ctx context.Context, userID uint, patches map[st
 	if err := s.repo.Upsert(ctx, items); err != nil {
 		return nil, err
 	}
-	if s.cacheInvalidator != nil {
+	if s.cacheRefresher != nil {
 		keys := make([]string, 0, len(items))
 		for _, item := range items {
 			keys = append(keys, item.Key)
 		}
-		s.cacheInvalidator(userID, keys)
+		s.cacheRefresher(ctx, userID, keys)
 	}
 	return s.ListSettings(ctx, userID)
 }

--- a/backend/internal/infra/cache/memory/cache.go
+++ b/backend/internal/infra/cache/memory/cache.go
@@ -13,7 +13,9 @@ type Cache struct {
 	mu  sync.Mutex
 	ops uint64
 
-	settings map[string]expiringString
+	settings            map[string]expiringString
+	userSettings        map[string]expiringString
+	userSettingVersions map[string]expiringString
 
 	fileSeq      int64
 	fileQueue    []repository.FileProcessingMessage
@@ -52,6 +54,8 @@ type expiringRAG struct {
 func New() *Cache {
 	return &Cache{
 		settings:                 map[string]expiringString{},
+		userSettings:             map[string]expiringString{},
+		userSettingVersions:      map[string]expiringString{},
 		fileInflight:             map[string]repository.FileProcessingMessage{},
 		fileNotify:               make(chan struct{}),
 		rag:                      map[string]expiringRAG{},

--- a/backend/internal/infra/cache/memory/maintenance.go
+++ b/backend/internal/infra/cache/memory/maintenance.go
@@ -22,6 +22,16 @@ func (c *Cache) sweepExpiredLocked(now time.Time) {
 			delete(c.settings, key)
 		}
 	}
+	for key, item := range c.userSettings {
+		if now.After(item.expiresAt) {
+			delete(c.userSettings, key)
+		}
+	}
+	for key, item := range c.userSettingVersions {
+		if now.After(item.expiresAt) {
+			delete(c.userSettingVersions, key)
+		}
+	}
 	for key, item := range c.rag {
 		if now.After(item.expiresAt) {
 			delete(c.rag, key)

--- a/backend/internal/infra/cache/memory/user_settings.go
+++ b/backend/internal/infra/cache/memory/user_settings.go
@@ -1,0 +1,72 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func (c *Cache) GetUserSettingCacheVersion(_ context.Context, userID uint, key string, ttl time.Duration) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	cacheKey := userSettingVersionKey(userID, key)
+	item, ok := c.userSettingVersions[cacheKey]
+	if ok && now.Before(item.expiresAt) {
+		item.expiresAt = ttlFromNow(ttl)
+		c.userSettingVersions[cacheKey] = item
+		return item.value, nil
+	}
+	version := uuid.NewString()
+	c.userSettingVersions[cacheKey] = expiringString{value: version, expiresAt: ttlFromNow(ttl)}
+	c.maybeSweepLocked(now)
+	return version, nil
+}
+
+func (c *Cache) AdvanceUserSettingCacheVersion(_ context.Context, userID uint, key string, ttl time.Duration) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cacheKey := userSettingVersionKey(userID, key)
+	version := uuid.NewString()
+	c.userSettingVersions[cacheKey] = expiringString{value: version, expiresAt: ttlFromNow(ttl)}
+	c.maybeSweepLocked(time.Now())
+	return version, nil
+}
+
+func (c *Cache) GetUserSettingCache(_ context.Context, userID uint, key, version string) (string, bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	cacheKey := userSettingValueKey(userID, key, version)
+	item, ok := c.userSettings[cacheKey]
+	if !ok {
+		return "", false, nil
+	}
+	if !now.Before(item.expiresAt) {
+		delete(c.userSettings, cacheKey)
+		return "", false, nil
+	}
+	return item.value, true, nil
+}
+
+func (c *Cache) SetUserSettingCache(_ context.Context, userID uint, key, version, value string, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	c.userSettings[userSettingValueKey(userID, key, version)] = expiringString{
+		value:     value,
+		expiresAt: ttlFromNow(ttl),
+	}
+	c.maybeSweepLocked(now)
+	return nil
+}
+
+func userSettingVersionKey(userID uint, key string) string {
+	return fmt.Sprintf("%d:%s", userID, key)
+}
+
+func userSettingValueKey(userID uint, key, version string) string {
+	return fmt.Sprintf("%d:%s:%s", userID, key, version)
+}

--- a/backend/internal/infra/cache/memory/user_settings_test.go
+++ b/backend/internal/infra/cache/memory/user_settings_test.go
@@ -1,0 +1,74 @@
+package memory
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestUserSettingCacheVersionsIsolateStaleValues(t *testing.T) {
+	ctx := context.Background()
+	cache := New()
+	const userID uint = 7
+	const key = "chat.file_mode"
+
+	initialVersion, err := cache.GetUserSettingCacheVersion(ctx, userID, key, time.Minute)
+	if err != nil {
+		t.Fatalf("get initial version: %v", err)
+	}
+	if err := cache.SetUserSettingCache(ctx, userID, key, initialVersion, "auto", time.Minute); err != nil {
+		t.Fatalf("set initial value: %v", err)
+	}
+	version, err := cache.AdvanceUserSettingCacheVersion(ctx, userID, key, time.Minute)
+	if err != nil || version == "" || version == initialVersion {
+		t.Fatalf("advanced version = %q (err %v), want a new version", version, err)
+	}
+	if value, ok, err := cache.GetUserSettingCache(ctx, userID, key, version); err != nil || ok {
+		t.Fatalf("new version unexpectedly resolved stale value %q (ok %v, err %v)", value, ok, err)
+	}
+	if err := cache.SetUserSettingCache(ctx, userID, key, version, "rag", time.Minute); err != nil {
+		t.Fatalf("set refreshed value: %v", err)
+	}
+	if value, ok, err := cache.GetUserSettingCache(ctx, userID, key, version); err != nil || !ok || value != "rag" {
+		t.Fatalf("refreshed value = %q (ok %v, err %v), want rag", value, ok, err)
+	}
+}
+
+func TestUserSettingCacheConcurrentVersionAdvance(t *testing.T) {
+	ctx := context.Background()
+	cache := New()
+	const advances = 100
+
+	var wg sync.WaitGroup
+	versions := make(chan string, advances)
+	wg.Add(advances)
+	for range advances {
+		go func() {
+			defer wg.Done()
+			version, err := cache.AdvanceUserSettingCacheVersion(ctx, 9, "chat.file_mode", time.Minute)
+			if err != nil {
+				t.Errorf("advance version: %v", err)
+				return
+			}
+			versions <- version
+		}()
+	}
+	wg.Wait()
+	close(versions)
+
+	seen := make(map[string]struct{}, advances)
+	for version := range versions {
+		seen[version] = struct{}{}
+	}
+	if len(seen) != advances {
+		t.Fatalf("unique versions = %d, want %d", len(seen), advances)
+	}
+	current, err := cache.GetUserSettingCacheVersion(ctx, 9, "chat.file_mode", time.Minute)
+	if err != nil {
+		t.Fatalf("get current version: %v", err)
+	}
+	if _, ok := seen[current]; !ok {
+		t.Fatalf("current version %q was not produced by an advance", current)
+	}
+}

--- a/backend/internal/infra/cache/redis/user_settings.go
+++ b/backend/internal/infra/cache/redis/user_settings.go
@@ -1,0 +1,63 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/google/uuid"
+)
+
+var getUserSettingCacheVersionScript = redis.NewScript(`
+local value = redis.call("GET", KEYS[1])
+if value then
+  redis.call("PEXPIRE", KEYS[1], ARGV[2])
+  return value
+end
+redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2])
+return ARGV[1]
+`)
+
+func (c *conversationCache) GetUserSettingCacheVersion(ctx context.Context, userID uint, key string, ttl time.Duration) (string, error) {
+	version := uuid.NewString()
+	return getUserSettingCacheVersionScript.Run(
+		ctx,
+		c.client,
+		[]string{userSettingVersionKey(userID, key)},
+		version,
+		ttl.Milliseconds(),
+	).Text()
+}
+
+func (c *conversationCache) AdvanceUserSettingCacheVersion(ctx context.Context, userID uint, key string, ttl time.Duration) (string, error) {
+	version := uuid.NewString()
+	if err := c.client.Set(ctx, userSettingVersionKey(userID, key), version, ttl).Err(); err != nil {
+		return "", err
+	}
+	return version, nil
+}
+
+func (c *conversationCache) GetUserSettingCache(ctx context.Context, userID uint, key, version string) (string, bool, error) {
+	value, err := c.client.Get(ctx, userSettingValueKey(userID, key, version)).Result()
+	if errors.Is(err, redis.Nil) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return value, true, nil
+}
+
+func (c *conversationCache) SetUserSettingCache(ctx context.Context, userID uint, key, version, value string, ttl time.Duration) error {
+	return c.client.Set(ctx, userSettingValueKey(userID, key, version), value, ttl).Err()
+}
+
+func userSettingVersionKey(userID uint, key string) string {
+	return fmt.Sprintf("conversation:user-setting:{%d}:%s:version", userID, key)
+}
+
+func userSettingValueKey(userID uint, key, version string) string {
+	return fmt.Sprintf("conversation:user-setting:{%d}:%s:value:%s", userID, key, version)
+}

--- a/backend/internal/infra/persistence/postgres/conversation/repository.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository.go
@@ -3368,6 +3368,27 @@ func (r *Repo) GetUserSettingValue(ctx context.Context, userID uint, key string)
 	return item.Value, nil
 }
 
+// GetUserSettingValues 批量查询指定用户的配置值，缺失的 key 返回空字符串。
+func (r *Repo) GetUserSettingValues(ctx context.Context, userID uint, keys []string) (map[string]string, error) {
+	values := make(map[string]string, len(keys))
+	for _, key := range keys {
+		values[key] = ""
+	}
+	if len(keys) == 0 {
+		return values, nil
+	}
+	var items []models.UserSetting
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ? AND key IN ?", userID, keys).
+		Find(&items).Error; err != nil {
+		return nil, translateError(err)
+	}
+	for _, item := range items {
+		values[item.Key] = item.Value
+	}
+	return values, nil
+}
+
 // GetFileObjectsByInternalIDs 按内部主键 ID 批量查询文件对象。
 func (r *Repo) GetFileObjectsByInternalIDs(ctx context.Context, userID uint, ids []uint) ([]domainconversation.FileObject, error) {
 	items := make([]models.FileObject, 0)

--- a/backend/internal/repository/conversation_cache.go
+++ b/backend/internal/repository/conversation_cache.go
@@ -59,9 +59,19 @@ type GenerationStreamCacheRepository interface {
 	ExpireGenerationStream(ctx context.Context, runID string, ttl time.Duration) error
 }
 
+// UserSettingCacheRepository 封装用户会话设置的共享缓存能力。
+// Version 是带 TTL 的不透明令牌；Advance 必须替换当前令牌，数据按令牌隔离。
+type UserSettingCacheRepository interface {
+	GetUserSettingCacheVersion(ctx context.Context, userID uint, key string, ttl time.Duration) (string, error)
+	AdvanceUserSettingCacheVersion(ctx context.Context, userID uint, key string, ttl time.Duration) (string, error)
+	GetUserSettingCache(ctx context.Context, userID uint, key, version string) (value string, ok bool, err error)
+	SetUserSettingCache(ctx context.Context, userID uint, key, version, value string, ttl time.Duration) error
+}
+
 // ConversationCacheRepository 聚合 conversation 领域缓存能力。
 type ConversationCacheRepository interface {
 	FileProcessingQueueRepository
 	RAGCacheRepository
 	GenerationStreamCacheRepository
+	UserSettingCacheRepository
 }

--- a/backend/internal/repository/conversation_file.go
+++ b/backend/internal/repository/conversation_file.go
@@ -121,4 +121,5 @@ func (input UpdateFileObjectProcessingInput) IsZero() bool {
 // ConversationSettingsRepository 封装会话域设置读取能力。
 type ConversationSettingsRepository interface {
 	GetUserSettingValue(ctx context.Context, userID uint, key string) (string, error)
+	GetUserSettingValues(ctx context.Context, userID uint, keys []string) (map[string]string, error)
 }


### PR DESCRIPTION
## Summary

Fixes stale conversation user-setting reads after an update while retaining the existing process-local user settings cache.

Successful updates through `usersettings.Service.PatchSettings` now invalidate only the affected cache entries. Subsequent reads in the same backend process reload the updated values, while unchanged settings retain the existing 10-minute cache behavior.

The cache-fill path also uses shard epochs to prevent an in-flight read that started before invalidation from repopulating the cache with a stale value.

This covers:

* `chat.reasoning_content_passback`
* `chat.context_compact_auto`
* `chat.file_mode`

Regression coverage includes successful targeted invalidation, failed writes retaining cached values, and deterministic prevention of stale cache repopulation from in-flight reads.

Fixes #589

## Change type

* [x] Bug fix
* [ ] Feature
* [ ] Documentation
* [ ] Refactor
* [ ] Configuration / deployment
* [ ] Security hardening
* [ ] Other

## Affected areas

* [ ] Frontend / UI
* [x] Backend / API
* [ ] Authentication / authorization
* [x] Conversations / streaming
* [ ] Files / RAG / extraction
* [ ] Model routing / providers
* [ ] MCP / tools
* [ ] Billing / payments
* [ ] Admin console
* [ ] Deployment / Docker / configuration
* [ ] Documentation

## Verification

* `go -C backend test ./...`

* `go -C backend test -race ./internal/application/conversation/... ./internal/application/usersettings/...`

* `go -C backend test -count=50 ./internal/application/conversation/... -run 'TestConversationSettingsCacheDoesNotRepopulateAfterInvalidation'`

* `pnpm check`

* `pnpm test`

* `pnpm build`

* `git diff --check`

* [ ] Not run; reason:

## Screenshots, API examples, or logs

Not applicable; this change has no UI changes or API contract changes.

## Configuration, migration, and compatibility notes

No configuration changes, database migrations, or API contract changes are required.

The existing process-local user settings cache is retained. Successful settings updates invalidate only the affected cache entries, so subsequent reads in the same backend process reload updated values while unchanged settings retain the existing cache behavior.

Cache invalidation remains process-local, consistent with the repository's existing cache invalidation pattern. Other backend replicas may retain a cached value until its existing 10-minute TTL expires.

## Documentation

* [x] Documentation is not needed for this change.
* [ ] Documentation was updated.
* [ ] Documentation still needs to be updated.

## Security and privacy

* [x] No secrets, tokens, credentials, local config, or personal data are included.
* [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
* [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

* [x] I searched existing issues and pull requests.
* [x] Changes are focused and do not include unrelated refactors.
* [x] Tests or static verification were run where practical.
* [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
* [x] Generated artifacts are included only when this project explicitly requires them.
* [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.
