### PR TITLE
fix: harden identity provider icons and bound query allocations

### DIFF
--- a/backend/internal/application/auth/provider.go
+++ b/backend/internal/application/auth/provider.go
@@ -712,7 +712,7 @@ func isValidProviderLogoURL(value string) bool {
 	if err != nil {
 		return false
 	}
-	if (parsedLogoURL.Scheme == "http" || parsedLogoURL.Scheme == "https") && parsedLogoURL.Host != "" {
+	if (parsedLogoURL.Scheme == "http" || parsedLogoURL.Scheme == "https") && parsedLogoURL.Host != "" && parsedLogoURL.User == nil {
 		return true
 	}
 	return parsedLogoURL.Scheme == "" &&

--- a/backend/internal/application/auth/provider_test.go
+++ b/backend/internal/application/auth/provider_test.go
@@ -102,6 +102,7 @@ func TestNormalizeProviderInputValidatesLogoURL(t *testing.T) {
 		{name: "https url", logoURL: "https://example.com/logo.svg"},
 		{name: "http url", logoURL: "http://example.com/logo.svg"},
 		{name: "absolute path", logoURL: "/identity-providers/acme.svg"},
+		{name: "url credentials", logoURL: "https://user:password@example.com/logo.svg", wantErr: true},
 		{name: "protocol relative url", logoURL: "//example.com/logo.svg", wantErr: true},
 		{name: "data url", logoURL: "data:image/svg+xml,<svg/>", wantErr: true},
 		{name: "javascript url", logoURL: "javascript:alert(1)", wantErr: true},

--- a/backend/internal/application/billing/service.go
+++ b/backend/internal/application/billing/service.go
@@ -22,6 +22,10 @@ import (
 const (
 	defaultPageSize            = 20
 	maxPageSize                = 1000
+	defaultMonthlyUsageMonths  = 12
+	maxMonthlyUsageMonths      = 24
+	defaultDailyUsageDays      = 30
+	maxDailyUsageDays          = 90
 	publicModelPricingCacheTTL = 30 * time.Second
 	nativeToolPricingSource    = "provider_official_defaults"
 )
@@ -2444,10 +2448,10 @@ func normalizePage(page int, pageSize int) (int, int) {
 // ListMonthlyUsage 查询用户月度用量聚合。
 func (s *Service) ListMonthlyUsage(ctx context.Context, userID uint, months int) ([]domainbilling.UsageMonthlySummary, error) {
 	if months <= 0 {
-		months = 12
+		months = defaultMonthlyUsageMonths
 	}
-	if months > 24 {
-		months = 24
+	if months > maxMonthlyUsageMonths {
+		months = maxMonthlyUsageMonths
 	}
 	items, err := s.repo.ListMonthlyUsageByUser(ctx, userID, months)
 	if err != nil {
@@ -2458,7 +2462,10 @@ func (s *Service) ListMonthlyUsage(ctx context.Context, userID uint, months int)
 
 func fillMonthlyUsageSummaries(items []domainbilling.UsageMonthlySummary, months int, now time.Time) []domainbilling.UsageMonthlySummary {
 	if months <= 0 {
-		months = 12
+		months = defaultMonthlyUsageMonths
+	}
+	if months > maxMonthlyUsageMonths {
+		months = maxMonthlyUsageMonths
 	}
 	if now.IsZero() {
 		now = time.Now()
@@ -2475,7 +2482,7 @@ func fillMonthlyUsageSummaries(items []domainbilling.UsageMonthlySummary, months
 		byMonth[month.Format("2006-01")] = item
 	}
 
-	results := make([]domainbilling.UsageMonthlySummary, 0, months)
+	results := make([]domainbilling.UsageMonthlySummary, 0)
 	for month := startMonth; !month.After(currentMonth); month = month.AddDate(0, 1, 0) {
 		if item, ok := byMonth[month.Format("2006-01")]; ok {
 			results = append(results, item)
@@ -2489,10 +2496,10 @@ func fillMonthlyUsageSummaries(items []domainbilling.UsageMonthlySummary, months
 // ListDailyUsage 查询用户每日用量聚合。
 func (s *Service) ListDailyUsage(ctx context.Context, userID uint, days int, now time.Time) ([]domainbilling.UsageDailySummary, error) {
 	if days <= 0 {
-		days = 30
+		days = defaultDailyUsageDays
 	}
-	if days > 90 {
-		days = 90
+	if days > maxDailyUsageDays {
+		days = maxDailyUsageDays
 	}
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	startDate := today.AddDate(0, 0, -(days - 1))
@@ -2507,7 +2514,7 @@ func (s *Service) ListDailyUsage(ctx context.Context, userID uint, days int, now
 	for _, item := range items {
 		byDate[item.UsageDate.Format("2006-01-02")] = item
 	}
-	results := make([]domainbilling.UsageDailySummary, 0, days)
+	results := make([]domainbilling.UsageDailySummary, 0)
 	for day := startDate; day.Before(endDate); day = day.AddDate(0, 0, 1) {
 		if item, ok := byDate[day.Format("2006-01-02")]; ok {
 			results = append(results, item)
@@ -2551,8 +2558,7 @@ func (s *Service) listDailyUsageBetween(ctx context.Context, userID uint, start 
 	for _, item := range items {
 		byDate[item.UsageDate.Format("2006-01-02")] = item
 	}
-	days := int(end.Sub(start).Hours() / 24)
-	results := make([]domainbilling.UsageDailySummary, 0, days)
+	results := make([]domainbilling.UsageDailySummary, 0)
 	for day := start; day.Before(end); day = day.AddDate(0, 0, 1) {
 		if item, ok := byDate[day.Format("2006-01-02")]; ok {
 			results = append(results, item)

--- a/backend/internal/application/billing/service_usage_summary_test.go
+++ b/backend/internal/application/billing/service_usage_summary_test.go
@@ -1,0 +1,16 @@
+package billing
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFillMonthlyUsageSummariesCapsRequestedMonths(t *testing.T) {
+	now := time.Date(2026, time.August, 13, 0, 0, 0, 0, time.UTC)
+
+	items := fillMonthlyUsageSummaries(nil, int(^uint(0)>>1), now)
+
+	if len(items) != maxMonthlyUsageMonths {
+		t.Fatalf("len(items) = %d, want %d", len(items), maxMonthlyUsageMonths)
+	}
+}

--- a/backend/internal/infra/persistence/postgres/billing/repository.go
+++ b/backend/internal/infra/persistence/postgres/billing/repository.go
@@ -919,7 +919,7 @@ func (r *Repo) ListRedemptionCodes(ctx context.Context, filter repository.Redemp
 	if limit > 200 {
 		limit = 200
 	}
-	items := make([]model.RedemptionCode, 0, limit)
+	items := make([]model.RedemptionCode, 0)
 	var total int64
 	query := r.db.WithContext(ctx).Model(&model.RedemptionCode{})
 	if len(filter.Modes) > 0 {
@@ -1857,7 +1857,7 @@ func (r *Repo) ListMonthlyUsageByUser(ctx context.Context, userID uint, limit in
 		BilledNanousd    int64  `gorm:"column:billed_nanousd"`
 	}
 
-	rows := make([]monthlyUsageRow, 0, limit)
+	rows := make([]monthlyUsageRow, 0)
 	monthKeyExpression := r.usageMonthKeyExpression()
 	if err := r.db.WithContext(ctx).
 		Model(&model.UsageLedger{}).

--- a/backend/internal/infra/persistence/postgres/conversation/repository.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository.go
@@ -20,6 +20,12 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+const (
+	defaultMessageQueryLimit = 20
+	maxMessageQueryLimit     = 1000
+	maxAncestorQueryDepth    = 2000
+)
+
 // translateError 将 gorm 底层错误统一映射为仓储语义错误。
 func translateError(err error) error {
 	if err == nil {
@@ -176,7 +182,7 @@ func (r *Repo) ListConversationsForSearch(
 	limit int,
 	searchQuery string,
 ) ([]domainconversation.Conversation, error) {
-	items := make([]models.Conversation, 0, limit)
+	items := make([]models.Conversation, 0)
 	query := r.db.WithContext(ctx).
 		Model(&models.Conversation{}).
 		Where("user_id = ?", userID)
@@ -1438,9 +1444,12 @@ func (r *Repo) ListMessages(ctx context.Context, conversationID uint, offset int
 // ListMessagesBeforeID 查询指定消息 ID 之前的一页会话消息（按时间升序返回）。
 func (r *Repo) ListMessagesBeforeID(ctx context.Context, conversationID uint, beforeID uint, limit int) ([]domainconversation.Message, int64, error) {
 	if limit <= 0 {
-		limit = 20
+		limit = defaultMessageQueryLimit
 	}
-	items := make([]models.Message, 0, limit)
+	if limit > maxMessageQueryLimit {
+		limit = maxMessageQueryLimit
+	}
+	items := make([]models.Message, 0)
 	var total int64
 
 	if err := r.db.WithContext(ctx).
@@ -2133,6 +2142,9 @@ func (r *Repo) ListMessageAncestors(ctx context.Context, conversationID uint, le
 	if maxDepth <= 0 {
 		maxDepth = 40
 	}
+	if maxDepth > maxAncestorQueryDepth {
+		maxDepth = maxAncestorQueryDepth
+	}
 
 	// WITH RECURSIVE：从叶节点沿 parent_message_id 向上递归，_depth 用于限制深度。
 	// 外层用 SELECT * 取全部列：GORM Scan 按列名映射并忽略未匹配的列，_depth 会被自然丢弃，
@@ -2157,7 +2169,7 @@ WITH RECURSIVE ancestors AS (
 SELECT * FROM ancestors
 ORDER BY id ASC`
 
-	path := make([]models.Message, 0, maxDepth)
+	path := make([]models.Message, 0)
 	if err := r.db.WithContext(ctx).Raw(cteSQL, leafMessageID, conversationID, maxDepth, conversationID).Scan(&path).Error; err != nil {
 		return nil, translateError(err)
 	}
@@ -2181,8 +2193,14 @@ func (r *Repo) ListLatestBranchPreviewMessages(
 	if maxDepth <= 0 {
 		maxDepth = 100
 	}
+	if maxDepth > maxAncestorQueryDepth {
+		maxDepth = maxAncestorQueryDepth
+	}
 	if limit <= 0 {
 		limit = 10
+	}
+	if limit > maxMessageQueryLimit {
+		limit = maxMessageQueryLimit
 	}
 
 	type previewMessageRow struct {
@@ -2192,7 +2210,7 @@ func (r *Repo) ListLatestBranchPreviewMessages(
 		Content      string `gorm:"column:content"`
 		ErrorMessage string `gorm:"column:error_message"`
 	}
-	rows := make([]previewMessageRow, 0, limit)
+	rows := make([]previewMessageRow, 0)
 	const previewSQL = `
 WITH RECURSIVE ancestors AS (
     SELECT id, conversation_id, parent_message_id, public_id, role, content, error_message, 1 AS depth
@@ -2249,6 +2267,9 @@ func (r *Repo) ListMessageAncestorsUntil(ctx context.Context, conversationID uin
 	if maxDepth <= 0 {
 		maxDepth = 200
 	}
+	if maxDepth > maxAncestorQueryDepth {
+		maxDepth = maxAncestorQueryDepth
+	}
 	if leafMessageID == 0 || stopMessageID == 0 {
 		return nil, false, repository.ErrInvalidInput
 	}
@@ -2271,7 +2292,7 @@ WITH RECURSIVE ancestors AS (
 SELECT * FROM ancestors
 ORDER BY id ASC`
 
-	path := make([]models.Message, 0, maxDepth)
+	path := make([]models.Message, 0)
 	if err := r.db.WithContext(ctx).Raw(cteSQL, leafMessageID, conversationID, maxDepth, stopMessageID, conversationID).Scan(&path).Error; err != nil {
 		return nil, false, translateError(err)
 	}
@@ -2295,7 +2316,10 @@ ORDER BY id ASC`
 // ListRecentMessages 查询会话最近消息窗口（按时间升序返回）。
 func (r *Repo) ListRecentMessages(ctx context.Context, conversationID uint, limit int) ([]domainconversation.Message, int64, error) {
 	if limit <= 0 {
-		limit = 20
+		limit = defaultMessageQueryLimit
+	}
+	if limit > maxMessageQueryLimit {
+		limit = maxMessageQueryLimit
 	}
 	var total int64
 	if err := r.db.WithContext(ctx).
@@ -2308,7 +2332,7 @@ func (r *Repo) ListRecentMessages(ctx context.Context, conversationID uint, limi
 	if offset < 0 {
 		offset = 0
 	}
-	items := make([]models.Message, 0, limit)
+	items := make([]models.Message, 0)
 	if err := r.db.WithContext(ctx).
 		Where("conversation_id = ?", conversationID).
 		Order("id ASC").

--- a/frontend/shared/components/identity-provider-icon.tsx
+++ b/frontend/shared/components/identity-provider-icon.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import {
   resolveIdentityProviderIconScale,
   resolveIdentityProviderIconURL,
+  resolveSafeIdentityProviderIconURL,
   shouldInvertIdentityProviderIcon,
 } from "@/shared/lib/identity-provider-icons";
 import { cn } from "@/lib/utils";
@@ -24,7 +25,7 @@ export function IdentityProviderIcon({
   iconClassName?: string;
   fallbackClassName?: string;
 }) {
-  const customLogoURL = logoURL?.trim() ?? "";
+  const customLogoURL = resolveSafeIdentityProviderIconURL(logoURL);
   const defaultIconURL = resolveIdentityProviderIconURL(name, slug);
   const iconCandidates = React.useMemo(
     () => [customLogoURL, defaultIconURL].filter((value): value is string => Boolean(value)),

--- a/frontend/shared/lib/identity-provider-icons.ts
+++ b/frontend/shared/lib/identity-provider-icons.ts
@@ -33,6 +33,34 @@ export function resolveIdentityProviderIconURL(name: string, slug: string): stri
   return resolveModelIconURL(icon);
 }
 
+export function resolveSafeIdentityProviderIconURL(value: string | null | undefined): string {
+  const normalized = value?.trim() ?? "";
+  if (!normalized) {
+    return "";
+  }
+  for (const character of normalized) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (codePoint <= 0x1f || codePoint === 0x7f) {
+      return "";
+    }
+  }
+
+  if (normalized.startsWith("/") && !normalized.startsWith("//") && !normalized.includes("\\")) {
+    const parsed = new URL(normalized, "https://identity-provider.local");
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    if ((parsed.protocol === "https:" || parsed.protocol === "http:") && parsed.hostname && !parsed.username && !parsed.password) {
+      return parsed.href;
+    }
+  } catch {
+    // Invalid and relative URLs are intentionally rejected.
+  }
+  return "";
+}
+
 export function resolveIdentityProviderIconScale(name: string, slug: string): number {
   const icon = resolveIdentityProviderIconKey(name, slug);
   if (icon === "x") return 0.78;


### PR DESCRIPTION
## Summary

- Validate identity provider logo URLs before rendering them in the DOM.
- Allow only HTTP(S) URLs and root-relative paths while rejecting dangerous protocols, protocol-relative URLs, credentials, control characters, and malformed paths.
- Align backend logo URL validation with frontend rendering rules.
- Fall back to the built-in provider icon or provider initial when a custom logo URL is invalid.
- Remove user-controlled values from Go slice capacity allocations.
- Add repository-level limits for message queries and ancestor traversal as defense in depth.
- Cap monthly and daily usage aggregation ranges inside the allocation functions.
- Cover oversized monthly usage input and credential-bearing logo URLs with tests.
- Resolve the reported CodeQL DOM reinterpretation and excessive slice allocation findings.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [x] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [x] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [x] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] Full backend test suite: `go test ./...`
- [x] Backend version check and `go vet ./...`
- [x] Frontend lint and TypeScript typecheck
- [x] API contract generated-output check and typecheck
- [x] Frontend Turbopack production build
- [x] `git diff --check`

## Screenshots, API examples, or logs

Not applicable.

## Configuration, migration, and compatibility notes

- No database migrations, environment variables, or API schema changes are required.
- Message query limits remain inclusive:
  - Requests for exactly 1,000 messages are supported.
  - Values above 1,000 are capped at 1,000.
- Ancestor traversal supports up to 2,000 messages.
- Monthly usage aggregation is capped at 24 months.
- Daily usage aggregation is capped at 90 days.
- Redemption-code queries remain capped at 200 records.
- Invalid historical provider logo URLs now fall back to the built-in icon or provider initial.
- Ordinary relative logo paths such as `icons/logo.svg` must use a root-relative form such as `/icons/logo.svg`.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local configuration, or personal data are included.
- [x] Untrusted logo URLs are validated before reaching DOM image sources.
- [x] Credential-bearing and dangerous URL forms are rejected consistently by the frontend and backend.
- [x] User-provided values no longer control Go slice allocation sizes.
- [x] Repository-level query limits protect internal callers that bypass application-level normalization.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests and static verification were run where practical.
- [x] Security-sensitive rendering and allocation paths were reviewed.
- [x] User-facing compatibility behavior is documented.
- [x] Generated artifacts are included only when explicitly required.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.