### PR TITLE
fix: preserve in progress assistant output across conversation reconnects

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -9066,6 +9066,12 @@ const docTemplate = `{
                         "description": "已接收的最后事件序号",
                         "name": "after",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "是否返回可替换当前正文的权威文本快照",
+                        "name": "snapshot",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -9059,6 +9059,12 @@
                         "description": "已接收的最后事件序号",
                         "name": "after",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "是否返回可替换当前正文的权威文本快照",
+                        "name": "snapshot",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -14628,6 +14628,10 @@ paths:
         in: query
         name: after
         type: integer
+      - description: 是否返回可替换当前正文的权威文本快照
+        in: query
+        name: snapshot
+        type: boolean
       produces:
       - application/x-ndjson
       responses:

--- a/backend/internal/application/conversation/generation_stream.go
+++ b/backend/internal/application/conversation/generation_stream.go
@@ -86,8 +86,9 @@ func (s *Service) SubscribeMessageGeneration(
 	userID uint,
 	runID string,
 	afterSeq int64,
+	includeTextSnapshot bool,
 ) ([]GenerationStreamEvent, <-chan GenerationStreamEvent, func(), bool) {
-	return s.generationStreams.subscribe(ctx, userID, normalizeRunID(runID), afterSeq)
+	return s.generationStreams.subscribe(ctx, userID, normalizeRunID(runID), afterSeq, includeTextSnapshot)
 }
 
 // FinishMessageGeneration 标记生成流结束，并在短期恢复窗口后释放事件缓存。
@@ -293,7 +294,11 @@ func (r *generationStreamRegistry) publish(ctx context.Context, runID string, pa
 	if err != nil {
 		return actual
 	}
-	record, err := r.append(ctx, r.store, runID, payloadJSON)
+	appendInput := repository.GenerationStreamAppend{PayloadJSON: payloadJSON}
+	if streamString(persisted["type"]) == "delta" {
+		appendInput.TextDelta = streamString(persisted["delta"])
+	}
+	record, err := r.append(ctx, r.store, runID, appendInput)
 	if err == nil && record.Seq > 0 {
 		actual["seq"] = record.Seq
 		if sanitized {
@@ -314,11 +319,11 @@ func (r *generationStreamRegistry) resetEvents(ctx context.Context, runID string
 	_ = r.store.ResetGenerationStreamEvents(ctx, runID)
 }
 
-func (r *generationStreamRegistry) append(ctx context.Context, store repository.GenerationStreamCacheRepository, runID string, payloadJSON string) (repository.GenerationStreamMessage, error) {
+func (r *generationStreamRegistry) append(ctx context.Context, store repository.GenerationStreamCacheRepository, runID string, input repository.GenerationStreamAppend) (repository.GenerationStreamMessage, error) {
 	if store == nil {
 		return repository.GenerationStreamMessage{}, nil
 	}
-	return store.AppendGenerationStreamEvent(ctx, runID, payloadJSON, int64(r.options.MaxEvents), r.options.ActiveTTL)
+	return store.AppendGenerationStreamEvent(ctx, runID, input, int64(r.options.MaxEvents), r.options.ActiveTTL)
 }
 
 func (r *generationStreamRegistry) subscribe(
@@ -326,11 +331,12 @@ func (r *generationStreamRegistry) subscribe(
 	userID uint,
 	runID string,
 	afterSeq int64,
+	includeTextSnapshot bool,
 ) ([]GenerationStreamEvent, <-chan GenerationStreamEvent, func(), bool) {
 	if runID == "" {
 		return nil, nil, nil, false
 	}
-	return r.subscribeStore(ctx, r.store, userID, runID, afterSeq)
+	return r.subscribeStore(ctx, r.store, userID, runID, afterSeq, includeTextSnapshot)
 }
 
 func (r *generationStreamRegistry) subscribeStore(
@@ -339,6 +345,7 @@ func (r *generationStreamRegistry) subscribeStore(
 	userID uint,
 	runID string,
 	afterSeq int64,
+	includeTextSnapshot bool,
 ) ([]GenerationStreamEvent, <-chan GenerationStreamEvent, func(), bool) {
 	if store == nil || !r.authorized(ctx, store, runID, userID) {
 		return nil, nil, nil, false
@@ -347,7 +354,21 @@ func (r *generationStreamRegistry) subscribeStore(
 	if err != nil {
 		return nil, nil, nil, false
 	}
-	replay, cursor, terminal := retainedStreamEvents(retained, afterSeq)
+	textSnapshot := repository.GenerationStreamTextSnapshot{}
+	hasTextSnapshot := false
+	if includeTextSnapshot {
+		// Read the snapshot after the retained window. Events appended in between
+		// are read again from cursor; visible deltas already covered by the snapshot
+		// are filtered by snapshot seq while non-text events remain replayable.
+		textSnapshot, hasTextSnapshot, err = store.GetGenerationStreamTextSnapshot(ctx, runID)
+		if err != nil {
+			return nil, nil, nil, false
+		}
+	}
+	replay, cursor, terminal, safe := retainedStreamEvents(retained, afterSeq, textSnapshot, hasTextSnapshot, includeTextSnapshot)
+	if !safe {
+		return nil, nil, nil, false
+	}
 	events := make(chan GenerationStreamEvent, r.options.SubscriberBuffer)
 	if terminal {
 		close(events)
@@ -355,7 +376,7 @@ func (r *generationStreamRegistry) subscribeStore(
 	}
 
 	readCtx, cancel := context.WithCancel(ctx)
-	go r.readStoreEvents(readCtx, store, runID, cursor, afterSeq, events)
+	go r.readStoreEvents(readCtx, store, runID, cursor, afterSeq, textSnapshot.Seq, events)
 	return replay, events, cancel, true
 }
 
@@ -365,6 +386,7 @@ func (r *generationStreamRegistry) readStoreEvents(
 	runID string,
 	cursor string,
 	afterSeq int64,
+	textSnapshotSeq int64,
 	out chan<- GenerationStreamEvent,
 ) {
 	defer close(out)
@@ -390,6 +412,9 @@ func (r *generationStreamRegistry) readStoreEvents(
 			}
 			event, ok := decodeStreamRecord(record)
 			if !ok {
+				continue
+			}
+			if streamString(event.Payload["type"]) == "delta" && event.Seq <= textSnapshotSeq {
 				continue
 			}
 			afterSeq = event.Seq
@@ -541,10 +566,32 @@ func stopActiveGeneration(active *activeGeneration) {
 	}
 }
 
-func retainedStreamEvents(records []repository.GenerationStreamMessage, afterSeq int64) ([]GenerationStreamEvent, string, bool) {
+func retainedStreamEvents(
+	records []repository.GenerationStreamMessage,
+	afterSeq int64,
+	textSnapshot repository.GenerationStreamTextSnapshot,
+	hasTextSnapshot bool,
+	includeTextSnapshot bool,
+) ([]GenerationStreamEvent, string, bool, bool) {
 	replay := make([]GenerationStreamEvent, 0)
 	cursor := "0-0"
 	terminal := false
+	snapshotPending := includeTextSnapshot && hasTextSnapshot
+	appendTextSnapshot := func() {
+		if !snapshotPending {
+			return
+		}
+		replay = append(replay, GenerationStreamEvent{
+			Seq: textSnapshot.Seq,
+			Payload: map[string]interface{}{
+				"type":    "delta",
+				"seq":     textSnapshot.Seq,
+				"delta":   textSnapshot.Content,
+				"replace": true,
+			},
+		})
+		snapshotPending = false
+	}
 	for _, record := range records {
 		if strings.TrimSpace(record.ID) != "" {
 			cursor = record.ID
@@ -553,14 +600,28 @@ func retainedStreamEvents(records []repository.GenerationStreamMessage, afterSeq
 		if !ok {
 			continue
 		}
+		if snapshotPending && event.Seq > textSnapshot.Seq {
+			appendTextSnapshot()
+		}
 		if isTerminalStreamPayload(event.Payload) {
 			terminal = true
+		}
+		if streamString(event.Payload["type"]) == "delta" {
+			// A text delta without a cumulative checkpoint cannot be replayed
+			// safely once the bounded event window has trimmed older chunks.
+			if includeTextSnapshot && !hasTextSnapshot {
+				return nil, cursor, terminal, false
+			}
+			if includeTextSnapshot && event.Seq <= textSnapshot.Seq {
+				continue
+			}
 		}
 		if event.Seq > afterSeq {
 			replay = append(replay, event)
 		}
 	}
-	return replay, cursor, terminal
+	appendTextSnapshot()
+	return replay, cursor, terminal, true
 }
 
 func decodeStreamRecord(record repository.GenerationStreamMessage) (GenerationStreamEvent, bool) {

--- a/backend/internal/application/conversation/generation_stream_test.go
+++ b/backend/internal/application/conversation/generation_stream_test.go
@@ -31,28 +31,194 @@ func TestGenerationStreamRegistryReplayAndTerminal(t *testing.T) {
 		t.Fatalf("unexpected seq values: first=%v second=%v", first["seq"], second["seq"])
 	}
 
-	replay, events, unsubscribe, ok := registry.subscribe(ctx, 7, runID, 1)
+	replay, events, unsubscribe, ok := registry.subscribe(ctx, 7, runID, 1, true)
 	if !ok {
 		t.Fatal("expected subscription to existing run")
 	}
 	defer unsubscribe()
-	if len(replay) != 1 || replay[0].Seq != 2 {
+	if len(replay) != 2 || replay[0].Seq != 1 || replay[0].Payload["type"] != "delta" || replay[0].Payload["delta"] != "a" || replay[0].Payload["replace"] != true || replay[1].Seq != 2 {
 		t.Fatalf("unexpected replay events: %+v", replay)
 	}
 	if _, ok := <-events; ok {
 		t.Fatal("terminal replay should close live event channel")
 	}
 
-	replay, events, unsubscribe, ok = registry.subscribe(ctx, 7, runID, 2)
+	replay, events, unsubscribe, ok = registry.subscribe(ctx, 7, runID, 2, true)
 	if !ok {
 		t.Fatal("expected subscription after terminal seq to existing run")
 	}
 	defer unsubscribe()
-	if len(replay) != 0 {
+	if len(replay) != 1 || replay[0].Payload["type"] != "delta" || replay[0].Payload["delta"] != "a" || replay[0].Payload["replace"] != true {
 		t.Fatalf("unexpected replay after terminal seq: %+v", replay)
 	}
 	if _, ok := <-events; ok {
 		t.Fatal("terminal state should close live event channel after last seq")
+	}
+}
+
+func TestGenerationStreamRegistryReplayUsesFullTextSnapshotBeyondWindow(t *testing.T) {
+	registry := newGenerationStreamRegistry(newTestGenerationStreamStore(), generationStreamOptions{
+		Retention:        time.Minute,
+		ActiveTTL:        time.Minute,
+		MaxEvents:        3,
+		SubscriberBuffer: 4,
+	})
+	ctx := context.Background()
+	runID := EnsureMessageGenerationRunID("")
+	registry.register(ctx, runID, 7, func() {})
+	defer registry.finish(ctx, runID)
+
+	for _, delta := range []string{"a", "b", "c", "d", "e", "f"} {
+		registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": delta})
+	}
+
+	replay, _, unsubscribe, ok := registry.subscribe(ctx, 7, runID, 0, true)
+	if !ok {
+		t.Fatal("expected long stream to remain resumable")
+	}
+	defer unsubscribe()
+	if len(replay) != 1 || replay[0].Payload["type"] != "delta" || replay[0].Payload["delta"] != "abcdef" || replay[0].Payload["replace"] != true || replay[0].Seq != 6 {
+		t.Fatalf("expected one complete text snapshot, got %+v", replay)
+	}
+}
+
+func TestGenerationStreamRegistryLegacyReplayKeepsOriginalDeltaProtocol(t *testing.T) {
+	registry := newGenerationStreamRegistry(newTestGenerationStreamStore(), generationStreamOptions{
+		Retention:        time.Minute,
+		ActiveTTL:        time.Minute,
+		MaxEvents:        8,
+		SubscriberBuffer: 4,
+	})
+	ctx := context.Background()
+	runID := EnsureMessageGenerationRunID("")
+	registry.register(ctx, runID, 7, func() {})
+	defer registry.finish(ctx, runID)
+	registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": "legacy"})
+
+	replay, _, unsubscribe, ok := registry.subscribe(ctx, 7, runID, 0, false)
+	if !ok {
+		t.Fatal("expected legacy subscription")
+	}
+	defer unsubscribe()
+	if len(replay) != 1 || replay[0].Payload["delta"] != "legacy" {
+		t.Fatalf("unexpected legacy replay: %+v", replay)
+	}
+	if _, exists := replay[0].Payload["replace"]; exists {
+		t.Fatalf("legacy replay unexpectedly received snapshot semantics: %+v", replay)
+	}
+}
+
+func TestGenerationStreamRegistrySnapshotThenLiveDeltaExactlyOnce(t *testing.T) {
+	registry := newGenerationStreamRegistry(newTestGenerationStreamStore(), generationStreamOptions{
+		Retention:        time.Minute,
+		ActiveTTL:        time.Minute,
+		MaxEvents:        3,
+		SubscriberBuffer: 4,
+	})
+	ctx := context.Background()
+	runID := EnsureMessageGenerationRunID("")
+	registry.register(ctx, runID, 7, func() {})
+	defer registry.finish(ctx, runID)
+	registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": "a"})
+	registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": "b"})
+
+	replay, events, unsubscribe, ok := registry.subscribe(ctx, 7, runID, 0, true)
+	if !ok {
+		t.Fatal("expected subscription")
+	}
+	defer unsubscribe()
+	if len(replay) != 1 || replay[0].Payload["delta"] != "ab" || replay[0].Payload["replace"] != true {
+		t.Fatalf("unexpected snapshot replay: %+v", replay)
+	}
+
+	registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": "c"})
+	select {
+	case event := <-events:
+		if event.Payload["type"] != "delta" || event.Payload["delta"] != "c" || event.Seq != 3 {
+			t.Fatalf("unexpected live event: %+v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for live delta")
+	}
+}
+
+func TestGenerationStreamRegistryKeepsNonTextReplayInSequenceOrder(t *testing.T) {
+	registry := newGenerationStreamRegistry(newTestGenerationStreamStore(), generationStreamOptions{
+		Retention:        time.Minute,
+		ActiveTTL:        time.Minute,
+		MaxEvents:        8,
+		SubscriberBuffer: 4,
+	})
+	ctx := context.Background()
+	runID := EnsureMessageGenerationRunID("")
+	registry.register(ctx, runID, 7, func() {})
+	defer registry.finish(ctx, runID)
+	registry.publish(ctx, runID, map[string]interface{}{"type": "file_proc", "message": "preparing"})
+	registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": "answer"})
+	registry.publish(ctx, runID, map[string]interface{}{"type": "usage", "output_tokens": 1})
+
+	replay, _, unsubscribe, ok := registry.subscribe(ctx, 7, runID, 0, true)
+	if !ok {
+		t.Fatal("expected subscription")
+	}
+	defer unsubscribe()
+	if len(replay) != 3 ||
+		replay[0].Seq != 1 || replay[0].Payload["type"] != "file_proc" ||
+		replay[1].Seq != 2 || replay[1].Payload["replace"] != true ||
+		replay[2].Seq != 3 || replay[2].Payload["type"] != "usage" {
+		t.Fatalf("unexpected ordered replay: %+v", replay)
+	}
+}
+
+func TestGenerationStreamRegistryRejectsTextReplayWithoutSnapshot(t *testing.T) {
+	store := newTestGenerationStreamStore()
+	registry := newGenerationStreamRegistry(store, generationStreamOptions{
+		Retention:        time.Minute,
+		ActiveTTL:        time.Minute,
+		MaxEvents:        3,
+		SubscriberBuffer: 4,
+	})
+	ctx := context.Background()
+	runID := EnsureMessageGenerationRunID("")
+	registry.register(ctx, runID, 7, func() {})
+	defer registry.finish(ctx, runID)
+	if _, err := store.AppendGenerationStreamEvent(ctx, runID, repository.GenerationStreamAppend{
+		PayloadJSON: `{"type":"delta","delta":"unsafe"}`,
+	}, 3, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, _, ok := registry.subscribe(ctx, 7, runID, 0, true); ok {
+		t.Fatal("expected replay without an authoritative text snapshot to be rejected")
+	}
+}
+
+func TestGenerationStreamRegistryResetClearsTextSnapshot(t *testing.T) {
+	store := newTestGenerationStreamStore()
+	registry := newGenerationStreamRegistry(store, generationStreamOptions{
+		Retention:        time.Minute,
+		ActiveTTL:        time.Minute,
+		MaxEvents:        3,
+		SubscriberBuffer: 4,
+	})
+	ctx := context.Background()
+	runID := EnsureMessageGenerationRunID("")
+	registry.register(ctx, runID, 7, func() {})
+	defer registry.finish(ctx, runID)
+	registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": "blocked text"})
+	registry.resetEvents(ctx, runID)
+	registry.publish(ctx, runID, map[string]interface{}{"type": "moderation_blocked"})
+
+	replay, events, unsubscribe, ok := registry.subscribe(ctx, 7, runID, 0, true)
+	if !ok {
+		t.Fatal("expected blocked stream to remain subscribable")
+	}
+	defer unsubscribe()
+	if len(replay) != 1 || replay[0].Payload["type"] != "moderation_blocked" {
+		t.Fatalf("blocked content was retained after reset: %+v", replay)
+	}
+	if _, ok := <-events; ok {
+		t.Fatal("expected moderation block to terminate replay")
 	}
 }
 
@@ -145,7 +311,7 @@ func TestGenerationStreamStoreReturnsLatestWindow(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := 0; i < 5; i++ {
-		if _, err := store.AppendGenerationStreamEvent(ctx, runID, `{"type":"delta"}`, 3, time.Minute); err != nil {
+		if _, err := store.AppendGenerationStreamEvent(ctx, runID, repository.GenerationStreamAppend{PayloadJSON: `{"type":"delta"}`}, 3, time.Minute); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -302,6 +468,8 @@ type testGenerationStream struct {
 	activeUntil time.Time
 	nextSeq     int64
 	events      []repository.GenerationStreamMessage
+	textContent strings.Builder
+	textSeq     int64
 	expiresAt   time.Time
 }
 
@@ -371,7 +539,7 @@ func (s *testGenerationStreamStore) IsGenerationStreamCanceled(_ context.Context
 	return ok && item.canceled, nil
 }
 
-func (s *testGenerationStreamStore) AppendGenerationStreamEvent(_ context.Context, runID string, payloadJSON string, maxEvents int64, ttl time.Duration) (repository.GenerationStreamMessage, error) {
+func (s *testGenerationStreamStore) AppendGenerationStreamEvent(_ context.Context, runID string, input repository.GenerationStreamAppend, maxEvents int64, ttl time.Duration) (repository.GenerationStreamMessage, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	item := s.ensureLocked(runID)
@@ -379,14 +547,32 @@ func (s *testGenerationStreamStore) AppendGenerationStreamEvent(_ context.Contex
 	record := repository.GenerationStreamMessage{
 		ID:          fmt.Sprintf("%d-0", item.nextSeq),
 		Seq:         item.nextSeq,
-		PayloadJSON: payloadJSON,
+		PayloadJSON: input.PayloadJSON,
 	}
 	item.events = append(item.events, record)
+	if input.TextDelta != "" {
+		_, _ = item.textContent.WriteString(input.TextDelta)
+		item.textSeq = item.nextSeq
+	}
 	if maxEvents > 0 && int64(len(item.events)) > maxEvents {
 		item.events = append([]repository.GenerationStreamMessage(nil), item.events[len(item.events)-int(maxEvents):]...)
 	}
 	item.expiresAt = time.Now().Add(ttl)
 	return record, nil
+}
+
+func (s *testGenerationStreamStore) GetGenerationStreamTextSnapshot(_ context.Context, runID string) (repository.GenerationStreamTextSnapshot, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cleanupLocked()
+	item, ok := s.items[runID]
+	if !ok || item.textSeq <= 0 {
+		return repository.GenerationStreamTextSnapshot{}, false, nil
+	}
+	return repository.GenerationStreamTextSnapshot{
+		Seq:     item.textSeq,
+		Content: item.textContent.String(),
+	}, true, nil
 }
 
 func (s *testGenerationStreamStore) ListGenerationStreamEvents(_ context.Context, runID string, limit int64) ([]repository.GenerationStreamMessage, error) {
@@ -424,6 +610,8 @@ func (s *testGenerationStreamStore) ResetGenerationStreamEvents(_ context.Contex
 	defer s.mu.Unlock()
 	if item, ok := s.items[runID]; ok {
 		item.events = nil
+		item.textContent.Reset()
+		item.textSeq = 0
 	}
 	return nil
 }

--- a/backend/internal/infra/cache/memory/generation_stream.go
+++ b/backend/internal/infra/cache/memory/generation_stream.go
@@ -17,6 +17,8 @@ type generationStream struct {
 	eventsExpiresAt time.Time
 	seq             int64
 	events          []repository.GenerationStreamMessage
+	textContent     strings.Builder
+	textSeq         int64
 	notify          chan struct{}
 }
 
@@ -86,7 +88,7 @@ func (c *Cache) IsGenerationStreamCanceled(ctx context.Context, runID string) (b
 	return stream != nil && !stream.cancelExpired(now), nil
 }
 
-func (c *Cache) AppendGenerationStreamEvent(ctx context.Context, runID string, payloadJSON string, maxEvents int64, ttl time.Duration) (repository.GenerationStreamMessage, error) {
+func (c *Cache) AppendGenerationStreamEvent(ctx context.Context, runID string, input repository.GenerationStreamAppend, maxEvents int64, ttl time.Duration) (repository.GenerationStreamMessage, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	stream := c.ensureStreamLocked(runID)
@@ -94,9 +96,13 @@ func (c *Cache) AppendGenerationStreamEvent(ctx context.Context, runID string, p
 	record := repository.GenerationStreamMessage{
 		ID:          strconv.FormatInt(stream.seq, 10),
 		Seq:         stream.seq,
-		PayloadJSON: payloadJSON,
+		PayloadJSON: input.PayloadJSON,
 	}
 	stream.events = append(stream.events, record)
+	if input.TextDelta != "" {
+		_, _ = stream.textContent.WriteString(input.TextDelta)
+		stream.textSeq = stream.seq
+	}
 	if maxEvents <= 0 {
 		maxEvents = 1024
 	}
@@ -107,6 +113,20 @@ func (c *Cache) AppendGenerationStreamEvent(ctx context.Context, runID string, p
 	stream.notifyLocked()
 	c.maybeSweepLocked(time.Now())
 	return record, nil
+}
+
+func (c *Cache) GetGenerationStreamTextSnapshot(ctx context.Context, runID string) (repository.GenerationStreamTextSnapshot, bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	stream := c.streams[strings.TrimSpace(runID)]
+	now := time.Now()
+	if stream == nil || stream.eventsExpired(now) || stream.textSeq <= 0 {
+		return repository.GenerationStreamTextSnapshot{}, false, nil
+	}
+	return repository.GenerationStreamTextSnapshot{
+		Seq:     stream.textSeq,
+		Content: stream.textContent.String(),
+	}, true, nil
 }
 
 func (c *Cache) ListGenerationStreamEvents(ctx context.Context, runID string, limit int64) ([]repository.GenerationStreamMessage, error) {
@@ -165,6 +185,8 @@ func (c *Cache) ResetGenerationStreamEvents(ctx context.Context, runID string) e
 		return nil
 	}
 	stream.events = nil
+	stream.textContent.Reset()
+	stream.textSeq = 0
 	// Keep seq monotonic so any in-flight afterSeq cursors stay valid.
 	stream.notifyLocked()
 	return nil

--- a/backend/internal/infra/cache/memory/generation_stream_test.go
+++ b/backend/internal/infra/cache/memory/generation_stream_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
 )
 
 func TestGenerationStreamRegisterDoesNotMarkCanceled(t *testing.T) {
@@ -37,6 +39,53 @@ func TestGenerationStreamRegisterDoesNotMarkCanceled(t *testing.T) {
 	}
 	if canceled, err := cache.IsGenerationStreamCanceled(ctx, runID); err != nil || canceled {
 		t.Fatalf("re-registered stream canceled=%v err=%v, want false nil", canceled, err)
+	}
+}
+
+func TestGenerationStreamTextSnapshotLifecycle(t *testing.T) {
+	cache := New()
+	ctx := context.Background()
+	runID := "run_memory_text_snapshot"
+	if err := cache.RegisterGenerationStream(ctx, runID, 7, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, delta := range []string{"完整", "恢复", "文本"} {
+		if _, err := cache.AppendGenerationStreamEvent(ctx, runID, repository.GenerationStreamAppend{
+			PayloadJSON: `{"type":"delta"}`,
+			TextDelta:   delta,
+		}, 2, time.Minute); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	snapshot, ok, err := cache.GetGenerationStreamTextSnapshot(ctx, runID)
+	if err != nil || !ok {
+		t.Fatalf("snapshot ok=%v err=%v", ok, err)
+	}
+	if snapshot.Content != "完整恢复文本" || snapshot.Seq != 3 {
+		t.Fatalf("unexpected snapshot: %+v", snapshot)
+	}
+	events, err := cache.ListGenerationStreamEvents(ctx, runID, 2)
+	if err != nil || len(events) != 2 {
+		t.Fatalf("expected bounded event window, events=%+v err=%v", events, err)
+	}
+
+	if err := cache.ResetGenerationStreamEvents(ctx, runID); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot, ok, err = cache.GetGenerationStreamTextSnapshot(ctx, runID); err != nil || ok {
+		t.Fatalf("snapshot survived reset: snapshot=%+v ok=%v err=%v", snapshot, ok, err)
+	}
+	if _, err := cache.AppendGenerationStreamEvent(ctx, runID, repository.GenerationStreamAppend{
+		PayloadJSON: `{"type":"delta"}`,
+		TextDelta:   "安全内容",
+	}, 2, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, ok, err = cache.GetGenerationStreamTextSnapshot(ctx, runID)
+	if err != nil || !ok || snapshot.Content != "安全内容" || snapshot.Seq != 4 {
+		t.Fatalf("unexpected snapshot after reset: snapshot=%+v ok=%v err=%v", snapshot, ok, err)
 	}
 }
 

--- a/backend/internal/infra/cache/redis/conversation_cache.go
+++ b/backend/internal/infra/cache/redis/conversation_cache.go
@@ -37,6 +37,45 @@ const (
 	generationStreamKeyPrefix = "conversation:generation:"
 )
 
+// appendGenerationStreamEventScript keeps the event sequence, bounded replay
+// window, and cumulative visible-text checkpoint consistent in one Redis
+// round trip. Key TTLs are initialized only when a value is first created;
+// FinishMessageGeneration shortens them to the post-run retention window.
+var appendGenerationStreamEventScript = redis.NewScript(`
+local events_missing = redis.call("EXISTS", KEYS[2]) == 0
+local has_text_delta = ARGV[4] ~= ""
+local text_missing = false
+if has_text_delta then
+	text_missing = redis.call("EXISTS", KEYS[3]) == 0
+end
+local seq = redis.call("INCR", KEYS[1])
+if has_text_delta then
+	redis.call("APPEND", KEYS[3], ARGV[4])
+	redis.call("SET", KEYS[4], tostring(seq), "KEEPTTL")
+end
+local id = redis.call(
+	"XADD",
+	KEYS[2],
+	"MAXLEN", "~", ARGV[2],
+	"*",
+	"seq", tostring(seq),
+	"payload", ARGV[1]
+)
+
+if seq == 1 then
+	redis.call("PEXPIRE", KEYS[1], ARGV[3])
+end
+if events_missing then
+	redis.call("PEXPIRE", KEYS[2], ARGV[3])
+end
+if has_text_delta and text_missing then
+	redis.call("PEXPIRE", KEYS[3], ARGV[3])
+	redis.call("PEXPIRE", KEYS[4], ARGV[3])
+end
+
+return {id, tostring(seq)}
+`)
+
 // conversationCache 实现 repository.ConversationCacheRepository。
 type conversationCache struct {
 	client *redis.Client
@@ -358,31 +397,70 @@ func (c *conversationCache) IsGenerationStreamCanceled(ctx context.Context, runI
 	return count > 0, nil
 }
 
-// AppendGenerationStreamEvent 追加生成流事件，使用独立 seq 保持前端游标稳定。
-func (c *conversationCache) AppendGenerationStreamEvent(ctx context.Context, runID string, payloadJSON string, maxEvents int64, ttl time.Duration) (repository.GenerationStreamMessage, error) {
+// AppendGenerationStreamEvent 原子追加生成事件，并同步维护可见文本快照。
+func (c *conversationCache) AppendGenerationStreamEvent(ctx context.Context, runID string, input repository.GenerationStreamAppend, maxEvents int64, ttl time.Duration) (repository.GenerationStreamMessage, error) {
 	if c.client == nil {
 		return repository.GenerationStreamMessage{}, nil
 	}
 	if maxEvents <= 0 {
 		maxEvents = 1024
 	}
-	seq, err := c.client.Incr(ctx, generationStreamSeqKey(runID)).Result()
-	if err != nil {
-		return repository.GenerationStreamMessage{}, err
+	if ttl <= 0 {
+		ttl = time.Minute
 	}
-	id, err := c.client.XAdd(ctx, &redis.XAddArgs{
-		Stream:       generationStreamEventsKey(runID),
-		MaxLenApprox: maxEvents,
-		Values: map[string]interface{}{
-			"seq":     seq,
-			"payload": payloadJSON,
+	result, err := appendGenerationStreamEventScript.Run(
+		ctx,
+		c.client,
+		[]string{
+			generationStreamSeqKey(runID),
+			generationStreamEventsKey(runID),
+			generationStreamTextKey(runID),
+			generationStreamTextSeqKey(runID),
 		},
-	}).Result()
+		input.PayloadJSON,
+		maxEvents,
+		ttl.Milliseconds(),
+		input.TextDelta,
+	).Result()
 	if err != nil {
 		return repository.GenerationStreamMessage{}, err
 	}
-	_ = c.ExpireGenerationStream(ctx, runID, ttl)
-	return repository.GenerationStreamMessage{ID: id, Seq: seq, PayloadJSON: payloadJSON}, nil
+	values, ok := result.([]interface{})
+	if !ok || len(values) != 2 {
+		return repository.GenerationStreamMessage{}, errors.New("invalid generation stream append result")
+	}
+	id := strings.TrimSpace(getStringVal(values[0]))
+	seq := getInt64Val(values[1])
+	if id == "" || seq <= 0 {
+		return repository.GenerationStreamMessage{}, errors.New("invalid generation stream append metadata")
+	}
+	return repository.GenerationStreamMessage{ID: id, Seq: seq, PayloadJSON: input.PayloadJSON}, nil
+}
+
+// GetGenerationStreamTextSnapshot 原子读取完整可见文本及其最后事件序号。
+func (c *conversationCache) GetGenerationStreamTextSnapshot(ctx context.Context, runID string) (repository.GenerationStreamTextSnapshot, bool, error) {
+	if c.client == nil {
+		return repository.GenerationStreamTextSnapshot{}, false, nil
+	}
+	values, err := c.client.MGet(
+		ctx,
+		generationStreamTextKey(runID),
+		generationStreamTextSeqKey(runID),
+	).Result()
+	if err != nil {
+		return repository.GenerationStreamTextSnapshot{}, false, err
+	}
+	if len(values) != 2 || values[0] == nil || values[1] == nil {
+		return repository.GenerationStreamTextSnapshot{}, false, nil
+	}
+	seq := getInt64Val(values[1])
+	if seq <= 0 {
+		return repository.GenerationStreamTextSnapshot{}, false, nil
+	}
+	return repository.GenerationStreamTextSnapshot{
+		Seq:     seq,
+		Content: getStringVal(values[0]),
+	}, true, nil
 }
 
 // ListGenerationStreamEvents 返回当前保留窗口内的生成流事件。
@@ -448,7 +526,12 @@ func (c *conversationCache) ResetGenerationStreamEvents(ctx context.Context, run
 		return nil
 	}
 	// Keep seq key so subsequent appends stay monotonic for reconnect cursors.
-	return c.client.Del(ctx, generationStreamEventsKey(runID)).Err()
+	return c.client.Del(
+		ctx,
+		generationStreamEventsKey(runID),
+		generationStreamTextKey(runID),
+		generationStreamTextSeqKey(runID),
+	).Err()
 }
 
 // ExpireGenerationStream 设置生成流相关键的过期时间。
@@ -459,6 +542,8 @@ func (c *conversationCache) ExpireGenerationStream(ctx context.Context, runID st
 	pipe := c.client.Pipeline()
 	pipe.Expire(ctx, generationStreamEventsKey(runID), ttl)
 	pipe.Expire(ctx, generationStreamSeqKey(runID), ttl)
+	pipe.Expire(ctx, generationStreamTextKey(runID), ttl)
+	pipe.Expire(ctx, generationStreamTextSeqKey(runID), ttl)
 	pipe.Expire(ctx, generationStreamOwnerKey(runID), ttl)
 	pipe.Expire(ctx, generationStreamCancelKey(runID), ttl)
 	_, err := pipe.Exec(ctx)
@@ -491,6 +576,14 @@ func generationStreamEventsKey(runID string) string {
 
 func generationStreamSeqKey(runID string) string {
 	return generationStreamKeyPrefix + strings.TrimSpace(runID) + ":seq"
+}
+
+func generationStreamTextKey(runID string) string {
+	return generationStreamKeyPrefix + strings.TrimSpace(runID) + ":text"
+}
+
+func generationStreamTextSeqKey(runID string) string {
+	return generationStreamKeyPrefix + strings.TrimSpace(runID) + ":text_seq"
 }
 
 func generationStreamOwnerKey(runID string) string {

--- a/backend/internal/repository/conversation_cache.go
+++ b/backend/internal/repository/conversation_cache.go
@@ -24,6 +24,19 @@ type GenerationStreamMessage struct {
 	PayloadJSON string
 }
 
+// GenerationStreamAppend 是一次原子追加所需的数据。
+// TextDelta 仅在可见文本 delta 事件中设置，用于同步维护完整恢复快照。
+type GenerationStreamAppend struct {
+	PayloadJSON string
+	TextDelta   string
+}
+
+// GenerationStreamTextSnapshot 是生成期间可恢复的完整可见文本及其事件序号。
+type GenerationStreamTextSnapshot struct {
+	Seq     int64
+	Content string
+}
+
 // FileProcessingQueueRepository 封装文件处理队列缓存能力。
 type FileProcessingQueueRepository interface {
 	InitFileProcessingStream(ctx context.Context) error
@@ -50,7 +63,8 @@ type GenerationStreamCacheRepository interface {
 	IsGenerationStreamActive(ctx context.Context, runID string) (bool, error)
 	RequestGenerationStreamCancel(ctx context.Context, runID string, ttl time.Duration) error
 	IsGenerationStreamCanceled(ctx context.Context, runID string) (bool, error)
-	AppendGenerationStreamEvent(ctx context.Context, runID string, payloadJSON string, maxEvents int64, ttl time.Duration) (GenerationStreamMessage, error)
+	AppendGenerationStreamEvent(ctx context.Context, runID string, input GenerationStreamAppend, maxEvents int64, ttl time.Duration) (GenerationStreamMessage, error)
+	GetGenerationStreamTextSnapshot(ctx context.Context, runID string) (GenerationStreamTextSnapshot, bool, error)
 	ListGenerationStreamEvents(ctx context.Context, runID string, limit int64) ([]GenerationStreamMessage, error)
 	ReadGenerationStreamEvents(ctx context.Context, runID string, afterID string, block time.Duration, limit int64) ([]GenerationStreamMessage, error)
 	// ResetGenerationStreamEvents clears retained events while keeping owner metadata so

--- a/backend/internal/transport/http/conversation/handler_message_send.go
+++ b/backend/internal/transport/http/conversation/handler_message_send.go
@@ -649,6 +649,7 @@ func (h *Handler) CancelMessageGeneration(c *gin.Context) {
 // @Security BearerAuth
 // @Param run_id path string true "运行 ID"
 // @Param after query int false "已接收的最后事件序号"
+// @Param snapshot query bool false "是否返回可替换当前正文的权威文本快照"
 // @Success 200 {string} string "NDJSON stream"
 // @Failure 404 {object} ErrorDoc
 // @Router /conversation-runs/{run_id}/stream [get]
@@ -663,11 +664,13 @@ func (h *Handler) ResumeMessageGenerationStream(c *gin.Context) {
 		afterSeq = 0
 	}
 	userID := middleware.MustUserID(c)
+	includeTextSnapshot, _ := strconv.ParseBool(strings.TrimSpace(c.Query("snapshot")))
 	replay, events, unsubscribe, ok := h.service.SubscribeMessageGeneration(
 		c.Request.Context(),
 		userID,
 		runID,
 		afterSeq,
+		includeTextSnapshot,
 	)
 	if !ok {
 		h.service.MarkMessageGenerationInterrupted(c.Request.Context(), userID, runID)

--- a/frontend/features/chat/hooks/use-chat-data.ts
+++ b/frontend/features/chat/hooks/use-chat-data.ts
@@ -26,50 +26,6 @@ type ActiveResumeStream = {
   accessToken: string | null;
 };
 
-type ResumeTextReplayState = {
-  baseContent: string;
-  replayedContent: string;
-  visibleContent: string;
-};
-
-function appendResumedTextDelta(state: ResumeTextReplayState, delta: string): string {
-  if (!delta) {
-    return state.visibleContent;
-  }
-
-  state.replayedContent += delta;
-  const { baseContent, replayedContent } = state;
-  if (!baseContent) {
-    state.visibleContent = replayedContent;
-    return state.visibleContent;
-  }
-
-  if (
-    replayedContent === baseContent ||
-    baseContent.startsWith(replayedContent) ||
-    baseContent.includes(replayedContent)
-  ) {
-    state.visibleContent = baseContent;
-    return state.visibleContent;
-  }
-
-  if (replayedContent.startsWith(baseContent)) {
-    state.visibleContent = replayedContent;
-    return state.visibleContent;
-  }
-
-  const maxOverlapLength = Math.min(baseContent.length, replayedContent.length);
-  for (let length = maxOverlapLength; length > 0; length -= 1) {
-    if (baseContent.endsWith(replayedContent.slice(0, length))) {
-      state.visibleContent = `${baseContent}${replayedContent.slice(length)}`;
-      return state.visibleContent;
-    }
-  }
-
-  state.visibleContent = `${state.visibleContent}${delta}`;
-  return state.visibleContent;
-}
-
 export function useChatData(
   conversationID: string | null,
   {
@@ -98,7 +54,7 @@ export function useChatData(
   const previousConversationIDRef = React.useRef<string | null>(conversationID);
   const resumeSeqByRunRef = React.useRef<Record<string, number>>({});
   const pendingAssistantContentRef = React.useRef("");
-  const resumeTextReplayByRunRef = React.useRef<Record<string, ResumeTextReplayState>>({});
+  const resumedTextByRunRef = React.useRef<Record<string, string>>({});
   const activeResumeStreamRef = React.useRef<ActiveResumeStream | null>(null);
   // 恢复游标只在对应的可见内容仍被保留时有效，两者必须同步清理。
   const clearResumeCheckpoint = React.useCallback((runID: string) => {
@@ -107,7 +63,7 @@ export function useChatData(
       return;
     }
     delete resumeSeqByRunRef.current[normalizedRunID];
-    delete resumeTextReplayByRunRef.current[normalizedRunID];
+    delete resumedTextByRunRef.current[normalizedRunID];
   }, []);
 
   React.useEffect(() => {
@@ -346,19 +302,15 @@ export function useChatData(
     let closed = false;
     const afterSeq = resumeSeqByRunRef.current[pendingRunID] ?? 0;
     const baseContent = pendingAssistantContentRef.current;
-    const resumeTextReplayByRun = resumeTextReplayByRunRef.current;
-    const clearResumeTextReplay = () => {
-      delete resumeTextReplayByRun[pendingRunID];
+    const resumedTextByRun = resumedTextByRunRef.current;
+    const clearResumedText = () => {
+      delete resumedTextByRun[pendingRunID];
     };
     const isResumeInactive = () => closed || controller.signal.aborted;
     const updateResumeState = (update: (current: ChatDataState) => ChatDataState) => {
       setState((current) => isResumeInactive() ? current : update(current));
     };
-    resumeTextReplayByRun[pendingRunID] = {
-      baseContent,
-      replayedContent: afterSeq > 0 ? baseContent : "",
-      visibleContent: baseContent,
-    };
+    resumedTextByRun[pendingRunID] = baseContent;
     activeResumeStreamRef.current = {
       controller,
       runID: pendingRunID,
@@ -413,7 +365,7 @@ export function useChatData(
             if (isResumeInactive()) {
               return;
             }
-            clearResumeTextReplay();
+            clearResumedText();
             const previewMarkdown = buildMediaImagePreviewMarkdown(event, tSubmit("imagePreviewAlt"));
             if (!previewMarkdown) {
               return;
@@ -428,21 +380,28 @@ export function useChatData(
               ),
             }));
           },
+          onTextSnapshot: (content) => {
+            if (isResumeInactive()) {
+              return;
+            }
+            setResumingActivityLabel("");
+            resumedTextByRun[pendingRunID] = content;
+            updateResumeState((prev) => ({
+              ...prev,
+              messages: prev.messages.map((message) =>
+                message.runID === pendingRunID && message.role === "assistant" && message.status === "pending"
+                  ? { ...message, content, contentType: "text" }
+                  : message,
+              ),
+            }));
+          },
           onDelta: (delta) => {
             if (isResumeInactive()) {
               return;
             }
             setResumingActivityLabel("");
-            let replayState = resumeTextReplayByRun[pendingRunID];
-            if (!replayState) {
-              replayState = {
-                baseContent: "",
-                replayedContent: "",
-                visibleContent: "",
-              };
-              resumeTextReplayByRun[pendingRunID] = replayState;
-            }
-            const nextContent = appendResumedTextDelta(replayState, delta);
+            const nextContent = `${resumedTextByRun[pendingRunID] ?? ""}${delta}`;
+            resumedTextByRun[pendingRunID] = nextContent;
             updateResumeState((prev) => ({
               ...prev,
               messages: prev.messages.map((message) =>
@@ -497,7 +456,7 @@ export function useChatData(
             if (isResumeInactive()) {
               return;
             }
-            clearResumeTextReplay();
+            clearResumedText();
             setResumingActivityLabel("");
             const categories = Array.isArray(event.categories) ? event.categories : [];
             updateResumeState((prev) => ({

--- a/frontend/shared/api/conversation.ts
+++ b/frontend/shared/api/conversation.ts
@@ -1,4 +1,5 @@
 import type {
+  ConversationRuns,
   MessageProcessTraceResponse,
   MessageTraceBlockResponse,
   MessageTraceEventResponse,
@@ -257,7 +258,11 @@ function handleStreamEvent(event: StreamMessageEvent, options: ConversationStrea
   }
 
   if (event.type === "delta") {
-    options.onDelta?.(event.delta);
+    if (event.replace) {
+      options.onTextSnapshot?.(event.delta);
+    } else {
+      options.onDelta?.(event.delta);
+    }
     return null;
   }
 
@@ -899,9 +904,16 @@ export async function resumeMessageGenerationStream(
   options: ConversationStreamOptions = {},
 ): Promise<SendMessageResult | null> {
   const afterSeq = options.afterSeq && options.afterSeq > 0 ? Math.floor(options.afterSeq) : 0;
-  const afterQuery = afterSeq > 0 ? `?after=${afterSeq}` : "";
+  const requestQuery = {
+    snapshot: true,
+    ...(afterSeq > 0 ? { after: afterSeq } : {}),
+  } satisfies ConversationRuns.StreamList.RequestQuery;
+  const query = new URLSearchParams({ snapshot: String(requestQuery.snapshot) });
+  if (requestQuery.after !== undefined) {
+    query.set("after", String(requestQuery.after));
+  }
   const response = await authedFetch(
-    `/api/v1/conversation-runs/${pathParam(runID)}/stream${afterQuery}`,
+    `/api/v1/conversation-runs/${pathParam(runID)}/stream?${query.toString()}`,
     {
       method: "GET",
       accessToken,
@@ -989,6 +1001,7 @@ export type ConversationStreamOptions = {
   afterSeq?: number;
   onEventSeq?: (seq: number) => void;
   onDelta?: (delta: string) => void;
+  onTextSnapshot?: (content: string) => void;
   onFileProc?: (message: string) => void;
   onRagSearch?: (message: string) => void;
   onMediaStatus?: (event: Extract<StreamMessageEvent, { type: "media_status" }>) => void;

--- a/frontend/shared/api/conversation.types.ts
+++ b/frontend/shared/api/conversation.types.ts
@@ -264,6 +264,7 @@ export type StreamMessageEvent =
       type: "delta";
       seq?: number;
       delta: string;
+      replace?: boolean;
     }
   | {
       type: "usage";

--- a/packages/api-contract/src/types.generated.ts
+++ b/packages/api-contract/src/types.generated.ts
@@ -7319,6 +7319,8 @@ export namespace ConversationRuns {
     export type RequestQuery = {
       /** 已接收的最后事件序号 */
       after?: number;
+      /** 是否返回可替换当前正文的权威文本快照 */
+      snapshot?: boolean;
     };
     export type RequestBody = never;
     export type RequestHeaders = {};


### PR DESCRIPTION
## Summary

- Fix long in-progress assistant responses appearing truncated after refreshing the page, opening a new conversation, or returning to an active conversation.
- Maintain an authoritative cumulative text snapshot alongside the bounded Redis event stream.
- Restore the complete assistant text from the snapshot before replaying newer stream events.
- Preserve non-text events and prevent duplicated or missing deltas during reconnection.
- Update Redis sequence, text snapshot, and bounded stream events atomically through a single Lua operation.
- Keep database persistence unchanged: the completed assistant response is still written once when generation finishes.
- Negotiate snapshot recovery explicitly so older frontend versions continue using the existing stream protocol.
- Clear retained snapshots together with stream events when moderation blocks generated content.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [x] Documentation

## Verification

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] Targeted Go race-detector tests for generation-stream recovery and in-memory cache behavior.
- [x] Frontend TypeScript check.
- [x] Generated API contract check.
- [x] `git diff --check`.
- [x] Redis 7 integration check for the atomic append script, cumulative snapshot, sequence tracking, bounded stream, and TTL behavior.

## Screenshots, API examples, or logs

The frontend now requests snapshot-capable recovery explicitly:

```http
GET /api/v1/conversations/{conversation_id}/runs/{run_id}/stream?snapshot=true&after={sequence}
```

When available, the backend returns the complete accumulated assistant text through the existing delta event shape with replacement semantics before replaying newer events.

## Configuration, migration, and compatibility notes

- No database migration is required.
- No new environment variables or deployment configuration are required.
- Redis stream retention remains bounded at 1,024 events.
- The cache additionally retains one cumulative text snapshot for each active generation.
- Snapshot, sequence, and event updates are performed atomically in one Redis round trip.
- Completed assistant messages continue to be persisted to the database once at generation completion.
- Existing clients that do not request snapshot recovery continue receiving the previous replay protocol.
- New clients remain compatible with older backend versions because unsupported query parameters are ignored.

## Documentation

- [ ] Documentation is not needed for this change.
- [x] Documentation was updated.
- [ ] Documentation still needs to be updated.

Swagger and the generated frontend API contract include the optional snapshot recovery parameter.

## Security and privacy

- [x] No secrets, tokens, credentials, local configuration, or personal data are included.
- [x] User data access remains scoped by authenticated conversation and run ownership.
- [x] Moderation-related cleanup was reviewed.

Blocked generated content is removed from both the retained event stream and the cumulative text snapshot.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests and static verification were run where practical.
- [x] API compatibility and recovery behavior are documented.
- [x] Generated artifacts are included only where required by the project.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.