### PR TITLE
fix: preserve raw code text when pasting manual selections

### DIFF
--- a/frontend/features/chat/utils/markdown-paste.ts
+++ b/frontend/features/chat/utils/markdown-paste.ts
@@ -1,6 +1,8 @@
 import TurndownService from "turndown";
 import { gfm } from "turndown-plugin-gfm";
 
+import { CODE_BLOCK_PLAIN_TEXT_MIME } from "@/shared/lib/clipboard";
+
 type ClipboardMarkdownPaste = {
   block: boolean;
   markdown: string;
@@ -115,6 +117,9 @@ function resolveRichTextMarkdownPaste(clipboardData: DataTransfer): ClipboardMar
 }
 
 export function resolveClipboardMarkdownPaste(clipboardData: DataTransfer): ClipboardMarkdownPaste | null {
+  if (clipboardData.getData(CODE_BLOCK_PLAIN_TEXT_MIME)) {
+    return null;
+  }
   if (clipboardData.getData(VSCODE_EDITOR_DATA_MIME)) {
     return resolveVSCodeCodePaste(clipboardData);
   }

--- a/frontend/shared/components/markdown/streamdown-render.tsx
+++ b/frontend/shared/components/markdown/streamdown-render.tsx
@@ -632,6 +632,7 @@ export const StreamdownRender = React.memo(function StreamdownRender({
   const {
     rootRef: markdownCopyRootRef,
     onClickCapture: handleMarkdownCopyClickCapture,
+    onCopyCapture: handleMarkdownCopyCapture,
     onKeyDownCapture: handleMarkdownCopyKeyDownCapture,
     onPointerDownCapture: handleMarkdownCopyPointerDownCapture,
   } = useMarkdownCopy({
@@ -678,6 +679,7 @@ export const StreamdownRender = React.memo(function StreamdownRender({
       className={cn("chat-font-content min-w-0 max-w-full overflow-hidden text-foreground [overflow-wrap:anywhere]", contentSpacingClassName, className)}
       data-chat-markdown-scope=""
       onClickCapture={handleMarkdownCopyClickCapture}
+      onCopyCapture={handleMarkdownCopyCapture}
       onKeyDownCapture={handleMarkdownCopyKeyDownCapture}
       onPointerDownCapture={handleMarkdownCopyPointerDownCapture}
     >

--- a/frontend/shared/components/markdown/use-markdown-copy.ts
+++ b/frontend/shared/components/markdown/use-markdown-copy.ts
@@ -4,12 +4,14 @@ import * as React from "react";
 import { useTranslations } from "next-intl";
 
 import { useCopyAction } from "@/shared/components/copy-action";
+import { CODE_BLOCK_PLAIN_TEXT_MIME } from "@/shared/lib/clipboard";
 
 const LATEX_COPYABLE_SELECTOR = ".katex, .katex-display";
 const LATEX_ANNOTATION_SELECTOR = "annotation[encoding='application/x-tex']";
 const LATEX_INTERACTION_EXCLUSION_SELECTOR = "a, button, input, textarea, select, summary, pre, code, [contenteditable='true']";
 const INLINE_CODE_COPYABLE_SELECTOR = "code:not(pre code)";
 const INLINE_CODE_INTERACTION_EXCLUSION_SELECTOR = "a, button, input, textarea, select, summary, [contenteditable='true']";
+const CODE_BLOCK_BODY_SELECTOR = "[data-streamdown='code-block-body']";
 const MARKDOWN_COPY_POINTER_DRAG_THRESHOLD = 6;
 
 type UseMarkdownCopyOptions = {
@@ -20,6 +22,7 @@ type UseMarkdownCopyOptions = {
 type UseMarkdownCopyResult = {
   rootRef: React.RefObject<HTMLDivElement | null>;
   onClickCapture: React.MouseEventHandler<HTMLDivElement>;
+  onCopyCapture: React.ClipboardEventHandler<HTMLDivElement>;
   onKeyDownCapture: React.KeyboardEventHandler<HTMLDivElement>;
   onPointerDownCapture: React.PointerEventHandler<HTMLDivElement>;
 };
@@ -42,6 +45,21 @@ function getHTMLElementFromTarget(target: EventTarget | null): HTMLElement | nul
 function hasNonCollapsedSelection(): boolean {
   const selection = window.getSelection();
   return Boolean(selection && !selection.isCollapsed && selection.toString().trim());
+}
+
+function getSelectedCodeText(root: HTMLElement): string {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed) {
+    return "";
+  }
+
+  const anchorBlock = getHTMLElementFromTarget(selection.anchorNode)?.closest<HTMLElement>(CODE_BLOCK_BODY_SELECTOR);
+  const focusBlock = getHTMLElementFromTarget(selection.focusNode)?.closest<HTMLElement>(CODE_BLOCK_BODY_SELECTOR);
+  if (!anchorBlock || anchorBlock !== focusBlock || !root.contains(anchorBlock)) {
+    return "";
+  }
+
+  return selection.toString();
 }
 
 function isDisplayLatexElement(element: HTMLElement): boolean {
@@ -191,6 +209,22 @@ export function useMarkdownCopy({ contentVersion, renderVersion }: UseMarkdownCo
     pointerDownRef.current = { x: event.clientX, y: event.clientY };
   }, []);
 
+  const onCopyCapture = React.useCallback<React.ClipboardEventHandler<HTMLDivElement>>((event) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    const code = getSelectedCodeText(event.currentTarget);
+    if (!code) {
+      return;
+    }
+
+    event.clipboardData.clearData();
+    event.clipboardData.setData(CODE_BLOCK_PLAIN_TEXT_MIME, "1");
+    event.clipboardData.setData("text/plain", code);
+    event.preventDefault();
+  }, []);
+
   const onClickCapture = React.useCallback<React.MouseEventHandler<HTMLDivElement>>(
     (event) => {
       if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
@@ -259,6 +293,7 @@ export function useMarkdownCopy({ contentVersion, renderVersion }: UseMarkdownCo
   return {
     rootRef,
     onClickCapture,
+    onCopyCapture,
     onKeyDownCapture,
     onPointerDownCapture,
   };

--- a/frontend/shared/lib/clipboard.ts
+++ b/frontend/shared/lib/clipboard.ts
@@ -1,3 +1,5 @@
+export const CODE_BLOCK_PLAIN_TEXT_MIME = "application/x-deeix-code-block-text";
+
 export async function writeClipboardText(value: string): Promise<void> {
   let clipboardError: unknown;
 


### PR DESCRIPTION
## Summary

Closes #629.

Fix manual text selection from rendered code blocks being escaped and losing line breaks when pasted into the chat input.

- Copy selected code as plain text while preserving its original characters and line breaks.
- Clear browser-generated rich-text clipboard data to prevent unintended HTML-to-Markdown conversion.
- Mark internal code-block copies so the chat input reliably bypasses rich-text processing.
- Keep normal rich-text paste, VS Code paste, inline copy actions, and cross-region selection behavior unchanged.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm check`
- [x] Biome lint: 592 files checked with no issues.
- [x] TypeScript typecheck.
- [x] `git diff --check`.
- [ ] Browser-based manual verification was not run.

## Screenshots, API examples, or logs

Before: manually copied code was pasted with escaped Markdown characters and collapsed line breaks.

```text
\# Heading
\*\*bold\*\*
```

After: pasted text preserves the original code exactly.

```text
# Heading
**bold**
```

## Configuration, migration, and compatibility notes

No configuration, database, API contract, deployment, or migration changes are required.

Normal rich-text paste and VS Code code paste behavior remain unchanged.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] No new HTML rendering or script execution path was introduced.
- [x] Clipboard handling is limited to user-selected code within the rendered Markdown area.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Static verification was run.
- [x] No API or deployment documentation changes are required.
- [x] No generated artifacts, caches, build output, `.env` files, or local storage data are included.