### PR TITLE
fix: normalize legacy duplicate reasoning events

### DIFF
--- a/backend/internal/application/conversation/service_message_hydration.go
+++ b/backend/internal/application/conversation/service_message_hydration.go
@@ -91,6 +91,7 @@ func buildMessageProcessTraceDTO(rows []model.MessageTrace, eventRows []model.Me
 	if len(rows) == 0 && len(eventRows) == 0 {
 		return nil
 	}
+	eventRows = normalizeLegacyThinkReplayEvents(eventRows)
 	result := &model.MessageProcessTrace{Enabled: true}
 	for _, row := range rows {
 		block := &model.MessageTraceBlock{

--- a/backend/internal/application/conversation/service_message_hydration_test.go
+++ b/backend/internal/application/conversation/service_message_hydration_test.go
@@ -1,0 +1,151 @@
+package conversation
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
+)
+
+func TestNormalizeLegacyThinkReplayEventsCollapsesStreamAndRepeatedFinalSnapshots(t *testing.T) {
+	startedAt := time.Now().UTC().Add(-time.Minute)
+	firstEndedAt := startedAt.Add(10 * time.Second)
+	finalEndedAt := startedAt.Add(12 * time.Second)
+	finalPayload := persistedReasoningTestPayload("response.completed", "reasoning_1")
+	rows := []model.MessageTraceEventRow{
+		persistedThinkTestRow("upstream_think_1", "round_1", 2, "相同思考", persistedReasoningTestPayload("chat.completion.chunk", ""), startedAt, &firstEndedAt),
+		{
+			RunID:     "run_1",
+			EventID:   "tools_1",
+			EventType: "tool",
+			Phase:     messageTraceTypeTools,
+			Stage:     messageTraceStageTool,
+			Status:    messageTraceStatusCompleted,
+			Seq:       3,
+			CreatedAt: startedAt.Add(11 * time.Second),
+		},
+		persistedThinkTestRow("upstream_think_2", "round_2", 4, "相同思考", finalPayload, startedAt.Add(12*time.Second), &finalEndedAt),
+		persistedThinkTestRow("upstream_think_3", "round_3", 5, "相同思考", finalPayload, startedAt.Add(12*time.Second+20*time.Millisecond), &finalEndedAt),
+	}
+	originalFirstPayload := rows[0].PayloadJSON
+
+	normalized := normalizeLegacyThinkReplayEvents(rows)
+
+	if len(normalized) != 2 {
+		t.Fatalf("normalized events = %#v, want canonical think plus tool", normalized)
+	}
+	think := normalized[0]
+	if think.EventID != "upstream_think_1" || think.RoundID != "round_1" || think.Seq != 2 {
+		t.Fatalf("canonical think identity changed: %#v", think)
+	}
+	if think.PayloadJSON != finalPayload || think.EndedAt == nil || !think.EndedAt.Equal(finalEndedAt) {
+		t.Fatalf("canonical think did not receive final snapshot: %#v", think)
+	}
+	if normalized[1].EventID != "tools_1" {
+		t.Fatalf("tool event order changed: %#v", normalized)
+	}
+	if rows[0].PayloadJSON != originalFirstPayload {
+		t.Fatalf("normalization mutated input rows: got %q want %q", rows[0].PayloadJSON, originalFirstPayload)
+	}
+}
+
+func TestNormalizeLegacyThinkReplayEventsCollapsesRepeatedCompletedSnapshots(t *testing.T) {
+	createdAt := time.Now().UTC()
+	endedAt := createdAt.Add(time.Second)
+	payload := persistedReasoningTestPayload("response.completed", "")
+	rows := []model.MessageTraceEventRow{
+		persistedThinkTestRow("upstream_think_1", "round_1", 2, "重复完成内容", payload, createdAt, &endedAt),
+		persistedThinkTestRow("upstream_think_2", "round_2", 3, "重复完成内容", payload, createdAt.Add(25*time.Millisecond), &endedAt),
+		persistedThinkTestRow("upstream_think_3", "round_3", 4, "重复完成内容", payload, createdAt.Add(50*time.Millisecond), &endedAt),
+	}
+
+	normalized := normalizeLegacyThinkReplayEvents(rows)
+
+	if len(normalized) != 1 || normalized[0].EventID != "upstream_think_1" {
+		t.Fatalf("normalized events = %#v, want first completed event only", normalized)
+	}
+}
+
+func TestNormalizeLegacyThinkReplayEventsPreservesUnconfirmedRounds(t *testing.T) {
+	createdAt := time.Now().UTC()
+	endedAt := createdAt.Add(time.Second)
+	tests := []struct {
+		name string
+		rows []model.MessageTraceEventRow
+	}{
+		{
+			name: "different reasoning items",
+			rows: []model.MessageTraceEventRow{
+				persistedThinkTestRow("upstream_think_1", "round_1", 2, "相同文本", persistedReasoningTestPayload("response.completed", "reasoning_1"), createdAt, &endedAt),
+				persistedThinkTestRow("upstream_think_2", "round_2", 3, "相同文本", persistedReasoningTestPayload("response.completed", "reasoning_2"), createdAt.Add(time.Millisecond), &endedAt),
+			},
+		},
+		{
+			name: "completed snapshots outside replay window",
+			rows: []model.MessageTraceEventRow{
+				persistedThinkTestRow("upstream_think_1", "round_1", 2, "相同文本", persistedReasoningTestPayload("response.completed", ""), createdAt, &endedAt),
+				persistedThinkTestRow("upstream_think_2", "round_2", 3, "相同文本", persistedReasoningTestPayload("response.completed", ""), createdAt.Add(legacyReasoningReplayMaxGap+time.Millisecond), &endedAt),
+			},
+		},
+		{
+			name: "single final reconciliation",
+			rows: []model.MessageTraceEventRow{
+				persistedThinkTestRow("upstream_think_1", "round_1", 2, "相同文本", persistedReasoningTestPayload("chat.completion.chunk", ""), createdAt, &endedAt),
+				persistedThinkTestRow("upstream_think_2", "round_2", 3, "相同文本", persistedReasoningTestPayload("response.completed", ""), createdAt.Add(time.Second), &endedAt),
+			},
+		},
+		{
+			name: "different final payloads",
+			rows: []model.MessageTraceEventRow{
+				persistedThinkTestRow("upstream_think_1", "round_1", 2, "相同文本", `{"reasoning":{"event_type":"response.completed","status":"first"}}`, createdAt, &endedAt),
+				persistedThinkTestRow("upstream_think_2", "round_2", 3, "相同文本", `{"reasoning":{"event_type":"response.completed","status":"second"}}`, createdAt.Add(time.Millisecond), &endedAt),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			normalized := normalizeLegacyThinkReplayEvents(test.rows)
+			if len(normalized) != len(test.rows) {
+				t.Fatalf("normalized events = %#v, want all %d rounds preserved", normalized, len(test.rows))
+			}
+		})
+	}
+}
+
+func persistedThinkTestRow(
+	eventID string,
+	roundID string,
+	seq int,
+	content string,
+	payloadJSON string,
+	createdAt time.Time,
+	endedAt *time.Time,
+) model.MessageTraceEventRow {
+	return model.MessageTraceEventRow{
+		MessageID:       1,
+		ConversationID:  2,
+		UserID:          3,
+		RunID:           "run_1",
+		EventID:         eventID,
+		EventType:       "think",
+		Phase:           messageTraceTypeUpstreamThink,
+		Stage:           messageTraceStageThink,
+		RoundID:         roundID,
+		Status:          messageTraceStatusCompleted,
+		Title:           "模型思考",
+		Summary:         content,
+		ContentMarkdown: content,
+		PayloadJSON:     payloadJSON,
+		Seq:             seq,
+		StartedAt:       createdAt,
+		EndedAt:         endedAt,
+		CreatedAt:       createdAt,
+		UpdatedAt:       createdAt,
+	}
+}
+
+func persistedReasoningTestPayload(eventType string, itemID string) string {
+	return fmt.Sprintf(`{"reasoning":{"event_type":%q,"item_id":%q,"status":"completed"}}`, eventType, itemID)
+}

--- a/backend/internal/application/conversation/service_trace_compat.go
+++ b/backend/internal/application/conversation/service_trace_compat.go
@@ -1,0 +1,184 @@
+package conversation
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
+)
+
+// The legacy finalization replay persisted its duplicate completion immediately
+// after the first one. Local production-shaped data tops out below two seconds;
+// keep a small margin while refusing to merge later, potentially real rounds.
+const legacyReasoningReplayMaxGap = 3 * time.Second
+
+type persistedReasoningEventMetadata struct {
+	EventType string
+	ItemID    string
+}
+
+type legacyThinkReplayCandidate struct {
+	rowIndex int
+	metadata persistedReasoningEventMetadata
+}
+
+// normalizeLegacyThinkReplayEvents hides reasoning snapshots replayed by the
+// legacy streaming finalization path. That path persisted the same final
+// response.completed payload twice and could first persist the identical live
+// chunk as another round. Keep the canonical event identity and merge the final
+// terminal snapshot into it without mutating the stored rows.
+func normalizeLegacyThinkReplayEvents(rows []model.MessageTraceEventRow) []model.MessageTraceEventRow {
+	if len(rows) < 2 {
+		return rows
+	}
+	workingRows := append([]model.MessageTraceEventRow(nil), rows...)
+
+	groups := make(map[string][]legacyThinkReplayCandidate)
+	for index, row := range workingRows {
+		if !isPersistedThinkTraceEvent(row) {
+			continue
+		}
+		content := strings.TrimSpace(row.ContentMarkdown)
+		if content == "" {
+			continue
+		}
+		metadata, ok := persistedReasoningMetadata(row.PayloadJSON)
+		if !ok {
+			continue
+		}
+		key := strings.TrimSpace(row.RunID) + "\x00" + content
+		groups[key] = append(groups[key], legacyThinkReplayCandidate{rowIndex: index, metadata: metadata})
+	}
+
+	removed := make(map[int]struct{})
+	for _, candidates := range groups {
+		if len(candidates) < 2 || hasConflictingReasoningItemIDs(candidates) {
+			continue
+		}
+		for position := 0; position < len(candidates); {
+			replayEnd := position
+			for replayEnd+1 < len(candidates) {
+				first := candidates[replayEnd]
+				second := candidates[replayEnd+1]
+				if !isLegacyCompletedReplayPair(workingRows[first.rowIndex], first.metadata, workingRows[second.rowIndex], second.metadata) {
+					break
+				}
+				replayEnd++
+			}
+			if replayEnd == position {
+				position++
+				continue
+			}
+
+			canonicalPosition := position
+			if position > 0 && isPersistedLiveReasoningEvent(candidates[position-1].metadata.EventType) {
+				canonicalPosition = position - 1
+			}
+			canonicalIndex := candidates[canonicalPosition].rowIndex
+			finalIndex := candidates[replayEnd].rowIndex
+			workingRows[canonicalIndex] = mergePersistedReasoningSnapshot(workingRows[canonicalIndex], workingRows[finalIndex])
+			for duplicatePosition := canonicalPosition + 1; duplicatePosition <= replayEnd; duplicatePosition++ {
+				removed[candidates[duplicatePosition].rowIndex] = struct{}{}
+			}
+			position = replayEnd + 1
+		}
+	}
+	if len(removed) == 0 {
+		return rows
+	}
+
+	normalized := make([]model.MessageTraceEventRow, 0, len(workingRows)-len(removed))
+	for index, row := range workingRows {
+		if _, duplicate := removed[index]; duplicate {
+			continue
+		}
+		normalized = append(normalized, row)
+	}
+	return normalized
+}
+
+func isPersistedThinkTraceEvent(row model.MessageTraceEventRow) bool {
+	return strings.EqualFold(strings.TrimSpace(row.EventType), "think") ||
+		strings.EqualFold(strings.TrimSpace(row.Phase), messageTraceTypeUpstreamThink) ||
+		strings.EqualFold(strings.TrimSpace(row.Stage), messageTraceStageThink)
+}
+
+func persistedReasoningMetadata(payloadJSON string) (persistedReasoningEventMetadata, bool) {
+	payload := struct {
+		Reasoning struct {
+			EventType string `json:"event_type"`
+			ItemID    string `json:"item_id"`
+		} `json:"reasoning"`
+	}{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(payloadJSON)), &payload); err != nil {
+		return persistedReasoningEventMetadata{}, false
+	}
+	metadata := persistedReasoningEventMetadata{
+		EventType: strings.ToLower(strings.TrimSpace(payload.Reasoning.EventType)),
+		ItemID:    strings.TrimSpace(payload.Reasoning.ItemID),
+	}
+	return metadata, metadata.EventType != ""
+}
+
+func hasConflictingReasoningItemIDs(candidates []legacyThinkReplayCandidate) bool {
+	itemID := ""
+	for _, candidate := range candidates {
+		if candidate.metadata.ItemID == "" {
+			continue
+		}
+		if itemID != "" && itemID != candidate.metadata.ItemID {
+			return true
+		}
+		itemID = candidate.metadata.ItemID
+	}
+	return false
+}
+
+func isLegacyCompletedReplayPair(
+	first model.MessageTraceEventRow,
+	firstMetadata persistedReasoningEventMetadata,
+	second model.MessageTraceEventRow,
+	secondMetadata persistedReasoningEventMetadata,
+) bool {
+	if firstMetadata.EventType != "response.completed" || secondMetadata.EventType != "response.completed" {
+		return false
+	}
+	if strings.TrimSpace(first.ContentMarkdown) != strings.TrimSpace(second.ContentMarkdown) ||
+		strings.TrimSpace(first.PayloadJSON) != strings.TrimSpace(second.PayloadJSON) {
+		return false
+	}
+	if first.CreatedAt.IsZero() || second.CreatedAt.Before(first.CreatedAt) {
+		return false
+	}
+	return second.CreatedAt.Sub(first.CreatedAt) <= legacyReasoningReplayMaxGap
+}
+
+func isPersistedLiveReasoningEvent(eventType string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(eventType))
+	return normalized == "chat.completion.chunk" || strings.HasSuffix(normalized, ".delta")
+}
+
+func mergePersistedReasoningSnapshot(
+	canonical model.MessageTraceEventRow,
+	final model.MessageTraceEventRow,
+) model.MessageTraceEventRow {
+	if strings.TrimSpace(final.Status) != "" {
+		canonical.Status = final.Status
+	}
+	if strings.TrimSpace(final.Title) != "" {
+		canonical.Title = final.Title
+	}
+	if strings.TrimSpace(final.Summary) != "" {
+		canonical.Summary = final.Summary
+	}
+	canonical.ContentMarkdown = final.ContentMarkdown
+	canonical.PayloadJSON = final.PayloadJSON
+	if final.EndedAt != nil {
+		canonical.EndedAt = final.EndedAt
+	}
+	if final.UpdatedAt.After(canonical.UpdatedAt) {
+		canonical.UpdatedAt = final.UpdatedAt
+	}
+	return canonical
+}


### PR DESCRIPTION
## Summary

Normalize duplicate reasoning events produced by the legacy streaming finalization path.

Older conversations may contain the same reasoning snapshot multiple times under different round IDs because the streamed reasoning and final `response.completed` snapshot were replayed during finalization. The current timeline renders those rows as separate thinking rounds.

This change:

- detects the confirmed legacy replay signature during trace hydration
- collapses repeated identical `response.completed` snapshots
- merges the final terminal snapshot into the canonical reasoning event
- preserves the canonical event ID, round ID, sequence, and ordering
- preserves real multi-round reasoning when content, payload, item identity, or timing differs
- keeps all persisted database rows unchanged

Related to #639. This PR only addresses the legacy duplicate reasoning display. Forked conversation trace preservation will be handled separately.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./internal/application/conversation ./internal/infra/persistence/postgres/conversation -count=1`
- [x] `cd backend && go test ./... -count=1`

Regression coverage includes:

- streamed reasoning followed by two repeated final snapshots
- repeated completed snapshots
- tool events between the streamed and final snapshots
- different reasoning item IDs
- different final payloads
- events outside the legacy replay window
- valid single final reconciliation

## Screenshots, API examples, or logs

Not applicable. This is a backend hydration compatibility fix.

## Configuration, migration, and compatibility notes

No database schema migration or configuration change is required.

Historical database rows are not deleted or modified. Duplicate legacy events are normalized only when responses are hydrated.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.