### PR TITLE
fix: preserve display traces in forked conversations

### DIFF
--- a/backend/internal/application/conversation/service_fork.go
+++ b/backend/internal/application/conversation/service_fork.go
@@ -14,8 +14,9 @@ import (
 const forkAncestorMaxDepth = 2000
 
 // ForkConversationFromMessage 将会话从开头到指定消息（含）的祖先链复制为一个新会话。
-// 新会话不携带原会话的生成运行、处理轨迹、计费与压缩快照；附件以引用方式复用原文件
-// 对象（同用户，不重复占用存储配额）。原会话保持不变。
+// 新会话保留历史消息的上下文规划、思考和工具展示轨迹，但不携带可执行的生成运行、
+// 原始工具审计日志、计费与压缩快照；附件以引用方式复用原文件对象（同用户，不重复
+// 占用存储配额）。原会话保持不变。
 func (s *Service) ForkConversationFromMessage(ctx context.Context, userID uint, conversationPublicID string, messagePublicID string) (*model.Conversation, error) {
 	normalizedConversationID := strings.TrimSpace(conversationPublicID)
 	if normalizedConversationID == "" {

--- a/backend/internal/infra/persistence/postgres/conversation/repository_fork.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository_fork.go
@@ -2,6 +2,8 @@ package conversation
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"strings"
 	"time"
 
@@ -11,7 +13,9 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// CreateForkedConversation 在一个事务内创建 fork 会话、重建消息父链并复制仍有效的附件引用。
+const forkDisplayTraceCreateBatchSize = 200
+
+// CreateForkedConversation 在一个事务内创建 fork 会话、重建消息父链，并复制仍有效的附件引用与历史展示轨迹。
 func (r *Repo) CreateForkedConversation(ctx context.Context, input repository.CreateForkedConversationInput) error {
 	if input.Conversation == nil ||
 		input.SourceConversationID == 0 ||
@@ -86,7 +90,10 @@ func (r *Repo) CreateForkedConversation(ctx context.Context, input repository.Cr
 			targetMessageIDs[item.SourceMessageID] = entity.ID
 		}
 
-		return cloneForkedAttachments(tx, target.UserID, input.SourceConversationID, createdConversation.ID, targetMessageIDs)
+		if err := cloneForkedAttachments(tx, target.UserID, input.SourceConversationID, createdConversation.ID, targetMessageIDs); err != nil {
+			return err
+		}
+		return cloneForkedDisplayTraces(tx, target.UserID, input.SourceConversationID, createdConversation.ID, targetMessageIDs)
 	})
 	if err != nil {
 		return translateError(err)
@@ -94,6 +101,81 @@ func (r *Repo) CreateForkedConversation(ctx context.Context, input repository.Cr
 
 	*input.Conversation = toConversationDomain(createdConversation)
 	return nil
+}
+
+func cloneForkedDisplayTraces(
+	tx *gorm.DB,
+	userID uint,
+	sourceConversationID uint,
+	targetConversationID uint,
+	targetMessageIDs map[uint]uint,
+) error {
+	sourceMessageIDs := make([]uint, 0, len(targetMessageIDs))
+	for sourceMessageID := range targetMessageIDs {
+		sourceMessageIDs = append(sourceMessageIDs, sourceMessageID)
+	}
+
+	sourceEvents := make([]models.ChatRunEvent, 0)
+	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where(
+			"conversation_id = ? AND user_id = ? AND message_id IN ? AND event_scope IN ?",
+			sourceConversationID,
+			userID,
+			sourceMessageIDs,
+			[]string{chatRunEventScopeTraceBlock, chatRunEventScopeTraceEvent},
+		).
+		Order("message_id ASC, seq ASC, id ASC").
+		Find(&sourceEvents).Error; err != nil {
+		return err
+	}
+	if len(sourceEvents) == 0 {
+		return nil
+	}
+
+	targetEvents := make([]models.ChatRunEvent, 0, len(sourceEvents))
+	for _, source := range sourceEvents {
+		targetMessageID, exists := targetMessageIDs[source.MessageID]
+		if !exists {
+			return repository.ErrInvalidInput
+		}
+		targetEvents = append(targetEvents, models.ChatRunEvent{
+			BaseModel: models.BaseModel{
+				CreatedAt: source.CreatedAt,
+				UpdatedAt: source.UpdatedAt,
+			},
+			MessageID:       targetMessageID,
+			ConversationID:  targetConversationID,
+			UserID:          userID,
+			RunID:           forkedDisplayTraceRunID(targetMessageID, source.RunID),
+			EventScope:      source.EventScope,
+			EventID:         source.EventID,
+			EventType:       source.EventType,
+			Phase:           source.Phase,
+			Stage:           source.Stage,
+			RoundID:         source.RoundID,
+			ParentEventID:   source.ParentEventID,
+			Status:          source.Status,
+			Title:           source.Title,
+			Summary:         source.Summary,
+			ContentMarkdown: source.ContentMarkdown,
+			PayloadJSON:     source.PayloadJSON,
+			Seq:             source.Seq,
+			ToolCallID:      source.ToolCallID,
+			ToolName:        source.ToolName,
+			LatencyMS:       source.LatencyMS,
+			InputJSON:       source.InputJSON,
+			OutputJSON:      source.OutputJSON,
+			ErrorJSON:       source.ErrorJSON,
+			StartedAt:       source.StartedAt,
+			EndedAt:         source.EndedAt,
+		})
+	}
+	return tx.CreateInBatches(&targetEvents, forkDisplayTraceCreateBatchSize).Error
+}
+
+func forkedDisplayTraceRunID(targetMessageID uint, sourceRunID string) string {
+	sourceRunHash := sha256.Sum256([]byte(sourceRunID))
+	return fmt.Sprintf("fork_trace_%d_%x", targetMessageID, sourceRunHash[:8])
 }
 
 func cloneForkedAttachments(

--- a/backend/internal/infra/persistence/postgres/conversation/repository_fork_test.go
+++ b/backend/internal/infra/persistence/postgres/conversation/repository_fork_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	domainconversation "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
 	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/models"
@@ -58,6 +59,46 @@ func TestCreateForkedConversationCommitsCompleteFork(t *testing.T) {
 	if err := db.Create(&sourceAttachments).Error; err != nil {
 		t.Fatalf("create source attachments: %v", err)
 	}
+	traceStartedAt := time.Date(2026, time.August, 20, 9, 30, 0, 0, time.UTC)
+	traceEndedAt := traceStartedAt.Add(1250 * time.Millisecond)
+	sourceTraceEvents := []model.ChatRunEvent{
+		{
+			BaseModel: model.BaseModel{CreatedAt: traceStartedAt, UpdatedAt: traceEndedAt},
+			MessageID: leaf.ID, ConversationID: source.ID, UserID: 1, RunID: "run_source_leaf",
+			EventScope: chatRunEventScopeTraceBlock, EventID: "trace_context", EventType: "context",
+			Phase: "process", Stage: "process", Status: "completed", Title: "上下文规划",
+			ContentMarkdown: "选择最近消息作为上下文", PayloadJSON: `{"kind":"context_plan"}`, Seq: 1,
+			StartedAt: traceStartedAt, EndedAt: &traceEndedAt,
+		},
+		{
+			BaseModel: model.BaseModel{CreatedAt: traceStartedAt, UpdatedAt: traceEndedAt},
+			MessageID: leaf.ID, ConversationID: source.ID, UserID: 1, RunID: "run_source_leaf",
+			EventScope: chatRunEventScopeTraceEvent, EventID: "reasoning_1", EventType: "reasoning",
+			Phase: "upstream_think", Stage: "think", RoundID: "round_1", Status: "completed",
+			ContentMarkdown: "先检查上下文", PayloadJSON: `{"type":"response.reasoning_summary_text.done"}`, Seq: 2,
+			StartedAt: traceStartedAt, EndedAt: &traceEndedAt,
+		},
+		{
+			BaseModel: model.BaseModel{CreatedAt: traceStartedAt, UpdatedAt: traceEndedAt},
+			MessageID: leaf.ID, ConversationID: source.ID, UserID: 1, RunID: "run_source_leaf",
+			EventScope: chatRunEventScopeTraceEvent, EventID: "tool_1", EventType: "tool",
+			Phase: "tools", Stage: "tool", RoundID: "round_1", ParentEventID: "reasoning_1", Status: "completed",
+			Title: "读取文件", PayloadJSON: `{"type":"response.function_call_arguments.done","name":"read_file"}`, Seq: 3,
+			ToolCallID: "call_1", ToolName: "read_file", LatencyMS: 25,
+			InputJSON: `{"path":"README.md"}`, OutputJSON: `{"ok":true}`,
+			StartedAt: traceStartedAt, EndedAt: &traceEndedAt,
+		},
+		{
+			MessageID: leaf.ID, ConversationID: source.ID, UserID: 1, RunID: "run_source_leaf",
+			EventScope: chatRunEventScopeToolCall, EventID: "call_1", EventType: "tool_call",
+			Phase: "tools", Stage: "tool", Status: "completed", Seq: 4,
+			ToolCallID: "call_1", ToolName: "read_file", InputJSON: `{"path":"README.md"}`, OutputJSON: `{"ok":true}`,
+			StartedAt: traceStartedAt, EndedAt: &traceEndedAt,
+		},
+	}
+	if err := db.Create(&sourceTraceEvents).Error; err != nil {
+		t.Fatalf("create source trace events: %v", err)
+	}
 
 	target := &domainconversation.Conversation{
 		UserID: 1, PublicID: "conv_fork", Title: "Source", LabelsJSON: "[]",
@@ -98,6 +139,59 @@ func TestCreateForkedConversationCommitsCompleteFork(t *testing.T) {
 	if parent := targetMessages[1].ParentMessageID; parent == nil || *parent != targetMessages[0].ID {
 		t.Fatalf("fork leaf parent = %v, want %d", parent, targetMessages[0].ID)
 	}
+	if targetMessages[1].RunID != "" {
+		t.Fatalf("fork leaf run ID = %q, want no executable source run", targetMessages[1].RunID)
+	}
+
+	var targetTraceEvents []model.ChatRunEvent
+	if err := db.Where("conversation_id = ?", target.ID).Order("seq ASC, id ASC").Find(&targetTraceEvents).Error; err != nil {
+		t.Fatalf("load target trace events: %v", err)
+	}
+	if len(targetTraceEvents) != 3 {
+		t.Fatalf("len(targetTraceEvents) = %d, want 3 display trace rows", len(targetTraceEvents))
+	}
+	wantEventIDs := []string{"trace_context", "reasoning_1", "tool_1"}
+	targetTraceRunID := forkedDisplayTraceRunID(targetMessages[1].ID, "run_source_leaf")
+	for index, event := range targetTraceEvents {
+		if event.MessageID != targetMessages[1].ID || event.ConversationID != target.ID || event.UserID != 1 {
+			t.Fatalf("target trace ownership = (%d, %d, %d), want (%d, %d, 1)", event.MessageID, event.ConversationID, event.UserID, targetMessages[1].ID, target.ID)
+		}
+		if event.RunID != targetTraceRunID || event.RunID == "run_source_leaf" {
+			t.Fatalf("target trace run ID = %q, want remapped %q", event.RunID, targetTraceRunID)
+		}
+		if event.EventID != wantEventIDs[index] {
+			t.Fatalf("target trace event[%d] ID = %q, want %q", index, event.EventID, wantEventIDs[index])
+		}
+		if event.EventScope == chatRunEventScopeToolCall {
+			t.Fatalf("target copied raw tool-call audit row: %+v", event)
+		}
+		if !event.CreatedAt.Equal(traceStartedAt) || !event.UpdatedAt.Equal(traceEndedAt) || !event.StartedAt.Equal(traceStartedAt) {
+			t.Fatalf("target trace timing was not preserved: %+v", event)
+		}
+		if event.EndedAt == nil || !event.EndedAt.Equal(traceEndedAt) {
+			t.Fatalf("target trace ended_at = %v, want %v", event.EndedAt, traceEndedAt)
+		}
+	}
+	if toolEvent := targetTraceEvents[2]; toolEvent.RoundID != "round_1" || toolEvent.ParentEventID != "reasoning_1" || toolEvent.ToolCallID != "call_1" || toolEvent.ToolName != "read_file" {
+		t.Fatalf("target tool display linkage was not preserved: %+v", toolEvent)
+	}
+	if targetTraceEvents[0].ContentMarkdown != sourceTraceEvents[0].ContentMarkdown || targetTraceEvents[0].PayloadJSON != sourceTraceEvents[0].PayloadJSON {
+		t.Fatalf("target context trace content was not preserved: %+v", targetTraceEvents[0])
+	}
+	displayBlocks, err := repo.ListConversationMessageTracesByMessageIDs(ctx, []uint{targetMessages[1].ID})
+	if err != nil {
+		t.Fatalf("ListConversationMessageTracesByMessageIDs() error = %v", err)
+	}
+	if len(displayBlocks) != 1 || displayBlocks[0].ContentMarkdown != "选择最近消息作为上下文" {
+		t.Fatalf("fork display blocks = %+v, want copied context plan", displayBlocks)
+	}
+	displayEvents, err := repo.ListConversationMessageTraceEventsByMessageIDs(ctx, []uint{targetMessages[1].ID})
+	if err != nil {
+		t.Fatalf("ListConversationMessageTraceEventsByMessageIDs() error = %v", err)
+	}
+	if len(displayEvents) != 2 || displayEvents[0].ContentMarkdown != "先检查上下文" || displayEvents[1].EventType != "tool" || displayEvents[1].PayloadJSON != sourceTraceEvents[2].PayloadJSON {
+		t.Fatalf("fork display events = %+v, want copied reasoning and tool details", displayEvents)
+	}
 
 	var targetAttachments []model.Attachment
 	if err := db.Where("conversation_id = ?", target.ID).Find(&targetAttachments).Error; err != nil {
@@ -123,6 +217,13 @@ func TestCreateForkedConversationCommitsCompleteFork(t *testing.T) {
 	}
 	if sourceMessageCount != 2 {
 		t.Fatalf("source message count = %d, want 2", sourceMessageCount)
+	}
+	var sourceTraceCount int64
+	if err := db.Model(&model.ChatRunEvent{}).Where("conversation_id = ?", source.ID).Count(&sourceTraceCount).Error; err != nil {
+		t.Fatalf("count source trace events: %v", err)
+	}
+	if sourceTraceCount != int64(len(sourceTraceEvents)) {
+		t.Fatalf("source trace count = %d, want %d", sourceTraceCount, len(sourceTraceEvents))
 	}
 }
 

--- a/backend/internal/repository/conversation_core.go
+++ b/backend/internal/repository/conversation_core.go
@@ -49,7 +49,7 @@ type CreateForkedConversationInput struct {
 	Messages             []ForkConversationMessage
 }
 
-// ConversationForkRepository 封装新会话、消息链和附件引用的原子复制能力。
+// ConversationForkRepository 封装新会话、消息链、附件引用和历史展示轨迹的原子复制能力。
 type ConversationForkRepository interface {
 	CreateForkedConversation(ctx context.Context, input CreateForkedConversationInput) error
 }


### PR DESCRIPTION
## Summary

related: #639 

- Copy historical display traces when forking a conversation so context planning, reasoning, and tool details remain visible.
- Remap conversation, message, user, and display-only run identities while preserving event order, timing, round linkage, content, and payloads.
- Keep the fork operation atomic with message and attachment cloning.
- Exclude executable generation runs, raw tool-call audit logs, billing records, and context compression snapshots.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && env GOCACHE=/private/tmp/deeix-chat-go-build-cache go test ./internal/infra/persistence/postgres/conversation -run 'TestCreateForkedConversation' -count=1`
- [x] `cd backend && env GOCACHE=/private/tmp/deeix-chat-go-build-cache go test ./... -count=1`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Not applicable. No frontend or public API contract changes.

## Configuration, migration, and compatibility notes

- No database schema, configuration, or API contract change.
- The fix applies to newly created forks.
- Existing forks that already lack trace rows are not automatically backfilled because they do not retain a reliable source-message relationship.
- Source conversations and their trace records remain unchanged.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.