### PR TITLE
fix: unify execution trace durations

### DIFF
--- a/frontend/features/chat/components/message/message-agent-tool-step.tsx
+++ b/frontend/features/chat/components/message/message-agent-tool-step.tsx
@@ -7,13 +7,12 @@ import { ArrowUpRight, Check, Copy, Wrench } from "lucide-react";
 import { AgentTraceStep } from "@/features/chat/components/message/message-agent-trace-step";
 import { useCopyAction } from "@/shared/components/copy-action";
 import { useAutoExpandDisclosure } from "@/shared/hooks/use-auto-expand-disclosure";
+import { useElapsedDurationMS } from "@/features/chat/hooks/use-elapsed-duration";
 import type { ChatTraceBlock } from "@/features/chat/types/messages";
 import type { ProcessTraceLabels } from "@/features/chat/hooks/use-process-trace-labels";
 import { cn } from "@/lib/utils";
-import {
-  formatTraceStepDuration,
-  type TraceDisplayEvent,
-} from "@/features/chat/model/message-process-trace";
+import { formatDurationMS } from "@/features/chat/model/duration";
+import type { TraceDisplayEvent } from "@/features/chat/model/message-process-trace";
 import {
   collectToolImageSources,
   collectToolNarrativeText,
@@ -413,6 +412,7 @@ export type ToolChainStep = {
   label: string;
   detail: string;
   failed: boolean;
+  startedAt?: string;
   latencyMS?: number;
   toolCallID?: string;
   toolType?: string;
@@ -536,6 +536,7 @@ export function buildToolChainSteps(events: TraceDisplayEvent[], labels: Process
           label: labels.tool.names.generic,
           detail: event.contentMarkdown?.trim() || event.summary?.trim() || event.title?.trim() || "",
           failed: isToolTraceStatusFailed(event.status),
+          startedAt: event.startedAt,
           toolStatus: event.status?.trim(),
         },
       ];
@@ -550,6 +551,7 @@ export function buildToolChainSteps(events: TraceDisplayEvent[], labels: Process
         label,
         detail,
         failed,
+        startedAt: event.startedAt,
         latencyMS: call.latency_ms,
         toolCallID: toolTraceCallID(call),
         toolType: call.type?.trim(),
@@ -577,6 +579,7 @@ function buildToolChainStepsFromBlock(block: ChatTraceBlock | undefined, labels:
         label: labels.tool.names.generic,
         detail,
         failed: isToolTraceStatusFailed(block.status),
+        startedAt: block.startedAt,
         toolStatus: block.status?.trim(),
       },
     ];
@@ -590,6 +593,7 @@ function buildToolChainStepsFromBlock(block: ChatTraceBlock | undefined, labels:
       label,
       detail,
       failed,
+      startedAt: block.startedAt,
       latencyMS: call.latency_ms,
       toolCallID: toolTraceCallID(call),
       toolType: call.type?.trim(),
@@ -858,7 +862,8 @@ export function AgentToolStepRow({
   const failed = step.failed;
   const statusText = isToolStepDone(step) ? "" : toolStatusLabel(step.toolCall?.status ?? step.toolStatus, labels);
   const expandable = Boolean(step.toolCall || step.detail);
-  const durationText = formatTraceStepDuration(step.latencyMS);
+  const liveDurationMS = useElapsedDurationMS(active, step.startedAt);
+  const durationText = formatDurationMS(active ? liveDurationMS : step.latencyMS);
 
   return (
     <li className="group/agent-trace-step">

--- a/frontend/features/chat/components/message/message-agent-trace.tsx
+++ b/frontend/features/chat/components/message/message-agent-trace.tsx
@@ -28,11 +28,13 @@ import { StreamdownRender } from "@/shared/components/markdown/streamdown-render
 import { useAutoExpandDisclosure } from "@/shared/hooks/use-auto-expand-disclosure";
 import { cn } from "@/lib/utils";
 import { TRACE_ROOT_CLASS } from "@/features/chat/components/shared/message-process-trace-shared";
+import { useElapsedDurationMS } from "@/features/chat/hooks/use-elapsed-duration";
 import {
-  formatTraceRunDuration,
-  formatTraceStepDuration,
-  type TraceDisplayEvent,
-} from "@/features/chat/model/message-process-trace";
+  durationBetweenMS,
+  formatDurationMS,
+  sumDurationsMS,
+} from "@/features/chat/model/duration";
+import type { TraceDisplayEvent } from "@/features/chat/model/message-process-trace";
 
 function traceEventToBlock(event: ChatTraceEvent): ChatTraceBlock {
   return {
@@ -238,41 +240,9 @@ function groupTraceDisplayEvents(
 }
 
 function thinkEventDurationMS(thinkEvents: TraceDisplayEvent[]): number | undefined {
-  let total = 0;
-  for (const item of thinkEvents) {
-    const { startedAt, endedAt, updatedAt } = item.event;
-    if (!startedAt) {
-      continue;
-    }
-    const startMS = new Date(startedAt).getTime();
-    if (!Number.isFinite(startMS)) {
-      continue;
-    }
-    // 部分历史事件只有 startedAt（未走到 complete 落盘），用快照更新时间兜底。
-    const rawEnd = endedAt?.trim() ? endedAt : updatedAt;
-    if (!rawEnd) {
-      continue;
-    }
-    const endMS = new Date(rawEnd).getTime();
-    if (!Number.isFinite(endMS) || endMS <= startMS) {
-      continue;
-    }
-    total += endMS - startMS;
-  }
-  return total > 0 ? total : undefined;
-}
-
-function thinkBlockDurationMS(block: ChatTraceBlock): number | undefined {
-  const { startedAt, updatedAt } = block;
-  if (!startedAt || !updatedAt) {
-    return undefined;
-  }
-  const startMS = new Date(startedAt).getTime();
-  const endMS = new Date(updatedAt).getTime();
-  if (!Number.isFinite(startMS) || !Number.isFinite(endMS) || endMS <= startMS) {
-    return undefined;
-  }
-  return endMS - startMS;
+  return sumDurationsMS(
+    thinkEvents.map(({ event }) => durationBetweenMS(event.startedAt, event.endedAt)),
+  );
 }
 
 type TraceTimelineItem =
@@ -297,7 +267,8 @@ function TraceThinkRow({
     autoExpand,
   });
 
-  const durationText = formatTraceStepDuration(durationMS);
+  const liveDurationMS = useElapsedDurationMS(streaming, block.startedAt);
+  const durationText = formatDurationMS(streaming ? liveDurationMS : durationMS);
 
   return (
     <li className="group/agent-trace-step">
@@ -370,7 +341,6 @@ export function MessageAgentTrace({
   autoCollapseReady,
   autoExpandThinking = true,
   autoExpandToolCalls = true,
-  runDurationMS,
 }: {
   events: ChatTraceEvent[];
   activeToolBlock?: ChatTraceBlock;
@@ -379,7 +349,6 @@ export function MessageAgentTrace({
   autoCollapseReady: boolean;
   autoExpandThinking?: boolean;
   autoExpandToolCalls?: boolean;
-  runDurationMS?: number;
 }) {
   const labels = useProcessTraceLabels();
   const displayEvents = React.useMemo(() => buildTraceDisplayEvents(traceEvents), [traceEvents]);
@@ -405,7 +374,7 @@ export function MessageAgentTrace({
           streaming,
           durationMS: streaming
             ? undefined
-            : thinkEventDurationMS(group.thinkEvents) ?? thinkBlockDurationMS(thinkBlock),
+            : thinkEventDurationMS(group.thinkEvents),
         });
       }
       groupToolSteps[index].forEach((step) => {
@@ -433,7 +402,10 @@ export function MessageAgentTrace({
 
   const renderedToolSteps = items.flatMap((item) => (item.kind === "tool" ? [item.step] : []));
   const thinkRounds = items.filter((item) => item.kind === "think").length;
-  const durationText = formatTraceRunDuration(runDurationMS);
+  const traceDurationMS = sumDurationsMS(
+    items.map((item) => (item.kind === "think" ? item.durationMS : item.step.latencyMS)),
+  );
+  const durationText = traceRunActive ? undefined : formatDurationMS(traceDurationMS);
 
   const subtitleParts: string[] = [];
   if (thinkRounds > 0) {

--- a/frontend/features/chat/components/message/message-bot.tsx
+++ b/frontend/features/chat/components/message/message-bot.tsx
@@ -374,7 +374,6 @@ export function ChatMessageBot({
         autoCollapseReady={hasStreamdownContent || Boolean(item.inlineAlert)}
         autoExpandThinking={autoExpandThinking}
         autoExpandToolCalls={autoExpandToolCalls}
-        runDurationMS={item.latencyMS}
       />
 
       <div

--- a/frontend/features/chat/components/message/message-meta.tsx
+++ b/frontend/features/chat/components/message/message-meta.tsx
@@ -32,6 +32,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  durationBetweenMS,
+  firstDurationMS,
+  formatDurationMS,
+} from "@/features/chat/model/duration";
+import { useElapsedDurationMS } from "@/features/chat/hooks/use-elapsed-duration";
 import { resolvePersistedPublicID } from "@/features/chat/model/message-submit";
 import type { ChatBillingCost, ChatMessageBranchNavigator } from "@/features/chat/types/messages";
 import { useLocalizedErrorMessage } from "@/i18n/use-localized-error";
@@ -399,84 +405,15 @@ function TokenMetric({ label, value, icon }: { label: string; value: number; ico
   );
 }
 
-function formatDuration(ms: number): string {
-  if (!Number.isFinite(ms) || ms <= 0) {
-    return "";
-  }
-  const wholeMS = Math.max(1, Math.floor(ms));
-  if (wholeMS <= 9999) {
-    return `${wholeMS}ms`;
-  }
-  return `${Math.floor(wholeMS / 1000)}s`;
-}
-
-function useLiveElapsedMS(enabled: boolean, createdAt?: string): number {
-  const [elapsedMS, setElapsedMS] = React.useState(0);
-
-  React.useEffect(() => {
-    if (!enabled) {
-      setElapsedMS(0);
-      return;
-    }
-    const startedAt = new Date(createdAt ?? "").getTime();
-    if (Number.isNaN(startedAt)) {
-      setElapsedMS(0);
-      return;
-    }
-
-    let frameID: number | null = null;
-    let timerID: number | null = null;
-
-    const tick = () => {
-      const nextElapsedMS = Math.max(0, Date.now() - startedAt);
-      setElapsedMS(nextElapsedMS);
-
-      if (nextElapsedMS < 9999) {
-        frameID = window.requestAnimationFrame(tick);
-        return;
-      }
-
-      const delayToNextSecond = Math.max(1, 1000 - (nextElapsedMS % 1000));
-      timerID = window.setTimeout(tick, delayToNextSecond);
-    };
-
-    tick();
-
-    return () => {
-      if (frameID !== null) {
-        window.cancelAnimationFrame(frameID);
-      }
-      if (timerID !== null) {
-        window.clearTimeout(timerID);
-      }
-    };
-  }, [createdAt, enabled]);
-
-  return enabled ? elapsedMS : 0;
-}
-
-function calculateElapsedMS(startedAt?: string, endedAt?: string): number {
-  if (!startedAt || !endedAt) {
-    return 0;
-  }
-  const startMS = new Date(startedAt).getTime();
-  const endMS = new Date(endedAt).getTime();
-  if (Number.isNaN(startMS) || Number.isNaN(endMS)) {
-    return 0;
-  }
-  return Math.max(0, endMS - startMS);
-}
-
 function LatencyBadge({ item }: { item: ChatMetaMessage }) {
   const t = useTranslations("chat.meta");
   const isLive = Boolean(item.isPending || item.isStreaming);
-  const liveLatencyMS = useLiveElapsedMS(isLive, item.createdAt);
-  const storedLatencyMS = item.latencyMS && item.latencyMS > 0 ? item.latencyMS : 0;
-  const calculatedLatencyMS = calculateElapsedMS(item.createdAt, item.updatedAt);
+  const liveLatencyMS = useElapsedDurationMS(isLive, item.createdAt);
+  const calculatedLatencyMS = durationBetweenMS(item.createdAt, item.updatedAt);
   const latencyMS = isLive
-    ? liveLatencyMS || calculatedLatencyMS || storedLatencyMS
-    : storedLatencyMS || calculatedLatencyMS;
-  const label = formatDuration(latencyMS);
+    ? firstDurationMS(liveLatencyMS, calculatedLatencyMS, item.latencyMS)
+    : firstDurationMS(item.latencyMS, calculatedLatencyMS);
+  const label = formatDurationMS(latencyMS);
   if (!label) {
     return null;
   }
@@ -1044,7 +981,7 @@ export function AssistantMessageMeta({
     (
       isLive ||
       (item.latencyMS && item.latencyMS > 0) ||
-      calculateElapsedMS(item.createdAt, item.updatedAt) > 0
+      durationBetweenMS(item.createdAt, item.updatedAt) !== undefined
     ),
   );
   const hasDetailBadges = Boolean(

--- a/frontend/features/chat/hooks/use-elapsed-duration.ts
+++ b/frontend/features/chat/hooks/use-elapsed-duration.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+
+const SUBSECOND_TICK_MS = 100;
+const WHOLE_SECOND_TICK_MS = 1000;
+
+export function useElapsedDurationMS(active: boolean, startedAt: string | undefined): number | undefined {
+  const [elapsedMS, setElapsedMS] = React.useState<number>();
+
+  React.useEffect(() => {
+    if (!active || !startedAt) {
+      setElapsedMS(undefined);
+      return;
+    }
+
+    const startedMS = new Date(startedAt).getTime();
+    if (!Number.isFinite(startedMS)) {
+      setElapsedMS(undefined);
+      return;
+    }
+
+    let timerID: number | undefined;
+    const tick = () => {
+      const nextElapsedMS = Math.max(0, Date.now() - startedMS);
+      setElapsedMS(nextElapsedMS);
+
+      const intervalMS = nextElapsedMS < 10_000 ? SUBSECOND_TICK_MS : WHOLE_SECOND_TICK_MS;
+      const delayMS = Math.max(1, intervalMS - (nextElapsedMS % intervalMS));
+      timerID = window.setTimeout(tick, delayMS);
+    };
+
+    tick();
+    return () => {
+      if (timerID !== undefined) {
+        window.clearTimeout(timerID);
+      }
+    };
+  }, [active, startedAt]);
+
+  return active ? elapsedMS : undefined;
+}

--- a/frontend/features/chat/model/duration.ts
+++ b/frontend/features/chat/model/duration.ts
@@ -1,0 +1,49 @@
+type DurationMS = number | null | undefined;
+
+function validDurationMS(value: DurationMS): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+export function durationBetweenMS(startedAt: string | undefined, endedAt: string | undefined): number | undefined {
+  if (!startedAt || !endedAt) {
+    return undefined;
+  }
+
+  const startedMS = new Date(startedAt).getTime();
+  const endedMS = new Date(endedAt).getTime();
+  if (!Number.isFinite(startedMS) || !Number.isFinite(endedMS)) {
+    return undefined;
+  }
+  return validDurationMS(endedMS - startedMS);
+}
+
+export function firstDurationMS(...values: DurationMS[]): number | undefined {
+  for (const value of values) {
+    const durationMS = validDurationMS(value);
+    if (durationMS !== undefined) {
+      return durationMS;
+    }
+  }
+  return undefined;
+}
+
+export function sumDurationsMS(values: Iterable<DurationMS>): number | undefined {
+  let totalMS = 0;
+  for (const value of values) {
+    totalMS += validDurationMS(value) ?? 0;
+  }
+  return validDurationMS(totalMS);
+}
+
+export function formatDurationMS(value: DurationMS): string | undefined {
+  const durationMS = validDurationMS(value);
+  if (durationMS === undefined) {
+    return undefined;
+  }
+
+  const seconds = durationMS / 1000;
+  if (seconds < 10) {
+    return `${Math.max(0.1, seconds).toFixed(1)}s`;
+  }
+  return `${Math.round(seconds)}s`;
+}

--- a/frontend/features/chat/model/message-process-trace.ts
+++ b/frontend/features/chat/model/message-process-trace.ts
@@ -58,27 +58,6 @@ export type TraceDisplayEvent = {
   kind: "think" | "tool";
 };
 
-export function formatTraceStepDuration(durationMS: number | undefined): string | undefined {
-  if (!durationMS || !Number.isFinite(durationMS) || durationMS <= 0) {
-    return undefined;
-  }
-  const seconds = durationMS / 1000;
-  return seconds < 10 ? `${seconds.toFixed(1)}s` : `${Math.round(seconds)}s`;
-}
-
-export function formatTraceRunDuration(durationMS: number | undefined): string | undefined {
-  if (!durationMS || !Number.isFinite(durationMS) || durationMS <= 0) {
-    return undefined;
-  }
-  const wholeSeconds = Math.max(1, Math.round(durationMS / 1000));
-  if (wholeSeconds < 60) {
-    return `${wholeSeconds}s`;
-  }
-  const minutes = Math.floor(wholeSeconds / 60);
-  const seconds = wholeSeconds % 60;
-  return `${minutes}m ${seconds}s`;
-}
-
 export function parseRAGCitations(payloadJson: string | undefined): RAGCitation[] {
   if (!payloadJson) return [];
   try {


### PR DESCRIPTION
## Summary

Closes #641.

- Fix the execution panel subtitle to show the aggregate duration of visible reasoning rounds and tool calls.
- Keep the aggregate duration hidden while execution is in progress and display it only after the panel reaches the completed state.
- Add real-time elapsed timers for active reasoning and tool-call rows.
- Keep the message footer duration as the end-to-end message latency.
- Use one shared duration module for validation, calculation, aggregation, and formatting.
- Remove the previous duplicated formatters and historical duration fallbacks.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm --filter @deeix/web lint`
- [x] `pnpm --filter @deeix/web typecheck`
- [x] `pnpm --filter @deeix/web build`
- [x] `git diff --check`

## Screenshots, API examples, or logs

No additional screenshots or logs are required. The issue already includes the relevant UI screenshot.

## Configuration, migration, and compatibility notes

- No database migration, API contract, configuration, or deployment change.
- Active reasoning rows use their explicit `startedAt` timestamp for real-time display.
- Active tool rows use their explicit event or block `startedAt` timestamp.
- Completed reasoning durations require a valid `startedAt` and `endedAt`.
- Historical `updatedAt` fallback logic was removed; traces without a valid end timestamp do not receive an inferred duration.
- Durations below 10 seconds display one decimal place. Durations of 10 seconds or more display whole seconds.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.