### PR TITLE
feat: show live conversation run status

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -9616,6 +9616,37 @@ const docTemplate = `{
                 }
             }
         },
+        "/conversation-runs/stream": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Sends an authoritative snapshot followed by live user-scoped run state events",
+                "produces": [
+                    "text/event-stream"
+                ],
+                "tags": [
+                    "chat"
+                ],
+                "summary": "Stream active conversation generations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ActiveMessageGenerationEventResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ConversationErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/conversation-runs/{run_id}/cancel": {
             "post": {
                 "security": [
@@ -13725,6 +13756,44 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "ActiveMessageGenerationEventResponse": {
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "conversationPublicID": {
+                    "type": "string"
+                },
+                "runID": {
+                    "type": "string"
+                },
+                "runs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ActiveMessageGenerationResponse"
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "ActiveMessageGenerationResponse": {
+            "type": "object",
+            "required": [
+                "conversationPublicID",
+                "runID"
+            ],
+            "properties": {
+                "conversationPublicID": {
+                    "type": "string"
+                },
+                "runID": {
+                    "type": "string"
+                }
+            }
+        },
         "ActiveSessionListResponse": {
             "type": "object",
             "required": [

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -9609,6 +9609,37 @@
                 }
             }
         },
+        "/conversation-runs/stream": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Sends an authoritative snapshot followed by live user-scoped run state events",
+                "produces": [
+                    "text/event-stream"
+                ],
+                "tags": [
+                    "chat"
+                ],
+                "summary": "Stream active conversation generations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ActiveMessageGenerationEventResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ConversationErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/conversation-runs/{run_id}/cancel": {
             "post": {
                 "security": [
@@ -13718,6 +13749,44 @@
         }
     },
     "definitions": {
+        "ActiveMessageGenerationEventResponse": {
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "conversationPublicID": {
+                    "type": "string"
+                },
+                "runID": {
+                    "type": "string"
+                },
+                "runs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ActiveMessageGenerationResponse"
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "ActiveMessageGenerationResponse": {
+            "type": "object",
+            "required": [
+                "conversationPublicID",
+                "runID"
+            ],
+            "properties": {
+                "conversationPublicID": {
+                    "type": "string"
+                },
+                "runID": {
+                    "type": "string"
+                }
+            }
+        },
         "ActiveSessionListResponse": {
             "type": "object",
             "required": [

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1,5 +1,30 @@
 basePath: /api/v1
 definitions:
+  ActiveMessageGenerationEventResponse:
+    properties:
+      conversationPublicID:
+        type: string
+      runID:
+        type: string
+      runs:
+        items:
+          $ref: '#/definitions/ActiveMessageGenerationResponse'
+        type: array
+      type:
+        type: string
+    required:
+    - type
+    type: object
+  ActiveMessageGenerationResponse:
+    properties:
+      conversationPublicID:
+        type: string
+      runID:
+        type: string
+    required:
+    - conversationPublicID
+    - runID
+    type: object
   ActiveSessionListResponse:
     properties:
       results:
@@ -15403,6 +15428,26 @@ paths:
       security:
       - BearerAuth: []
       summary: 恢复流式生成订阅
+      tags:
+      - chat
+  /conversation-runs/stream:
+    get:
+      description: Sends an authoritative snapshot followed by live user-scoped run
+        state events
+      produces:
+      - text/event-stream
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/ActiveMessageGenerationEventResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/ConversationErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: Stream active conversation generations
       tags:
       - chat
   /conversations:

--- a/backend/internal/application/conversation/generation_active_stream.go
+++ b/backend/internal/application/conversation/generation_active_stream.go
@@ -1,0 +1,257 @@
+package conversation
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
+)
+
+const (
+	activeGenerationEventRetention = 2 * time.Hour
+	activeGenerationEventMaxEvents = 8192
+	activeGenerationEventReadBlock = 5 * time.Minute
+	activeGenerationEventBuffer    = 32
+	activeGenerationEventStreamID  = "active_events_v1"
+)
+
+// ActiveMessageGeneration is the authoritative, user-scoped runtime snapshot.
+type ActiveMessageGeneration struct {
+	RunID                string
+	ConversationPublicID string
+}
+
+// ActiveMessageGenerationEvent is one user-scoped navigation state change.
+type ActiveMessageGenerationEvent struct {
+	Type                 string
+	RunID                string
+	ConversationPublicID string
+	UserID               uint
+}
+
+type activeMessageGenerationEventPayload struct {
+	Type                 string `json:"type"`
+	RunID                string `json:"runID"`
+	ConversationPublicID string `json:"conversationPublicID,omitempty"`
+	UserID               uint   `json:"userID"`
+}
+
+// SubscribeActiveMessageGenerations returns an authoritative snapshot followed
+// by live user-scoped run state events. Redis Streams bridge multiple API nodes.
+func (s *Service) SubscribeActiveMessageGenerations(
+	ctx context.Context,
+	userID uint,
+) ([]ActiveMessageGeneration, <-chan ActiveMessageGenerationEvent, context.CancelFunc, error) {
+	if s == nil || s.generationStreams == nil || userID == 0 {
+		return []ActiveMessageGeneration{}, nil, func() {}, nil
+	}
+	return s.generationStreams.subscribeActive(ctx, userID)
+}
+
+func (r *generationStreamRegistry) listActive(ctx context.Context, userID uint) ([]ActiveMessageGeneration, error) {
+	if r == nil || r.store == nil || userID == 0 {
+		return []ActiveMessageGeneration{}, nil
+	}
+	stored, err := r.store.ListActiveGenerationStreams(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]ActiveMessageGeneration, 0, len(stored))
+	seen := make(map[string]struct{}, len(stored))
+	for _, item := range stored {
+		runID := normalizeRunID(item.RunID)
+		conversationPublicID := normalizePublicID(item.ConversationPublicID)
+		if runID == "" || conversationPublicID == "" {
+			continue
+		}
+		if _, exists := seen[runID]; exists {
+			continue
+		}
+		seen[runID] = struct{}{}
+		items = append(items, ActiveMessageGeneration{
+			RunID:                runID,
+			ConversationPublicID: conversationPublicID,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].RunID < items[j].RunID })
+	return items, nil
+}
+
+func (r *generationStreamRegistry) publishActiveEvent(
+	ctx context.Context,
+	userID uint,
+	eventType string,
+	runID string,
+	conversationPublicID string,
+) {
+	if r == nil || r.store == nil || userID == 0 || (eventType != "started" && eventType != "finished") {
+		return
+	}
+	payload, err := json.Marshal(activeMessageGenerationEventPayload{
+		Type:                 eventType,
+		RunID:                normalizeRunID(runID),
+		ConversationPublicID: normalizePublicID(conversationPublicID),
+		UserID:               userID,
+	})
+	if err != nil {
+		return
+	}
+	_, _ = r.store.AppendGenerationStreamEvent(ctx, activeGenerationEventStreamID, repository.GenerationStreamAppend{
+		PayloadJSON: string(payload),
+	}, activeGenerationEventMaxEvents, activeGenerationEventRetention)
+	_ = r.store.ExpireGenerationStream(ctx, activeGenerationEventStreamID, activeGenerationEventRetention)
+}
+
+func (r *generationStreamRegistry) subscribeActive(
+	ctx context.Context,
+	userID uint,
+) ([]ActiveMessageGeneration, <-chan ActiveMessageGenerationEvent, context.CancelFunc, error) {
+	if r == nil || r.store == nil || userID == 0 {
+		return []ActiveMessageGeneration{}, nil, func() {}, nil
+	}
+	if err := r.ensureActiveEventReader(ctx); err != nil {
+		return nil, nil, nil, err
+	}
+	events, cancel := r.addActiveSubscriber(userID)
+	snapshot, err := r.listActive(ctx, userID)
+	if err != nil {
+		cancel()
+		return nil, nil, nil, err
+	}
+	return snapshot, events, cancel, nil
+}
+
+func (r *generationStreamRegistry) ensureActiveEventReader(ctx context.Context) error {
+	r.mu.Lock()
+	if r.activeEventReaderStarted {
+		r.mu.Unlock()
+		return nil
+	}
+	r.mu.Unlock()
+
+	latest, err := r.store.ListGenerationStreamEvents(ctx, activeGenerationEventStreamID, 1)
+	if err != nil {
+		return err
+	}
+	cursor := "0-0"
+	if len(latest) > 0 && strings.TrimSpace(latest[len(latest)-1].ID) != "" {
+		cursor = latest[len(latest)-1].ID
+	}
+
+	r.mu.Lock()
+	if r.activeEventReaderStarted {
+		r.mu.Unlock()
+		return nil
+	}
+	r.activeEventReaderStarted = true
+	r.mu.Unlock()
+	go r.readActiveEventBus(cursor)
+	return nil
+}
+
+func (r *generationStreamRegistry) addActiveSubscriber(
+	userID uint,
+) (<-chan ActiveMessageGenerationEvent, context.CancelFunc) {
+	r.mu.Lock()
+	r.activeSubscriberSeq++
+	subscriberID := r.activeSubscriberSeq
+	events := make(chan ActiveMessageGenerationEvent, activeGenerationEventBuffer)
+	if r.activeSubscribers[userID] == nil {
+		r.activeSubscribers[userID] = make(map[uint64]chan ActiveMessageGenerationEvent)
+	}
+	r.activeSubscribers[userID][subscriberID] = events
+	r.mu.Unlock()
+
+	var once sync.Once
+	cancel := func() {
+		once.Do(func() {
+			r.mu.Lock()
+			subscribers := r.activeSubscribers[userID]
+			if current, ok := subscribers[subscriberID]; ok {
+				delete(subscribers, subscriberID)
+				close(current)
+			}
+			if len(subscribers) == 0 {
+				delete(r.activeSubscribers, userID)
+			}
+			r.mu.Unlock()
+		})
+	}
+	return events, cancel
+}
+
+func (r *generationStreamRegistry) readActiveEventBus(cursor string) {
+	retryDelay := time.Second
+	for {
+		records, err := r.store.ReadGenerationStreamEvents(
+			context.Background(),
+			activeGenerationEventStreamID,
+			cursor,
+			activeGenerationEventReadBlock,
+			activeGenerationEventBuffer,
+		)
+		if err != nil {
+			r.closeActiveSubscribers()
+			time.Sleep(retryDelay)
+			if retryDelay < 30*time.Second {
+				retryDelay *= 2
+			}
+			continue
+		}
+		retryDelay = time.Second
+		for _, record := range records {
+			if strings.TrimSpace(record.ID) != "" {
+				cursor = record.ID
+			}
+			var payload activeMessageGenerationEventPayload
+			if json.Unmarshal([]byte(record.PayloadJSON), &payload) != nil {
+				continue
+			}
+			event := ActiveMessageGenerationEvent{
+				Type:                 payload.Type,
+				RunID:                payload.RunID,
+				ConversationPublicID: payload.ConversationPublicID,
+				UserID:               payload.UserID,
+			}
+			event.RunID = normalizeRunID(event.RunID)
+			event.ConversationPublicID = normalizePublicID(event.ConversationPublicID)
+			if event.UserID == 0 || event.RunID == "" || (event.Type != "started" && event.Type != "finished") {
+				continue
+			}
+			r.fanOutActiveEvent(event)
+		}
+	}
+}
+
+func (r *generationStreamRegistry) fanOutActiveEvent(event ActiveMessageGenerationEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	subscribers := r.activeSubscribers[event.UserID]
+	for subscriberID, events := range subscribers {
+		select {
+		case events <- event:
+		default:
+			close(events)
+			delete(subscribers, subscriberID)
+		}
+	}
+	if len(subscribers) == 0 {
+		delete(r.activeSubscribers, event.UserID)
+	}
+}
+
+func (r *generationStreamRegistry) closeActiveSubscribers() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for userID, subscribers := range r.activeSubscribers {
+		for subscriberID, events := range subscribers {
+			close(events)
+			delete(subscribers, subscriberID)
+		}
+		delete(r.activeSubscribers, userID)
+	}
+}

--- a/backend/internal/application/conversation/generation_stream.go
+++ b/backend/internal/application/conversation/generation_stream.go
@@ -151,16 +151,20 @@ type GenerationStreamEvent struct {
 
 type activeGeneration struct {
 	userID          uint
+	conversationID  string
 	cancel          context.CancelFunc
 	leaseCancel     context.CancelFunc
 	maxRuntimeTimer *time.Timer
 }
 
 type generationStreamRegistry struct {
-	mu      sync.Mutex
-	active  map[string]*activeGeneration
-	store   repository.GenerationStreamCacheRepository
-	options generationStreamOptions
+	mu                       sync.Mutex
+	active                   map[string]*activeGeneration
+	store                    repository.GenerationStreamCacheRepository
+	options                  generationStreamOptions
+	activeEventReaderStarted bool
+	activeSubscriberSeq      uint64
+	activeSubscribers        map[uint]map[uint64]chan ActiveMessageGenerationEvent
 }
 
 func newGenerationStreamRegistry(store repository.GenerationStreamCacheRepository, options generationStreamOptions) *generationStreamRegistry {
@@ -183,28 +187,36 @@ func newGenerationStreamRegistry(store repository.GenerationStreamCacheRepositor
 		options.SubscriberBuffer = generationStreamSubscriberBuffer
 	}
 	return &generationStreamRegistry{
-		active:  map[string]*activeGeneration{},
-		store:   store,
-		options: options,
+		active:            map[string]*activeGeneration{},
+		store:             store,
+		options:           options,
+		activeSubscribers: map[uint]map[uint64]chan ActiveMessageGenerationEvent{},
 	}
 }
 
-func (r *generationStreamRegistry) register(ctx context.Context, runID string, userID uint, cancel context.CancelFunc) {
+func (r *generationStreamRegistry) register(ctx context.Context, runID string, userID uint, conversationPublicID string, cancel context.CancelFunc) {
 	if runID == "" {
 		if cancel != nil {
 			cancel()
 		}
 		return
 	}
+	conversationPublicID = normalizePublicID(conversationPublicID)
+	if userID == 0 || conversationPublicID == "" {
+		if cancel != nil {
+			cancel()
+		}
+		return
+	}
 	if r.store != nil {
-		_ = r.store.RegisterGenerationStream(ctx, runID, userID, r.options.ActiveTTL)
+		_ = r.store.RegisterGenerationStream(ctx, runID, userID, conversationPublicID, r.options.ActiveTTL)
 	}
 
 	var replaced *activeGeneration
 	r.mu.Lock()
 	replaced = r.active[runID]
-	active := &activeGeneration{userID: userID, cancel: cancel}
-	active.leaseCancel = r.startActiveLease(runID)
+	active := &activeGeneration{userID: userID, conversationID: conversationPublicID, cancel: cancel}
+	active.leaseCancel = r.startActiveLease(runID, userID)
 	r.active[runID] = active
 	r.scheduleActiveExpiryLocked(runID, active)
 	r.mu.Unlock()
@@ -214,7 +226,11 @@ func (r *generationStreamRegistry) register(ctx context.Context, runID string, u
 		if replaced.cancel != nil {
 			replaced.cancel()
 		}
+		if replaced.userID != userID || replaced.conversationID != conversationPublicID {
+			r.publishActiveEvent(context.Background(), replaced.userID, "finished", runID, replaced.conversationID)
+		}
 	}
+	r.publishActiveEvent(context.Background(), userID, "started", runID, conversationPublicID)
 }
 
 func (r *generationStreamRegistry) cancel(ctx context.Context, userID uint, runID string) bool {
@@ -253,7 +269,16 @@ func (r *generationStreamRegistry) cancelActive(ctx context.Context, userID uint
 	if ok && active.cancel != nil {
 		active.cancel()
 	}
-	r.clearActive(context.Background(), runID)
+	clearUserID := userID
+	if active != nil && active.userID != 0 {
+		clearUserID = active.userID
+	}
+	r.clearActive(context.Background(), runID, clearUserID)
+	conversationID := ""
+	if active != nil {
+		conversationID = active.conversationID
+	}
+	r.publishActiveEvent(context.Background(), clearUserID, "finished", runID, conversationID)
 	return true
 }
 
@@ -434,17 +459,30 @@ func (r *generationStreamRegistry) finish(ctx context.Context, runID string) {
 	if runID == "" {
 		return
 	}
-	r.clearActive(ctx, runID)
-	if r.store != nil {
-		_ = r.store.ExpireGenerationStream(ctx, runID, r.options.Retention)
-	}
-
 	r.mu.Lock()
 	active, ok := r.active[runID]
 	if ok {
 		delete(r.active, runID)
 	}
 	r.mu.Unlock()
+	userID := uint(0)
+	if active != nil {
+		userID = active.userID
+	}
+	if userID == 0 && r.store != nil {
+		if ownerID, found, err := r.store.GetGenerationStreamOwner(ctx, runID); err == nil && found {
+			userID = ownerID
+		}
+	}
+	r.clearActive(ctx, runID, userID)
+	conversationID := ""
+	if active != nil {
+		conversationID = active.conversationID
+	}
+	r.publishActiveEvent(context.Background(), userID, "finished", runID, conversationID)
+	if r.store != nil {
+		_ = r.store.ExpireGenerationStream(ctx, runID, r.options.Retention)
+	}
 	if ok {
 		stopActiveGeneration(active)
 	}
@@ -472,18 +510,23 @@ func (r *generationStreamRegistry) scheduleActiveExpiryLocked(runID string, acti
 	active.maxRuntimeTimer = time.AfterFunc(activeTTL, func() {
 		var cancel context.CancelFunc
 		var leaseCancel context.CancelFunc
+		expired := false
 		r.mu.Lock()
 		current, ok := r.active[runID]
-		if ok && current == active && current.cancel != nil {
+		if ok && current == active {
 			delete(r.active, runID)
 			cancel = current.cancel
 			leaseCancel = current.leaseCancel
+			expired = true
 		}
 		r.mu.Unlock()
 		if leaseCancel != nil {
 			leaseCancel()
 		}
-		r.clearActive(context.Background(), runID)
+		if expired {
+			r.clearActive(context.Background(), runID, active.userID)
+			r.publishActiveEvent(context.Background(), active.userID, "finished", runID, active.conversationID)
+		}
 		if cancel != nil {
 			cancel()
 		}
@@ -516,9 +559,9 @@ func (r *generationStreamRegistry) hasActive(ctx context.Context, runID string) 
 	return false
 }
 
-func (r *generationStreamRegistry) startActiveLease(runID string) context.CancelFunc {
+func (r *generationStreamRegistry) startActiveLease(runID string, userID uint) context.CancelFunc {
 	ctx, cancel := context.WithCancel(context.Background())
-	r.touchActive(ctx, runID)
+	r.touchActiveForOwner(ctx, runID, userID)
 	go func() {
 		ticker := time.NewTicker(r.options.LeaseRefresh)
 		defer ticker.Stop()
@@ -527,7 +570,7 @@ func (r *generationStreamRegistry) startActiveLease(runID string) context.Cancel
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				r.touchActive(ctx, runID)
+				r.touchActiveForOwner(ctx, runID, userID)
 			}
 		}
 	}()
@@ -538,17 +581,27 @@ func (r *generationStreamRegistry) touchActive(ctx context.Context, runID string
 	if runID == "" {
 		return
 	}
-	if r.store != nil {
-		_ = r.store.TouchGenerationStreamActive(ctx, runID, r.options.LeaseTTL)
+	r.mu.Lock()
+	active := r.active[runID]
+	r.mu.Unlock()
+	if active != nil {
+		r.touchActiveForOwner(ctx, runID, active.userID)
 	}
 }
 
-func (r *generationStreamRegistry) clearActive(ctx context.Context, runID string) {
+func (r *generationStreamRegistry) touchActiveForOwner(ctx context.Context, runID string, userID uint) {
+	if runID == "" || userID == 0 || r.store == nil {
+		return
+	}
+	_ = r.store.TouchGenerationStreamActive(ctx, runID, userID, r.options.LeaseTTL)
+}
+
+func (r *generationStreamRegistry) clearActive(ctx context.Context, runID string, userID uint) {
 	if runID == "" {
 		return
 	}
 	if r.store != nil {
-		_ = r.store.ClearGenerationStreamActive(ctx, runID)
+		_ = r.store.ClearGenerationStreamActive(ctx, runID, userID)
 	}
 }
 

--- a/backend/internal/application/conversation/generation_stream_test.go
+++ b/backend/internal/application/conversation/generation_stream_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	cachememory "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/cache/memory"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
 )
 
@@ -22,7 +23,7 @@ func TestGenerationStreamRegistryReplayAndTerminal(t *testing.T) {
 	})
 	ctx := context.Background()
 	runID := EnsureMessageGenerationRunID("")
-	registry.register(ctx, runID, 7, func() {})
+	registry.register(ctx, runID, 7, "conv_test", func() {})
 	defer registry.finish(ctx, runID)
 
 	first := registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": "a"})
@@ -65,7 +66,7 @@ func TestGenerationStreamRegistryReplayUsesFullTextSnapshotBeyondWindow(t *testi
 	})
 	ctx := context.Background()
 	runID := EnsureMessageGenerationRunID("")
-	registry.register(ctx, runID, 7, func() {})
+	registry.register(ctx, runID, 7, "conv_test", func() {})
 	defer registry.finish(ctx, runID)
 
 	for _, delta := range []string{"a", "b", "c", "d", "e", "f"} {
@@ -91,7 +92,7 @@ func TestGenerationStreamRegistryLegacyReplayKeepsOriginalDeltaProtocol(t *testi
 	})
 	ctx := context.Background()
 	runID := EnsureMessageGenerationRunID("")
-	registry.register(ctx, runID, 7, func() {})
+	registry.register(ctx, runID, 7, "conv_test", func() {})
 	defer registry.finish(ctx, runID)
 	registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": "legacy"})
 
@@ -117,7 +118,7 @@ func TestGenerationStreamRegistrySnapshotThenLiveDeltaExactlyOnce(t *testing.T) 
 	})
 	ctx := context.Background()
 	runID := EnsureMessageGenerationRunID("")
-	registry.register(ctx, runID, 7, func() {})
+	registry.register(ctx, runID, 7, "conv_test", func() {})
 	defer registry.finish(ctx, runID)
 	registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": "a"})
 	registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": "b"})
@@ -151,7 +152,7 @@ func TestGenerationStreamRegistryKeepsNonTextReplayInSequenceOrder(t *testing.T)
 	})
 	ctx := context.Background()
 	runID := EnsureMessageGenerationRunID("")
-	registry.register(ctx, runID, 7, func() {})
+	registry.register(ctx, runID, 7, "conv_test", func() {})
 	defer registry.finish(ctx, runID)
 	registry.publish(ctx, runID, map[string]interface{}{"type": "file_proc", "message": "preparing"})
 	registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": "answer"})
@@ -180,7 +181,7 @@ func TestGenerationStreamRegistryRejectsTextReplayWithoutSnapshot(t *testing.T) 
 	})
 	ctx := context.Background()
 	runID := EnsureMessageGenerationRunID("")
-	registry.register(ctx, runID, 7, func() {})
+	registry.register(ctx, runID, 7, "conv_test", func() {})
 	defer registry.finish(ctx, runID)
 	if _, err := store.AppendGenerationStreamEvent(ctx, runID, repository.GenerationStreamAppend{
 		PayloadJSON: `{"type":"delta","delta":"unsafe"}`,
@@ -203,7 +204,7 @@ func TestGenerationStreamRegistryResetClearsTextSnapshot(t *testing.T) {
 	})
 	ctx := context.Background()
 	runID := EnsureMessageGenerationRunID("")
-	registry.register(ctx, runID, 7, func() {})
+	registry.register(ctx, runID, 7, "conv_test", func() {})
 	defer registry.finish(ctx, runID)
 	registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": "blocked text"})
 	registry.resetEvents(ctx, runID)
@@ -232,7 +233,7 @@ func TestGenerationStreamRegistryCancelUsesSharedMarker(t *testing.T) {
 	ctx := context.Background()
 	runID := EnsureMessageGenerationRunID("")
 	canceled := false
-	registry.register(ctx, runID, 9, func() { canceled = true })
+	registry.register(ctx, runID, 9, "conv_test", func() { canceled = true })
 	defer registry.finish(ctx, runID)
 
 	if !registry.cancel(ctx, 9, runID) {
@@ -269,10 +270,17 @@ func TestGenerationStreamRegistryActiveLeaseLifecycle(t *testing.T) {
 	})
 	ctx := context.Background()
 	runID := EnsureMessageGenerationRunID("")
-	registry.register(ctx, runID, 7, func() {})
+	registry.register(ctx, runID, 7, "conv_test", func() {})
 
 	if !registry.hasActive(ctx, runID) {
 		t.Fatal("expected active lease after register")
+	}
+	items, err := registry.listActive(ctx, 7)
+	if err != nil || len(items) != 1 || items[0].RunID != runID || items[0].ConversationPublicID != "conv_test" {
+		t.Fatalf("active generation snapshot=%+v err=%v, want registered run", items, err)
+	}
+	if otherItems, otherErr := registry.listActive(ctx, 8); otherErr != nil || len(otherItems) != 0 {
+		t.Fatalf("other user snapshot=%+v err=%v, want empty", otherItems, otherErr)
 	}
 
 	registry.finish(ctx, runID)
@@ -285,13 +293,76 @@ func TestGenerationStreamRegistryActiveLeaseLifecycle(t *testing.T) {
 	if stillTracked {
 		t.Fatal("expected local active generation to be removed after finish")
 	}
+	if items, err = registry.listActive(ctx, 7); err != nil || len(items) != 0 {
+		t.Fatalf("active generation snapshot after finish=%+v err=%v, want empty", items, err)
+	}
+}
+
+func TestGenerationStreamRegistryActiveSubscriptionStartsWithSnapshotAndStreamsEvents(t *testing.T) {
+	store := cachememory.New()
+	registry := newGenerationStreamRegistry(store, generationStreamOptions{
+		Retention:        time.Minute,
+		ActiveTTL:        time.Minute,
+		LeaseTTL:         time.Second,
+		LeaseRefresh:     100 * time.Millisecond,
+		MaxEvents:        8,
+		SubscriberBuffer: 4,
+	})
+	ctx := context.Background()
+	registry.register(ctx, "run_snapshot", 7, "conv_snapshot", func() {})
+	defer registry.finish(ctx, "run_snapshot")
+
+	snapshot, events, cancel, err := registry.subscribeActive(ctx, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancel()
+	if len(snapshot) != 1 || snapshot[0].RunID != "run_snapshot" || snapshot[0].ConversationPublicID != "conv_snapshot" {
+		t.Fatalf("snapshot = %+v, want the active run", snapshot)
+	}
+	otherSnapshot, otherEvents, cancelOther, err := registry.subscribeActive(ctx, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancelOther()
+	if len(otherSnapshot) != 0 {
+		t.Fatalf("other user snapshot = %+v, want empty", otherSnapshot)
+	}
+
+	registry.register(ctx, "run_live", 7, "conv_live", func() {})
+	select {
+	case event := <-events:
+		if event.Type != "started" || event.RunID != "run_live" || event.ConversationPublicID != "conv_live" {
+			t.Fatalf("started event = %+v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for started event")
+	}
+	select {
+	case event := <-otherEvents:
+		t.Fatalf("other user received event = %+v", event)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	registry.finish(ctx, "run_live")
+	select {
+	case event := <-events:
+		if event.Type != "finished" || event.RunID != "run_live" {
+			t.Fatalf("finished event = %+v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for finished event")
+	}
 }
 
 func TestGenerationStreamStoreActiveLeaseExpires(t *testing.T) {
 	store := newTestGenerationStreamStore()
 	ctx := context.Background()
 	runID := EnsureMessageGenerationRunID("")
-	if err := store.TouchGenerationStreamActive(ctx, runID, 10*time.Millisecond); err != nil {
+	if err := store.RegisterGenerationStream(ctx, runID, 7, "conv_test", time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.TouchGenerationStreamActive(ctx, runID, 7, 10*time.Millisecond); err != nil {
 		t.Fatal(err)
 	}
 	if active, err := store.IsGenerationStreamActive(ctx, runID); err != nil || !active {
@@ -307,7 +378,7 @@ func TestGenerationStreamStoreReturnsLatestWindow(t *testing.T) {
 	store := newTestGenerationStreamStore()
 	ctx := context.Background()
 	runID := EnsureMessageGenerationRunID("")
-	if err := store.RegisterGenerationStream(ctx, runID, 11, time.Minute); err != nil {
+	if err := store.RegisterGenerationStream(ctx, runID, 11, "conv_test", time.Minute); err != nil {
 		t.Fatal(err)
 	}
 	for i := 0; i < 5; i++ {
@@ -338,7 +409,7 @@ func TestGenerationStreamSanitizesOversizedTracePayload(t *testing.T) {
 	})
 	ctx := context.Background()
 	runID := EnsureMessageGenerationRunID("")
-	registry.register(ctx, runID, 7, func() {})
+	registry.register(ctx, runID, 7, "conv_test", func() {})
 	defer registry.finish(ctx, runID)
 
 	largeOutput := strings.Repeat("x", generationStreamMaxPayloadBytes)
@@ -424,7 +495,7 @@ func TestGenerationStreamDoesNotCompactOversizedCompletedPayload(t *testing.T) {
 	})
 	ctx := context.Background()
 	runID := EnsureMessageGenerationRunID("")
-	registry.register(ctx, runID, 7, func() {})
+	registry.register(ctx, runID, 7, "conv_test", func() {})
 	defer registry.finish(ctx, runID)
 
 	largeContent := strings.Repeat("a", generationStreamMaxPayloadBytes)
@@ -463,25 +534,27 @@ type testGenerationStreamStore struct {
 }
 
 type testGenerationStream struct {
-	userID      uint
-	canceled    bool
-	activeUntil time.Time
-	nextSeq     int64
-	events      []repository.GenerationStreamMessage
-	textContent strings.Builder
-	textSeq     int64
-	expiresAt   time.Time
+	userID         uint
+	conversationID string
+	canceled       bool
+	activeUntil    time.Time
+	nextSeq        int64
+	events         []repository.GenerationStreamMessage
+	textContent    strings.Builder
+	textSeq        int64
+	expiresAt      time.Time
 }
 
 func newTestGenerationStreamStore() *testGenerationStreamStore {
 	return &testGenerationStreamStore{items: map[string]*testGenerationStream{}}
 }
 
-func (s *testGenerationStreamStore) RegisterGenerationStream(_ context.Context, runID string, userID uint, ttl time.Duration) error {
+func (s *testGenerationStreamStore) RegisterGenerationStream(_ context.Context, runID string, userID uint, conversationPublicID string, ttl time.Duration) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	item := s.ensureLocked(runID)
 	item.userID = userID
+	item.conversationID = conversationPublicID
 	item.canceled = false
 	item.expiresAt = time.Now().Add(ttl)
 	return nil
@@ -498,17 +571,20 @@ func (s *testGenerationStreamStore) GetGenerationStreamOwner(_ context.Context, 
 	return item.userID, true, nil
 }
 
-func (s *testGenerationStreamStore) TouchGenerationStreamActive(_ context.Context, runID string, ttl time.Duration) error {
+func (s *testGenerationStreamStore) TouchGenerationStreamActive(_ context.Context, runID string, userID uint, ttl time.Duration) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.ensureLocked(runID).activeUntil = time.Now().Add(ttl)
+	item := s.ensureLocked(runID)
+	if item.userID == userID {
+		item.activeUntil = time.Now().Add(ttl)
+	}
 	return nil
 }
 
-func (s *testGenerationStreamStore) ClearGenerationStreamActive(_ context.Context, runID string) error {
+func (s *testGenerationStreamStore) ClearGenerationStreamActive(_ context.Context, runID string, userID uint) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if item, ok := s.items[runID]; ok {
+	if item, ok := s.items[runID]; ok && item.userID == userID {
 		item.activeUntil = time.Time{}
 	}
 	return nil
@@ -520,6 +596,20 @@ func (s *testGenerationStreamStore) IsGenerationStreamActive(_ context.Context, 
 	s.cleanupLocked()
 	item, ok := s.items[runID]
 	return ok && !item.activeUntil.IsZero() && time.Now().Before(item.activeUntil), nil
+}
+
+func (s *testGenerationStreamStore) ListActiveGenerationStreams(_ context.Context, userID uint) ([]repository.ActiveGenerationStream, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cleanupLocked()
+	items := make([]repository.ActiveGenerationStream, 0)
+	for runID, item := range s.items {
+		if item.userID != userID || item.activeUntil.IsZero() || !time.Now().Before(item.activeUntil) || item.conversationID == "" {
+			continue
+		}
+		items = append(items, repository.ActiveGenerationStream{RunID: runID, ConversationPublicID: item.conversationID})
+	}
+	return items, nil
 }
 
 func (s *testGenerationStreamStore) RequestGenerationStreamCancel(_ context.Context, runID string, ttl time.Duration) error {

--- a/backend/internal/application/conversation/service_media_generation.go
+++ b/backend/internal/application/conversation/service_media_generation.go
@@ -230,7 +230,7 @@ func (s *Service) StreamMediaImage(ctx context.Context, input MediaImageInput) (
 	}()
 	cancelCtx, cancel := context.WithCancel(ctx)
 	ctx = cancelCtx
-	s.generationStreams.register(ctx, runID, input.UserID, cancel)
+	s.generationStreams.register(ctx, runID, input.UserID, conversation.PublicID, cancel)
 
 	assistantMessage = &model.Message{
 		ConversationID: input.ConversationID,

--- a/backend/internal/application/conversation/service_media_video.go
+++ b/backend/internal/application/conversation/service_media_video.go
@@ -204,7 +204,7 @@ func (s *Service) StreamMediaVideo(ctx context.Context, input MediaVideoInput) (
 	}()
 	cancelCtx, cancel := context.WithCancel(ctx)
 	ctx = cancelCtx
-	s.generationStreams.register(ctx, runID, input.UserID, cancel)
+	s.generationStreams.register(ctx, runID, input.UserID, conversation.PublicID, cancel)
 
 	assistantMessage = &model.Message{
 		ConversationID: input.ConversationID,

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -213,7 +213,7 @@ func (s *Service) sendMessageInternal(
 	if input.Cancelable {
 		cancelCtx, cancel := context.WithCancel(ctx)
 		ctx = cancelCtx
-		s.generationStreams.register(ctx, runID, input.UserID, cancel)
+		s.generationStreams.register(ctx, runID, input.UserID, conversation.PublicID, cancel)
 	}
 
 	currentPlatformModelName := strings.TrimSpace(conversation.Model)

--- a/backend/internal/infra/cache/memory/cache.go
+++ b/backend/internal/infra/cache/memory/cache.go
@@ -25,7 +25,8 @@ type Cache struct {
 
 	rag map[string]expiringRAG
 
-	streams map[string]*generationStream
+	streams      map[string]*generationStream
+	streamNotify chan struct{}
 
 	upstreamCB   map[uint]*circuitState
 	modelCB      map[string]*circuitState
@@ -60,6 +61,7 @@ func New() *Cache {
 		fileNotify:               make(chan struct{}),
 		rag:                      map[string]expiringRAG{},
 		streams:                  map[string]*generationStream{},
+		streamNotify:             make(chan struct{}),
 		upstreamCB:               map[uint]*circuitState{},
 		modelCB:                  map[string]*circuitState{},
 		upstreamMeta:             map[uint]upstreamMetadata{},

--- a/backend/internal/infra/cache/memory/generation_stream.go
+++ b/backend/internal/infra/cache/memory/generation_stream.go
@@ -11,6 +11,7 @@ import (
 
 type generationStream struct {
 	ownerID         uint
+	conversationID  string
 	ownerExpiresAt  time.Time
 	activeExpiresAt time.Time
 	cancelExpiresAt time.Time
@@ -22,11 +23,12 @@ type generationStream struct {
 	notify          chan struct{}
 }
 
-func (c *Cache) RegisterGenerationStream(ctx context.Context, runID string, userID uint, ttl time.Duration) error {
+func (c *Cache) RegisterGenerationStream(ctx context.Context, runID string, userID uint, conversationPublicID string, ttl time.Duration) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	stream := c.ensureStreamLocked(runID)
 	stream.ownerID = userID
+	stream.conversationID = strings.TrimSpace(conversationPublicID)
 	stream.ownerExpiresAt = ttlFromNow(ttl)
 	stream.cancelExpiresAt = time.Time{}
 	c.maybeSweepLocked(time.Now())
@@ -44,22 +46,43 @@ func (c *Cache) GetGenerationStreamOwner(ctx context.Context, runID string) (uin
 	return stream.ownerID, true, nil
 }
 
-func (c *Cache) TouchGenerationStreamActive(ctx context.Context, runID string, ttl time.Duration) error {
+func (c *Cache) TouchGenerationStreamActive(ctx context.Context, runID string, userID uint, ttl time.Duration) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	stream := c.ensureStreamLocked(runID)
+	if stream.ownerID != userID {
+		return nil
+	}
 	stream.activeExpiresAt = ttlFromNow(ttl)
 	c.maybeSweepLocked(time.Now())
 	return nil
 }
 
-func (c *Cache) ClearGenerationStreamActive(ctx context.Context, runID string) error {
+func (c *Cache) ClearGenerationStreamActive(ctx context.Context, runID string, userID uint) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if stream := c.streams[strings.TrimSpace(runID)]; stream != nil {
+	if stream := c.streams[strings.TrimSpace(runID)]; stream != nil && stream.ownerID == userID {
 		stream.activeExpiresAt = time.Time{}
 	}
 	return nil
+}
+
+func (c *Cache) ListActiveGenerationStreams(ctx context.Context, userID uint) ([]repository.ActiveGenerationStream, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	c.maybeSweepLocked(now)
+	items := make([]repository.ActiveGenerationStream, 0)
+	for runID, stream := range c.streams {
+		if stream.ownerID != userID || stream.activeExpired(now) || strings.TrimSpace(stream.conversationID) == "" {
+			continue
+		}
+		items = append(items, repository.ActiveGenerationStream{
+			RunID:                runID,
+			ConversationPublicID: stream.conversationID,
+		})
+	}
+	return items, nil
 }
 
 func (c *Cache) IsGenerationStreamActive(ctx context.Context, runID string) (bool, error) {
@@ -111,6 +134,7 @@ func (c *Cache) AppendGenerationStreamEvent(ctx context.Context, runID string, i
 	}
 	stream.eventsExpiresAt = ttlFromNow(ttl)
 	stream.notifyLocked()
+	c.notifyGenerationStreamsLocked()
 	c.maybeSweepLocked(time.Now())
 	return record, nil
 }
@@ -157,8 +181,16 @@ func (c *Cache) ReadGenerationStreamEvents(ctx context.Context, runID string, af
 		stream := c.streams[strings.TrimSpace(runID)]
 		now := time.Now()
 		if stream == nil || stream.eventsExpired(now) {
+			notify := c.streamNotify
 			c.mu.Unlock()
-			return nil, nil
+			select {
+			case <-ctx.Done():
+				return nil, nil
+			case <-time.After(time.Until(deadline)):
+				return nil, nil
+			case <-notify:
+				continue
+			}
 		}
 		records := generationEventsAfter(stream.events, afterSeq, limit)
 		if len(records) > 0 {
@@ -175,6 +207,11 @@ func (c *Cache) ReadGenerationStreamEvents(ctx context.Context, runID string, af
 		case <-notify:
 		}
 	}
+}
+
+func (c *Cache) notifyGenerationStreamsLocked() {
+	close(c.streamNotify)
+	c.streamNotify = make(chan struct{})
 }
 
 func (c *Cache) ResetGenerationStreamEvents(ctx context.Context, runID string) error {

--- a/backend/internal/infra/cache/memory/generation_stream_test.go
+++ b/backend/internal/infra/cache/memory/generation_stream_test.go
@@ -13,7 +13,7 @@ func TestGenerationStreamRegisterDoesNotMarkCanceled(t *testing.T) {
 	ctx := context.Background()
 	runID := "run_memory_cancel_state"
 
-	if err := cache.RegisterGenerationStream(ctx, runID, 7, time.Minute); err != nil {
+	if err := cache.RegisterGenerationStream(ctx, runID, 7, "conv_test", time.Minute); err != nil {
 		t.Fatalf("register generation stream: %v", err)
 	}
 
@@ -34,7 +34,7 @@ func TestGenerationStreamRegisterDoesNotMarkCanceled(t *testing.T) {
 		t.Fatalf("requested stream canceled=%v err=%v, want true nil", canceled, err)
 	}
 
-	if err := cache.RegisterGenerationStream(ctx, runID, 7, time.Minute); err != nil {
+	if err := cache.RegisterGenerationStream(ctx, runID, 7, "conv_test", time.Minute); err != nil {
 		t.Fatalf("register generation stream after cancel: %v", err)
 	}
 	if canceled, err := cache.IsGenerationStreamCanceled(ctx, runID); err != nil || canceled {
@@ -46,7 +46,7 @@ func TestGenerationStreamTextSnapshotLifecycle(t *testing.T) {
 	cache := New()
 	ctx := context.Background()
 	runID := "run_memory_text_snapshot"
-	if err := cache.RegisterGenerationStream(ctx, runID, 7, time.Minute); err != nil {
+	if err := cache.RegisterGenerationStream(ctx, runID, 7, "conv_test", time.Minute); err != nil {
 		t.Fatal(err)
 	}
 
@@ -94,20 +94,30 @@ func TestGenerationStreamClearActiveMarksInactive(t *testing.T) {
 	ctx := context.Background()
 	runID := "run_memory_active_state"
 
-	if err := cache.RegisterGenerationStream(ctx, runID, 7, time.Minute); err != nil {
+	if err := cache.RegisterGenerationStream(ctx, runID, 7, "conv_test", time.Minute); err != nil {
 		t.Fatalf("register generation stream: %v", err)
 	}
-	if err := cache.TouchGenerationStreamActive(ctx, runID, time.Minute); err != nil {
+	if err := cache.TouchGenerationStreamActive(ctx, runID, 7, time.Minute); err != nil {
 		t.Fatalf("touch active stream: %v", err)
 	}
 	if active, err := cache.IsGenerationStreamActive(ctx, runID); err != nil || !active {
 		t.Fatalf("touched stream active=%v err=%v, want true nil", active, err)
 	}
+	items, err := cache.ListActiveGenerationStreams(ctx, 7)
+	if err != nil || len(items) != 1 || items[0].RunID != runID || items[0].ConversationPublicID != "conv_test" {
+		t.Fatalf("active streams=%+v err=%v, want registered run", items, err)
+	}
+	if otherItems, otherErr := cache.ListActiveGenerationStreams(ctx, 8); otherErr != nil || len(otherItems) != 0 {
+		t.Fatalf("other user active streams=%+v err=%v, want empty", otherItems, otherErr)
+	}
 
-	if err := cache.ClearGenerationStreamActive(ctx, runID); err != nil {
+	if err := cache.ClearGenerationStreamActive(ctx, runID, 7); err != nil {
 		t.Fatalf("clear active stream: %v", err)
 	}
 	if active, err := cache.IsGenerationStreamActive(ctx, runID); err != nil || active {
 		t.Fatalf("cleared stream active=%v err=%v, want false nil", active, err)
+	}
+	if items, err = cache.ListActiveGenerationStreams(ctx, 7); err != nil || len(items) != 0 {
+		t.Fatalf("active streams after clear=%+v err=%v, want empty", items, err)
 	}
 }

--- a/backend/internal/infra/cache/redis/conversation_cache.go
+++ b/backend/internal/infra/cache/redis/conversation_cache.go
@@ -35,6 +35,7 @@ const (
 	fileProcessingMinIdle    = 45 * time.Second
 
 	generationStreamKeyPrefix = "conversation:generation:"
+	generationStreamIndexTTL  = 2 * time.Hour
 )
 
 // appendGenerationStreamEventScript keeps the event sequence, bounded replay
@@ -74,6 +75,24 @@ if has_text_delta and text_missing then
 end
 
 return {id, tostring(seq)}
+`)
+
+var touchGenerationStreamActiveScript = redis.NewScript(`
+if redis.call("GET", KEYS[1]) ~= ARGV[1] then
+	return 0
+end
+redis.call("SET", KEYS[2], "1", "PX", ARGV[2])
+redis.call("ZADD", KEYS[3], ARGV[3], ARGV[4])
+redis.call("PEXPIRE", KEYS[3], ARGV[5])
+return 1
+`)
+
+var clearGenerationStreamActiveScript = redis.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+	redis.call("DEL", KEYS[2])
+end
+redis.call("ZREM", KEYS[3], ARGV[2])
+return 1
 `)
 
 // conversationCache 实现 repository.ConversationCacheRepository。
@@ -302,8 +321,9 @@ func (c *conversationCache) SetRAGCache(ctx context.Context, key string, chunks 
 // 生成流恢复
 // ---------------------------------------------------------------------------
 
-// RegisterGenerationStream 记录 run 归属用户，并清除上一轮取消标记。
-func (c *conversationCache) RegisterGenerationStream(ctx context.Context, runID string, userID uint, ttl time.Duration) error {
+// RegisterGenerationStream records the run owner and conversation without mixing
+// ephemeral execution state into persisted conversation records.
+func (c *conversationCache) RegisterGenerationStream(ctx context.Context, runID string, userID uint, conversationPublicID string, ttl time.Duration) error {
 	if c.client == nil {
 		return nil
 	}
@@ -313,6 +333,7 @@ func (c *conversationCache) RegisterGenerationStream(ctx context.Context, runID 
 	}
 	pipe := c.client.Pipeline()
 	pipe.Set(ctx, generationStreamOwnerKey(runID), strconv.FormatUint(uint64(userID), 10), ttl)
+	pipe.Set(ctx, generationStreamConversationKey(runID), strings.TrimSpace(conversationPublicID), ttl)
 	pipe.Del(ctx, generationStreamCancelKey(runID))
 	_, err := pipe.Exec(ctx)
 	return err
@@ -338,7 +359,7 @@ func (c *conversationCache) GetGenerationStreamOwner(ctx context.Context, runID 
 }
 
 // TouchGenerationStreamActive 刷新 run 的活跃租约。
-func (c *conversationCache) TouchGenerationStreamActive(ctx context.Context, runID string, ttl time.Duration) error {
+func (c *conversationCache) TouchGenerationStreamActive(ctx context.Context, runID string, userID uint, ttl time.Duration) error {
 	if c.client == nil || ttl <= 0 {
 		return nil
 	}
@@ -346,11 +367,19 @@ func (c *conversationCache) TouchGenerationStreamActive(ctx context.Context, run
 	if runID == "" {
 		return nil
 	}
-	return c.client.Set(ctx, generationStreamActiveKey(runID), "1", ttl).Err()
+	if userID == 0 {
+		return nil
+	}
+	owner := strconv.FormatUint(uint64(userID), 10)
+	return touchGenerationStreamActiveScript.Run(ctx, c.client, []string{
+		generationStreamOwnerKey(runID),
+		generationStreamActiveKey(runID),
+		generationStreamActiveIndexKey(userID),
+	}, owner, ttl.Milliseconds(), time.Now().Add(ttl).UnixMilli(), runID, generationStreamIndexTTL.Milliseconds()).Err()
 }
 
 // ClearGenerationStreamActive 清理 run 的活跃租约。
-func (c *conversationCache) ClearGenerationStreamActive(ctx context.Context, runID string) error {
+func (c *conversationCache) ClearGenerationStreamActive(ctx context.Context, runID string, userID uint) error {
 	if c.client == nil {
 		return nil
 	}
@@ -358,7 +387,15 @@ func (c *conversationCache) ClearGenerationStreamActive(ctx context.Context, run
 	if runID == "" {
 		return nil
 	}
-	return c.client.Del(ctx, generationStreamActiveKey(runID)).Err()
+	if userID == 0 {
+		return nil
+	}
+	owner := strconv.FormatUint(uint64(userID), 10)
+	return clearGenerationStreamActiveScript.Run(ctx, c.client, []string{
+		generationStreamOwnerKey(runID),
+		generationStreamActiveKey(runID),
+		generationStreamActiveIndexKey(userID),
+	}, owner, runID).Err()
 }
 
 // IsGenerationStreamActive 查询 run 是否仍有活跃生成租约。
@@ -375,6 +412,58 @@ func (c *conversationCache) IsGenerationStreamActive(ctx context.Context, runID 
 		return false, err
 	}
 	return count > 0, nil
+}
+
+// ListActiveGenerationStreams returns the user's active runs from a compact
+// Redis index. Expired leases and entries reassigned to another user are
+// removed opportunistically.
+func (c *conversationCache) ListActiveGenerationStreams(ctx context.Context, userID uint) ([]repository.ActiveGenerationStream, error) {
+	if c.client == nil || userID == 0 {
+		return []repository.ActiveGenerationStream{}, nil
+	}
+	indexKey := generationStreamActiveIndexKey(userID)
+	now := time.Now().UnixMilli()
+	pipe := c.client.Pipeline()
+	pipe.ZRemRangeByScore(ctx, indexKey, "-inf", strconv.FormatInt(now, 10))
+	activeCmd := pipe.ZRangeByScore(ctx, indexKey, &redis.ZRangeBy{
+		Min: strconv.FormatInt(now+1, 10),
+		Max: "+inf",
+	})
+	if _, err := pipe.Exec(ctx); err != nil {
+		return nil, err
+	}
+	runIDs := activeCmd.Val()
+	if len(runIDs) == 0 {
+		return []repository.ActiveGenerationStream{}, nil
+	}
+	keys := make([]string, 0, len(runIDs)*2)
+	for _, runID := range runIDs {
+		keys = append(keys, generationStreamOwnerKey(runID), generationStreamConversationKey(runID))
+	}
+	metadata, err := c.client.MGet(ctx, keys...).Result()
+	if err != nil {
+		return nil, err
+	}
+	items := make([]repository.ActiveGenerationStream, 0, len(runIDs))
+	staleRunIDs := make([]interface{}, 0)
+	wantedOwner := strconv.FormatUint(uint64(userID), 10)
+	for index, runID := range runIDs {
+		owner, _ := metadata[index*2].(string)
+		conversationPublicID, _ := metadata[index*2+1].(string)
+		conversationPublicID = strings.TrimSpace(conversationPublicID)
+		if strings.TrimSpace(owner) != wantedOwner || conversationPublicID == "" {
+			staleRunIDs = append(staleRunIDs, runID)
+			continue
+		}
+		items = append(items, repository.ActiveGenerationStream{
+			RunID:                runID,
+			ConversationPublicID: conversationPublicID,
+		})
+	}
+	if len(staleRunIDs) > 0 {
+		_ = c.client.ZRem(ctx, indexKey, staleRunIDs...).Err()
+	}
+	return items, nil
 }
 
 // RequestGenerationStreamCancel 标记 run 已被用户显式取消。
@@ -545,6 +634,7 @@ func (c *conversationCache) ExpireGenerationStream(ctx context.Context, runID st
 	pipe.Expire(ctx, generationStreamTextKey(runID), ttl)
 	pipe.Expire(ctx, generationStreamTextSeqKey(runID), ttl)
 	pipe.Expire(ctx, generationStreamOwnerKey(runID), ttl)
+	pipe.Expire(ctx, generationStreamConversationKey(runID), ttl)
 	pipe.Expire(ctx, generationStreamCancelKey(runID), ttl)
 	_, err := pipe.Exec(ctx)
 	return err
@@ -588,6 +678,14 @@ func generationStreamTextSeqKey(runID string) string {
 
 func generationStreamOwnerKey(runID string) string {
 	return generationStreamKeyPrefix + strings.TrimSpace(runID) + ":owner"
+}
+
+func generationStreamConversationKey(runID string) string {
+	return generationStreamKeyPrefix + strings.TrimSpace(runID) + ":conversation"
+}
+
+func generationStreamActiveIndexKey(userID uint) string {
+	return generationStreamKeyPrefix + "user:" + strconv.FormatUint(uint64(userID), 10) + ":active"
 }
 
 func generationStreamActiveKey(runID string) string {

--- a/backend/internal/repository/conversation_cache.go
+++ b/backend/internal/repository/conversation_cache.go
@@ -56,11 +56,12 @@ type RAGCacheRepository interface {
 
 // GenerationStreamCacheRepository 封装对话生成流的短期恢复存储。
 type GenerationStreamCacheRepository interface {
-	RegisterGenerationStream(ctx context.Context, runID string, userID uint, ttl time.Duration) error
+	RegisterGenerationStream(ctx context.Context, runID string, userID uint, conversationPublicID string, ttl time.Duration) error
 	GetGenerationStreamOwner(ctx context.Context, runID string) (uint, bool, error)
-	TouchGenerationStreamActive(ctx context.Context, runID string, ttl time.Duration) error
-	ClearGenerationStreamActive(ctx context.Context, runID string) error
+	TouchGenerationStreamActive(ctx context.Context, runID string, userID uint, ttl time.Duration) error
+	ClearGenerationStreamActive(ctx context.Context, runID string, userID uint) error
 	IsGenerationStreamActive(ctx context.Context, runID string) (bool, error)
+	ListActiveGenerationStreams(ctx context.Context, userID uint) ([]ActiveGenerationStream, error)
 	RequestGenerationStreamCancel(ctx context.Context, runID string, ttl time.Duration) error
 	IsGenerationStreamCanceled(ctx context.Context, runID string) (bool, error)
 	AppendGenerationStreamEvent(ctx context.Context, runID string, input GenerationStreamAppend, maxEvents int64, ttl time.Duration) (GenerationStreamMessage, error)
@@ -71,6 +72,12 @@ type GenerationStreamCacheRepository interface {
 	// blocked rounds cannot be replayed with withdrawn content on reconnect.
 	ResetGenerationStreamEvents(ctx context.Context, runID string) error
 	ExpireGenerationStream(ctx context.Context, runID string, ttl time.Duration) error
+}
+
+// ActiveGenerationStream identifies one currently leased generation owned by a user.
+type ActiveGenerationStream struct {
+	RunID                string
+	ConversationPublicID string
 }
 
 // UserSettingCacheRepository 封装用户会话设置的共享缓存能力。

--- a/backend/internal/transport/http/conversation/dto_response.go
+++ b/backend/internal/transport/http/conversation/dto_response.go
@@ -1200,6 +1200,18 @@ type CancelMessageGenerationResponse struct {
 	Canceled bool `json:"canceled"`
 }
 
+type ActiveMessageGenerationResponse struct {
+	RunID                string `json:"runID"`
+	ConversationPublicID string `json:"conversationPublicID"`
+}
+
+type ActiveMessageGenerationEventResponse struct {
+	Type                 string                            `json:"type"`
+	Runs                 []ActiveMessageGenerationResponse `json:"runs,omitempty"`
+	RunID                string                            `json:"runID,omitempty"`
+	ConversationPublicID string                            `json:"conversationPublicID,omitempty"`
+}
+
 func toSendMessageResponse(r *appconversation.SendMessageResult) SendMessageResponse {
 	run := model.Run{
 		PlatformModelName: r.PlatformModelName,

--- a/backend/internal/transport/http/conversation/handler_message_send.go
+++ b/backend/internal/transport/http/conversation/handler_message_send.go
@@ -648,6 +648,87 @@ func (h *Handler) CancelMessageGeneration(c *gin.Context) {
 	response.Success(c, CancelMessageGenerationResponse{Canceled: canceled})
 }
 
+// StreamActiveMessageGenerations godoc
+// @Summary Stream active conversation generations
+// @Description Sends an authoritative snapshot followed by live user-scoped run state events
+// @Tags chat
+// @Produce text/event-stream
+// @Security BearerAuth
+// @Success 200 {object} ActiveMessageGenerationEventResponse
+// @Failure 500 {object} ErrorDoc
+// @Router /conversation-runs/stream [get]
+func (h *Handler) StreamActiveMessageGenerations(c *gin.Context) {
+	snapshot, events, unsubscribe, err := h.service.SubscribeActiveMessageGenerations(
+		c.Request.Context(),
+		middleware.MustUserID(c),
+	)
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, "failed to subscribe to active conversation generations")
+		return
+	}
+	defer unsubscribe()
+
+	c.Header("Content-Type", "text/event-stream; charset=utf-8")
+	c.Header("Cache-Control", "no-cache, no-transform")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no")
+	c.Status(http.StatusOK)
+
+	writeEvent := func(payload ActiveMessageGenerationEventResponse) bool {
+		encoded, marshalErr := json.Marshal(payload)
+		if marshalErr != nil {
+			return true
+		}
+		if _, writeErr := c.Writer.Write([]byte("data: ")); writeErr != nil {
+			return false
+		}
+		if _, writeErr := c.Writer.Write(encoded); writeErr != nil {
+			return false
+		}
+		if _, writeErr := c.Writer.Write([]byte("\n\n")); writeErr != nil {
+			return false
+		}
+		c.Writer.Flush()
+		return true
+	}
+
+	runs := make([]ActiveMessageGenerationResponse, 0, len(snapshot))
+	for _, item := range snapshot {
+		runs = append(runs, ActiveMessageGenerationResponse{
+			RunID:                item.RunID,
+			ConversationPublicID: item.ConversationPublicID,
+		})
+	}
+	if !writeEvent(ActiveMessageGenerationEventResponse{Type: "snapshot", Runs: runs}) {
+		return
+	}
+
+	keepalive := time.NewTicker(20 * time.Second)
+	defer keepalive.Stop()
+	for {
+		select {
+		case <-c.Request.Context().Done():
+			return
+		case <-keepalive.C:
+			if _, writeErr := c.Writer.Write([]byte(": keepalive\n\n")); writeErr != nil {
+				return
+			}
+			c.Writer.Flush()
+		case event, ok := <-events:
+			if !ok {
+				return
+			}
+			if !writeEvent(ActiveMessageGenerationEventResponse{
+				Type:                 event.Type,
+				RunID:                event.RunID,
+				ConversationPublicID: event.ConversationPublicID,
+			}) {
+				return
+			}
+		}
+	}
+}
+
 // ResumeMessageGenerationStream godoc
 // @Summary 恢复流式生成订阅
 // @Description 页面刷新后按 run_id 重新订阅仍在运行的生成流，返回 NDJSON 事件

--- a/backend/internal/transport/http/conversation/router.go
+++ b/backend/internal/transport/http/conversation/router.go
@@ -41,6 +41,7 @@ func (m *Module) RegisterRoutes(authRequired *gin.RouterGroup) {
 	authRequired.POST("/conversations/:id/media/videos/generations/stream", m.Handler.StreamVideoGeneration)
 	authRequired.POST("/conversations/:id/media/videos/extensions/stream", m.Handler.StreamVideoExtension)
 	authRequired.GET("/context-artifacts/:id", m.Handler.GetContextArtifact)
+	authRequired.GET("/conversation-runs/stream", m.Handler.StreamActiveMessageGenerations)
 	authRequired.GET("/conversation-runs/:run_id/stream", m.Handler.ResumeMessageGenerationStream)
 	authRequired.POST("/conversation-runs/:run_id/cancel", m.Handler.CancelMessageGeneration)
 	authRequired.PATCH("/messages/:id", m.Handler.UpdateMessage)

--- a/frontend/features/chat/components/app-chat-area.tsx
+++ b/frontend/features/chat/components/app-chat-area.tsx
@@ -173,7 +173,14 @@ export function AppChatArea() {
   const searchParams = useSearchParams();
   const routeConversationID = searchParams.get("conversation_id")?.trim() || null;
   const routeProjectID = searchParams.get("project_id")?.trim() || null;
-  const { newConversationRevision, newConversationProjectID: requestedNewConversationProjectID, requestNewConversation } = useChatSession();
+  const {
+    detachConversationRun,
+    finishConversationRun,
+    newConversationRevision,
+    newConversationProjectID: requestedNewConversationProjectID,
+    registerConversationRun,
+    requestNewConversation,
+  } = useChatSession();
   const [locallyCreatedConversationID, setLocallyCreatedConversationID] = React.useState<string | null>(null);
   const [newConversationOverride, setNewConversationOverride] = React.useState<{
     ignoredConversationID: string | null;
@@ -253,10 +260,12 @@ export function AppChatArea() {
     reload,
     replaceMessage,
     resumingActivityLabel,
+    resumingConversationID,
     resumingRunID,
   } = useChatData(conversationID, {
     activeGenerationRunsRef,
     activeGenerationRunsRevision,
+    onConversationRunFinished: finishConversationRun,
   });
   const { greetingTitle } = useChatViewerProfile();
   const [manualConversationTitle, setManualConversationTitle] = React.useState("");
@@ -692,9 +701,21 @@ export function AppChatArea() {
     activeGenerationRunsRef,
     activeGenerationRunsRevision,
     onActiveGenerationRunsChange,
+    onConversationRunDetached: detachConversationRun,
+    onConversationRunFinished: finishConversationRun,
+    onConversationRunStarted: registerConversationRun,
     resumingActivityLabel,
     resumingRunID,
   });
+  React.useEffect(() => {
+    const normalizedConversationID = resumingConversationID.trim();
+    const normalizedRunID = resumingRunID.trim();
+    if (!normalizedConversationID || !normalizedRunID) {
+      return;
+    }
+    registerConversationRun(normalizedRunID, normalizedConversationID);
+    return () => detachConversationRun(normalizedRunID);
+  }, [detachConversationRun, registerConversationRun, resumingConversationID, resumingRunID]);
   const generating = sending;
   const uploadDropDisabled = loading || uploading;
   const onStopActiveMessage = React.useCallback(() => {

--- a/frontend/features/chat/context/chat-session-context.tsx
+++ b/frontend/features/chat/context/chat-session-context.tsx
@@ -2,33 +2,59 @@
 
 import * as React from "react";
 
+import { useConversationRunState } from "@/features/chat/hooks/use-conversation-run-state";
+import type { ConversationRunStore } from "@/features/chat/model/conversation-run-store";
+
 type ChatSessionContextValue = {
   newConversationRevision: number;
   newConversationProjectID: string;
+  detachConversationRun: (runID: string) => void;
+  finishConversationRun: (runID: string) => void;
+  registerConversationRun: (runID: string, conversationPublicID: string) => void;
   requestNewConversation: (options?: { projectID?: string }) => void;
 };
 
 const ChatSessionContext = React.createContext<ChatSessionContextValue | null>(null);
+const ConversationRunStoreContext = React.createContext<ConversationRunStore | null>(null);
 
 export function ChatSessionProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = React.useState({ revision: 0, projectID: "" });
+  const {
+    detachConversationRun,
+    finishConversationRun,
+    registerConversationRun,
+    store,
+  } = useConversationRunState();
   const requestNewConversation = React.useCallback((options?: { projectID?: string }) => {
     setState((prev) => ({
       revision: prev.revision + 1,
       projectID: options?.projectID?.trim() ?? "",
     }));
   }, []);
-
   const value = React.useMemo(
     () => ({
       newConversationRevision: state.revision,
       newConversationProjectID: state.projectID,
+      detachConversationRun,
+      finishConversationRun,
+      registerConversationRun,
       requestNewConversation,
     }),
-    [requestNewConversation, state.projectID, state.revision],
+    [
+      detachConversationRun,
+      finishConversationRun,
+      registerConversationRun,
+      requestNewConversation,
+      state.projectID,
+      state.revision,
+    ],
   );
 
-  return <ChatSessionContext.Provider value={value}>{children}</ChatSessionContext.Provider>;
+  return (
+    <ConversationRunStoreContext.Provider value={store}>
+      <ChatSessionContext.Provider value={value}>{children}</ChatSessionContext.Provider>
+    </ConversationRunStoreContext.Provider>
+  );
 }
 
 export function useChatSession() {
@@ -37,4 +63,21 @@ export function useChatSession() {
     throw new Error("useChatSession must be used within ChatSessionProvider");
   }
   return context;
+}
+
+export function useConversationRunning(conversationPublicID: string): boolean {
+  const store = React.useContext(ConversationRunStoreContext);
+  if (!store) {
+    throw new Error("useConversationRunning must be used within ChatSessionProvider");
+  }
+  const conversationID = conversationPublicID.trim();
+  const subscribe = React.useCallback(
+    (listener: () => void) => store.subscribe(conversationID, listener),
+    [conversationID, store],
+  );
+  const getSnapshot = React.useCallback(
+    () => store.isConversationRunning(conversationID),
+    [conversationID, store],
+  );
+  return React.useSyncExternalStore(subscribe, getSnapshot, () => false);
 }

--- a/frontend/features/chat/hooks/use-chat-data.ts
+++ b/frontend/features/chat/hooks/use-chat-data.ts
@@ -12,6 +12,7 @@ import type { MessageDTO } from "@/shared/api/conversation.types";
 const MESSAGE_PAGE_SIZE = 100;
 
 type ChatDataState = {
+  conversationPublicID: string;
   loading: boolean;
   loadingOlder: boolean;
   errorMsg: string;
@@ -26,19 +27,27 @@ type ActiveResumeStream = {
   accessToken: string | null;
 };
 
+type ResumingRun = {
+  conversationPublicID: string;
+  runID: string;
+};
+
 export function useChatData(
   conversationID: string | null,
   {
     activeGenerationRunsRef,
     activeGenerationRunsRevision = 0,
+    onConversationRunFinished,
   }: {
     activeGenerationRunsRef?: React.RefObject<Set<string>>;
     activeGenerationRunsRevision?: number;
+    onConversationRunFinished?: (runID: string) => void;
   } = {},
 ) {
   const t = useTranslations("chat.data");
   const tSubmit = useTranslations("chat.submit");
   const [state, setState] = React.useState<ChatDataState>({
+    conversationPublicID: conversationID ?? "",
     loading: Boolean(conversationID),
     loadingOlder: false,
     errorMsg: "",
@@ -47,7 +56,8 @@ export function useChatData(
     hasOlder: false,
   });
   const [reloadToken, setReloadToken] = React.useState(0);
-  const [resumingRunID, setResumingRunID] = React.useState("");
+  const [resumingRun, setResumingRun] = React.useState<ResumingRun | null>(null);
+  const resumingRunID = resumingRun?.runID ?? "";
   const [resumingActivityLabel, setResumingActivityLabel] = React.useState("");
   const stateRef = React.useRef(state);
   stateRef.current = state;
@@ -72,6 +82,7 @@ export function useChatData(
     async function load() {
       if (!conversationID) {
         setState({
+          conversationPublicID: "",
           loading: false,
           loadingOlder: false,
           errorMsg: "",
@@ -85,6 +96,7 @@ export function useChatData(
       const isConversationSwitch = previousConversationIDRef.current !== conversationID;
       previousConversationIDRef.current = conversationID;
       setState((prev) => ({
+        conversationPublicID: conversationID,
         loading: isConversationSwitch || prev.messages.length === 0,
         loadingOlder: false,
         errorMsg: "",
@@ -97,6 +109,7 @@ export function useChatData(
         if (!token) {
           if (!cancelled) {
             setState({
+              conversationPublicID: conversationID,
               loading: false,
               loadingOlder: false,
               errorMsg: t("signInRequired"),
@@ -128,6 +141,7 @@ export function useChatData(
               : prev.messages.filter((message) => message.id < firstTailMessageID);
           const messages = [...loadedOlderMessages, ...data.results];
           return {
+            conversationPublicID: conversationID,
             loading: false,
             loadingOlder: false,
             errorMsg: "",
@@ -169,7 +183,14 @@ export function useChatData(
 
   const loadOlderMessages = React.useCallback(async () => {
     const current = stateRef.current;
-    if (!conversationID || current.loading || current.loadingOlder || !current.hasOlder || current.messages.length === 0) {
+    if (
+      !conversationID ||
+      current.conversationPublicID !== conversationID ||
+      current.loading ||
+      current.loadingOlder ||
+      !current.hasOlder ||
+      current.messages.length === 0
+    ) {
       return false;
     }
 
@@ -254,7 +275,7 @@ export function useChatData(
 
     active.controller.abort();
     clearResumeCheckpoint(active.runID);
-    setResumingRunID("");
+    setResumingRun(null);
 
     const token = active.accessToken ?? (await resolveAccessToken());
     if (!token) {
@@ -262,11 +283,17 @@ export function useChatData(
     }
 
     const result = await cancelMessageGeneration(token, active.runID).catch(() => null);
+    if (result?.canceled) {
+      onConversationRunFinished?.(active.runID);
+    }
     reload();
     return Boolean(result?.canceled);
-  }, [clearResumeCheckpoint, reload]);
+  }, [clearResumeCheckpoint, onConversationRunFinished, reload]);
 
   const pendingAssistant = React.useMemo(() => {
+    if (!conversationID || state.conversationPublicID !== conversationID) {
+      return null;
+    }
     for (let index = state.messages.length - 1; index >= 0; index -= 1) {
       const message = state.messages[index];
       if (message.role === "assistant" && message.status === "pending") {
@@ -274,7 +301,7 @@ export function useChatData(
       }
     }
     return null;
-  }, [state.messages]);
+  }, [conversationID, state.conversationPublicID, state.messages]);
 
   const pendingRunID = pendingAssistant?.runID?.trim() || "";
   // revision 仅用于重新读取可变 Set；effect 只依赖当前 pending run 的实际活动状态。
@@ -293,7 +320,7 @@ export function useChatData(
       !pendingRunID ||
       pendingRunIsActive
     ) {
-      setResumingRunID("");
+      setResumingRun(null);
       setResumingActivityLabel("");
       return;
     }
@@ -308,7 +335,11 @@ export function useChatData(
     };
     const isResumeInactive = () => closed || controller.signal.aborted;
     const updateResumeState = (update: (current: ChatDataState) => ChatDataState) => {
-      setState((current) => isResumeInactive() ? current : update(current));
+      setState((current) =>
+        isResumeInactive() || current.conversationPublicID !== conversationID
+          ? current
+          : update(current),
+      );
     };
     resumedTextByRun[pendingRunID] = baseContent;
     activeResumeStreamRef.current = {
@@ -316,7 +347,7 @@ export function useChatData(
       runID: pendingRunID,
       accessToken: null,
     };
-    setResumingRunID(pendingRunID);
+    setResumingRun({ conversationPublicID: conversationID, runID: pendingRunID });
     setResumingActivityLabel("");
 
     async function resume() {
@@ -331,6 +362,9 @@ export function useChatData(
         await resumeMessageGenerationStream(token, pendingRunID, {
           signal: controller.signal,
           afterSeq,
+          onTerminal: () => {
+            onConversationRunFinished?.(pendingRunID);
+          },
           onEventSeq: (seq) => {
             if (isResumeInactive()) {
               return;
@@ -492,7 +526,7 @@ export function useChatData(
       } catch (error) {
         if (!controller.signal.aborted && error instanceof Error && error.name !== "AbortError") {
           clearResumeCheckpoint(pendingRunID);
-          setResumingRunID("");
+          setResumingRun(null);
           setResumingActivityLabel("");
           reload();
         }
@@ -501,7 +535,7 @@ export function useChatData(
           activeResumeStreamRef.current = null;
         }
         if (!controller.signal.aborted && !closed) {
-          setResumingRunID("");
+          setResumingRun(null);
           setResumingActivityLabel("");
         }
       }
@@ -522,6 +556,7 @@ export function useChatData(
     conversationID,
     pendingRunID,
     pendingRunIsActive,
+    onConversationRunFinished,
     reload,
     tSubmit,
   ]);
@@ -551,6 +586,7 @@ export function useChatData(
     reload,
     replaceMessage,
     resumingActivityLabel,
+    resumingConversationID: resumingRun?.conversationPublicID ?? "",
     resumingRunID,
   };
 }

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -496,6 +496,9 @@ export function useChatMessageSubmit({
   activeGenerationRunsRef,
   activeGenerationRunsRevision,
   onActiveGenerationRunsChange,
+  onConversationRunDetached,
+  onConversationRunFinished,
+  onConversationRunStarted,
   resumeGenerationActive = false,
 }: {
   conversationID: string | null;
@@ -543,6 +546,9 @@ export function useChatMessageSubmit({
   activeGenerationRunsRef?: React.RefObject<Set<string>>;
   activeGenerationRunsRevision: number;
   onActiveGenerationRunsChange?: () => void;
+  onConversationRunDetached?: (runID: string) => void;
+  onConversationRunFinished?: (runID: string) => void;
+  onConversationRunStarted?: (runID: string, conversationPublicID: string) => void;
   resumeGenerationActive?: boolean;
 }) {
   const t = useTranslations("chat.submit");
@@ -867,6 +873,9 @@ export function useChatMessageSubmit({
         cancelRequested: false,
         cancelSettlementTimer: null,
       });
+      if (targetConversationID) {
+        onConversationRunStarted?.(clientRunID, targetConversationID);
+      }
       syncActiveRuns();
       if (resetComposer) {
         setDraft("");
@@ -969,6 +978,7 @@ export function useChatMessageSubmit({
           };
           targetConversationID = created.publicID;
           targetConversation = created;
+          onConversationRunStarted?.(clientRunID, created.publicID);
           const createdActiveStream = activeStreamsRef.current.get(clientRunID);
           if (createdActiveStream) {
             createdActiveStream.conversationScopeKey = targetConversationScopeKey;
@@ -1057,6 +1067,9 @@ export function useChatMessageSubmit({
         let terminalStreamError: Extract<StreamMessageEvent, { type: "error" }> | null = null;
         const streamOptions: ConversationStreamOptions = {
           signal: streamAbortController.signal,
+          onTerminal: () => {
+            onConversationRunFinished?.(clientRunID);
+          },
           onInterrupted: (event) => {
             terminalStreamError = event;
           },
@@ -1508,6 +1521,7 @@ export function useChatMessageSubmit({
           activeStreamsRef.current.delete(clientRunID);
         }
         activeGenerationRunsRef?.current.delete(clientRunID);
+        onConversationRunDetached?.(clientRunID);
         if (
           branchRunIsVisible(
             targetBranchScope,
@@ -1535,6 +1549,9 @@ export function useChatMessageSubmit({
       flushUpstreamThinkNow,
       options,
       onConversationCreated,
+      onConversationRunDetached,
+      onConversationRunFinished,
+      onConversationRunStarted,
       prependNewConversation,
       releaseAttachments,
       reload,

--- a/frontend/features/chat/hooks/use-chat-runtime.ts
+++ b/frontend/features/chat/hooks/use-chat-runtime.ts
@@ -116,6 +116,9 @@ export function useChatRuntime({
   activeGenerationRunsRef,
   activeGenerationRunsRevision,
   onActiveGenerationRunsChange,
+  onConversationRunDetached,
+  onConversationRunFinished,
+  onConversationRunStarted,
   resumingRunID = "",
   resumingActivityLabel = "",
 }: {
@@ -148,6 +151,9 @@ export function useChatRuntime({
   activeGenerationRunsRef?: React.RefObject<Set<string>>;
   activeGenerationRunsRevision: number;
   onActiveGenerationRunsChange?: () => void;
+  onConversationRunDetached?: (runID: string) => void;
+  onConversationRunFinished?: (runID: string) => void;
+  onConversationRunStarted?: (runID: string, conversationPublicID: string) => void;
   resumingRunID?: string;
   resumingActivityLabel?: string;
 }) {
@@ -233,6 +239,9 @@ export function useChatRuntime({
     activeGenerationRunsRef,
     activeGenerationRunsRevision,
     onActiveGenerationRunsChange,
+    onConversationRunDetached,
+    onConversationRunFinished,
+    onConversationRunStarted,
     resumeGenerationActive: visibleResumeGenerationActive,
   });
 

--- a/frontend/features/chat/hooks/use-chat-submit-stream.ts
+++ b/frontend/features/chat/hooks/use-chat-submit-stream.ts
@@ -57,6 +57,9 @@ export function useChatSubmitStream({
   activeGenerationRunsRef,
   activeGenerationRunsRevision,
   onActiveGenerationRunsChange,
+  onConversationRunDetached,
+  onConversationRunFinished,
+  onConversationRunStarted,
   resumeGenerationActive,
 }: {
   conversationID: string | null;
@@ -98,6 +101,9 @@ export function useChatSubmitStream({
   activeGenerationRunsRef?: React.RefObject<Set<string>>;
   activeGenerationRunsRevision: number;
   onActiveGenerationRunsChange?: () => void;
+  onConversationRunDetached?: (runID: string) => void;
+  onConversationRunFinished?: (runID: string) => void;
+  onConversationRunStarted?: (runID: string, conversationPublicID: string) => void;
   resumeGenerationActive?: boolean;
 }) {
   const streamBuffer = useChatStreamBuffer({
@@ -150,6 +156,9 @@ export function useChatSubmitStream({
     activeGenerationRunsRef,
     activeGenerationRunsRevision,
     onActiveGenerationRunsChange,
+    onConversationRunDetached,
+    onConversationRunFinished,
+    onConversationRunStarted,
     resumeGenerationActive,
   });
 

--- a/frontend/features/chat/hooks/use-conversation-run-state.ts
+++ b/frontend/features/chat/hooks/use-conversation-run-state.ts
@@ -1,0 +1,222 @@
+"use client";
+
+import * as React from "react";
+
+import { ConversationRunStore } from "@/features/chat/model/conversation-run-store";
+import { streamActiveConversationRuns } from "@/shared/api/conversation";
+import type { ActiveConversationRunEvent } from "@/shared/api/conversation.types";
+import { useOptionalAuthSession } from "@/shared/auth/auth-session-context";
+
+const RUN_STREAM_RECONNECT_MIN_MS = 1_000;
+const RUN_STREAM_RECONNECT_MAX_MS = 30_000;
+const RUN_STREAM_RECONNECT_JITTER_RATIO = 0.2;
+const RUN_STATE_CHANNEL = "deeix-conversation-runs";
+
+export function useConversationRunState() {
+  const authSession = useOptionalAuthSession();
+  const accessToken = authSession?.accessToken ?? "";
+  const userPublicID = authSession?.user?.publicID.trim() ?? "";
+  const storeRef = React.useRef<ConversationRunStore | null>(null);
+  const storeUserPublicIDRef = React.useRef(userPublicID);
+  const runStateChannelRef = React.useRef<BroadcastChannel | null>(null);
+  if (!storeRef.current) {
+    storeRef.current = new ConversationRunStore();
+  }
+  const store = storeRef.current;
+
+  const registerConversationRun = React.useCallback(
+    (runID: string, conversationPublicID: string) => {
+      const normalizedRunID = runID.trim();
+      const normalizedConversationID = conversationPublicID.trim();
+      if (!normalizedRunID || !normalizedConversationID) {
+        return;
+      }
+      runStateChannelRef.current?.postMessage({
+        type: "started",
+        runID: normalizedRunID,
+        conversationPublicID: normalizedConversationID,
+      });
+      store.register(normalizedRunID, normalizedConversationID);
+    },
+    [store],
+  );
+
+  const detachConversationRun = React.useCallback(
+    (runID: string) => store.detach(runID),
+    [store],
+  );
+
+  const finishConversationRun = React.useCallback(
+    (runID: string) => {
+      const normalizedRunID = runID.trim();
+      if (!normalizedRunID) {
+        return;
+      }
+      runStateChannelRef.current?.postMessage({ type: "finished", runID: normalizedRunID });
+      store.settle(normalizedRunID);
+    },
+    [store],
+  );
+
+  React.useEffect(() => {
+    if (storeUserPublicIDRef.current === userPublicID) {
+      return;
+    }
+    storeUserPublicIDRef.current = userPublicID;
+    store.clear();
+  }, [store, userPublicID]);
+
+  React.useEffect(() => {
+    if (typeof BroadcastChannel === "undefined" || !userPublicID) {
+      return;
+    }
+    const channel = new BroadcastChannel(`${RUN_STATE_CHANNEL}:${userPublicID}`);
+    runStateChannelRef.current = channel;
+    channel.onmessage = (event: MessageEvent<unknown>) => {
+      if (!event.data || typeof event.data !== "object") {
+        return;
+      }
+      const message = event.data as {
+        type?: unknown;
+        runID?: unknown;
+        conversationPublicID?: unknown;
+      };
+      const runID = typeof message.runID === "string" ? message.runID.trim() : "";
+      if (!runID) {
+        return;
+      }
+      if (message.type === "finished") {
+        store.applyFinished(runID, false);
+        return;
+      }
+      const conversationPublicID =
+        typeof message.conversationPublicID === "string"
+          ? message.conversationPublicID.trim()
+          : "";
+      if (message.type === "started" && conversationPublicID) {
+        store.applyStarted(runID, conversationPublicID);
+      }
+    };
+    return () => {
+      runStateChannelRef.current = null;
+      channel.close();
+    };
+  }, [store, userPublicID]);
+
+  React.useEffect(() => {
+    if (!accessToken) {
+      store.clear();
+      return;
+    }
+    let disposed = false;
+    let reconnectAttempt = 0;
+    let reconnectTimer: number | null = null;
+    let streamController: AbortController | null = null;
+
+    function clearReconnectTimer() {
+      if (reconnectTimer !== null) {
+        window.clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+    }
+
+    function scheduleReconnect() {
+      if (disposed || document.visibilityState !== "visible" || navigator.onLine === false) {
+        return;
+      }
+      clearReconnectTimer();
+      const baseDelay = Math.min(
+        RUN_STREAM_RECONNECT_MIN_MS * 2 ** reconnectAttempt,
+        RUN_STREAM_RECONNECT_MAX_MS,
+      );
+      reconnectAttempt += 1;
+      const jitter =
+        baseDelay * RUN_STREAM_RECONNECT_JITTER_RATIO * (Math.random() * 2 - 1);
+      reconnectTimer = window.setTimeout(connect, Math.max(0, Math.round(baseDelay + jitter)));
+    }
+
+    function handleEvent(event: ActiveConversationRunEvent) {
+      reconnectAttempt = 0;
+      if (event.type === "snapshot") {
+        store.synchronize(event.runs);
+      } else if (event.type === "started") {
+        store.applyStarted(event.runID, event.conversationPublicID ?? "");
+      } else {
+        store.applyFinished(event.runID, true);
+      }
+    }
+
+    function connect() {
+      if (
+        disposed ||
+        streamController ||
+        document.visibilityState !== "visible" ||
+        navigator.onLine === false
+      ) {
+        return;
+      }
+      clearReconnectTimer();
+      const controller = new AbortController();
+      streamController = controller;
+      void streamActiveConversationRuns(accessToken, {
+        signal: controller.signal,
+        onEvent: handleEvent,
+      })
+        .catch(() => {
+          // Reconnect below with bounded exponential backoff.
+        })
+        .finally(() => {
+          if (streamController === controller) {
+            streamController = null;
+          }
+          if (
+            !disposed &&
+            document.visibilityState === "visible" &&
+            navigator.onLine !== false
+          ) {
+            if (controller.signal.aborted) {
+              connect();
+            } else {
+              scheduleReconnect();
+            }
+          }
+        });
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        connect();
+        return;
+      }
+      clearReconnectTimer();
+      streamController?.abort();
+    };
+    const handleOnline = () => connect();
+    const handleOffline = () => {
+      clearReconnectTimer();
+      streamController?.abort();
+    };
+
+    connect();
+    window.addEventListener("focus", handleOnline);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      disposed = true;
+      clearReconnectTimer();
+      streamController?.abort();
+      window.removeEventListener("focus", handleOnline);
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [accessToken, store]);
+
+  return {
+    detachConversationRun,
+    finishConversationRun,
+    registerConversationRun,
+    store,
+  };
+}

--- a/frontend/features/chat/index.ts
+++ b/frontend/features/chat/index.ts
@@ -1,4 +1,5 @@
 export {
   ChatSessionProvider,
   useChatSession,
+  useConversationRunning,
 } from "@/features/chat/context/chat-session-context";

--- a/frontend/features/chat/model/conversation-run-store.ts
+++ b/frontend/features/chat/model/conversation-run-store.ts
@@ -1,0 +1,221 @@
+export type ConversationRunSnapshot = {
+  runID: string;
+  conversationPublicID: string;
+};
+
+type ConversationRunRecord = {
+  conversationPublicID: string;
+  status: "local" | "detached" | "server" | "settled";
+};
+
+type Listener = () => void;
+
+export class ConversationRunStore {
+  private readonly records = new Map<string, ConversationRunRecord>();
+  private readonly listeners = new Map<string, Set<Listener>>();
+
+  subscribe(conversationPublicID: string, listener: Listener): () => void {
+    const conversationID = conversationPublicID.trim();
+    if (!conversationID) {
+      return () => undefined;
+    }
+    let conversationListeners = this.listeners.get(conversationID);
+    if (!conversationListeners) {
+      conversationListeners = new Set();
+      this.listeners.set(conversationID, conversationListeners);
+    }
+    conversationListeners.add(listener);
+    return () => {
+      conversationListeners.delete(listener);
+      if (conversationListeners.size === 0) {
+        this.listeners.delete(conversationID);
+      }
+    };
+  }
+
+  isConversationRunning(conversationPublicID: string): boolean {
+    const conversationID = conversationPublicID.trim();
+    if (!conversationID) {
+      return false;
+    }
+    for (const record of this.records.values()) {
+      if (record.conversationPublicID === conversationID && record.status !== "settled") {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  register(runID: string, conversationPublicID: string): void {
+    const normalizedRunID = runID.trim();
+    const conversationID = conversationPublicID.trim();
+    if (!normalizedRunID || !conversationID) {
+      return;
+    }
+    this.mutate(() => {
+      const existing = this.records.get(normalizedRunID);
+      if (
+        existing &&
+        (existing.conversationPublicID !== conversationID || existing.status === "settled")
+      ) {
+        return;
+      }
+      if (existing?.status === "local") {
+        return;
+      }
+      this.records.set(normalizedRunID, {
+        conversationPublicID: conversationID,
+        status: "local",
+      });
+    });
+  }
+
+  detach(runID: string): void {
+    const normalizedRunID = runID.trim();
+    if (!normalizedRunID) {
+      return;
+    }
+    this.mutate(() => {
+      const existing = this.records.get(normalizedRunID);
+      if (existing?.status === "local") {
+        this.records.set(normalizedRunID, { ...existing, status: "detached" });
+      }
+    });
+  }
+
+  settle(runID: string): void {
+    const normalizedRunID = runID.trim();
+    if (!normalizedRunID) {
+      return;
+    }
+    this.mutate(() => {
+      const existing = this.records.get(normalizedRunID);
+      if (existing && existing.status !== "settled") {
+        this.records.set(normalizedRunID, { ...existing, status: "settled" });
+      }
+    });
+  }
+
+  applyStarted(runID: string, conversationPublicID: string): void {
+    const normalizedRunID = runID.trim();
+    const conversationID = conversationPublicID.trim();
+    if (!normalizedRunID || !conversationID) {
+      return;
+    }
+    this.mutate(() => {
+      const existing = this.records.get(normalizedRunID);
+      if (existing?.status === "settled") {
+        return;
+      }
+      if (
+        existing?.conversationPublicID === conversationID &&
+        (existing.status === "local" || existing.status === "server")
+      ) {
+        return;
+      }
+      this.records.set(normalizedRunID, {
+        conversationPublicID: conversationID,
+        status: "server",
+      });
+    });
+  }
+
+  applyFinished(runID: string, authoritative: boolean): void {
+    const normalizedRunID = runID.trim();
+    if (!normalizedRunID) {
+      return;
+    }
+    this.mutate(() => {
+      const existing = this.records.get(normalizedRunID);
+      if (!existing) {
+        return;
+      }
+      if (authoritative) {
+        this.records.delete(normalizedRunID);
+      } else if (existing.status !== "settled") {
+        this.records.set(normalizedRunID, { ...existing, status: "settled" });
+      }
+    });
+  }
+
+  synchronize(snapshots: readonly ConversationRunSnapshot[]): void {
+    const snapshotRunOwners = new Map<string, string>();
+    for (const snapshot of snapshots) {
+      const runID = snapshot.runID.trim();
+      const conversationID = snapshot.conversationPublicID.trim();
+      if (runID && conversationID && !snapshotRunOwners.has(runID)) {
+        snapshotRunOwners.set(runID, conversationID);
+      }
+    }
+
+    this.mutate(() => {
+      for (const [runID, record] of this.records) {
+        const serverOwner = snapshotRunOwners.get(runID);
+        if (record.status === "settled") {
+          if (!serverOwner) {
+            this.records.delete(runID);
+          }
+          continue;
+        }
+        if (serverOwner && serverOwner !== record.conversationPublicID) {
+          this.records.set(runID, {
+            conversationPublicID: serverOwner,
+            status: "server",
+          });
+          continue;
+        }
+        if ((record.status === "detached" || record.status === "server") && !serverOwner) {
+          this.records.delete(runID);
+          continue;
+        }
+        if (record.status === "detached" && serverOwner) {
+          this.records.set(runID, { ...record, status: "server" });
+        }
+      }
+
+      for (const [runID, conversationPublicID] of snapshotRunOwners) {
+        const existing = this.records.get(runID);
+        if (
+          existing?.status === "settled" &&
+          existing.conversationPublicID === conversationPublicID
+        ) {
+          continue;
+        }
+        if (
+          existing?.conversationPublicID === conversationPublicID &&
+          (existing.status === "local" || existing.status === "server")
+        ) {
+          continue;
+        }
+        this.records.set(runID, { conversationPublicID, status: "server" });
+      }
+    });
+  }
+
+  clear(): void {
+    this.mutate(() => this.records.clear());
+  }
+
+  private activeConversationIDs(): Set<string> {
+    const result = new Set<string>();
+    for (const record of this.records.values()) {
+      if (record.status !== "settled") {
+        result.add(record.conversationPublicID);
+      }
+    }
+    return result;
+  }
+
+  private mutate(update: () => void): void {
+    const previous = this.activeConversationIDs();
+    update();
+    const next = this.activeConversationIDs();
+    for (const conversationID of new Set([...previous, ...next])) {
+      if (previous.has(conversationID) !== next.has(conversationID)) {
+        for (const listener of this.listeners.get(conversationID) ?? []) {
+          listener();
+        }
+      }
+    }
+  }
+}

--- a/frontend/features/layouts/components/navigation/sidebar-conversation-item.tsx
+++ b/frontend/features/layouts/components/navigation/sidebar-conversation-item.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { Archive, PencilLine, Trash, type LucideIcon } from "lucide-react";
+import { Archive, Loader2Icon, PencilLine, Trash, type LucideIcon } from "lucide-react";
 import { motion } from "motion/react";
 import { useTranslations } from "next-intl";
 
@@ -20,6 +20,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { SIDEBAR_TRANSFER_TRANSITION } from "@/features/layouts/model/sidebar-motion";
+import { useConversationRunning } from "@/features/chat";
 import { ConversationProjectSubmenu } from "@/shared/components/conversation-project-submenu";
 import { ConversationShareExportSubmenu } from "@/shared/components/conversation-share-export-menu";
 import { ConversationLabelsMenuItem } from "@/entities/conversation";
@@ -75,6 +76,36 @@ type SidebarConversationItemProps = {
   onDelete: (publicID: string, title: string) => void;
   onNavigate?: (url: string, event: React.MouseEvent<HTMLAnchorElement>) => void;
 };
+
+const SidebarConversationRunIndicator = React.memo(function SidebarConversationRunIndicator({
+  conversationPublicID,
+  hidden,
+}: {
+  conversationPublicID: string;
+  hidden: boolean;
+}) {
+  const runtimeT = useTranslations("common.runtime.status");
+  const running = useConversationRunning(conversationPublicID);
+  if (!running) {
+    return null;
+  }
+  return (
+    <span
+      className={cn(
+        "pointer-events-none absolute right-0 flex size-8 items-center justify-center text-sidebar-foreground/45 opacity-100 transition-opacity duration-150 group-hover/conversation-row:opacity-0 group-focus-within/conversation-row:opacity-0",
+        hidden && "opacity-0",
+      )}
+    >
+      <span
+        role="status"
+        aria-label={runtimeT("running")}
+        className="inline-flex size-3.5 shrink-0 animate-spin will-change-transform [animation-duration:1.6s] [animation-timing-function:linear]"
+      >
+        <Loader2Icon aria-hidden className="size-full" />
+      </span>
+    </span>
+  );
+});
 
 export function SidebarConversationItem({
   item,
@@ -177,6 +208,11 @@ export function SidebarConversationItem({
           textClassName="text-current"
         />
       </Link>
+
+      <SidebarConversationRunIndicator
+        conversationPublicID={item.publicID}
+        hidden={isMenuOpen}
+      />
 
       <DropdownMenu modal={false} open={isMenuOpen} onOpenChange={setIsMenuOpen}>
         <DropdownMenuTrigger asChild>

--- a/frontend/shared/api/conversation.ts
+++ b/frontend/shared/api/conversation.ts
@@ -7,6 +7,7 @@ import type {
 import { authedFetch, authedRequest } from "@/shared/api/authed-client";
 import type { PagePayload } from "@/shared/api/common.types";
 import type {
+  ActiveConversationRunEvent,
   BatchSetConversationProjectRequest,
   BatchSetConversationProjectResult,
   ContextArtifactDTO,
@@ -288,18 +289,23 @@ function handleStreamEvent(event: StreamMessageEvent, options: ConversationStrea
   }
 
   if (event.type === "moderation_blocked") {
+    options.onTerminal?.(event);
     options.onModerationBlocked?.(event);
     // Terminal event for blocked rounds; synthetic result is optional.
     return null;
   }
 
   if (event.type === "completed") {
+    options.onTerminal?.(event);
     return event.data;
   }
 
-  if (event.type === "error" && event.data) {
-    options.onInterrupted?.(event);
-    return event.data;
+  if (event.type === "error") {
+    options.onTerminal?.(event);
+    if (event.data) {
+      options.onInterrupted?.(event);
+      return event.data;
+    }
   }
 
   throw new ApiError(event.message || "stream failed", responseStatus, event.debug, event.errorCode);
@@ -804,6 +810,66 @@ export async function listConversationRuns(
   };
 }
 
+export async function streamActiveConversationRuns(
+  accessToken: string,
+  options: {
+    signal?: AbortSignal;
+    onEvent: (event: ActiveConversationRunEvent) => void;
+  },
+): Promise<void> {
+  const response = await authedFetch(
+    "/api/v1/conversation-runs/stream",
+    {
+      accessToken,
+      headers: { Accept: "text/event-stream" },
+      signal: options.signal,
+    },
+    true,
+  );
+  if (!response.body) {
+    throw new ApiError("active conversation run stream is unavailable", response.status);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const consumeFrames = (flush: boolean) => {
+    buffer += flush ? decoder.decode() : "";
+    const frames = buffer.split(/\r?\n\r?\n/);
+    buffer = flush ? "" : (frames.pop() ?? "");
+    for (const frame of frames) {
+      const data = frame
+        .split(/\r?\n/)
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5).trimStart())
+        .join("\n")
+        .trim();
+      if (!data) {
+        continue;
+      }
+      try {
+        options.onEvent(JSON.parse(data) as ActiveConversationRunEvent);
+      } catch {
+        // Ignore malformed events and keep the long-lived connection healthy.
+      }
+    }
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        consumeFrames(true);
+        return;
+      }
+      buffer += decoder.decode(value, { stream: true });
+      consumeFrames(false);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
 export async function getContextArtifact(
   accessToken: string,
   artifactID: number,
@@ -1012,6 +1078,7 @@ export type ConversationStreamOptions = {
   onUpstreamThinkDelta?: (event: Extract<StreamMessageEvent, { type: "upstream_think_delta" }>) => void;
   onUsage?: (event: Extract<StreamMessageEvent, { type: "usage" }>) => void;
   onInterrupted?: (event: Extract<StreamMessageEvent, { type: "error" }>) => void;
+  onTerminal?: (event: Extract<StreamMessageEvent, { type: "completed" | "error" | "moderation_blocked" }>) => void;
   onModerationChecking?: (event: Extract<StreamMessageEvent, { type: "moderation_checking" }>) => void;
   onModerationBlocked?: (event: Extract<StreamMessageEvent, { type: "moderation_blocked" }>) => void;
 };

--- a/frontend/shared/api/conversation.types.ts
+++ b/frontend/shared/api/conversation.types.ts
@@ -48,6 +48,15 @@ export type ConversationDTO = ConversationResponse;
 
 export type ConversationSearchResultDTO = ConversationSearchResultResponse;
 
+export type ActiveConversationRunSnapshot = {
+  runID: string;
+  conversationPublicID: string;
+};
+
+export type ActiveConversationRunEvent =
+  | { type: "snapshot"; runs: ActiveConversationRunSnapshot[] }
+  | { type: "started" | "finished"; runID: string; conversationPublicID?: string };
+
 export type ConversationSearchPageDTO = Omit<ConversationSearchPageResponse, "results"> & {
   results: ConversationSearchResultDTO[];
 };

--- a/packages/api-contract/src/types.generated.ts
+++ b/packages/api-contract/src/types.generated.ts
@@ -11,6 +11,18 @@
  * ---------------------------------------------------------------
  */
 
+export interface ActiveMessageGenerationEventResponse {
+  conversationPublicID?: string;
+  runID?: string;
+  runs?: ActiveMessageGenerationResponse[];
+  type: string;
+}
+
+export interface ActiveMessageGenerationResponse {
+  conversationPublicID: string;
+  runID: string;
+}
+
 export interface ActiveSessionListResponse {
   results: ActiveSessionResponse[];
   total: number;
@@ -7746,6 +7758,22 @@ export namespace ConversationProjects {
 
 export namespace ConversationRuns {
   /**
+   * @description Sends an authoritative snapshot followed by live user-scoped run state events
+   * @tags chat
+   * @name StreamList
+   * @summary Stream active conversation generations
+   * @request GET:/conversation-runs/stream
+   * @secure
+   */
+  export namespace StreamList {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = ActiveMessageGenerationEventResponse;
+  }
+
+  /**
    * @description 仅在用户显式点击暂停时取消对应 run；浏览器刷新或断开连接不会调用此接口
    * @tags chat
    * @name CancelCreate
@@ -7767,12 +7795,14 @@ export namespace ConversationRuns {
   /**
    * @description 页面刷新后按 run_id 重新订阅仍在运行的生成流，返回 NDJSON 事件
    * @tags chat
-   * @name StreamList
+   * @name StreamList2
    * @summary 恢复流式生成订阅
    * @request GET:/conversation-runs/{run_id}/stream
+   * @originalName streamList
+   * @duplicate
    * @secure
    */
-  export namespace StreamList {
+  export namespace StreamList2 {
     export type RequestParams = {
       /** 运行 ID */
       runId: string;


### PR DESCRIPTION
## Summary

Add a live running indicator to conversation rows in the sidebar and keep the state accurate across conversation switching, branch switching, page refreshes, reconnects, and multiple browser tabs.

The frontend now combines immediate local run state with an authoritative server snapshot and live events. Active-run HTTP polling has been removed and replaced with one authenticated SSE connection.

The backend maintains expiring active-run metadata in the configured cache. Redis deployments use a bounded Redis Stream with one blocking reader per backend instance and user-scoped in-process fan-out, avoiding one Redis connection per browser client.

The sidebar displays a running spinner while a conversation is generating. Hovering or focusing the row restores the normal action button. The spinner uses a memoized, per-conversation subscription and an isolated HTML animation layer so streaming message updates do not interrupt the animation.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [x] Documentation

## Verification

- [x] `cd backend && go test ./...`
- [x] `cd backend && go test -race ./internal/application/conversation ./internal/infra/cache/memory`
- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm typecheck`
- [x] `pnpm api:check`
- [x] `pnpm --filter @deeix/web build`
- [x] `git diff --check`

## Screenshots, API examples, or logs

The browser keeps one authenticated SSE request open while the page is visible and online:

`GET /api/v1/conversation-runs/stream`

The stream sends:

- An authoritative `snapshot` event after connecting.
- A `started` event when a conversation run begins.
- A `finished` event when a conversation run ends.
- Lightweight keepalive comments over the same connection.

The sidebar shows a running spinner for each active conversation and restores the row action button on hover or keyboard focus.

## Configuration, migration, and compatibility notes

No database migration, configuration change, or new environment variable is required.

The active-run state is ephemeral and does not modify persisted conversation records.

Redis deployments use:

- An expiring per-user active-run index.
- Owner-guarded active-run leases.
- A bounded Redis Stream for cross-instance events.
- One Redis Stream reader per backend instance with local user-scoped fan-out.

The in-memory cache implementation supports the same application contract for single-instance deployments.

The previous active-run polling implementation was removed. No compatibility polling endpoint or legacy fallback was retained.

The generated Swagger files and TypeScript API contract include the new authenticated SSE endpoint.

## Documentation

- [ ] Documentation is not needed for this change.
- [x] Documentation was updated.
- [ ] Documentation still needs to be updated.

Generated Swagger documentation and the TypeScript API contract were updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

The SSE endpoint requires authentication. Snapshots and live events are scoped to the authenticated user, and internal user identifiers are not exposed in client event payloads.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.