### PR TITLE
fix: correct chat position and outline navigation

### DIFF
--- a/backend/internal/application/conversation/service_message_hydration_test.go
+++ b/backend/internal/application/conversation/service_message_hydration_test.go
@@ -67,6 +67,85 @@ func TestNormalizeLegacyThinkReplayEventsCollapsesRepeatedCompletedSnapshots(t *
 	}
 }
 
+func TestNormalizeLegacyThinkReplayEventsCollapsesSingleFinalReconciliation(t *testing.T) {
+	createdAt := time.Now().UTC()
+	endedAt := createdAt.Add(time.Second)
+	finalPayload := persistedReasoningTestPayload("response.completed", "")
+	rows := []model.MessageTraceEventRow{
+		persistedThinkTestRow("upstream_think_1", "round_1", 2, "相同文本", persistedReasoningTestPayload("chat.completion.chunk", ""), createdAt, &endedAt),
+		persistedThinkTestRow("upstream_think_2", "round_2", 3, "相同文本", finalPayload, createdAt.Add(time.Second), &endedAt),
+	}
+
+	normalized := normalizeLegacyThinkReplayEvents(rows)
+
+	if len(normalized) != 1 || normalized[0].EventID != "upstream_think_1" {
+		t.Fatalf("normalized events = %#v, want canonical live event only", normalized)
+	}
+	if normalized[0].PayloadJSON != finalPayload {
+		t.Fatalf("canonical event payload = %q, want final payload %q", normalized[0].PayloadJSON, finalPayload)
+	}
+}
+
+func TestNormalizeLegacyThinkReplayEventsCollapsesReasoningDoneAndFinalSnapshot(t *testing.T) {
+	createdAt := time.Now().UTC()
+	endedAt := createdAt.Add(time.Second)
+	finalPayload := persistedReasoningTestPayload("response.completed", "reasoning_1")
+	rows := []model.MessageTraceEventRow{
+		persistedThinkTestRow("upstream_think_1", "round_1", 2, "最终思考", persistedReasoningTestPayload("response.reasoning_text.done", "reasoning_1"), createdAt, &endedAt),
+		persistedThinkTestRow("upstream_think_2", "round_2", 3, "最终思考", finalPayload, createdAt.Add(20*time.Millisecond), &endedAt),
+	}
+
+	normalized := normalizeLegacyThinkReplayEvents(rows)
+
+	if len(normalized) != 1 || normalized[0].EventID != "upstream_think_1" {
+		t.Fatalf("normalized events = %#v, want canonical reasoning done event only", normalized)
+	}
+	if normalized[0].PayloadJSON != finalPayload {
+		t.Fatalf("canonical event payload = %q, want final payload %q", normalized[0].PayloadJSON, finalPayload)
+	}
+}
+
+func TestNormalizeLegacyThinkReplayEventsCollapsesCompletedSnapshotsWithoutMetadata(t *testing.T) {
+	createdAt := time.Now().UTC()
+	endedAt := createdAt.Add(time.Second)
+	rows := []model.MessageTraceEventRow{
+		persistedThinkTestRow("upstream_think_1", "round_1", 2, "旧思考内容", "", createdAt, &endedAt),
+		persistedThinkTestRow("upstream_think_2", "round_2", 3, "旧思考内容", "{}", createdAt.Add(25*time.Millisecond), &endedAt),
+		persistedThinkTestRow("upstream_think_3", "round_3", 4, "旧思考内容", `{"reasoning":{"kind":"content"}}`, createdAt.Add(50*time.Millisecond), &endedAt),
+	}
+
+	normalized := normalizeLegacyThinkReplayEvents(rows)
+
+	if len(normalized) != 1 || normalized[0].EventID != "upstream_think_1" {
+		t.Fatalf("normalized events = %#v, want one canonical legacy event", normalized)
+	}
+}
+
+func TestNormalizeLegacyThinkReplayEventsPreservesUnknownRoundsSeparatedByTool(t *testing.T) {
+	createdAt := time.Now().UTC()
+	endedAt := createdAt.Add(time.Second)
+	rows := []model.MessageTraceEventRow{
+		persistedThinkTestRow("upstream_think_1", "round_1", 2, "相同文本", "", createdAt, &endedAt),
+		{
+			RunID:     "run_1",
+			EventID:   "tools_1",
+			EventType: "tool",
+			Phase:     messageTraceTypeTools,
+			Stage:     messageTraceStageTool,
+			Status:    messageTraceStatusCompleted,
+			Seq:       3,
+			CreatedAt: createdAt.Add(10 * time.Millisecond),
+		},
+		persistedThinkTestRow("upstream_think_2", "round_2", 4, "相同文本", "", createdAt.Add(25*time.Millisecond), &endedAt),
+	}
+
+	normalized := normalizeLegacyThinkReplayEvents(rows)
+
+	if len(normalized) != len(rows) {
+		t.Fatalf("normalized events = %#v, want tool-separated rounds preserved", normalized)
+	}
+}
+
 func TestNormalizeLegacyThinkReplayEventsPreservesUnconfirmedRounds(t *testing.T) {
 	createdAt := time.Now().UTC()
 	endedAt := createdAt.Add(time.Second)
@@ -86,13 +165,6 @@ func TestNormalizeLegacyThinkReplayEventsPreservesUnconfirmedRounds(t *testing.T
 			rows: []model.MessageTraceEventRow{
 				persistedThinkTestRow("upstream_think_1", "round_1", 2, "相同文本", persistedReasoningTestPayload("response.completed", ""), createdAt, &endedAt),
 				persistedThinkTestRow("upstream_think_2", "round_2", 3, "相同文本", persistedReasoningTestPayload("response.completed", ""), createdAt.Add(legacyReasoningReplayMaxGap+time.Millisecond), &endedAt),
-			},
-		},
-		{
-			name: "single final reconciliation",
-			rows: []model.MessageTraceEventRow{
-				persistedThinkTestRow("upstream_think_1", "round_1", 2, "相同文本", persistedReasoningTestPayload("chat.completion.chunk", ""), createdAt, &endedAt),
-				persistedThinkTestRow("upstream_think_2", "round_2", 3, "相同文本", persistedReasoningTestPayload("response.completed", ""), createdAt.Add(time.Second), &endedAt),
 			},
 		},
 		{

--- a/backend/internal/application/conversation/service_trace_compat.go
+++ b/backend/internal/application/conversation/service_trace_compat.go
@@ -23,11 +23,10 @@ type legacyThinkReplayCandidate struct {
 	metadata persistedReasoningEventMetadata
 }
 
-// normalizeLegacyThinkReplayEvents hides reasoning snapshots replayed by the
-// legacy streaming finalization path. That path persisted the same final
-// response.completed payload twice and could first persist the identical live
-// chunk as another round. Keep the canonical event identity and merge the final
-// terminal snapshot into it without mutating the stored rows.
+// normalizeLegacyThinkReplayEvents hides reasoning snapshots replayed by legacy
+// streaming finalization paths. They could persist the same live and terminal
+// content as separate rounds, sometimes without reasoning metadata. Keep the
+// canonical identity and merge the terminal snapshot without mutating storage.
 func normalizeLegacyThinkReplayEvents(rows []model.MessageTraceEventRow) []model.MessageTraceEventRow {
 	if len(rows) < 2 {
 		return rows
@@ -43,17 +42,14 @@ func normalizeLegacyThinkReplayEvents(rows []model.MessageTraceEventRow) []model
 		if content == "" {
 			continue
 		}
-		metadata, ok := persistedReasoningMetadata(row.PayloadJSON)
-		if !ok {
-			continue
-		}
+		metadata, _ := persistedReasoningMetadata(row.PayloadJSON)
 		key := strings.TrimSpace(row.RunID) + "\x00" + content
 		groups[key] = append(groups[key], legacyThinkReplayCandidate{rowIndex: index, metadata: metadata})
 	}
 
 	removed := make(map[int]struct{})
 	for _, candidates := range groups {
-		if len(candidates) < 2 || hasConflictingReasoningItemIDs(candidates) {
+		if len(candidates) < 2 {
 			continue
 		}
 		for position := 0; position < len(candidates); {
@@ -61,7 +57,7 @@ func normalizeLegacyThinkReplayEvents(rows []model.MessageTraceEventRow) []model
 			for replayEnd+1 < len(candidates) {
 				first := candidates[replayEnd]
 				second := candidates[replayEnd+1]
-				if !isLegacyCompletedReplayPair(workingRows[first.rowIndex], first.metadata, workingRows[second.rowIndex], second.metadata) {
+				if !isLegacyReasoningReplayPair(workingRows, first, second) {
 					break
 				}
 				replayEnd++
@@ -121,42 +117,59 @@ func persistedReasoningMetadata(payloadJSON string) (persistedReasoningEventMeta
 	return metadata, metadata.EventType != ""
 }
 
-func hasConflictingReasoningItemIDs(candidates []legacyThinkReplayCandidate) bool {
-	itemID := ""
-	for _, candidate := range candidates {
-		if candidate.metadata.ItemID == "" {
-			continue
-		}
-		if itemID != "" && itemID != candidate.metadata.ItemID {
+func isLegacyReasoningReplayPair(
+	rows []model.MessageTraceEventRow,
+	firstCandidate legacyThinkReplayCandidate,
+	secondCandidate legacyThinkReplayCandidate,
+) bool {
+	first := rows[firstCandidate.rowIndex]
+	second := rows[secondCandidate.rowIndex]
+	if strings.TrimSpace(first.ContentMarkdown) != strings.TrimSpace(second.ContentMarkdown) ||
+		reasoningItemIDsConflict(firstCandidate.metadata, secondCandidate.metadata) ||
+		first.CreatedAt.IsZero() || second.CreatedAt.Before(first.CreatedAt) ||
+		second.CreatedAt.Sub(first.CreatedAt) > legacyReasoningReplayMaxGap {
+		return false
+	}
+
+	firstEventType := firstCandidate.metadata.EventType
+	secondEventType := secondCandidate.metadata.EventType
+	if isPersistedLiveReasoningEvent(firstEventType) && secondEventType == "response.completed" {
+		return true
+	}
+	if firstEventType == "response.completed" && secondEventType == "response.completed" {
+		return strings.TrimSpace(first.PayloadJSON) == strings.TrimSpace(second.PayloadJSON)
+	}
+	if firstEventType != "" && secondEventType != "" {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(first.Status), messageTraceStatusCompleted) ||
+		!strings.EqualFold(strings.TrimSpace(second.Status), messageTraceStatusCompleted) {
+		return false
+	}
+	return !hasInterveningToolTraceEvent(rows, firstCandidate.rowIndex, secondCandidate.rowIndex)
+}
+
+func reasoningItemIDsConflict(first persistedReasoningEventMetadata, second persistedReasoningEventMetadata) bool {
+	return first.ItemID != "" && second.ItemID != "" && first.ItemID != second.ItemID
+}
+
+func hasInterveningToolTraceEvent(rows []model.MessageTraceEventRow, firstIndex int, secondIndex int) bool {
+	for index := firstIndex + 1; index < secondIndex; index++ {
+		row := rows[index]
+		if strings.EqualFold(strings.TrimSpace(row.EventType), "tool") ||
+			strings.EqualFold(strings.TrimSpace(row.Phase), messageTraceTypeTools) ||
+			strings.EqualFold(strings.TrimSpace(row.Stage), messageTraceStageTool) {
 			return true
 		}
-		itemID = candidate.metadata.ItemID
 	}
 	return false
 }
 
-func isLegacyCompletedReplayPair(
-	first model.MessageTraceEventRow,
-	firstMetadata persistedReasoningEventMetadata,
-	second model.MessageTraceEventRow,
-	secondMetadata persistedReasoningEventMetadata,
-) bool {
-	if firstMetadata.EventType != "response.completed" || secondMetadata.EventType != "response.completed" {
-		return false
-	}
-	if strings.TrimSpace(first.ContentMarkdown) != strings.TrimSpace(second.ContentMarkdown) ||
-		strings.TrimSpace(first.PayloadJSON) != strings.TrimSpace(second.PayloadJSON) {
-		return false
-	}
-	if first.CreatedAt.IsZero() || second.CreatedAt.Before(first.CreatedAt) {
-		return false
-	}
-	return second.CreatedAt.Sub(first.CreatedAt) <= legacyReasoningReplayMaxGap
-}
-
 func isPersistedLiveReasoningEvent(eventType string) bool {
 	normalized := strings.ToLower(strings.TrimSpace(eventType))
-	return normalized == "chat.completion.chunk" || strings.HasSuffix(normalized, ".delta")
+	return normalized == "chat.completion.chunk" ||
+		strings.HasSuffix(normalized, ".delta") ||
+		(strings.Contains(normalized, "reasoning") && strings.HasSuffix(normalized, ".done"))
 }
 
 func mergePersistedReasoningSnapshot(

--- a/frontend/features/chat/components/message/message-agent-trace.tsx
+++ b/frontend/features/chat/components/message/message-agent-trace.tsx
@@ -202,14 +202,28 @@ function groupTraceDisplayEvents(
     ensureGroup(key, item.event.seq).toolEvents.push(item);
   }
 
-  // Live streaming blocks join their own round; unmatched blocks are appended last.
+  // Snapshot blocks enrich their matching event round; unmatched live fallbacks are appended last.
   const attachActiveBlock = (block: ChatTraceBlock | undefined, kind: "think" | "tool") => {
     if (!block) {
       return;
     }
     const roundID = block.roundID?.trim() || "";
     const parentID = block.parentEventID?.trim() || "";
-    const matchedKey = (roundID && thinkRoundIDToKey.get(roundID)) || (parentID && thinkEventIDToKey.get(parentID));
+    let matchedKey = (roundID && thinkRoundIDToKey.get(roundID)) || (parentID && thinkEventIDToKey.get(parentID));
+    if (!matchedKey && kind === "think") {
+      const blockText = traceBlockDisplayText(block);
+      if (blockText) {
+        for (const [key, group] of groups) {
+          if (
+            group.thinkEvents.some(
+              (item) => traceBlockDisplayText(item.event) === blockText,
+            )
+          ) {
+            matchedKey = key;
+          }
+        }
+      }
+    }
     if (matchedKey) {
       const matched = groups.get(matchedKey);
       if (matched) {

--- a/frontend/features/chat/components/sections/chat-message-position-rail.tsx
+++ b/frontend/features/chat/components/sections/chat-message-position-rail.tsx
@@ -6,6 +6,7 @@ import { createPortal } from "react-dom";
 
 import {
   useMessageScroller,
+  useMessageScrollerScrollable,
   useMessageScrollerVisibility,
 } from "@/components/ui/message-scroller";
 import type { ChatAreaMessage } from "@/features/chat/types/messages";
@@ -142,7 +143,8 @@ function ChatMessagePositionRailComponent({
   messages: ChatAreaMessage[];
 }) {
   const { scrollToMessage } = useMessageScroller();
-  const { currentAnchorId, visibleMessageIds } = useMessageScrollerVisibility();
+  const { end: canScrollToEnd } = useMessageScrollerScrollable();
+  const { visibleMessageIds } = useMessageScrollerVisibility();
   const [hoveredID, setHoveredID] = React.useState<string | null>(null);
   const [previewPosition, setPreviewPosition] = React.useState<PreviewPosition | null>(null);
   const [previewHeight, setPreviewHeight] = React.useState(PREVIEW_ESTIMATED_HEIGHT_PX);
@@ -203,8 +205,8 @@ function ChatMessagePositionRailComponent({
   const visibleIDs = React.useMemo(() => new Set(visibleMessageIds), [visibleMessageIds]);
   const turnIsActive = React.useCallback(
     (item: TurnPreviewItem) =>
-      item.messageIDs.some((messageID) => messageID === currentAnchorId || visibleIDs.has(messageID)),
-    [currentAnchorId, visibleIDs],
+      item.messageIDs.some((messageID) => visibleIDs.has(messageID)),
+    [visibleIDs],
   );
   const activatePreview = React.useCallback((id: string, target: HTMLElement) => {
     const targetRect = target.getBoundingClientRect();
@@ -226,7 +228,8 @@ function ChatMessagePositionRailComponent({
     setPreviewPosition(null);
   }, []);
 
-  const currentIndex = items.findIndex(turnIsActive);
+  const visibleIndex = items.findIndex(turnIsActive);
+  const currentIndex = !canScrollToEnd && items.length > 0 ? items.length - 1 : visibleIndex;
   const hoveredIndex = hoveredID ? items.findIndex((item) => item.id === hoveredID) : -1;
   const activeIndex = hoveredIndex >= 0 ? hoveredIndex : currentIndex >= 0 ? currentIndex : items.length - 1;
   const railLineDistributionActive = hoveredIndex >= 0;

--- a/frontend/features/chat/components/sections/chat-response-outline-rail.tsx
+++ b/frontend/features/chat/components/sections/chat-response-outline-rail.tsx
@@ -4,7 +4,10 @@ import { useTranslations } from "next-intl";
 import * as React from "react";
 
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
-import { useMessageScrollerVisibility } from "@/components/ui/message-scroller";
+import {
+  useMessageScroller,
+  useMessageScrollerVisibility,
+} from "@/components/ui/message-scroller";
 import { cn } from "@/lib/utils";
 
 const MIN_OUTLINE_HEADINGS = 2;
@@ -67,12 +70,9 @@ function keepItemVisible(viewport: HTMLElement, item: HTMLElement) {
 
 function resolveActiveAssistantMessage(
   viewport: HTMLElement,
-  currentAnchorID: string,
   visibleMessageIDs: Iterable<string>,
 ): HTMLElement | null {
-  const candidateIDs = Array.from(
-    new Set([currentAnchorID, ...visibleMessageIDs].filter(Boolean)),
-  );
+  const candidateIDs = Array.from(new Set(visibleMessageIDs));
   if (candidateIDs.length === 0) {
     return null;
   }
@@ -101,13 +101,6 @@ function resolveActiveAssistantMessage(
     return guideCandidate.element;
   }
 
-  const anchorCandidate = candidates.find(
-    (candidate) => candidate.element.dataset.chatMessageId === currentAnchorID,
-  );
-  if (anchorCandidate) {
-    return anchorCandidate.element;
-  }
-
   return candidates.reduce((closest, candidate) =>
     distanceToGuide(candidate.rect, guideY) < distanceToGuide(closest.rect, guideY)
       ? candidate
@@ -123,7 +116,8 @@ function ChatResponseOutlineRailComponent({
   disabled?: boolean;
 }) {
   const t = useTranslations("chat.messages");
-  const { currentAnchorId, visibleMessageIds } = useMessageScrollerVisibility();
+  const { scrollToMessage } = useMessageScroller();
+  const { visibleMessageIds } = useMessageScrollerVisibility();
   const [headings, setHeadings] = React.useState<ResponseOutlineHeading[]>([]);
   const [activeHeadingIndex, setActiveHeadingIndex] = React.useState(0);
   const [hoveredHeadingIndex, setHoveredHeadingIndex] = React.useState<number | null>(null);
@@ -137,11 +131,11 @@ function ChatResponseOutlineRailComponent({
   const railItemRefs = React.useRef(new Map<number, HTMLButtonElement>());
   const menuViewportRef = React.useRef<HTMLDivElement | null>(null);
   const menuItemRefs = React.useRef(new Map<number, HTMLButtonElement>());
-  const visibilityRef = React.useRef({ currentAnchorId, visibleMessageIds });
+  const visibleMessageIDsRef = React.useRef(visibleMessageIds);
 
   React.useLayoutEffect(() => {
-    visibilityRef.current = { currentAnchorId, visibleMessageIds };
-  }, [currentAnchorId, visibleMessageIds]);
+    visibleMessageIDsRef.current = visibleMessageIds;
+  }, [visibleMessageIds]);
 
   const clearOutline = React.useCallback(() => {
     headingElementsRef.current = [];
@@ -183,12 +177,7 @@ function ChatResponseOutlineRailComponent({
       return;
     }
 
-    const visibility = visibilityRef.current;
-    const message = resolveActiveAssistantMessage(
-      viewport,
-      visibility.currentAnchorId,
-      visibility.visibleMessageIds,
-    );
+    const message = resolveActiveAssistantMessage(viewport, visibleMessageIDsRef.current);
     if (!message) {
       clearOutline();
       return;
@@ -297,23 +286,27 @@ function ChatResponseOutlineRailComponent({
 
   const scrollToHeading = React.useCallback(
     (index: number) => {
-      const viewport = boundaryRef.current;
       const heading = headingElementsRef.current[index];
-      if (!viewport || !heading) {
+      const message = heading?.closest<HTMLElement>(ASSISTANT_MESSAGE_SELECTOR);
+      const messageID = message?.dataset.chatMessageId?.trim() ?? "";
+      if (!heading || !message || !messageID) {
         return;
       }
-      const viewportRect = viewport.getBoundingClientRect();
+
       const headingRect = heading.getBoundingClientRect();
-      const top =
-        viewport.scrollTop + headingRect.top - viewportRect.top - OUTLINE_SCROLL_MARGIN_PX;
+      const messageRect = message.getBoundingClientRect();
+      const headingOffset = headingRect.top - messageRect.top;
       const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-      viewport.scrollTo({
-        top: Math.max(0, top),
+      const scrolled = scrollToMessage(messageID, {
+        align: "start",
         behavior: reducedMotion ? "auto" : "smooth",
+        scrollMargin: OUTLINE_SCROLL_MARGIN_PX - headingOffset,
       });
-      setActiveHeadingIndex(index);
+      if (scrolled) {
+        setActiveHeadingIndex(index);
+      }
     },
-    [boundaryRef],
+    [scrollToMessage],
   );
 
   if (disabled || headings.length < MIN_OUTLINE_HEADINGS) {


### PR DESCRIPTION
## Summary

Closes #648.

Fix inconsistent chat navigation indicators and response outline positioning.

- ensure the message position rail selects the latest completed turn when the conversation reaches the bottom
- continue using visible-message detection while scrolling through earlier messages
- route response outline navigation through the shared MessageScroller state
- correctly position headings near the end of an assistant response using scroll offset compensation
- preserve smooth scrolling and reduced-motion behavior
- remove unused message anchor branches and redundant state references

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm --filter @deeix/web lint`
- [x] `pnpm --filter @deeix/web typecheck`
- [x] `pnpm --filter @deeix/web build`
- [x] `git diff --check`

The production build completed successfully in an isolated workspace and generated all 33 static pages.

## Screenshots, API examples, or logs

Not included. This change affects scroll positioning and navigation state; no browser-based visual verification was performed.

## Configuration, migration, and compatibility notes

- No configuration or environment variable changes.
- No database migrations.
- No API contract changes.
- No backend compatibility impact.
- Existing smooth-scroll and reduced-motion behavior is preserved.
- No third-party MessageScroller implementation was modified.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.