### PR TITLE
fix: preserve thinking timer across page refreshes

### DIFF
--- a/backend/internal/application/conversation/service_trace.go
+++ b/backend/internal/application/conversation/service_trace.go
@@ -1212,12 +1212,13 @@ func (r *messageTraceRecorder) emitUpstreamThinkDelta(update upstreamThinkLiveUp
 		return
 	}
 	payload := map[string]interface{}{
-		"status":  r.upstreamThink.status,
-		"title":   r.upstreamThink.title,
-		"summary": r.upstreamThink.summary,
-		"stage":   r.upstreamThink.stage,
-		"roundID": r.upstreamThink.roundID,
-		"eventID": r.upstreamThink.eventID,
+		"status":    r.upstreamThink.status,
+		"title":     r.upstreamThink.title,
+		"summary":   r.upstreamThink.summary,
+		"stage":     r.upstreamThink.stage,
+		"roundID":   r.upstreamThink.roundID,
+		"eventID":   r.upstreamThink.eventID,
+		"startedAt": r.upstreamThink.startedAt,
 	}
 	if update.kind != "" {
 		payload["kind"] = update.kind

--- a/backend/internal/application/conversation/service_trace_tool_test.go
+++ b/backend/internal/application/conversation/service_trace_tool_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
@@ -732,6 +733,10 @@ func TestUpstreamThinkingDeltaIsCoalescedBetweenFlushes(t *testing.T) {
 	if len(events) != 1 || events[0]["delta"] != "a" {
 		t.Fatalf("expected first live event to carry only first delta, got %#v", events)
 	}
+	startedAt, ok := events[0]["startedAt"].(time.Time)
+	if !ok || recorder.upstreamThink == nil || !startedAt.Equal(recorder.upstreamThink.startedAt) {
+		t.Fatalf("expected live event to carry the authoritative thinking start, got %#v", events[0]["startedAt"])
+	}
 	if _, ok := events[0]["trace"]; ok {
 		t.Fatalf("live thinking delta must not carry full trace: %#v", events[0])
 	}
@@ -748,6 +753,11 @@ func TestUpstreamThinkingDeltaIsCoalescedBetweenFlushes(t *testing.T) {
 	}
 	if events[1]["delta"] != "bc" || events[1]["status"] != messageTraceStatusCompleted {
 		t.Fatalf("expected completion to flush coalesced delta with completed status, got %#v", events[1])
+	}
+	completedStartedAt, ok := events[1]["startedAt"].(time.Time)
+	if !ok || !completedStartedAt.Equal(startedAt) {
+		t.Fatalf("expected all deltas in one thinking round to retain startedAt, got %v then %v",
+			events[0]["startedAt"], events[1]["startedAt"])
 	}
 }
 

--- a/frontend/features/chat/model/chat-thread.ts
+++ b/frontend/features/chat/model/chat-thread.ts
@@ -50,6 +50,7 @@ function parseProcessTrace(item: MessageDTO) {
           stage: block.stage,
           roundID: block.roundID,
           parentEventID: block.parentEventID,
+          startedAt: block.startedAt,
           updatedAt: block.updatedAt,
           payloadJson: block.payloadJSON,
         }

--- a/frontend/features/chat/model/upstream-think-store.ts
+++ b/frontend/features/chat/model/upstream-think-store.ts
@@ -34,6 +34,9 @@ function mergeUpstreamThinkBlock(current: ChatTraceBlock | undefined, event: Ups
   const roundID = event.roundID || current?.roundID;
   const roundChanged = Boolean(roundID && current?.roundID && roundID !== current.roundID);
   const contentMarkdown = mergeContent(roundChanged ? "" : (current?.contentMarkdown ?? ""), event);
+  const eventStartedAt = typeof event.startedAt === "string"
+    ? event.startedAt.trim() || undefined
+    : undefined;
   return {
     title: event.title?.trim() || current?.title || "",
     summary: event.summary?.trim() || current?.summary || "",
@@ -42,7 +45,7 @@ function mergeUpstreamThinkBlock(current: ChatTraceBlock | undefined, event: Ups
     stage: event.stage || current?.stage || "think",
     roundID,
     parentEventID: current?.parentEventID,
-    startedAt: !current || roundChanged ? nowISO() : current?.startedAt ?? nowISO(),
+    startedAt: eventStartedAt ?? (roundChanged ? undefined : current?.startedAt) ?? nowISO(),
     updatedAt: nowISO(),
     payloadJson: current?.payloadJson,
   };

--- a/frontend/shared/api/conversation.ts
+++ b/frontend/shared/api/conversation.ts
@@ -82,6 +82,7 @@ function normalizeTraceBlock(block: unknown): TraceBlockDTO | undefined {
     stage: raw.stage,
     roundID: raw.roundID,
     parentEventID: raw.parentEventID,
+    startedAt: raw.startedAt,
     updatedAt: raw.updatedAt ?? "",
     payloadJSON: raw.payloadJSON,
   };

--- a/frontend/shared/api/conversation.types.ts
+++ b/frontend/shared/api/conversation.types.ts
@@ -278,6 +278,7 @@ export type StreamMessageEvent =
       stage?: string;
       roundID?: string;
       eventID?: string;
+      startedAt?: string;
       kind?: ReasoningDeltaDTO["kind"] | string;
       delta?: string;
       contentMarkdown?: string;


### PR DESCRIPTION

## Summary

Fixes #652.

Preserve the original deep-reasoning start time when an active conversation is restored after a page refresh.

- Include the authoritative `startedAt` timestamp in `upstream_think_delta` stream events.
- Preserve trace block `startedAt` during API normalization and message hydration.
- Use the server timestamp when rebuilding live thinking state instead of restarting from the browser refresh time.
- Keep timestamps isolated by `roundID` so multi-round reasoning uses the correct start time for each round.
- Add regression coverage ensuring all deltas in the same reasoning round retain the same start time.

Completed reasoning durations continue to use persisted server-side start and end timestamps.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm check`
- [x] `go test ./...`
- [x] `pnpm build`
- [x] `git diff --check`
- [ ] Not run; reason:

## Screenshots, API examples, or logs

No visual layout changes.

The existing thinking stream event now includes an additive `startedAt` field:

```json
{
  "type": "upstream_think_delta",
  "status": "streaming",
  "roundID": "round_1",
  "eventID": "think_1",
  "startedAt": "2026-08-25T10:00:00Z"
}
```

## Configuration, migration, and compatibility notes

- No database migrations.
- No configuration or environment variable changes.
- No dependency changes.
- No generated artifact changes.
- `startedAt` is an additive optional field in the frontend stream event contract.
- Existing completed-message duration behavior is unchanged.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.
