### PR TITLE
fix: keep reasoning durations visible while responses stream

### DIFF
--- a/backend/internal/application/conversation/service_trace.go
+++ b/backend/internal/application/conversation/service_trace.go
@@ -1232,6 +1232,9 @@ func (r *messageTraceRecorder) emitUpstreamThinkDelta(update upstreamThinkLiveUp
 	if len(update.reasoning) > 0 {
 		payload["reasoning"] = update.reasoning
 	}
+	if r.upstreamThink.endedAt != nil {
+		payload["endedAt"] = *r.upstreamThink.endedAt
+	}
 	emitEvent(r.onEvent, "upstream_think_delta", payload)
 }
 

--- a/backend/internal/application/conversation/service_trace_tool_test.go
+++ b/backend/internal/application/conversation/service_trace_tool_test.go
@@ -737,6 +737,9 @@ func TestUpstreamThinkingDeltaIsCoalescedBetweenFlushes(t *testing.T) {
 	if !ok || recorder.upstreamThink == nil || !startedAt.Equal(recorder.upstreamThink.startedAt) {
 		t.Fatalf("expected live event to carry the authoritative thinking start, got %#v", events[0]["startedAt"])
 	}
+	if _, ok := events[0]["endedAt"]; ok {
+		t.Fatalf("streaming thinking event must not carry endedAt, got %#v", events[0]["endedAt"])
+	}
 	if _, ok := events[0]["trace"]; ok {
 		t.Fatalf("live thinking delta must not carry full trace: %#v", events[0])
 	}
@@ -758,6 +761,10 @@ func TestUpstreamThinkingDeltaIsCoalescedBetweenFlushes(t *testing.T) {
 	if !ok || !completedStartedAt.Equal(startedAt) {
 		t.Fatalf("expected all deltas in one thinking round to retain startedAt, got %v then %v",
 			events[0]["startedAt"], events[1]["startedAt"])
+	}
+	endedAt, ok := events[1]["endedAt"].(time.Time)
+	if !ok || recorder.upstreamThink == nil || recorder.upstreamThink.endedAt == nil || !endedAt.Equal(*recorder.upstreamThink.endedAt) {
+		t.Fatalf("expected completed thinking event to carry the authoritative end, got %#v", events[1]["endedAt"])
 	}
 }
 

--- a/frontend/features/chat/components/message/message-agent-trace.tsx
+++ b/frontend/features/chat/components/message/message-agent-trace.tsx
@@ -46,6 +46,7 @@ function traceEventToBlock(event: ChatTraceEvent): ChatTraceBlock {
     roundID: event.roundID,
     parentEventID: event.parentEventID,
     startedAt: event.startedAt,
+    endedAt: event.endedAt,
     updatedAt: event.updatedAt,
     payloadJson: event.payloadJson,
   };
@@ -381,6 +382,8 @@ export function MessageAgentTrace({
       const thinkBlock = mergeThinkTraceBlock(group.thinkEvents, group.thinkBlock);
       if (thinkBlock) {
         const streaming = Boolean(messageStreaming && thinkBlock.status === "streaming");
+        const completedDurationMS = thinkEventDurationMS(group.thinkEvents)
+          ?? durationBetweenMS(thinkBlock.startedAt, thinkBlock.endedAt);
         list.push({
           kind: "think",
           key: `${group.key}:think`,
@@ -388,7 +391,7 @@ export function MessageAgentTrace({
           streaming,
           durationMS: streaming
             ? undefined
-            : thinkEventDurationMS(group.thinkEvents),
+            : completedDurationMS,
         });
       }
       groupToolSteps[index].forEach((step) => {

--- a/frontend/features/chat/hooks/use-chat-stream-buffer.ts
+++ b/frontend/features/chat/hooks/use-chat-stream-buffer.ts
@@ -49,6 +49,48 @@ function resolveThinkFlushSize(pendingLength: number) {
   return Math.min(pendingLength, STREAM_THINK_BASE_CHARS_PER_FLUSH);
 }
 
+function isTerminalThinkEvent(event: UpstreamThinkDeltaEvent) {
+  const status = event.status.trim().toLowerCase();
+  return status === "completed" || status === "error";
+}
+
+function isDifferentThinkEvent(current: UpstreamThinkDeltaEvent, next: UpstreamThinkDeltaEvent) {
+  const currentRoundID = current.roundID?.trim() || "";
+  const nextRoundID = next.roundID?.trim() || "";
+  if (currentRoundID && nextRoundID && currentRoundID !== nextRoundID) {
+    return true;
+  }
+  const currentEventID = current.eventID?.trim() || "";
+  const nextEventID = next.eventID?.trim() || "";
+  return Boolean(currentEventID && nextEventID && currentEventID !== nextEventID);
+}
+
+function cancelThinkFlush(buffer: StreamBuffer) {
+  if (buffer.thinkFrame !== null) {
+    window.cancelAnimationFrame(buffer.thinkFrame);
+    buffer.thinkFrame = null;
+  }
+  if (buffer.thinkTimeout !== null) {
+    window.clearTimeout(buffer.thinkTimeout);
+    buffer.thinkTimeout = null;
+  }
+}
+
+function flushPendingThink(buffer: StreamBuffer) {
+  if (!buffer.runID || !buffer.pendingThinkEvent) {
+    return false;
+  }
+  upsertLiveUpstreamThinkTrace(buffer.runID, {
+    ...buffer.pendingThinkEvent,
+    delta: buffer.pendingThinkDelta,
+    contentMarkdown: buffer.pendingThinkDelta ? undefined : buffer.pendingThinkEvent.contentMarkdown,
+  });
+  buffer.pendingThinkDelta = "";
+  buffer.pendingThinkEvent = null;
+  buffer.lastThinkFlushAt = performance.now();
+  return true;
+}
+
 function cancelBufferTimers(buffer: StreamBuffer) {
   if (buffer.textFrame !== null) {
     window.cancelAnimationFrame(buffer.textFrame);
@@ -56,12 +98,7 @@ function cancelBufferTimers(buffer: StreamBuffer) {
   if (buffer.textTimeout !== null) {
     window.clearTimeout(buffer.textTimeout);
   }
-  if (buffer.thinkFrame !== null) {
-    window.cancelAnimationFrame(buffer.thinkFrame);
-  }
-  if (buffer.thinkTimeout !== null) {
-    window.clearTimeout(buffer.thinkTimeout);
-  }
+  cancelThinkFlush(buffer);
 }
 
 export function useChatStreamBuffer({
@@ -181,16 +218,25 @@ export function useChatStreamBuffer({
     if (!buffer) {
       return;
     }
+    if (buffer.pendingThinkEvent && isDifferentThinkEvent(buffer.pendingThinkEvent, event)) {
+      cancelThinkFlush(buffer);
+      flushPendingThink(buffer);
+    }
     if (event.trace?.enabled || typeof event.contentMarkdown === "string") {
       buffer.pendingThinkDelta = "";
       buffer.pendingThinkEvent = event;
-      scheduleUpstreamThinkFlush(exchangeKey);
-      return;
+    } else {
+      if (event.delta) {
+        buffer.pendingThinkDelta += event.delta;
+      }
+      buffer.pendingThinkEvent = { ...event, delta: "" };
     }
-    if (event.delta) {
-      buffer.pendingThinkDelta += event.delta;
+    if (isTerminalThinkEvent(event)) {
+      cancelThinkFlush(buffer);
+      if (flushPendingThink(buffer)) {
+        return;
+      }
     }
-    buffer.pendingThinkEvent = { ...event, delta: "" };
     scheduleUpstreamThinkFlush(exchangeKey);
   }, [scheduleUpstreamThinkFlush]);
 
@@ -225,24 +271,8 @@ export function useChatStreamBuffer({
     if (!buffer) {
       return;
     }
-    if (buffer.thinkFrame !== null) {
-      window.cancelAnimationFrame(buffer.thinkFrame);
-      buffer.thinkFrame = null;
-    }
-    if (buffer.thinkTimeout !== null) {
-      window.clearTimeout(buffer.thinkTimeout);
-      buffer.thinkTimeout = null;
-    }
-    if (!buffer.runID || !buffer.pendingThinkEvent) {
-      return;
-    }
-    upsertLiveUpstreamThinkTrace(buffer.runID, {
-      ...buffer.pendingThinkEvent,
-      delta: buffer.pendingThinkDelta,
-      contentMarkdown: buffer.pendingThinkDelta ? undefined : buffer.pendingThinkEvent.contentMarkdown,
-    });
-    buffer.pendingThinkDelta = "";
-    buffer.pendingThinkEvent = null;
+    cancelThinkFlush(buffer);
+    flushPendingThink(buffer);
   }, []);
 
   const resetStreamBuffer = React.useCallback((exchangeKey?: string) => {

--- a/frontend/features/chat/model/upstream-think-store.ts
+++ b/frontend/features/chat/model/upstream-think-store.ts
@@ -37,6 +37,9 @@ function mergeUpstreamThinkBlock(current: ChatTraceBlock | undefined, event: Ups
   const eventStartedAt = typeof event.startedAt === "string"
     ? event.startedAt.trim() || undefined
     : undefined;
+  const eventEndedAt = typeof event.endedAt === "string"
+    ? event.endedAt.trim() || undefined
+    : undefined;
   return {
     title: event.title?.trim() || current?.title || "",
     summary: event.summary?.trim() || current?.summary || "",
@@ -46,6 +49,7 @@ function mergeUpstreamThinkBlock(current: ChatTraceBlock | undefined, event: Ups
     roundID,
     parentEventID: current?.parentEventID,
     startedAt: eventStartedAt ?? (roundChanged ? undefined : current?.startedAt) ?? nowISO(),
+    endedAt: eventEndedAt ?? (roundChanged ? undefined : current?.endedAt),
     updatedAt: nowISO(),
     payloadJson: current?.payloadJson,
   };

--- a/frontend/features/chat/types/messages.ts
+++ b/frontend/features/chat/types/messages.ts
@@ -47,6 +47,7 @@ export type ChatTraceBlock = {
   roundID?: string;
   parentEventID?: string;
   startedAt?: string;
+  endedAt?: string;
   updatedAt?: string;
   payloadJson?: string;
 };

--- a/frontend/shared/api/conversation.types.ts
+++ b/frontend/shared/api/conversation.types.ts
@@ -279,6 +279,7 @@ export type StreamMessageEvent =
       roundID?: string;
       eventID?: string;
       startedAt?: string;
+      endedAt?: string;
       kind?: ReasoningDeltaDTO["kind"] | string;
       delta?: string;
       contentMarkdown?: string;


### PR DESCRIPTION
## Summary

Fixes #655.

Keep deep-reasoning step durations visible after reasoning finishes and while the final response is still streaming.

- Include the authoritative `endedAt` timestamp in terminal `upstream_think_delta` events.
- Preserve the completed reasoning duration in the frontend live trace.
- Immediately calculate and display `startedAt → endedAt` before the final message finishes.
- Include the final reasoning step in the execution summary’s total duration.
- Flush completed and failed reasoning events immediately instead of waiting for the animation buffer.
- Flush pending content before switching `roundID` or `eventID`, preventing timestamps or content from being merged across reasoning rounds.
- Preserve the existing 40ms buffered animation for ordinary same-round reasoning deltas.
- Add regression assertions for streaming and terminal reasoning timestamps.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm check`
- [x] `go test ./...`
- [x] `pnpm build`
- [x] `git diff --check`
- [ ] Not run; reason:

## Screenshots, API examples, or logs

No visual layout changes.

Terminal reasoning stream events now include an additive `endedAt` field:

```json
{
  "type": "upstream_think_delta",
  "status": "completed",
  "roundID": "round_1",
  "eventID": "think_1",
  "startedAt": "2026-08-25T10:00:00Z",
  "endedAt": "2026-08-25T10:00:04Z"
}
```

During final-response streaming, the UI immediately displays the fixed four-second reasoning duration and includes it in the execution summary.

## Configuration, migration, and compatibility notes

- No database migrations.
- No configuration or environment variable changes.
- No dependency changes.
- No generated artifact changes.
- `endedAt` is an additive optional field in the frontend stream event contract.
- Existing completed-message duration behavior remains unchanged.
- Same-round streaming animation timing remains unchanged.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.