### PR TITLE
refactor: stabilize sidebar interactions and Streamdown rendering

### DIFF
--- a/frontend/components/ui/sidebar-hover-transition.ts
+++ b/frontend/components/ui/sidebar-hover-transition.ts
@@ -1,0 +1,47 @@
+export type SidebarRevealTarget = "expanded" | "collapsed";
+
+export type SidebarRevealTransitionState = {
+  target: SidebarRevealTarget;
+  layout: SidebarRevealTarget;
+  resizing: boolean;
+};
+
+export type SidebarRevealTransitionAction =
+  | { type: "begin"; target: SidebarRevealTarget }
+  | { type: "settle"; target: SidebarRevealTarget }
+  | { type: "sync"; target: SidebarRevealTarget };
+
+export function createSidebarRevealTransitionState(
+  target: SidebarRevealTarget,
+): SidebarRevealTransitionState {
+  return { target, layout: target, resizing: false };
+}
+
+export function sidebarRevealTransitionReducer(
+  state: SidebarRevealTransitionState,
+  action: SidebarRevealTransitionAction,
+): SidebarRevealTransitionState {
+  if (action.type === "sync") {
+    return createSidebarRevealTransitionState(action.target);
+  }
+
+  if (action.type === "begin") {
+    return {
+      target: action.target,
+      // Expanded children must be laid out before the shell reveals them. On
+      // collapse, keep that geometry stable until the width transition ends.
+      layout: action.target === "expanded" ? "expanded" : state.layout,
+      resizing: true,
+    };
+  }
+
+  if (action.target !== state.target) {
+    return state;
+  }
+
+  return {
+    target: action.target,
+    layout: action.target,
+    resizing: false,
+  };
+}

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -1,13 +1,10 @@
 "use client"
 
-import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { PanelLeftIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { Slot } from "radix-ui"
-
-import { useIsMobile } from "@/shared/hooks/use-mobile"
-import { cn } from "@/lib/utils"
+import * as React from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
@@ -25,6 +22,12 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+import { useIsMobile } from "@/shared/hooks/use-mobile"
+import {
+  createSidebarRevealTransitionState,
+  sidebarRevealTransitionReducer,
+} from "./sidebar-hover-transition"
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
@@ -35,6 +38,9 @@ const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 const SIDEBAR_AUTO_COLLAPSE_AT = 1180
 const SIDEBAR_AUTO_RESTORE_AT = 1360
+const SIDEBAR_HOVER_COLLAPSE_DELAY_MS = 80
+const SIDEBAR_HOVER_REVEAL_DURATION_MS = 200
+const SIDEBAR_TRANSITION_FALLBACK_MS = SIDEBAR_HOVER_REVEAL_DURATION_MS + 50
 
 type SidebarContextProps = {
   state: "expanded" | "collapsed"
@@ -46,8 +52,13 @@ type SidebarContextProps = {
   toggleSidebar: () => void
 }
 
+type SidebarHoverExpansionContextProps = {
+  acquireLock: () => () => void
+}
+
 const SidebarContext = React.createContext<SidebarContextProps | null>(null)
 const SidebarVisualStateContext = React.createContext<SidebarContextProps["state"] | null>(null)
+const SidebarHoverExpansionContext = React.createContext<SidebarHoverExpansionContextProps | null>(null)
 
 function useSidebar() {
   const context = React.useContext(SidebarContext)
@@ -67,12 +78,30 @@ function useSidebarVisualState() {
   return state
 }
 
+function useSidebarHoverExpansionLock(active: boolean) {
+  const context = React.useContext(SidebarHoverExpansionContext)
+
+  React.useLayoutEffect(() => {
+    if (!active || !context) {
+      return
+    }
+    return context.acquireLock()
+  }, [active, context])
+}
+
 function shouldAutoCollapseSidebar() {
   return typeof window !== "undefined" && window.innerWidth < SIDEBAR_AUTO_COLLAPSE_AT
 }
 
 function shouldAutoRestoreSidebar() {
   return typeof window !== "undefined" && window.innerWidth >= SIDEBAR_AUTO_RESTORE_AT
+}
+
+function shouldReduceSidebarMotion() {
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  )
 }
 
 function readSidebarInitialOpen(defaultOpen: boolean) {
@@ -277,6 +306,7 @@ function Sidebar({
   children,
   onPointerEnter,
   onPointerLeave,
+  onTransitionEnd,
   ...props
 }: React.ComponentProps<"div"> & {
   side?: "left" | "right"
@@ -291,18 +321,126 @@ function Sidebar({
     setOpenMobile,
   } = useSidebar()
   const [hoverExpanded, setHoverExpanded] = React.useState(false)
+  const hoverCollapseTimerRef = React.useRef<number | null>(null)
+  const hoverExpansionLockCountRef = React.useRef(0)
+  const pointerInsideRef = React.useRef(false)
   const visualState = open || hoverExpanded ? "expanded" : "collapsed"
+  const usesHoverReveal = expandOnHover && collapsible === "icon" && variant === "sidebar"
+  // Keep the stable child layout separate from the animated shell target.
+  const [revealTransition, dispatchRevealTransition] = React.useReducer(
+    sidebarRevealTransitionReducer,
+    visualState,
+    createSidebarRevealTransitionState
+  )
+  const layoutState = revealTransition.layout
+  const isResizing = revealTransition.resizing
+  const transitionTargetRef = React.useRef<SidebarContextProps["state"]>(visualState)
+  const transitionTimerRef = React.useRef<number | null>(null)
   const t = useTranslations("common.navigation")
+
+  const clearHoverCollapseTimer = React.useCallback(() => {
+    if (hoverCollapseTimerRef.current === null) {
+      return
+    }
+    window.clearTimeout(hoverCollapseTimerRef.current)
+    hoverCollapseTimerRef.current = null
+  }, [])
+
+  const clearTransitionTimer = React.useCallback(() => {
+    if (transitionTimerRef.current === null) {
+      return
+    }
+    window.clearTimeout(transitionTimerRef.current)
+    transitionTimerRef.current = null
+  }, [])
+
+  const settleTransition = React.useCallback(
+    (state: SidebarContextProps["state"]) => {
+      clearTransitionTimer()
+      dispatchRevealTransition({ type: "settle", target: state })
+    },
+    [clearTransitionTimer]
+  )
+
+  const syncTransition = React.useCallback(
+    (state: SidebarContextProps["state"]) => {
+      clearTransitionTimer()
+      dispatchRevealTransition({ type: "sync", target: state })
+    },
+    [clearTransitionTimer]
+  )
+
+  const scheduleHoverCollapse = React.useCallback(() => {
+    clearHoverCollapseTimer()
+    hoverCollapseTimerRef.current = window.setTimeout(() => {
+      hoverCollapseTimerRef.current = null
+      setHoverExpanded(false)
+    }, SIDEBAR_HOVER_COLLAPSE_DELAY_MS)
+  }, [clearHoverCollapseTimer])
+
+  const acquireHoverExpansionLock = React.useCallback(() => {
+    let released = false
+    hoverExpansionLockCountRef.current += 1
+    clearHoverCollapseTimer()
+
+    return () => {
+      if (released) {
+        return
+      }
+      released = true
+      hoverExpansionLockCountRef.current = Math.max(0, hoverExpansionLockCountRef.current - 1)
+      if (hoverExpansionLockCountRef.current === 0 && !pointerInsideRef.current) {
+        scheduleHoverCollapse()
+      }
+    }
+  }, [clearHoverCollapseTimer, scheduleHoverCollapse])
+
+  const hoverExpansionContextValue = React.useMemo<SidebarHoverExpansionContextProps>(
+    () => ({ acquireLock: acquireHoverExpansionLock }),
+    [acquireHoverExpansionLock]
+  )
 
   React.useEffect(() => {
     if (isMobile || open || !expandOnHover || collapsible !== "icon") {
+      clearHoverCollapseTimer()
       setHoverExpanded(false)
     }
-  }, [collapsible, expandOnHover, isMobile, open])
+  }, [clearHoverCollapseTimer, collapsible, expandOnHover, isMobile, open])
+
+  React.useLayoutEffect(() => {
+    clearTransitionTimer()
+
+    if (!usesHoverReveal || shouldReduceSidebarMotion()) {
+      transitionTargetRef.current = visualState
+      syncTransition(visualState)
+      return
+    }
+
+    if (transitionTargetRef.current === visualState) {
+      return
+    }
+
+    transitionTargetRef.current = visualState
+    dispatchRevealTransition({ type: "begin", target: visualState })
+
+    transitionTimerRef.current = window.setTimeout(() => {
+      settleTransition(visualState)
+    }, SIDEBAR_TRANSITION_FALLBACK_MS)
+  }, [clearTransitionTimer, settleTransition, syncTransition, usesHoverReveal, visualState])
+
+  React.useEffect(
+    () => () => {
+      clearHoverCollapseTimer()
+      clearTransitionTimer()
+    },
+    [clearHoverCollapseTimer, clearTransitionTimer]
+  )
 
   const handlePointerEnter = React.useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       onPointerEnter?.(event)
+      pointerInsideRef.current = true
+      clearHoverCollapseTimer()
       if (
         expandOnHover &&
         collapsible === "icon" &&
@@ -312,17 +450,37 @@ function Sidebar({
         setHoverExpanded(true)
       }
     },
-    [collapsible, expandOnHover, onPointerEnter, open, setHoverExpanded]
+    [clearHoverCollapseTimer, collapsible, expandOnHover, onPointerEnter, open]
   )
 
   const handlePointerLeave = React.useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       onPointerLeave?.(event)
+      pointerInsideRef.current = false
       if (expandOnHover && collapsible === "icon" && event.pointerType === "mouse") {
-        setHoverExpanded(false)
+        if (hoverExpansionLockCountRef.current > 0) {
+          return
+        }
+        scheduleHoverCollapse()
       }
     },
-    [collapsible, expandOnHover, onPointerLeave, setHoverExpanded]
+    [collapsible, expandOnHover, onPointerLeave, scheduleHoverCollapse]
+  )
+
+  const handleContainerTransitionEnd = React.useCallback(
+    (event: React.TransitionEvent<HTMLDivElement>) => {
+      onTransitionEnd?.(event)
+      if (
+        !usesHoverReveal ||
+        event.target !== event.currentTarget ||
+        event.propertyName !== "width"
+      ) {
+        return
+      }
+
+      settleTransition(transitionTargetRef.current)
+    },
+    [onTransitionEnd, settleTransition, usesHoverReveal]
   )
 
   if (collapsible === "none") {
@@ -377,8 +535,9 @@ function Sidebar({
     <div
       className="group peer hidden text-sidebar-foreground md:block"
       data-state={visualState}
+      data-resizing={isResizing ? "true" : "false"}
       data-hover-expanded={hoverExpanded && !open ? "true" : "false"}
-      data-collapsible={visualState === "collapsed" ? collapsible : ""}
+      data-collapsible={layoutState === "collapsed" ? collapsible : ""}
       data-variant={variant}
       data-side={side}
       data-slot="sidebar"
@@ -399,15 +558,21 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) md:flex",
+          usesHoverReveal
+            ? "overflow-hidden transition-[width,box-shadow] duration-200 ease-linear motion-reduce:transition-none group-data-[state=collapsed]:w-(--sidebar-width-icon)"
+            : "transition-[left,right,width] duration-200 ease-linear",
           side === "left"
             ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
-            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r-[0.5px] group-data-[side=right]:border-l-[0.5px]",
-          "group-data-[hover-expanded=true]:z-30",
+            : cn(
+                "group-data-[side=left]:border-r-[0.5px] group-data-[side=right]:border-l-[0.5px]",
+                !usesHoverReveal && "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
+              ),
+          "group-data-[hover-expanded=true]:z-40 group-data-[resizing=true]:z-40",
           side === "left"
             ? "group-data-[hover-expanded=true]:shadow-[8px_0_28px_-10px_rgb(0_0_0_/_0.16),1px_0_0_rgb(0_0_0_/_0.05)] dark:group-data-[hover-expanded=true]:shadow-[10px_0_32px_-10px_rgb(0_0_0_/_0.44),1px_0_0_rgb(255_255_255_/_0.06)]"
             : "group-data-[hover-expanded=true]:shadow-[-8px_0_28px_-10px_rgb(0_0_0_/_0.16),-1px_0_0_rgb(0_0_0_/_0.05)] dark:group-data-[hover-expanded=true]:shadow-[-10px_0_32px_-10px_rgb(0_0_0_/_0.44),-1px_0_0_rgb(255_255_255_/_0.06)]",
@@ -415,19 +580,29 @@ function Sidebar({
         )}
         onPointerEnter={handlePointerEnter}
         onPointerLeave={handlePointerLeave}
+        onTransitionEnd={handleContainerTransitionEnd}
         {...props}
       >
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
           className={cn(
-            "flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm",
-            expandOnHover && "whitespace-nowrap"
+            "flex h-full shrink-0 flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm",
+            usesHoverReveal
+              ? cn(
+                  "whitespace-nowrap",
+                  layoutState === "collapsed"
+                    ? "w-(--sidebar-width-icon)"
+                    : "w-(--sidebar-width)"
+                )
+              : "w-full"
           )}
         >
-          <SidebarVisualStateContext.Provider value={visualState}>
-            {children}
-          </SidebarVisualStateContext.Provider>
+          <SidebarHoverExpansionContext.Provider value={hoverExpansionContextValue}>
+            <SidebarVisualStateContext.Provider value={layoutState}>
+              {children}
+            </SidebarVisualStateContext.Provider>
+          </SidebarHoverExpansionContext.Provider>
         </div>
       </div>
     </div>
@@ -532,6 +707,26 @@ function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-footer"
       data-sidebar="footer"
       className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarTransitionContent({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "div"
+
+  return (
+    <Comp
+      data-slot="sidebar-transition-content"
+      data-sidebar="transition-content"
+      className={cn(
+        "group-data-[resizing=true]:pointer-events-none group-data-[resizing=true]:invisible",
+        className
+      )}
       {...props}
     />
   )
@@ -902,7 +1097,9 @@ export {
   SidebarProvider,
   SidebarRail,
   SidebarSeparator,
+  SidebarTransitionContent,
   SidebarTrigger,
-  useSidebarVisualState,
   useSidebar,
+  useSidebarHoverExpansionLock,
+  useSidebarVisualState,
 }

--- a/frontend/features/layouts/components/navigation/app-sidebar.tsx
+++ b/frontend/features/layouts/components/navigation/app-sidebar.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import type { ComponentProps } from "react";
 import { LayoutGroup, motion } from "motion/react";
 import { useTranslations } from "next-intl";
+import type { ComponentProps } from "react";
 
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
   SidebarHeader,
+  SidebarTransitionContent,
 } from "@/components/ui/sidebar";
 import { NavControl } from "@/features/layouts/components/navigation/nav-control";
 import { NavMain } from "@/features/layouts/components/navigation/nav-main";
@@ -50,19 +51,21 @@ export function AppSidebar({
       </SidebarHeader>
       <SidebarContent className="min-h-0 gap-0 overflow-hidden group-data-[collapsible=icon]:bg-background">
         <NavMain onCreateConversation={onCreateConversation} />
-        <motion.div
-          layoutScroll
-          data-sidebar-scroll-root="true"
-          className="min-h-0 flex-1 overflow-y-auto [overflow-anchor:none] [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
-        >
-          <LayoutGroup id="sidebar-conversations">
-            <NavProjects />
-            <NavStarred />
-            <NavRecents />
-          </LayoutGroup>
-        </motion.div>
+        <SidebarTransitionContent asChild>
+          <motion.div
+            layoutScroll
+            data-sidebar-scroll-root="true"
+            className="min-h-0 flex-1 overflow-y-auto [overflow-anchor:none] [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+          >
+            <LayoutGroup id="sidebar-conversations">
+              <NavProjects />
+              <NavStarred />
+              <NavRecents />
+            </LayoutGroup>
+          </motion.div>
+        </SidebarTransitionContent>
       </SidebarContent>
-      <SidebarFooter className="group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:bg-background group-data-[collapsible=icon]:px-0">
+      <SidebarFooter className="px-0 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:bg-background">
         <NavUser user={user} />
       </SidebarFooter>
     </Sidebar>

--- a/frontend/features/layouts/components/navigation/nav-control.tsx
+++ b/frontend/features/layouts/components/navigation/nav-control.tsx
@@ -5,8 +5,13 @@ import { useTranslations } from "next-intl";
 import { PanelLeft } from "@/components/animate-ui/icons/panel-left";
 import { PanelRight } from "@/components/animate-ui/icons/panel-right";
 import { Button } from "@/components/ui/button";
-import { useSidebar, useSidebarVisualState } from "@/components/ui/sidebar";
-import { SidebarMenu, SidebarMenuItem } from "@/components/ui/sidebar";
+import {
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarTransitionContent,
+  useSidebar,
+  useSidebarVisualState,
+} from "@/components/ui/sidebar";
 import {
   Tooltip,
   TooltipContent,
@@ -26,21 +31,23 @@ export function NavControl() {
     <SidebarMenu>
       <SidebarMenuItem>
         <div className="relative flex h-8 w-full items-center rounded-md text-sm">
-          <span
-            className={cn(
-              "flex min-w-0 items-center overflow-hidden whitespace-nowrap pl-2 transition-[max-width,opacity,transform,padding-left] ease-linear",
-              isVisuallyCollapsed
-                ? "max-w-0 -translate-x-2 pl-0 opacity-0 duration-100"
-                : "max-w-[160px] translate-x-0 pl-2 opacity-100 duration-150",
-            )}
-          >
-            <AppLogo
-              width={64}
-              height={48}
-              priority
-              className="h-5 w-auto object-contain"
-            />
-          </span>
+          <SidebarTransitionContent asChild>
+            <span
+              className={cn(
+                "flex min-w-0 items-center overflow-hidden whitespace-nowrap pl-2 transition-[max-width,opacity,transform,padding-left] ease-linear group-data-[resizing=true]:max-w-0 group-data-[resizing=true]:-translate-x-2 group-data-[resizing=true]:pl-0",
+                isVisuallyCollapsed
+                  ? "max-w-0 -translate-x-2 pl-0 opacity-0 duration-100"
+                  : "max-w-[160px] translate-x-0 pl-2 opacity-100 duration-150",
+              )}
+            >
+              <AppLogo
+                width={64}
+                height={48}
+                priority
+                className="h-5 w-auto object-contain"
+              />
+            </span>
+          </SidebarTransitionContent>
 
           <Tooltip>
             <TooltipTrigger asChild>
@@ -51,7 +58,7 @@ export function NavControl() {
                 aria-label={t("toggleSidebar")}
                 onClick={toggleSidebar}
                 className={cn(
-                  "shrink-0 text-sidebar-foreground transition-[background-color,color,margin-left] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-sidebar-ring/50 [&_svg]:pointer-events-auto",
+                  "shrink-0 text-sidebar-foreground transition-[background-color,color,margin-left] group-data-[resizing=true]:ml-0 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-sidebar-ring/50 [&_svg]:pointer-events-auto",
                   isVisuallyCollapsed ? "ml-0" : "ml-auto",
                 )}
               >

--- a/frontend/features/layouts/components/navigation/nav-main-item.tsx
+++ b/frontend/features/layouts/components/navigation/nav-main-item.tsx
@@ -6,7 +6,10 @@ import * as React from "react";
 
 import { Button } from "@/components/ui/button";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
-import { SidebarMenuItem } from "@/components/ui/sidebar";
+import {
+  SidebarMenuItem,
+  SidebarTransitionContent,
+} from "@/components/ui/sidebar";
 import {
   Tooltip,
   TooltipContent,
@@ -64,7 +67,7 @@ export function NavMainItem({
   }, []);
 
   const itemClassName = cn(
-    "group/item h-8 gap-0 rounded-md px-0 text-left text-sm font-normal text-sidebar-foreground transition-colors focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+    "group/item h-8 gap-0 overflow-hidden rounded-md px-0 text-left text-sm font-normal text-sidebar-foreground transition-colors focus-visible:ring-2 focus-visible:ring-sidebar-ring",
     isCollapsed
       ? "w-8 justify-center hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
       : "w-full justify-start hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
@@ -96,26 +99,28 @@ export function NavMainItem({
         )}
       </span>
 
-      <span
-        className={cn(
-          "ml-1 flex min-w-0 flex-1 items-center overflow-hidden transition-[opacity,max-width,margin-left] duration-200 ease-linear",
-          isCollapsed && "ml-0",
-        )}
-      >
-        <span className="flex-1 truncate">{title}</span>
-        {item.shortcut && !isCollapsed ? (
-          <KbdGroup className="mr-2 shrink-0 opacity-0 transition-opacity duration-150 group-hover/item:opacity-100">
-            {item.shortcut.map((value) => (
-              <Kbd
-                key={value}
-                className="h-auto min-w-0 bg-transparent px-0"
-              >
-                <ShortcutGlyph value={value} modifierLabel={modifierLabel} />
-              </Kbd>
-            ))}
-          </KbdGroup>
-        ) : null}
-      </span>
+      <SidebarTransitionContent asChild>
+        <span
+          className={cn(
+            "ml-1 flex min-w-0 flex-1 items-center overflow-hidden transition-[opacity,max-width,margin-left] duration-200 ease-linear",
+            isCollapsed && "ml-0",
+          )}
+        >
+          <span className="flex-1 truncate">{title}</span>
+          {item.shortcut && !isCollapsed ? (
+            <KbdGroup className="mr-2 shrink-0 opacity-0 transition-opacity duration-150 group-hover/item:opacity-100">
+              {item.shortcut.map((value) => (
+                <Kbd
+                  key={value}
+                  className="h-auto min-w-0 bg-transparent px-0"
+                >
+                  <ShortcutGlyph value={value} modifierLabel={modifierLabel} />
+                </Kbd>
+              ))}
+            </KbdGroup>
+          ) : null}
+        </span>
+      </SidebarTransitionContent>
     </>
   );
 

--- a/frontend/features/layouts/components/navigation/nav-user.tsx
+++ b/frontend/features/layouts/components/navigation/nav-user.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import * as React from "react";
-import { useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
 import {
   Check,
   ChevronDown,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import * as React from "react";
 
 import {
   Avatar,
@@ -17,8 +17,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
-  DropdownMenuItemIcon,
   DropdownMenuItem,
+  DropdownMenuItemIcon,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuSub,
@@ -30,15 +30,17 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarTransitionContent,
+  useSidebarHoverExpansionLock,
 } from "@/components/ui/sidebar";
 import { SpinnerLabel } from "@/components/ui/spinner";
+import { useAppLocale } from "@/i18n/app-i18n-provider";
+import { APP_LOCALE_LABELS, APP_LOCALES, type AppLocale } from "@/i18n/config";
 import { logout, patchMe } from "@/shared/api/auth";
 import { useAuthSession } from "@/shared/auth/auth-session-context";
 import { clearSessionAndRedirectToLogin } from "@/shared/auth/session";
 import { dispatchUserProfileUpdated } from "@/shared/auth/user-profile-events";
 import { dispatchOpenAnnouncements, getAnnouncementUnread, subscribeAnnouncementUnreadChanged } from "@/shared/events/announcement-events";
-import { useAppLocale } from "@/i18n/app-i18n-provider";
-import { APP_LOCALE_LABELS, APP_LOCALES, type AppLocale } from "@/i18n/config";
 
 export function NavUser({
   user,
@@ -60,6 +62,8 @@ export function NavUser({
   const [hasUnreadAnnouncement, setHasUnreadAnnouncement] = React.useState(() => getAnnouncementUnread());
   const skipTriggerFocusRef = React.useRef(false);
   const isAdmin = user.role === "admin" || user.role === "superadmin";
+
+  useSidebarHoverExpansionLock(open);
 
   React.useEffect(() => subscribeAnnouncementUnreadChanged(setHasUnreadAnnouncement), []);
 
@@ -134,17 +138,21 @@ export function NavUser({
               id="sidebar-user-menu-trigger"
               type="button"
               size="lg"
-              className="mb-1 transition-[background-color,color,width,height,padding,margin] data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:mb-0 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:overflow-visible"
+              className="mb-1 pr-2 pl-2.5 transition-[background-color,color,width,height,padding,margin] data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:mb-0 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:overflow-visible"
               aria-label={user.name}
             >
               <Avatar className="size-7 shrink-0 rounded-full">
                 <AvatarImage src={user.avatar || undefined} alt={user.name} />
                 <AvatarFallback className="rounded-full bg-foreground text-xs font-medium text-background">{user.name.charAt(0).toUpperCase()}</AvatarFallback>
               </Avatar>
-              <div className="grid min-w-0 flex-1 gap-0.5 overflow-hidden pl-1.5 text-left text-sm leading-tight transition-opacity duration-200 ease-linear group-data-[collapsible=icon]:hidden">
-                <span className="truncate font-medium text-foreground/95">{user.name}</span>
-              </div>
-              <ChevronDown aria-hidden className="ml-auto size-4 stroke-1 transition-opacity duration-200 ease-linear group-data-[collapsible=icon]:hidden" />
+              <SidebarTransitionContent asChild>
+                <div className="grid min-w-0 flex-1 gap-0.5 overflow-hidden pl-1.5 text-left text-sm leading-tight transition-opacity duration-200 ease-linear group-data-[collapsible=icon]:hidden">
+                  <span className="truncate font-medium text-foreground/95">{user.name}</span>
+                </div>
+              </SidebarTransitionContent>
+              <SidebarTransitionContent asChild>
+                <ChevronDown aria-hidden className="ml-auto size-4 stroke-1 transition-opacity duration-200 ease-linear group-data-[collapsible=icon]:hidden" />
+              </SidebarTransitionContent>
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent

--- a/frontend/i18n/messages/en-US/chat.json
+++ b/frontend/i18n/messages/en-US/chat.json
@@ -137,6 +137,14 @@
     "downloadImage": "Download image",
     "scrollableTable": "Scrollable data table",
     "scrollableTableHint": "Scroll horizontally to view more columns.",
+    "table": {
+      "download": "Download",
+      "downloadAsCsv": "Download CSV",
+      "downloadAsMarkdown": "Download Markdown",
+      "formatCsv": "CSV",
+      "formatMarkdown": "Markdown",
+      "downloadFailed": "Could not download table"
+    },
     "copyLatex": "Copy formula source",
     "latexCopied": "Formula source copied",
     "latexCopyFailed": "Could not copy formula source",
@@ -147,10 +155,6 @@
       "copy": "Copy link",
       "copied": "Link copied",
       "copyFailed": "Could not copy link"
-    },
-    "codeBlock": {
-      "collapse": "Collapse",
-      "expand": "Expand {count} lines"
     },
     "artifact": {
       "openPreview": "Preview",
@@ -170,10 +174,16 @@
       "done": "Thinking complete"
     },
     "diagram": {
-      "downloadDiagram": "Download diagram",
+      "downloadDiagram": "Download",
       "downloadDiagramAsSvg": "Download diagram as SVG",
       "downloadDiagramAsPng": "Download diagram as PNG",
-      "downloadDiagramAsMmd": "Download diagram as MMD"
+      "downloadDiagramAsMmd": "Download diagram as MMD",
+      "copyDiagram": "Copy",
+      "viewFullscreen": "Fullscreen",
+      "exitFullscreen": "Exit",
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out",
+      "resetView": "Reset view"
     }
   },
   "artifacts": {

--- a/frontend/i18n/messages/zh-CN/chat.json
+++ b/frontend/i18n/messages/zh-CN/chat.json
@@ -137,6 +137,14 @@
     "downloadImage": "下载图片",
     "scrollableTable": "可横向滚动的数据表格",
     "scrollableTableHint": "横向滚动可查看更多列。",
+    "table": {
+      "download": "下载",
+      "downloadAsCsv": "下载 CSV",
+      "downloadAsMarkdown": "下载 Markdown",
+      "formatCsv": "CSV",
+      "formatMarkdown": "Markdown",
+      "downloadFailed": "表格下载失败"
+    },
     "copyLatex": "复制公式源码",
     "latexCopied": "已复制公式源码",
     "latexCopyFailed": "公式源码复制失败",
@@ -147,10 +155,6 @@
       "copy": "复制链接",
       "copied": "已复制链接",
       "copyFailed": "链接复制失败"
-    },
-    "codeBlock": {
-      "collapse": "折叠",
-      "expand": "展开 {count} 行"
     },
     "artifact": {
       "openPreview": "预览",
@@ -170,10 +174,16 @@
       "done": "思考完成"
     },
     "diagram": {
-      "downloadDiagram": "下载图表",
+      "downloadDiagram": "下载",
       "downloadDiagramAsSvg": "导出为 SVG",
       "downloadDiagramAsPng": "导出为 PNG",
-      "downloadDiagramAsMmd": "导出为 MMD 源码"
+      "downloadDiagramAsMmd": "导出为 MMD 源码",
+      "copyDiagram": "复制",
+      "viewFullscreen": "全屏",
+      "exitFullscreen": "退出",
+      "zoomIn": "放大",
+      "zoomOut": "缩小",
+      "resetView": "重置视图"
     }
   },
   "artifacts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,7 @@
     "react-dom": "19.2.5",
     "recharts": "3.8.0",
     "sonner": "^2.0.7",
-    "streamdown": "^2.5.0",
+    "streamdown": "^2.6.0",
     "tailwind-merge": "^3.5.0",
     "turndown": "^7.2.4",
     "turndown-plugin-gfm": "^1.0.2",

--- a/frontend/shared/components/markdown/adaptive-markdown-table.tsx
+++ b/frontend/shared/components/markdown/adaptive-markdown-table.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import * as React from "react";
 import { useTranslations } from "next-intl";
+import * as React from "react";
+import { toast } from "sonner";
+import { TableDownloadDropdown } from "streamdown";
 
 import { cn } from "@/lib/utils";
 import {
-  classifyTableColumns,
   type ColumnAnalyzerOptions,
   type ColumnType,
+  classifyTableColumns,
   mergeColumnType,
 } from "./markdown-table-analyzer";
 
@@ -77,31 +79,40 @@ export function AdaptiveMarkdownTable({ children, className, node: _node, ...pro
 
   return (
     <div
-      className="markdown-table-shell"
+      className="markdown-table-shell relative"
       data-content-columns={contentColumnBucket}
+      data-streamdown="table-wrapper"
     >
-      {/* Keyboard users need to focus the horizontal scroll region itself. */}
-      <div
-        ref={scrollRef}
-        aria-describedby={hasHorizontalOverflow ? hintID : undefined}
-        aria-label={t("scrollableTable")}
-        className="markdown-table-scroll scroll-fade-x scroll-fade-12"
-        role="region"
-        tabIndex={hasHorizontalOverflow ? 0 : undefined}
-      >
-        <table {...props} className={cn("markdown-table", className)} data-streamdown="table">
-          <colgroup>
-            {columnTypes.map((type, index) => (
-              <col
-                // Column order is dynamic; this key only identifies the current rendered column.
-                key={`${index}-${type}`}
-                className={`markdown-table-col markdown-table-col--${type}`}
-                data-markdown-column-type={type}
-              />
-            ))}
-          </colgroup>
-          {decoratedChildren}
-        </table>
+      <div className="flex min-w-0 items-start gap-2">
+        {/* Keyboard users need to focus the horizontal scroll region itself. */}
+        <div
+          ref={scrollRef}
+          aria-describedby={hasHorizontalOverflow ? hintID : undefined}
+          aria-label={t("scrollableTable")}
+          className="markdown-table-scroll scroll-fade-x scroll-fade-12 min-w-0 flex-1"
+          role="region"
+          tabIndex={hasHorizontalOverflow ? 0 : undefined}
+        >
+          <table {...props} className={cn("markdown-table", className)} data-streamdown="table">
+            <colgroup>
+              {columnTypes.map((type, index) => (
+                <col
+                  // Column order is dynamic; this key only identifies the current rendered column.
+                  key={`${index}-${type}`}
+                  className={`markdown-table-col markdown-table-col--${type}`}
+                  data-markdown-column-type={type}
+                />
+              ))}
+            </colgroup>
+            {decoratedChildren}
+          </table>
+        </div>
+        <div className="mt-3 shrink-0" data-streamdown="table-download-actions">
+          <TableDownloadDropdown
+            className="inline-flex size-5 items-center justify-center rounded-none p-1 align-middle hover:bg-foreground/[0.04] focus-visible:bg-foreground/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35"
+            onError={() => toast.error(t("table.downloadFailed"))}
+          />
+        </div>
       </div>
       <span id={hintID} className="sr-only">
         {t("scrollableTableHint")}

--- a/frontend/shared/components/markdown/streamdown-adapter-styles.tsx
+++ b/frontend/shared/components/markdown/streamdown-adapter-styles.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * Streamdown does not currently expose class-name slots for its download menus
+ * or fullscreen Mermaid toolbar. Keep the unavoidable upstream DOM adaptation
+ * in one place so version upgrades have a single compatibility surface.
+ */
+export const StreamdownAdapterStyles = React.memo(function StreamdownAdapterStyles() {
+  return (
+    <style jsx global>{`
+      :is(
+          [data-streamdown="mermaid-block-actions"],
+          [data-streamdown="table-download-actions"]
+        )
+        > div
+        > div {
+        z-index: 50;
+        margin-top: 0.375rem;
+        min-width: 8rem;
+        overflow: hidden;
+        border: 0.5px solid var(--border);
+        border-radius: 0.75rem;
+        background: var(--popover);
+        padding: 0.375rem;
+        color: var(--popover-foreground);
+        font-family: var(--font-sans);
+        box-shadow: var(--shadow-xs);
+        animation: streamdown-action-menu-enter 150ms ease-out;
+      }
+
+      :is(
+          [data-streamdown="mermaid-block-actions"],
+          [data-streamdown="table-download-actions"]
+        )
+        > div
+        > div
+        > button {
+        width: 100%;
+        border-radius: 0.375rem;
+        padding: 0.375rem 0.5rem;
+        outline: none;
+        font-size: 0.75rem;
+        line-height: 1.25rem;
+        text-align: left;
+      }
+
+      :is(
+          [data-streamdown="mermaid-block-actions"],
+          [data-streamdown="table-download-actions"]
+        )
+        > div
+        > div
+        > button:hover,
+      :is(
+          [data-streamdown="mermaid-block-actions"],
+          [data-streamdown="table-download-actions"]
+        )
+        > div
+        > div
+        > button:focus-visible {
+        background: color-mix(in oklch, var(--accent) 40%, transparent);
+        color: var(--accent-foreground);
+      }
+
+      [data-streamdown="mermaid-fullscreen"] > div:first-child {
+        gap: 0.5rem;
+      }
+
+      [data-streamdown="mermaid-fullscreen"] > div:first-child > button,
+      [data-streamdown="mermaid-fullscreen"] > div:first-child > div > button {
+        display: inline-flex;
+        width: 1.25rem;
+        height: 1.25rem;
+        align-items: center;
+        justify-content: center;
+        padding: 0.25rem;
+        border: 0;
+        border-radius: 0;
+        background: transparent;
+        color: var(--muted-foreground);
+        box-shadow: none;
+        transition: color 150ms, background-color 150ms;
+      }
+
+      [data-streamdown="mermaid-fullscreen"] > div:first-child > button:hover,
+      [data-streamdown="mermaid-fullscreen"] > div:first-child > button:focus-visible,
+      [data-streamdown="mermaid-fullscreen"] > div:first-child > div > button:hover,
+      [data-streamdown="mermaid-fullscreen"] > div:first-child > div > button:focus-visible {
+        background: color-mix(in oklch, var(--foreground) 4%, transparent);
+        color: var(--foreground);
+      }
+
+      [data-streamdown="mermaid-fullscreen"] > div:first-child button svg {
+        width: 0.75rem;
+        height: 0.75rem;
+      }
+
+      @keyframes streamdown-action-menu-enter {
+        from {
+          opacity: 0;
+          transform: translateY(-0.5rem) scale(0.95);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0) scale(1);
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        :is(
+            [data-streamdown="mermaid-block-actions"],
+            [data-streamdown="table-download-actions"]
+          )
+          > div
+          > div {
+          animation: none;
+        }
+      }
+    `}</style>
+  );
+});

--- a/frontend/shared/components/markdown/streamdown-components.tsx
+++ b/frontend/shared/components/markdown/streamdown-components.tsx
@@ -4,8 +4,6 @@ import { CornerUpLeft, Download, Eye, Maximize2, WandSparkles } from "lucide-rea
 import { useTranslations } from "next-intl";
 import * as React from "react";
 
-import { ChevronDown } from "@/components/animate-ui/icons/chevron-down";
-import { ChevronUp } from "@/components/animate-ui/icons/chevron-up";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -24,10 +22,13 @@ import {
   resolveMarkdownImageSource,
   resolveProtectedMarkdownImageSource,
 } from "@/shared/lib/markdown-image-source";
+import { MarkdownFootnotesContext } from "./streamdown-html";
+import { StreamdownCheckIcon, StreamdownCopyIcon } from "./streamdown-icons";
 import { sanitizeHTMLStyle } from "./streamdown-style";
 
-const CODE_BLOCK_COLLAPSE_LINE_THRESHOLD = 16;
 const DEFAULT_CODE_BLOCK_LANGUAGE = "markdown";
+const CODE_BLOCK_ACTION_BUTTON_CLASSNAME =
+  "size-5 cursor-pointer rounded-none p-1 text-muted-foreground transition-all hover:bg-foreground/[0.04] hover:text-foreground focus-visible:bg-foreground/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35 disabled:cursor-not-allowed disabled:opacity-50";
 
 type ResolvedLinkKind = "same-origin" | "external" | "special" | "invalid";
 
@@ -38,7 +39,7 @@ type ExternalLinkSafetyDialogProps = {
   url: string;
 };
 
-type CollapsiblePreProps = React.HTMLAttributes<HTMLPreElement> & {
+type MarkdownCodePreProps = React.HTMLAttributes<HTMLPreElement> & {
   children?: React.ReactNode;
   node?: unknown;
   "data-markdown-source-line"?: string | number;
@@ -78,7 +79,17 @@ type MarkdownParagraphProps = React.HTMLAttributes<HTMLParagraphElement> & {
   node?: unknown;
 };
 
+type MarkdownOrderedListProps = React.OlHTMLAttributes<HTMLOListElement> & {
+  children?: React.ReactNode;
+  node?: unknown;
+};
+
 type MarkdownStrongProps = React.HTMLAttributes<HTMLElement> & {
+  children?: React.ReactNode;
+  node?: unknown;
+};
+
+type MarkdownSupProps = React.HTMLAttributes<HTMLElement> & {
   children?: React.ReactNode;
   node?: unknown;
 };
@@ -116,12 +127,28 @@ function resolveLinkKind(href: string): ResolvedLinkKind {
   }
 }
 
-function isFootnoteBackref(props: React.AnchorHTMLAttributes<HTMLAnchorElement>): boolean {
-  return "data-footnote-backref" in props;
+function isFootnoteBackref(
+  props: React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  children?: React.ReactNode,
+): boolean {
+  const href = props.href?.trim() ?? "";
+  const childText = children == null ? "" : getReactNodeText(children);
+  return (
+    "data-footnote-backref" in props ||
+    /^#(?:user-content-)?fnref(?:[-\d]|$)/i.test(href) ||
+    (href.includes("#") && childText.includes("↩"))
+  );
 }
 
 function isFootnoteReference(props: React.AnchorHTMLAttributes<HTMLAnchorElement>): boolean {
   return "data-footnote-ref" in props;
+}
+
+function isSuperscriptReferenceElement(node: React.ReactNode): boolean {
+  return (
+    React.isValidElement<React.AnchorHTMLAttributes<HTMLAnchorElement>>(node) &&
+    (isFootnoteReference(node.props) || typeof node.props.href === "string")
+  );
 }
 
 function resolveHashTarget(href: string, scope: HTMLElement | null): HTMLElement | null {
@@ -192,6 +219,18 @@ function getReactNodeText(node: React.ReactNode): string {
     .join("");
 }
 
+function containsFootnoteBackref(node: React.ReactNode): boolean {
+  return React.Children.toArray(node).some((child) => {
+    if (!React.isValidElement<React.AnchorHTMLAttributes<HTMLAnchorElement>>(child)) {
+      return false;
+    }
+    if (isFootnoteBackref(child.props, child.props.children)) {
+      return true;
+    }
+    return containsFootnoteBackref(child.props.children);
+  });
+}
+
 function resolveFootnoteBackrefIndex(children: React.ReactNode, ariaLabel?: string): string {
   const ariaMatch = ariaLabel?.trim().match(/(\d+)(?:-(\d+))?$/);
   if (ariaMatch) {
@@ -215,11 +254,39 @@ function FootnoteBackrefContent({
 
   return (
     <>
-      <CornerUpLeft className="size-3.5" strokeWidth={1.8} />
+      <CornerUpLeft className="size-3" strokeWidth={2} />
       {shouldShowIndex ? <span className="ml-0.5 text-[10px] leading-none">{backrefIndex}</span> : null}
       <span className="sr-only">{t("back")}</span>
     </>
   );
+}
+
+export function MarkdownOrderedList({
+  children,
+  className,
+  node: _node,
+  style,
+  ...props
+}: MarkdownOrderedListProps) {
+  const footnoteList = containsFootnoteBackref(children);
+
+  const list = (
+    <ol
+      {...props}
+      className={cn(
+        "list-inside list-decimal whitespace-normal [li_&]:pl-6",
+        footnoteList &&
+          "mt-6 border-foreground/15 border-t pt-3 pl-4 text-[11px] leading-5 text-muted-foreground/82 [&_li]:py-0.5 [&_p]:my-0 [&_p]:text-[11px] [&_p]:leading-5",
+        className,
+      )}
+      data-streamdown={footnoteList ? "footnote-list" : "ordered-list"}
+      style={sanitizeHTMLStyle(style)}
+    >
+      {children}
+    </ol>
+  );
+
+  return footnoteList ? <MarkdownFootnotesContext.Provider value>{list}</MarkdownFootnotesContext.Provider> : list;
 }
 
 function getCodeTextFromChild(child: React.ReactElement<StreamdownCodeChildProps>): string {
@@ -256,14 +323,6 @@ function ensureCodeBlockLanguage(
   });
 }
 
-function getLineCount(value: string): number {
-  if (!value) {
-    return 0;
-  }
-
-  return value.replace(/\n$/, "").split("\n").length;
-}
-
 function isMermaidLanguage(language: string): boolean {
   return language === "mermaid" || language === "mmd";
 }
@@ -283,7 +342,7 @@ function CodeBlockActionButton({
         <button
           type="button"
           aria-label={label}
-          className="inline-flex size-6 items-center justify-center rounded-md p-1 text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35"
+          className={CODE_BLOCK_ACTION_BUTTON_CLASSNAME}
           onClick={onClick}
         >
           {children}
@@ -321,10 +380,13 @@ function CodeBlockActions({
 
   return (
     <div className="pointer-events-none absolute right-0 top-0 z-20 flex h-8 items-center justify-end">
-      <div className="pointer-events-auto flex shrink-0 items-center gap-2">
+      <div
+        className="pointer-events-auto flex shrink-0 items-center gap-2"
+        data-streamdown="code-block-actions"
+      >
         {canOpenArtifact ? (
           <CodeBlockActionButton label={artifactCopy("openPreview")} onClick={handleOpenArtifact}>
-            <Eye className="size-4" strokeWidth={1.8} />
+            <Eye className="size-3" strokeWidth={2.25} />
           </CodeBlockActionButton>
         ) : null}
         <Tooltip>
@@ -334,10 +396,11 @@ function CodeBlockActions({
               type="button"
               variant="ghost"
               size="icon-xs"
-              className="inline-flex size-6 items-center justify-center rounded-md p-1 text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35"
+              className={CODE_BLOCK_ACTION_BUTTON_CLASSNAME}
               value={copyCode}
               messages={{ copied: commonActions("copied"), failed: commonErrors("copyFailed") }}
-              iconClassName="size-3.5"
+              copyIcon={<StreamdownCopyIcon className="size-3" />}
+              copiedIcon={<StreamdownCheckIcon className="size-3" />}
               aria-label={commonActions("copy")}
             />
           </TooltipTrigger>
@@ -418,21 +481,18 @@ function isImageLinkElement(node: React.ReactNode): boolean {
 }
 
 function isFootnoteBackrefElement(node: React.ReactNode): boolean {
-  return React.isValidElement<React.AnchorHTMLAttributes<HTMLAnchorElement>>(node) && isFootnoteBackref(node.props);
+  return (
+    React.isValidElement<React.AnchorHTMLAttributes<HTMLAnchorElement>>(node) &&
+    isFootnoteBackref(node.props, node.props.children)
+  );
 }
 
-export function CollapsibleCodePre({ children, node: _node, "data-markdown-source-line": sourceLine }: CollapsiblePreProps) {
-  const t = useTranslations("chat.markdown.codeBlock");
+export function MarkdownCodePre({ children, node: _node, "data-markdown-source-line": sourceLine }: MarkdownCodePreProps) {
   const childElement = React.isValidElement<StreamdownCodeChildProps>(children) ? ensureCodeBlockLanguage(children) : null;
   const codeContent = childElement ? getCodeTextFromChild(childElement) : "";
-  const lineCount = getLineCount(codeContent);
   const language = childElement ? getCodeLanguage(childElement.props.className) : "";
   const mermaid = isMermaidLanguage(language);
   const artifactPreviewable = Boolean(resolveArtifactPreviewKind(language, codeContent));
-  const isCollapsible =
-    childElement != null && !mermaid && lineCount > CODE_BLOCK_COLLAPSE_LINE_THRESHOLD;
-  const [expanded, setExpanded] = React.useState(false);
-  const [isToggleHovered, setIsToggleHovered] = React.useState(false);
 
   if (!childElement) {
     return children;
@@ -440,55 +500,23 @@ export function CollapsibleCodePre({ children, node: _node, "data-markdown-sourc
 
   const codeBlock = React.cloneElement(childElement, { "data-block": "true" });
 
-  if (!isCollapsible) {
-    return (
-      <div className="relative w-full" data-markdown-source-line={sourceLine}>
-        {!mermaid ? <CodeBlockActions code={codeContent} language={language} previewable={artifactPreviewable} /> : null}
-        {codeBlock}
-      </div>
-    );
-  }
-
   return (
     <div className="relative w-full" data-markdown-source-line={sourceLine}>
-      <CodeBlockActions code={codeContent} language={language} previewable={artifactPreviewable} />
-      <div
-        className={cn(
-          "w-full",
-          "[&_[data-streamdown='code-block-body']]:transition-[max-height] [&_[data-streamdown='code-block-body']]:duration-300 [&_[data-streamdown='code-block-body']]:ease-out",
-          !expanded &&
-            "[mask-image:linear-gradient(to_bottom,#000_calc(100%_-_3rem),transparent)] [-webkit-mask-image:linear-gradient(to_bottom,#000_calc(100%_-_3rem),transparent)] [&_[data-streamdown='code-block-body']]:max-h-[22rem] [&_[data-streamdown='code-block-body']]:overflow-hidden",
-        )}
-      >
-        {codeBlock}
-      </div>
-      <div className="flex justify-center">
-        <button
-          type="button"
-          onClick={() => setExpanded((current) => !current)}
-          onMouseEnter={() => setIsToggleHovered(true)}
-          onMouseLeave={() => setIsToggleHovered(false)}
-          className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
-        >
-          {expanded ? (
-            <ChevronUp className="size-3.5" animate={isToggleHovered ? "default" : undefined} />
-          ) : (
-            <ChevronDown className="size-3.5" animate={isToggleHovered ? "default" : undefined} />
-          )}
-          <span>{expanded ? t("collapse") : t("expand", { count: lineCount })}</span>
-        </button>
-      </div>
+      {!mermaid ? <CodeBlockActions code={codeContent} language={language} previewable={artifactPreviewable} /> : null}
+      {codeBlock}
     </div>
   );
 }
 
 export function MarkdownLink({ children, className, href, onClick, style, ...props }: MarkdownLinkProps) {
   const t = useTranslations("chat.markdown");
+  const insideFootnotes = React.useContext(MarkdownFootnotesContext);
   const [modalOpen, setModalOpen] = React.useState(false);
   const [pendingURL, setPendingURL] = React.useState("");
   const incomplete = href === "streamdown:incomplete-link";
   const linkKind = React.useMemo(() => (href ? resolveLinkKind(href) : "invalid"), [href]);
-  const footnoteBackref = isFootnoteBackref(props);
+  const footnoteBackref =
+    isFootnoteBackref(props, children) || (insideFootnotes && getReactNodeText(children).includes("↩"));
   const footnoteReference = isFootnoteReference(props);
   const normalizedChildren = React.useMemo(
     () => React.Children.toArray(children).filter((child) => !isEmptyReactNode(child)),
@@ -565,8 +593,10 @@ export function MarkdownLink({ children, className, href, onClick, style, ...pro
         {...props}
         className={cn(
           "wrap-anywhere font-medium text-primary underline",
-          footnoteReference && "text-[0.72em] no-underline",
-          footnoteBackref && "ml-1 inline-flex align-baseline text-muted-foreground/75 no-underline hover:text-muted-foreground",
+          footnoteReference &&
+            "inline-block whitespace-nowrap font-normal leading-none no-underline",
+          footnoteBackref &&
+            "ml-1 inline-flex size-4 items-center justify-center align-middle text-muted-foreground/75 no-underline hover:text-foreground",
           className,
         )}
         aria-label={footnoteBackref ? t("footnoteBackref") : props["aria-label"]}
@@ -592,6 +622,26 @@ export function MarkdownLink({ children, className, href, onClick, style, ...pro
         url={pendingURL}
       />
     </>
+  );
+}
+
+export function MarkdownSup({ children, className, node: _node, style, ...props }: MarkdownSupProps) {
+  const reference = React.Children.toArray(children).some(isSuperscriptReferenceElement);
+
+  return (
+    <sup
+      {...props}
+      className={cn(
+        reference
+          ? "relative -top-[0.42em] ml-1 align-baseline text-[11px] font-normal leading-none [&_a]:!font-normal [&_a]:no-underline"
+          : "text-sm",
+        className,
+      )}
+      data-streamdown={reference ? "footnote-reference" : "superscript"}
+      style={sanitizeHTMLStyle(style)}
+    >
+      {children}
+    </sup>
   );
 }
 

--- a/frontend/shared/components/markdown/streamdown-content.ts
+++ b/frontend/shared/components/markdown/streamdown-content.ts
@@ -53,19 +53,12 @@ const HTML_VISUAL_MARKDOWN_FENCE_RE = /(^|\n)([ \t]{0,3})(```|~~~)[ \t]*(?:(?:ma
 const HTML_VISUAL_FRAGMENT_RE = /^\s*<(?:div|section|article|aside|main|details|table)\b[\s\S]*<\/(?:div|section|article|aside|main|details|table)>\s*$/i;
 const HTML_VISUAL_STYLE_RE = /\sstyle\s*=\s*["'][^"']{8,}["']/i;
 const HTML_TAG_RE = /<\/?[A-Za-z][^>\n]*>/g;
-const HTML_BLOCK_CONTAINER_OPEN_RE = /<(div|section|article|aside|main|details|table)\b[^>]*>/i;
-const HTML_BLOCK_TAG_SCAN_RE = /<\/?(div|p|section|article|aside|main|blockquote|ul|ol|li|table|thead|tbody|tr|th|td|h[1-6]|pre|details|summary|nav|header|footer|figure|figcaption)\b[^>]*>/gi;
-const HTML_BLOCK_BLANK_LINE_RE = /\n(?:[ \t]*\n)+(?=[ \t]*(?:<!--|<\/?(?:div|p|section|article|aside|main|blockquote|ul|ol|li|table|thead|tbody|tr|th|td|h[1-6]|pre|details|summary|nav|header|footer|figure|figcaption)\b))/gi;
-const HTML_VISUAL_MARKDOWN_BLOCK_START_RE =
-  /(<(?:div|section|article|aside|main|details)\b(?=[^>]*\sstyle\s*=)[^>]*>)(\n[ \t]*\n)(?=[ \t]*(?:#{1,6}\s|[-*+]\s|\d+[.)]\s|>\s|[*_]{1,3}\S|`{3,}|~{3,}|\$\$|!\[|\[[^\]\n]+\]\())/gi;
 const INLINE_DOLLAR_MATH_RE = /(^|[^\\$])\$([^$\n]{1,800})\$/g;
 const ESCAPED_INLINE_DOLLAR_MATH_RE = /\\\$([^$\n]{1,400})\\\$/g;
 const DISPLAY_DOLLAR_MATH_RE = /(\${2,})([\s\S]*?)(\1)/g;
 const CURRENCY_DOLLAR_RE = /(^|[^\\$])\$((?:\d{1,3}(?:,\d{3})+|\d+\.\d{1,2}))(?!\$)(?=\b)/g;
-const GFM_TABLE_DELIMITER_LINE_RE = /^[ \t]*\|?[ \t]*:?-{3,}:?[ \t]*(?:\|[ \t]*:?-{3,}:?[ \t]*)+\|?[ \t]*$/;
 const MARKDOWN_DISPLAY_MATH_RE = /(?:^|\n)\s*\$\$[\s\S]+?\$\$|\\\[[\s\S]+?\\\]|\\begin\{[a-z*]+\}/i;
 const MARKDOWN_INLINE_MATH_RE = /(^|[^\\$])\$[^$\n]{1,400}\$/;
-const MARKDOWN_STRONG_RE = /(^|[^\\])(?:\*\*[^*\n]+?\*\*|__[^_\n]+?__)/;
 
 function isMarkdownLiteralFragment(fragment: string): boolean {
   return fragment.startsWith("```") || fragment.startsWith("~~~") || fragment.startsWith("`");
@@ -223,34 +216,12 @@ export function normalizeCurrencyDollars(source: string): string {
   );
 }
 
-export function containsGFMTable(source: string): boolean {
-  if (!source.includes("|")) {
-    return false;
-  }
-
-  const lines = source.split("\n");
-  for (let index = 1; index < lines.length; index += 1) {
-    if (GFM_TABLE_DELIMITER_LINE_RE.test(lines[index]) && lines[index - 1]?.includes("|")) {
-      return true;
-    }
-  }
-  return false;
-}
-
 export function containsMarkdownMath(source: string): boolean {
   if (!source.includes("$") && !source.includes("\\") && !source.includes("\\begin")) {
     return false;
   }
 
   return MARKDOWN_DISPLAY_MATH_RE.test(source) || MARKDOWN_INLINE_MATH_RE.test(source);
-}
-
-export function containsMarkdownInlineFormatting(source: string): boolean {
-  if (!source.includes("**") && !source.includes("__")) {
-    return false;
-  }
-
-  return MARKDOWN_STRONG_RE.test(source);
 }
 
 const LATEX_UNICODE_SYMBOLS: Array<[RegExp, string]> = [
@@ -345,68 +316,6 @@ export function normalizeHTMLVisualMarkdownFences(source: string): string {
       return `${prefix}${trimmedCode}`;
     },
   );
-}
-
-function isSelfClosingHTMLTag(tag: string): boolean {
-  return tag.trimEnd().endsWith("/>");
-}
-
-function findHTMLVisualBlockEnd(source: string, start: number): number {
-  HTML_BLOCK_TAG_SCAN_RE.lastIndex = start;
-  const stack: string[] = [];
-  while (true) {
-    const match = HTML_BLOCK_TAG_SCAN_RE.exec(source);
-    if (match === null) {
-      break;
-    }
-    const tag = match[0];
-    const tagName = match[1].toLowerCase();
-    if (tag.startsWith("</")) {
-      const lastIndex = stack.lastIndexOf(tagName);
-      if (lastIndex >= 0) {
-        stack.splice(lastIndex);
-      }
-      if (stack.length === 0) {
-        return HTML_BLOCK_TAG_SCAN_RE.lastIndex;
-      }
-      continue;
-    }
-    if (!isSelfClosingHTMLTag(tag)) {
-      stack.push(tagName);
-    }
-  }
-  return source.length;
-}
-
-function normalizeHTMLVisualBlankLinesInText(source: string): string {
-  if (!/<(?:div|section|article|aside|main|details|table)\b/i.test(source)) {
-    return source;
-  }
-
-  let cursor = 0;
-  let normalized = "";
-  while (cursor < source.length) {
-    const tail = source.slice(cursor);
-    const match = HTML_BLOCK_CONTAINER_OPEN_RE.exec(tail);
-    if (!match) {
-      normalized += tail;
-      break;
-    }
-
-    const blockStart = cursor + match.index;
-    const blockEnd = findHTMLVisualBlockEnd(source, blockStart);
-    normalized += source.slice(cursor, blockStart);
-    normalized += source
-      .slice(blockStart, blockEnd)
-      .replace(HTML_VISUAL_MARKDOWN_BLOCK_START_RE, "$1\n\n\n")
-      .replace(HTML_BLOCK_BLANK_LINE_RE, "\n");
-    cursor = blockEnd;
-  }
-  return normalized;
-}
-
-export function normalizeHTMLVisualBlankLines(source: string): string {
-  return mapMarkdownTextFragments(source, normalizeHTMLVisualBlankLinesInText);
 }
 
 export function parseStreamdownSegments(

--- a/frontend/shared/components/markdown/streamdown-html.tsx
+++ b/frontend/shared/components/markdown/streamdown-html.tsx
@@ -3,11 +3,7 @@
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
-import {
-  containsGFMTable,
-  containsMarkdownInlineFormatting,
-  containsMarkdownMath,
-} from "./streamdown-content";
+import { containsMarkdownMath } from "./streamdown-content";
 import {
   sanitizeHTMLStyle,
   sanitizeKatexHTMLStyle,
@@ -28,13 +24,12 @@ type MarkdownHTMLDetailsProps = React.DetailsHTMLAttributes<HTMLDetailsElement> 
   node?: unknown;
 };
 
-type MarkdownHTMLMarkdownRenderer = (source: string) => React.ReactNode;
+type MarkdownHTMLInlineRenderer = (source: string) => React.ReactNode;
 
-export const MarkdownHTMLMarkdownRendererContext = React.createContext<MarkdownHTMLMarkdownRenderer | null>(null);
+export const MarkdownHTMLInlineRendererContext = React.createContext<MarkdownHTMLInlineRenderer | null>(null);
+export const MarkdownFootnotesContext = React.createContext(false);
 
-const INLINE_MARKDOWN_STRONG_RE = /(\*\*|__)([\s\S]+?)\1/g;
-const HTML_MARKDOWN_SOURCE_MAX_LENGTH = 64_000;
-const HTML_MARKDOWN_SOURCE_MAX_LINES = 800;
+const INLINE_MARKDOWN_STRONG_RE = /(\*\*|__)([^\n]+?)\1/g;
 const INLINE_MARKDOWN_SOURCE_MAX_LENGTH = 64_000;
 
 const KATEX_SPAN_CLASS_NAMES = [
@@ -84,7 +79,7 @@ function isKatexSpan(className: string | undefined, style: React.CSSProperties |
   ));
 }
 
-function getPlainReactNodeText(node: React.ReactNode): string | null {
+function getPlainInlineText(node: React.ReactNode): string | null {
   let text = "";
   let plain = true;
 
@@ -92,71 +87,40 @@ function getPlainReactNodeText(node: React.ReactNode): string | null {
     if (!plain || child == null || typeof child === "boolean") {
       return;
     }
-
     if (typeof child === "string" || typeof child === "number") {
       text += String(child);
-      if (text.length > HTML_MARKDOWN_SOURCE_MAX_LENGTH) {
-        plain = false;
-      }
+      plain = text.length <= INLINE_MARKDOWN_SOURCE_MAX_LENGTH;
       return;
     }
-
     if (React.isValidElement<{ children?: React.ReactNode }>(child) && child.type === React.Fragment) {
-      const fragmentText = getPlainReactNodeText(child.props.children);
+      const fragmentText = getPlainInlineText(child.props.children);
       if (fragmentText == null) {
         plain = false;
         return;
       }
       text += fragmentText;
-      if (text.length > HTML_MARKDOWN_SOURCE_MAX_LENGTH) {
-        plain = false;
-      }
+      plain = text.length <= INLINE_MARKDOWN_SOURCE_MAX_LENGTH;
       return;
     }
-
     plain = false;
   });
 
   return plain ? text : null;
 }
 
-function normalizeHTMLMarkdownText(source: string): string {
-  const trimmedSource = source.replace(/^\n+|\n+$/g, "");
-  const indents = trimmedSource
-    .split("\n")
-    .filter((line) => line.trim())
-    .map((line) => line.match(/^[ \t]*/)?.[0].length ?? 0);
-  const minIndent = indents.length > 0 ? Math.min(...indents) : 0;
-
-  if (minIndent <= 0) {
-    return trimmedSource;
-  }
-
-  return trimmedSource
-    .split("\n")
-    .map((line) => (line.trim() ? line.slice(minIndent) : line))
-    .join("\n");
-}
-
-function renderInlineStrongMarkdownText(source: string): React.ReactNode {
-  if (source.length > INLINE_MARKDOWN_SOURCE_MAX_LENGTH || !containsMarkdownInlineFormatting(source)) {
+function renderInlineStrongText(source: string): React.ReactNode {
+  if (source.length > INLINE_MARKDOWN_SOURCE_MAX_LENGTH || (!source.includes("**") && !source.includes("__"))) {
     return source;
   }
 
   const nodes: React.ReactNode[] = [];
   let cursor = 0;
   INLINE_MARKDOWN_STRONG_RE.lastIndex = 0;
-
-  while (true) {
-    const match = INLINE_MARKDOWN_STRONG_RE.exec(source);
-    if (match === null) {
-      break;
-    }
+  for (const match of source.matchAll(INLINE_MARKDOWN_STRONG_RE)) {
     const [raw, _delimiter, content] = match;
-    if (!content.trim()) {
+    if (!content.trim() || match.index == null) {
       continue;
     }
-
     if (match.index > cursor) {
       nodes.push(source.slice(cursor, match.index));
     }
@@ -175,61 +139,32 @@ function renderInlineStrongMarkdownText(source: string): React.ReactNode {
   if (cursor === 0) {
     return source;
   }
-
   if (cursor < source.length) {
     nodes.push(source.slice(cursor));
   }
-
   return nodes;
 }
 
-function renderHTMLInlineMarkdownChildren(children: React.ReactNode): React.ReactNode {
+function renderInlineStrongChildren(children: React.ReactNode): React.ReactNode {
   return React.Children.map(children, (child) => {
     if (typeof child === "string" || typeof child === "number") {
-      return renderInlineStrongMarkdownText(String(child));
+      return renderInlineStrongText(String(child));
     }
-
-    if (!React.isValidElement<{ children?: React.ReactNode }>(child)) {
+    if (!React.isValidElement<{ children?: React.ReactNode }>(child) || !("children" in child.props)) {
       return child;
     }
-
-    if (!("children" in child.props)) {
-      return child;
-    }
-
-    const renderedChildren = renderHTMLInlineMarkdownChildren(child.props.children);
-    return React.cloneElement(child, undefined, renderedChildren);
+    return React.cloneElement(child, undefined, renderInlineStrongChildren(child.props.children));
   });
 }
 
 function useHTMLMarkdownChildren(children: React.ReactNode): React.ReactNode {
-  const renderMarkdown = React.useContext(MarkdownHTMLMarkdownRendererContext);
-  const source = React.useMemo(() => getPlainReactNodeText(children), [children]);
-  const normalizedSource = React.useMemo(
-    () => (source == null ? "" : normalizeHTMLMarkdownText(source)),
-    [source],
-  );
-  const renderedInlineChildren = React.useMemo(() => {
-    if (source != null && !containsMarkdownInlineFormatting(source)) {
-      return children;
-    }
-    return renderHTMLInlineMarkdownChildren(children);
-  }, [children, source]);
+  const renderInlineMarkdown = React.useContext(MarkdownHTMLInlineRendererContext);
+  const source = React.useMemo(() => getPlainInlineText(children), [children]);
 
-  if (!renderMarkdown || !normalizedSource.trim()) {
-    return renderedInlineChildren;
+  if (source != null && !source.includes("\n") && containsMarkdownMath(source)) {
+    return renderInlineMarkdown?.(source) ?? children;
   }
-
-  const sourceLineCount = normalizedSource.split("\n", HTML_MARKDOWN_SOURCE_MAX_LINES + 1).length;
-  if (
-    normalizedSource.length > HTML_MARKDOWN_SOURCE_MAX_LENGTH ||
-    sourceLineCount > HTML_MARKDOWN_SOURCE_MAX_LINES ||
-    (!containsGFMTable(normalizedSource) && !containsMarkdownMath(normalizedSource))
-  ) {
-    return renderedInlineChildren;
-  }
-
-  return renderMarkdown(normalizedSource);
+  return renderInlineStrongChildren(children);
 }
 
 export function MarkdownHTMLDiv({ children, className, node: _node, style }: MarkdownHTMLBlockProps) {
@@ -241,13 +176,16 @@ export function MarkdownHTMLDiv({ children, className, node: _node, style }: Mar
   );
 }
 
-export function MarkdownHTMLSection({ children, className, node: _node, style }: MarkdownHTMLBlockProps) {
+export function MarkdownHTMLSection({ children, className, node: _node, style, ...props }: MarkdownHTMLBlockProps) {
   const renderedChildren = useHTMLMarkdownChildren(children);
-  return (
-    <section className={cn("min-w-0 max-w-full", className)} style={sanitizeHTMLStyle(style)}>
+  const footnotes = "data-footnotes" in props || className?.split(/\s+/).includes("footnotes") === true;
+  const section = (
+    <section {...props} className={cn("min-w-0 max-w-full", className)} style={sanitizeHTMLStyle(style)}>
       {renderedChildren}
     </section>
   );
+
+  return footnotes ? <MarkdownFootnotesContext.Provider value>{section}</MarkdownFootnotesContext.Provider> : section;
 }
 
 export function MarkdownHTMLArticle({ children, className, node: _node, style }: MarkdownHTMLBlockProps) {

--- a/frontend/shared/components/markdown/streamdown-icons.tsx
+++ b/frontend/shared/components/markdown/streamdown-icons.tsx
@@ -1,0 +1,181 @@
+import * as React from "react";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+type StreamdownIconProps = React.SVGProps<SVGSVGElement> & {
+  size?: number;
+};
+
+type StreamdownIconComponent = React.ComponentType<StreamdownIconProps>;
+
+export function createStreamdownTooltipIcon(
+  Icon: StreamdownIconComponent,
+  label: string,
+): StreamdownIconComponent {
+  function StreamdownTooltipIcon({ className, ...props }: StreamdownIconProps) {
+    const triggerRef = React.useRef<HTMLSpanElement>(null);
+    const [open, setOpen] = React.useState(false);
+
+    React.useLayoutEffect(() => {
+      const button = triggerRef.current?.closest<HTMLButtonElement>("button");
+      if (!button) {
+        return;
+      }
+
+      const originalTitle = button.getAttribute("title");
+      const originalAriaLabel = button.getAttribute("aria-label");
+      const fallbackLabel = originalTitle?.trim() || label;
+      const suppliedAriaLabel = !originalAriaLabel && Boolean(fallbackLabel);
+
+      // Streamdown exposes icon overrides but owns the surrounding button.
+      // Preserve its semantics while replacing the native title with the
+      // shared visual tooltip, then restore the DOM when the icon changes.
+      if (suppliedAriaLabel) {
+        button.setAttribute("aria-label", fallbackLabel);
+      }
+      button.removeAttribute("title");
+
+      const showTooltip = () => setOpen(true);
+      const hideTooltip = () => setOpen(false);
+      button.addEventListener("focus", showTooltip);
+      button.addEventListener("blur", hideTooltip);
+      button.addEventListener("pointerenter", showTooltip);
+      button.addEventListener("pointerleave", hideTooltip);
+
+      return () => {
+        button.removeEventListener("focus", showTooltip);
+        button.removeEventListener("blur", hideTooltip);
+        button.removeEventListener("pointerenter", showTooltip);
+        button.removeEventListener("pointerleave", hideTooltip);
+        if (originalTitle !== null && !button.hasAttribute("title")) {
+          button.setAttribute("title", originalTitle);
+        }
+        if (suppliedAriaLabel && button.getAttribute("aria-label") === fallbackLabel) {
+          button.removeAttribute("aria-label");
+        }
+      };
+    }, []);
+
+    return (
+      <Tooltip open={open} onOpenChange={setOpen}>
+        <TooltipTrigger asChild>
+          <span ref={triggerRef} className="-m-1 inline-flex size-5 items-center justify-center">
+            <Icon {...props} className={cn("size-3", className)} />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className="z-[60]" side="top" sideOffset={6}>
+          {label}
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  StreamdownTooltipIcon.displayName = `StreamdownTooltipIcon(${Icon.name || "Icon"})`;
+  return StreamdownTooltipIcon;
+}
+
+export function StreamdownCheckIcon({ size = 16, ...props }: StreamdownIconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      color="currentColor"
+      height={size}
+      strokeLinejoin="round"
+      viewBox="0 0 16 16"
+      width={size}
+      {...props}
+    >
+      <path
+        clipRule="evenodd"
+        d="M15.5607 3.99999L15.0303 4.53032L6.23744 13.3232C5.55403 14.0066 4.44599 14.0066 3.76257 13.3232L4.2929 12.7929L3.76257 13.3232L0.969676 10.5303L0.439346 9.99999L1.50001 8.93933L2.03034 9.46966L4.82323 12.2626C4.92086 12.3602 5.07915 12.3602 5.17678 12.2626L13.9697 3.46966L14.5 2.93933L15.5607 3.99999Z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+export function StreamdownCopyIcon({ size = 16, ...props }: StreamdownIconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      color="currentColor"
+      height={size}
+      strokeLinejoin="round"
+      viewBox="0 0 16 16"
+      width={size}
+      {...props}
+    >
+      <path
+        clipRule="evenodd"
+        d="M2.75 0.5C1.7835 0.5 1 1.2835 1 2.25V9.75C1 10.7165 1.7835 11.5 2.75 11.5H3.75H4.5V10H3.75H2.75C2.61193 10 2.5 9.88807 2.5 9.75V2.25C2.5 2.11193 2.61193 2 2.75 2H8.25C8.38807 2 8.5 2.11193 8.5 2.25V3H10V2.25C10 1.2835 9.2165 0.5 8.25 0.5H2.75ZM7.75 4.5C6.7835 4.5 6 5.2835 6 6.25V13.75C6 14.7165 6.7835 15.5 7.75 15.5H13.25C14.2165 15.5 15 14.7165 15 13.75V6.25C15 5.2835 14.2165 4.5 13.25 4.5H7.75ZM7.5 6.25C7.5 6.11193 7.61193 6 7.75 6H13.25C13.3881 6 13.5 6.11193 13.5 6.25V13.75C13.5 13.8881 13.3881 14 13.25 14H7.75C7.61193 14 7.5 13.8881 7.5 13.75V6.25Z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+export function StreamdownDownloadIcon({ size = 16, ...props }: StreamdownIconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      color="currentColor"
+      height={size}
+      strokeLinejoin="round"
+      viewBox="0 0 16 16"
+      width={size}
+      {...props}
+    >
+      <path
+        clipRule="evenodd"
+        d="M8.75 1V1.75V8.68934L10.7197 6.71967L11.25 6.18934L12.3107 7.25L11.7803 7.78033L8.70711 10.8536C8.31658 11.2441 7.68342 11.2441 7.29289 10.8536L4.21967 7.78033L3.68934 7.25L4.75 6.18934L5.28033 6.71967L7.25 8.68934V1.75V1H8.75ZM13.5 9.25V13.5H2.5V9.25V8.5H1V9.25V14C1 14.5523 1.44771 15 2 15H14C14.5523 15 15 14.5523 15 14V9.25V8.5H13.5V9.25Z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+export function StreamdownMaximizeIcon({ size = 16, ...props }: StreamdownIconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      color="currentColor"
+      height={size}
+      strokeLinejoin="round"
+      viewBox="0 0 16 16"
+      width={size}
+      {...props}
+    >
+      <path
+        clipRule="evenodd"
+        d="M1 5.25V6H2.5V5.25V2.5H5.25H6V1H5.25H2C1.44772 1 1 1.44772 1 2V5.25ZM5.25 14.9994H6V13.4994H5.25H2.5V10.7494V9.99939H1V10.7494V13.9994C1 14.5517 1.44772 14.9994 2 14.9994H5.25ZM15 10V10.75V14C15 14.5523 14.5523 15 14 15H10.75H10V13.5H10.75H13.5V10.75V10H15ZM10.75 1H10V2.5H10.75H13.5V5.25V6H15V5.25V2C15 1.44772 14.5523 1 14 1H10.75Z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+export function StreamdownCloseIcon({ size = 16, ...props }: StreamdownIconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      color="currentColor"
+      height={size}
+      strokeLinejoin="round"
+      viewBox="0 0 16 16"
+      width={size}
+      {...props}
+    >
+      <path
+        clipRule="evenodd"
+        d="M12.4697 13.5303L13 14.0607L14.0607 13L13.5303 12.4697L9.06065 7.99999L13.5303 3.53032L14.0607 2.99999L13 1.93933L12.4697 2.46966L7.99999 6.93933L3.53032 2.46966L2.99999 1.93933L1.93933 2.99999L2.46966 3.53032L6.93933 7.99999L2.46966 12.4697L1.93933 13L2.99999 14.0607L3.53032 13.5303L7.99999 9.06065L12.4697 13.5303Z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
+  );
+}

--- a/frontend/shared/components/markdown/streamdown-render.tsx
+++ b/frontend/shared/components/markdown/streamdown-render.tsx
@@ -1,17 +1,18 @@
 "use client";
 
-import * as React from "react";
 import { cjk } from "@streamdown/cjk";
 import { createMathPlugin } from "@streamdown/math";
+import { useTranslations } from "next-intl";
+import * as React from "react";
 import {
-  defaultRehypePlugins,
   type AllowedTags,
   type Components,
+  defaultRehypePlugins,
+  type IconMap,
   type PluginConfig,
   Streamdown,
   type StreamdownProps,
 } from "streamdown";
-import { useTranslations } from "next-intl";
 
 import { ChevronDown } from "@/components/animate-ui/icons/chevron-down";
 import {
@@ -27,46 +28,55 @@ import {
   AdaptiveMarkdownTable,
   MarkdownTableStreamingContext,
 } from "./adaptive-markdown-table";
-import { useMarkdownCopy } from "./use-markdown-copy";
-
+import { StreamdownAdapterStyles } from "./streamdown-adapter-styles";
 import {
-  CollapsibleCodePre,
-  MarkdownImageActionsContext,
-  MarkdownImage,
-  MarkdownLink,
-  MarkdownParagraph,
-  MarkdownArtifactActionsContext,
-  MarkdownStrong,
-  ThinkingHeading,
   type MarkdownArtifactActions,
+  MarkdownArtifactActionsContext,
+  MarkdownCodePre,
+  MarkdownImage,
   type MarkdownImageActions,
+  MarkdownImageActionsContext,
+  MarkdownLink,
+  MarkdownOrderedList,
+  MarkdownParagraph,
+  MarkdownStrong,
+  MarkdownSup,
+  ThinkingHeading,
 } from "./streamdown-components";
+import {
+  containsMarkdownMath,
+  normalizeContent,
+  normalizeCurrencyDollars,
+  normalizeEscapedHTMLAttributeQuotes,
+  normalizeHTMLVisualMarkdownFences,
+  normalizeLatexUnicodeSymbols,
+  normalizeMathDelimiters,
+  normalizeMermaidBlocks,
+  parseStreamdownSegments,
+  type RenderSegment,
+} from "./streamdown-content";
 import {
   MarkdownHTMLArticle,
   MarkdownHTMLAside,
   MarkdownHTMLDetails,
   MarkdownHTMLDiv,
+  MarkdownHTMLInlineRendererContext,
   MarkdownHTMLMain,
-  MarkdownHTMLMarkdownRendererContext,
   MarkdownHTMLSection,
   MarkdownHTMLSpan,
   MarkdownHTMLSummary,
 } from "./streamdown-html";
 import { renderRawHTMLMathRehypePlugin } from "./streamdown-html-math";
 import {
-  normalizeContent,
-  normalizeCurrencyDollars,
-  normalizeEscapedHTMLAttributeQuotes,
-  normalizeHTMLVisualBlankLines,
-  normalizeHTMLVisualMarkdownFences,
-  normalizeLatexUnicodeSymbols,
-  normalizeMathDelimiters,
-  normalizeMermaidBlocks,
-  parseStreamdownSegments,
-  containsMarkdownMath,
-  type RenderSegment,
-} from "./streamdown-content";
+  createStreamdownTooltipIcon,
+  StreamdownCheckIcon,
+  StreamdownCloseIcon,
+  StreamdownCopyIcon,
+  StreamdownDownloadIcon,
+  StreamdownMaximizeIcon,
+} from "./streamdown-icons";
 import { normalizeBareURLRehypePlugin } from "./streamdown-url-normalize";
+import { useMarkdownCopy } from "./use-markdown-copy";
 
 type StreamdownRenderProps = {
   content: unknown;
@@ -114,13 +124,38 @@ const STREAMDOWN_CONTROLS = {
 } as const;
 
 function useStreamdownTranslations() {
+  const t = useTranslations("chat.markdown");
+  return React.useMemo(
+    () => ({
+      downloadDiagram: t("diagram.downloadDiagram"),
+      downloadDiagramAsSvg: t("diagram.downloadDiagramAsSvg"),
+      downloadDiagramAsPng: t("diagram.downloadDiagramAsPng"),
+      downloadDiagramAsMmd: t("diagram.downloadDiagramAsMmd"),
+      copyCode: t("diagram.copyDiagram"),
+      viewFullscreen: t("diagram.viewFullscreen"),
+      exitFullscreen: t("diagram.exitFullscreen"),
+      zoomIn: t("diagram.zoomIn"),
+      zoomOut: t("diagram.zoomOut"),
+      resetView: t("diagram.resetView"),
+      downloadTable: t("table.download"),
+      downloadTableAsCsv: t("table.downloadAsCsv"),
+      downloadTableAsMarkdown: t("table.downloadAsMarkdown"),
+      tableFormatCsv: t("table.formatCsv"),
+      tableFormatMarkdown: t("table.formatMarkdown"),
+    }),
+    [t],
+  );
+}
+
+function useStreamdownIcons(): Partial<IconMap> {
   const t = useTranslations("chat.markdown.diagram");
   return React.useMemo(
     () => ({
-      downloadDiagram: t("downloadDiagram"),
-      downloadDiagramAsSvg: t("downloadDiagramAsSvg"),
-      downloadDiagramAsPng: t("downloadDiagramAsPng"),
-      downloadDiagramAsMmd: t("downloadDiagramAsMmd"),
+      CheckIcon: createStreamdownTooltipIcon(StreamdownCheckIcon, t("copyDiagram")),
+      CopyIcon: createStreamdownTooltipIcon(StreamdownCopyIcon, t("copyDiagram")),
+      DownloadIcon: createStreamdownTooltipIcon(StreamdownDownloadIcon, t("downloadDiagram")),
+      Maximize2Icon: createStreamdownTooltipIcon(StreamdownMaximizeIcon, t("viewFullscreen")),
+      XIcon: createStreamdownTooltipIcon(StreamdownCloseIcon, t("exitFullscreen")),
     }),
     [t],
   );
@@ -131,16 +166,20 @@ const STREAMDOWN_REMEND = {
 } as const;
 
 const STREAMDOWN_CARET = "circle" as const;
+const STREAMDOWN_CODE_BLOCK_MAX_HEIGHT = "22rem";
 const STREAMDOWN_LINK_SAFETY = { enabled: false } as const;
-const STREAMDOWN_ALLOWED_HTML_TAGS = {
-  a: ["href", "title", "style"],
+const STREAMDOWN_MARKDOWN_CONTAINER_TAGS = {
   article: ["style"],
   aside: ["style"],
   details: ["open", "style"],
   div: ["style"],
   main: ["style"],
-  p: ["style"],
   section: ["style"],
+} satisfies AllowedTags;
+const STREAMDOWN_ALLOWED_HTML_TAGS = {
+  ...STREAMDOWN_MARKDOWN_CONTAINER_TAGS,
+  a: ["href", "title", "style"],
+  p: ["style"],
   span: ["style"],
   summary: ["style"],
 } satisfies AllowedTags;
@@ -218,16 +257,8 @@ const SOURCE_POSITION_STREAMDOWN_REHYPE_PLUGINS = buildStreamdownRehypePlugins(t
 const FENCED_CODE_BLOCK_RE = /(?:^|\n)[ \t]*(?:```|~~~)(?!\s*(?:mermaid|mmd)\b)[^\n]*(?:\n|$)/i;
 const MERMAID_CODE_BLOCK_RE = /(?:^|\n)[ \t]*(?:```|~~~)\s*(?:mermaid|mmd)\b/i;
 
-// Streamdown does not expose a download-menu render slot. Keep its export
-// implementation and mirror the shared DropdownMenu design tokens here.
-const STREAMDOWN_MERMAID_DROPDOWN_CLASSNAME = cn(
-  "[&_[data-streamdown='mermaid-block-actions']>div>div]:!z-50 [&_[data-streamdown='mermaid-block-actions']>div>div]:!mt-1.5 [&_[data-streamdown='mermaid-block-actions']>div>div]:!min-w-32 [&_[data-streamdown='mermaid-block-actions']>div>div]:!rounded-xl [&_[data-streamdown='mermaid-block-actions']>div>div]:!border-[0.5px] [&_[data-streamdown='mermaid-block-actions']>div>div]:!border-border [&_[data-streamdown='mermaid-block-actions']>div>div]:!bg-popover [&_[data-streamdown='mermaid-block-actions']>div>div]:!p-1.5 [&_[data-streamdown='mermaid-block-actions']>div>div]:!font-sans [&_[data-streamdown='mermaid-block-actions']>div>div]:!text-popover-foreground [&_[data-streamdown='mermaid-block-actions']>div>div]:!shadow-xs [&_[data-streamdown='mermaid-block-actions']>div>div]:animate-in [&_[data-streamdown='mermaid-block-actions']>div>div]:fade-in-0 [&_[data-streamdown='mermaid-block-actions']>div>div]:zoom-in-95 [&_[data-streamdown='mermaid-block-actions']>div>div]:slide-in-from-top-2",
-  "[&_[data-streamdown='mermaid-block-actions']>div>div>button]:!rounded-md [&_[data-streamdown='mermaid-block-actions']>div>div>button]:!px-2 [&_[data-streamdown='mermaid-block-actions']>div>div>button]:!py-1.5 [&_[data-streamdown='mermaid-block-actions']>div>div>button]:!text-xs [&_[data-streamdown='mermaid-block-actions']>div>div>button]:!leading-5 [&_[data-streamdown='mermaid-block-actions']>div>div>button]:outline-none [&_[data-streamdown='mermaid-block-actions']>div>div>button:hover]:!bg-accent/40 [&_[data-streamdown='mermaid-block-actions']>div>div>button:hover]:!text-accent-foreground [&_[data-streamdown='mermaid-block-actions']>div>div>button:focus-visible]:!bg-accent/40 [&_[data-streamdown='mermaid-block-actions']>div>div>button:focus-visible]:!text-accent-foreground",
-);
-
 const BASE_MARKDOWN_CLASSNAME = cn(
   "chat-font-content min-w-0 max-w-full overflow-hidden leading-6 text-foreground [overflow-wrap:anywhere]",
-  STREAMDOWN_MERMAID_DROPDOWN_CLASSNAME,
   "[&>*:last-child]:after:text-muted-foreground/55",
   "[&_p]:min-w-0 [&_p]:max-w-full [&_p]:break-words [&_p]:[overflow-wrap:anywhere]",
   "[&_li]:min-w-0 [&_li]:max-w-full [&_li]:break-words [&_li]:[overflow-wrap:anywhere]",
@@ -250,17 +281,18 @@ const BASE_MARKDOWN_CLASSNAME = cn(
   "[&_[data-streamdown='code-block']]:![content-visibility:visible] [&_[data-streamdown='code-block']]:![contain-intrinsic-size:none]",
   "[&_[data-streamdown='code-block']>div:first-child]:min-h-0 [&_[data-streamdown='code-block']>div:first-child]:justify-between [&_[data-streamdown='code-block']>div:first-child]:gap-2 [&_[data-streamdown='code-block']>div:first-child]:border-0 [&_[data-streamdown='code-block']>div:first-child]:bg-transparent [&_[data-streamdown='code-block']>div:first-child]:mt-2 [&_[data-streamdown='code-block']>div:first-child]:pb-6 [&_[data-streamdown='code-block']>div:first-child]:text-[11px] [&_[data-streamdown='code-block']>div:first-child]:font-medium [&_[data-streamdown='code-block']>div:first-child]:tracking-[0.06em] [&_[data-streamdown='code-block']>div:first-child]:text-muted-foreground/85 [&_[data-streamdown='code-block']>div:first-child]:shadow-none",
   "[&_[data-streamdown='code-block']>div:last-child]:!w-full [&_[data-streamdown='code-block']>div:last-child]:min-w-0 [&_[data-streamdown='code-block']>div:last-child]:border-0 [&_[data-streamdown='code-block']>div:last-child]:rounded-none [&_[data-streamdown='code-block']>div:last-child]:bg-transparent [&_[data-streamdown='code-block']>div:last-child]:p-0 [&_[data-streamdown='code-block']>div:last-child]:shadow-none",
-  "[&_[data-streamdown='code-block-body']]:!bg-muted/40 [&_[data-streamdown='code-block-body']]:!rounded-xl",
-  "[&_pre]:group [&_pre]:my-0 [&_pre]:block [&_pre]:!w-full [&_pre]:!min-w-0 [&_pre]:max-w-full [&_pre]:overflow-x-auto [&_pre]:overflow-y-hidden [&_pre]:border-0 [&_pre]:bg-transparent [&_pre]:px-0 [&_pre]:pt-0 [&_pre]:pb-2 [&_pre]:shadow-none [&_pre]:outline-none [&_pre]:ring-0",
-  "[&_pre>code]:block [&_pre>code]:w-max [&_pre>code]:min-w-full [&_pre>code]:max-w-none [&_pre>code]:border-0 [&_pre>code]:bg-transparent [&_pre>code]:py-4 [&_pre>code]:font-mono [&_pre>code]:text-[13px] [&_pre>code]:leading-5 [&_pre>code]:text-foreground/92 [&_pre>code]:shadow-none [&_pre>code]:outline-none [&_pre>code]:ring-0",
+  "[&_[data-streamdown='code-block-body']]:!rounded-xl [&_[data-streamdown='code-block-body']]:!border-[0.75rem] [&_[data-streamdown='code-block-body']]:!border-transparent [&_[data-streamdown='code-block-body']]:!bg-muted/40 [&_[data-streamdown='code-block-body']]:!p-0",
+  "[&_pre]:group [&_pre]:my-0 [&_pre]:block [&_pre]:!w-full [&_pre]:!min-w-0 [&_pre]:max-w-full [&_pre]:overflow-visible [&_pre]:border-0 [&_pre]:bg-transparent [&_pre]:p-0 [&_pre]:shadow-none [&_pre]:outline-none [&_pre]:ring-0",
+  "[&_pre>code]:block [&_pre>code]:w-max [&_pre>code]:min-w-full [&_pre>code]:max-w-none [&_pre>code]:border-0 [&_pre>code]:bg-transparent [&_pre>code]:font-mono [&_pre>code]:text-[12px] [&_pre>code]:leading-5 [&_pre>code]:text-foreground/92 [&_pre>code]:shadow-none [&_pre>code]:outline-none [&_pre>code]:ring-0",
+  "[&_pre>code>span]:before:text-[11px]",
   "[&_[data-streamdown='code-block-actions']]:gap-2 [&_[data-streamdown='code-block-actions']]:!opacity-100 [&_[data-streamdown='code-block-actions']]:border-0 [&_[data-streamdown='code-block-actions']]:rounded-none [&_[data-streamdown='code-block-actions']]:bg-transparent [&_[data-streamdown='code-block-actions']]:p-0 [&_[data-streamdown='code-block-actions']]:shadow-none [&_[data-streamdown='code-block-actions']]:backdrop-blur-none",
-  "[&_[data-streamdown='code-block-actions']_button]:inline-flex [&_[data-streamdown='code-block-actions']_button]:items-center [&_[data-streamdown='code-block-actions']_button]:justify-center [&_[data-streamdown='code-block-actions']_button]:rounded-md [&_[data-streamdown='code-block-actions']_button]:border-0 [&_[data-streamdown='code-block-actions']_button]:bg-transparent [&_[data-streamdown='code-block-actions']_button]:p-1 [&_[data-streamdown='code-block-actions']_button]:text-muted-foreground [&_[data-streamdown='code-block-actions']_button]:shadow-none [&_[data-streamdown='code-block-actions']_button:hover]:bg-foreground/[0.04] [&_[data-streamdown='code-block-actions']_button:hover]:text-foreground",
+  "[&_[data-streamdown='code-block-actions']_button]:inline-flex [&_[data-streamdown='code-block-actions']_button]:items-center [&_[data-streamdown='code-block-actions']_button]:justify-center [&_[data-streamdown='code-block-actions']_button]:rounded-none [&_[data-streamdown='code-block-actions']_button]:border-0 [&_[data-streamdown='code-block-actions']_button]:bg-transparent [&_[data-streamdown='code-block-actions']_button]:p-1 [&_[data-streamdown='code-block-actions']_button]:text-muted-foreground [&_[data-streamdown='code-block-actions']_button]:shadow-none [&_[data-streamdown='code-block-actions']_button:hover]:bg-foreground/[0.04] [&_[data-streamdown='code-block-actions']_button:hover]:text-foreground",
   "[&_[data-streamdown='code-block-actions']_svg]:size-3",
-  "[&_[data-footnotes]]:mt-8 [&_[data-footnotes]]:border-t [&_[data-footnotes]]:border-border/45 [&_[data-footnotes]]:pt-3 [&_[data-footnotes]]:text-[13px] [&_[data-footnotes]]:leading-6 [&_[data-footnotes]]:text-muted-foreground/82",
+  "[&_[data-footnotes]]:mt-6 [&_[data-footnotes]]:border-t [&_[data-footnotes]]:border-foreground/15 [&_[data-footnotes]]:pt-3 [&_[data-footnotes]]:text-[11px] [&_[data-footnotes]]:leading-5 [&_[data-footnotes]]:text-muted-foreground/82",
   "[&_[data-footnotes]_h2]:sr-only",
-  "[&_[data-footnotes]_ol]:my-0 [&_[data-footnotes]_ol]:pl-4",
-  "[&_[data-footnotes]_li]:my-1 [&_[data-footnotes]_li]:pl-1 [&_[data-footnotes]_li]:text-muted-foreground/82",
-  "[&_[data-footnotes]_p]:my-0 [&_[data-footnotes]_p]:text-[13px] [&_[data-footnotes]_p]:leading-6 [&_[data-footnotes]_p]:text-muted-foreground/82",
+  "[&_[data-footnotes]_ol]:my-0 [&_[data-footnotes]_ol]:pl-4 [&_[data-footnotes]_ol]:text-[11px] [&_[data-footnotes]_ol]:leading-5",
+  "[&_[data-footnotes]_li]:my-0.5 [&_[data-footnotes]_li]:!py-0.5 [&_[data-footnotes]_li]:pl-1 [&_[data-footnotes]_li]:text-[11px] [&_[data-footnotes]_li]:leading-5 [&_[data-footnotes]_li]:text-muted-foreground/82",
+  "[&_[data-footnotes]_p]:my-0 [&_[data-footnotes]_p]:text-[11px] [&_[data-footnotes]_p]:leading-5 [&_[data-footnotes]_p]:text-muted-foreground/82",
   "[&_.katex]:text-[1.04em]",
   "[&_.katex-display]:my-3.5 [&_.katex-display]:block [&_.katex-display]:max-w-full [&_.katex-display]:overflow-x-auto [&_.katex-display]:overflow-y-hidden [&_.katex-display]:px-1 [&_.katex-display]:py-1.5 [&_.katex-display]:text-center",
   "[&_.katex-display>.katex]:inline-block [&_.katex-display>.katex]:min-w-fit [&_.katex-display>.katex]:max-w-none [&_.katex-display>.katex]:text-center",
@@ -321,11 +353,13 @@ const DEFAULT_STREAMDOWN_COMPONENTS = {
   div: MarkdownHTMLDiv,
   img: MarkdownImage,
   main: MarkdownHTMLMain,
+  ol: MarkdownOrderedList,
   p: MarkdownParagraph,
-  pre: CollapsibleCodePre,
+  pre: MarkdownCodePre,
   section: MarkdownHTMLSection,
   span: MarkdownHTMLSpan,
   strong: MarkdownStrong,
+  sup: MarkdownSup,
   summary: MarkdownHTMLSummary,
   table: AdaptiveMarkdownTable,
 } as const;
@@ -351,7 +385,7 @@ function normalizeStreamdownContent(content: unknown, preserveSourceLines = fals
   );
   return preserveSourceLines
     ? normalizedContent
-    : normalizeHTMLVisualBlankLines(normalizeHTMLVisualMarkdownFences(normalizedContent));
+    : normalizeHTMLVisualMarkdownFences(normalizedContent);
 }
 
 function detectStreamdownFeatures(content: string): StreamdownFeatureFlags {
@@ -481,6 +515,7 @@ function ThinkingSegmentBlock({
 }) {
   const t = useTranslations("chat.markdown.thinking");
   const translations = useStreamdownTranslations();
+  const icons = useStreamdownIcons();
   const active = streaming && incomplete;
   const { open, onOpenChange } = useAutoExpandDisclosure({ active, autoExpand });
 
@@ -522,16 +557,18 @@ function ThinkingSegmentBlock({
           />
         </AccordionTrigger>
         <AccordionContent className="px-0 pb-0 pt-1.5 duration-[350ms] ease-in-out">
-          <HTMLMarkdownRenderProvider
+          <HTMLInlineMarkdownProvider
             className={cn(THINKING_MARKDOWN_CLASSNAME, "text-[12px] leading-6 text-muted-foreground/84")}
             components={THINKING_STREAMDOWN_COMPONENTS}
             plugins={plugins}
           >
             <Streamdown
-              allowedTags={STREAMDOWN_ALLOWED_HTML_TAGS}
+              allowedTags={STREAMDOWN_MARKDOWN_CONTAINER_TAGS}
               className={cn(THINKING_MARKDOWN_CLASSNAME, "text-[12px] leading-6 text-muted-foreground/84")}
+              codeBlockMaxHeight={STREAMDOWN_CODE_BLOCK_MAX_HEIGHT}
               components={THINKING_STREAMDOWN_COMPONENTS}
               controls={STREAMDOWN_CONTROLS}
+              icons={icons}
               plugins={plugins}
               rehypePlugins={STREAMDOWN_REHYPE_PLUGINS}
               remend={STREAMDOWN_REMEND}
@@ -544,14 +581,14 @@ function ThinkingSegmentBlock({
             >
               {content}
             </Streamdown>
-          </HTMLMarkdownRenderProvider>
+          </HTMLInlineMarkdownProvider>
         </AccordionContent>
       </AccordionItem>
     </Accordion>
   );
 }
 
-function HTMLMarkdownRenderProvider({
+function HTMLInlineMarkdownProvider({
   children,
   className,
   components,
@@ -563,14 +600,14 @@ function HTMLMarkdownRenderProvider({
   plugins: PluginConfig;
 }) {
   const translations = useStreamdownTranslations();
-  const renderHTMLMarkdown = React.useCallback(
+  const renderInlineMarkdown = React.useCallback(
     (source: string) => (
-      <MarkdownHTMLMarkdownRendererContext.Provider value={null}>
+      <MarkdownHTMLInlineRendererContext.Provider value={null}>
         <Streamdown
-          allowedTags={STREAMDOWN_ALLOWED_HTML_TAGS}
           className={className}
+          codeBlockMaxHeight={STREAMDOWN_CODE_BLOCK_MAX_HEIGHT}
           components={components}
-          controls={STREAMDOWN_CONTROLS}
+          controls={false}
           plugins={plugins}
           rehypePlugins={STREAMDOWN_REHYPE_PLUGINS}
           remend={STREAMDOWN_REMEND}
@@ -584,15 +621,15 @@ function HTMLMarkdownRenderProvider({
         >
           {source}
         </Streamdown>
-      </MarkdownHTMLMarkdownRendererContext.Provider>
+      </MarkdownHTMLInlineRendererContext.Provider>
     ),
     [className, components, plugins, translations],
   );
 
   return (
-    <MarkdownHTMLMarkdownRendererContext.Provider value={renderHTMLMarkdown}>
+    <MarkdownHTMLInlineRendererContext.Provider value={renderInlineMarkdown}>
       {children}
-    </MarkdownHTMLMarkdownRendererContext.Provider>
+    </MarkdownHTMLInlineRendererContext.Provider>
   );
 }
 
@@ -634,6 +671,7 @@ export const StreamdownRender = React.memo(function StreamdownRender({
     [segments],
   );
   const translations = useStreamdownTranslations();
+  const icons = useStreamdownIcons();
   const markdownSegments = React.useMemo(
     () => segments.filter((segment): segment is Extract<RenderSegment, { type: "markdown" }> => segment.type === "markdown"),
     [segments],
@@ -673,6 +711,7 @@ export const StreamdownRender = React.memo(function StreamdownRender({
       onKeyDownCapture={handleMarkdownCopyKeyDownCapture}
       onPointerDownCapture={handleMarkdownCopyPointerDownCapture}
     >
+      <StreamdownAdapterStyles />
       <MarkdownTableStreamingContext.Provider value={streaming}>
         {mergedThinkingContent ? (
           <ThinkingSegmentBlock
@@ -686,16 +725,18 @@ export const StreamdownRender = React.memo(function StreamdownRender({
       {markdownSegments.map((segment, index) => (
         <MarkdownArtifactActionsContext.Provider key={`markdown-${index}`} value={artifactActions ?? null}>
           <MarkdownImageActionsContext.Provider value={imageActions ?? null}>
-            <HTMLMarkdownRenderProvider
+            <HTMLInlineMarkdownProvider
               className={activeMarkdownClassName}
               components={components}
               plugins={plugins}
             >
               <Streamdown
-                allowedTags={STREAMDOWN_ALLOWED_HTML_TAGS}
+                allowedTags={STREAMDOWN_MARKDOWN_CONTAINER_TAGS}
                 className={activeMarkdownClassName}
+                codeBlockMaxHeight={STREAMDOWN_CODE_BLOCK_MAX_HEIGHT}
                 components={components}
                 controls={STREAMDOWN_CONTROLS}
+                icons={icons}
                 plugins={plugins}
                 rehypePlugins={rehypePlugins}
                 remend={STREAMDOWN_REMEND}
@@ -710,7 +751,7 @@ export const StreamdownRender = React.memo(function StreamdownRender({
               >
                 {segment.content}
               </Streamdown>
-            </HTMLMarkdownRenderProvider>
+            </HTMLInlineMarkdownProvider>
           </MarkdownImageActionsContext.Provider>
         </MarkdownArtifactActionsContext.Provider>
         ))}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "pnpm": {
     "overrides": {
-      "dompurify": "3.4.13"
+      "dompurify": "3.4.14"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  dompurify: 3.4.13
+  dompurify: 3.4.14
 
 importers:
 
@@ -143,8 +143,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       streamdown:
-        specifier: ^2.5.0
-        version: 2.5.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: ^2.6.0
+        version: 2.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.6.0
@@ -2721,8 +2721,8 @@ packages:
   docx-preview@0.3.7:
     resolution: {integrity: sha512-Lav69CTA/IYZPJTsKH7oYeoZjyg96N0wEJMNslGJnZJ+dMUZK85Lt5ASC79yUlD48ecWjuv+rkcmFt6EVPV0Xg==}
 
-  dompurify@3.4.13:
-    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
   dot-prop@6.0.1:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
@@ -4137,8 +4137,8 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  remend@1.3.0:
-    resolution: {integrity: sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==}
+  remend@1.3.1:
+    resolution: {integrity: sha512-N3DiY5qbRPoa5vkxn1oDLMyXOVTeo6Hp+XOj6SIqJAYUgLS0Q587gILPMom/qm86AQ/ZrcOdwEIzCz8V3J0nxQ==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4312,8 +4312,8 @@ packages:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
 
-  streamdown@2.5.0:
-    resolution: {integrity: sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA==}
+  streamdown@2.6.0:
+    resolution: {integrity: sha512-nQZVUn4GvB2R5SAlDNph20iKZeW+RM4gv6G1H3ACypEnmQf8PgTHZ/1Ta2OACRwQ2coK7aW5AeIAa7Ls5zk+RA==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -7093,7 +7093,7 @@ snapshots:
     dependencies:
       jszip: 3.10.1
 
-  dompurify@3.4.13:
+  dompurify@3.4.14:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7967,7 +7967,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.13
+      dompurify: 3.4.14
       es-toolkit: 1.49.0
       katex: 0.16.47
       khroma: 2.1.0
@@ -8237,7 +8237,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.13
+      dompurify: 3.4.14
       marked: 14.0.0
 
   motion-dom@12.42.2:
@@ -8849,7 +8849,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remend@1.3.0: {}
+  remend@1.3.1: {}
 
   require-directory@2.1.1: {}
 
@@ -9100,13 +9100,12 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  streamdown@2.5.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  streamdown@2.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       clsx: 2.1.1
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       marked: 17.0.6
-      mermaid: 11.16.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       rehype-harden: 1.1.8
@@ -9115,7 +9114,7 @@ snapshots:
       remark-gfm: 4.0.1
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
-      remend: 1.3.0
+      remend: 1.3.1
       tailwind-merge: 3.6.0
       unified: 11.0.5
       unist-util-visit: 5.1.0
@@ -9515,7 +9514,7 @@ snapshots:
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       dayjs: 1.11.21
-      dompurify: 3.4.13
+      dompurify: 3.4.14
       nanoid: 5.1.16
       tailwind-merge: 3.6.0
     optionalDependencies:


### PR DESCRIPTION
## Summary

Improve the collapsed sidebar interaction model and complete the Streamdown 2.6 migration and Markdown rendering cleanup.

- Separate the sidebar target, stable layout, and transition states to prevent flickering and layout shifts during expansion, collapse, and rapid reversals.
- Settle sidebar transitions using the actual `width` transition event with a timeout fallback.
- Lock hover expansion while user menus and submenus are open.
- Keep the user avatar visible when collapsed and align navigation content visibility, stacking, and shadows during transitions.
- Upgrade Streamdown to 2.6 and use the official `codeBlockMaxHeight` behavior for long code blocks.
- Remove the custom code-block collapse implementation and redundant HTML blank-line and GFM table parsing logic.
- Refine code block fonts, sizes, line numbers, spacing, and action buttons.
- Adapt Mermaid download, copy, fullscreen, zoom, and localized tooltip controls.
- Add CSV and Markdown table downloads.
- Improve standard footnotes and `<sup>` link references, including back-reference icons, typography, and separators.
- Centralize Streamdown menu and fullscreen compatibility styles in a dedicated adapter without modifying global styles.
- Preserve accessible labels and keyboard-triggered tooltips for third-party action buttons.
- Update the DOMPurify override to 3.4.14.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm typecheck`
- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm exec biome check ...`
- [x] `cd frontend && pnpm build`
- [x] `git diff --check`
- [ ] Not run; reason: Browser-based visual and interaction testing was not run per the local validation constraint.

## Screenshots, API examples, or logs

No screenshots are included. No API contracts or backend behavior changed.

## Configuration, migration, and compatibility notes

- Upgraded `streamdown` from `^2.5.0` to `^2.6.0`.
- Updated the root DOMPurify override from `3.4.13` to `3.4.14`.
- The DOMPurify override remains necessary because `monaco-editor@0.55.1` still pins an older DOMPurify release.
- No environment variables, database migrations, API contracts, deployment steps, or public URLs changed.
- Streamdown DOM-specific styling is isolated in a dedicated adapter to localize future compatibility updates.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.