### PR TITLE
feat: add admin redemption records with code and balance context

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -6745,6 +6745,102 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/redemptions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "管理员分页查看兑换码兑换明细，含奖励内容与余额变动，已删除兑换码的历史仍可查询",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "管理员查询兑换记录",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "页码",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "每页数量",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "搜索兑换流水号、兑换码摘要、兑换码备注",
+                        "name": "query",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "兑换码ID",
+                        "name": "code_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "用户ID",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "奖励类型(balance/subscription)",
+                        "name": "reward_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "兑换时间起点(RFC3339)",
+                        "name": "created_from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "兑换时间终点(RFC3339)",
+                        "name": "created_to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "排序方式",
+                        "name": "sort",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/RedemptionRecordListResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/settings": {
             "get": {
                 "security": [
@@ -23592,6 +23688,136 @@ const docTemplate = `{
                     "$ref": "#/definitions/RedemptionCodeDataResponse"
                 },
                 "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "RedemptionRecordListResponseDoc": {
+            "type": "object",
+            "required": [
+                "data",
+                "errorMsg"
+            ],
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "required": [
+                        "results",
+                        "total"
+                    ],
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RedemptionRecordResponse"
+                            }
+                        },
+                        "total": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "RedemptionRecordResponse": {
+            "type": "object",
+            "required": [
+                "balanceAfterNanousd",
+                "balanceBeforeNanousd",
+                "codeDescription",
+                "codeHint",
+                "codeID",
+                "codeStatus",
+                "createdAt",
+                "creditNanousd",
+                "creditUSD",
+                "durationDays",
+                "id",
+                "mode",
+                "planID",
+                "planName",
+                "refNo",
+                "rewardType",
+                "snapshotJSON",
+                "subscriptionID",
+                "userDisplayName",
+                "userID",
+                "userLabel",
+                "username"
+            ],
+            "properties": {
+                "balanceAfterNanousd": {
+                    "type": "integer",
+                    "x-nullable": true,
+                    "x-omitempty": false
+                },
+                "balanceBeforeNanousd": {
+                    "description": "BalanceBeforeNanousd / BalanceAfterNanousd 来自余额流水；订阅类兑换无流水时为 null。",
+                    "type": "integer",
+                    "x-nullable": true,
+                    "x-omitempty": false
+                },
+                "codeDescription": {
+                    "type": "string"
+                },
+                "codeHint": {
+                    "type": "string"
+                },
+                "codeID": {
+                    "type": "integer"
+                },
+                "codeStatus": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "creditNanousd": {
+                    "type": "integer"
+                },
+                "creditUSD": {
+                    "type": "number"
+                },
+                "durationDays": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "mode": {
+                    "type": "string"
+                },
+                "planID": {
+                    "type": "integer"
+                },
+                "planName": {
+                    "type": "string"
+                },
+                "refNo": {
+                    "type": "string"
+                },
+                "rewardType": {
+                    "type": "string"
+                },
+                "snapshotJSON": {
+                    "type": "string"
+                },
+                "subscriptionID": {
+                    "type": "integer"
+                },
+                "userDisplayName": {
+                    "type": "string"
+                },
+                "userID": {
+                    "type": "integer"
+                },
+                "userLabel": {
+                    "type": "string"
+                },
+                "username": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -6738,6 +6738,102 @@
                 }
             }
         },
+        "/admin/redemptions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "管理员分页查看兑换码兑换明细，含奖励内容与余额变动，已删除兑换码的历史仍可查询",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "管理员查询兑换记录",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "页码",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "每页数量",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "搜索兑换流水号、兑换码摘要、兑换码备注",
+                        "name": "query",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "兑换码ID",
+                        "name": "code_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "用户ID",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "奖励类型(balance/subscription)",
+                        "name": "reward_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "兑换时间起点(RFC3339)",
+                        "name": "created_from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "兑换时间终点(RFC3339)",
+                        "name": "created_to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "排序方式",
+                        "name": "sort",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/RedemptionRecordListResponseDoc"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/AdminErrorDoc"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/settings": {
             "get": {
                 "security": [
@@ -23585,6 +23681,136 @@
                     "$ref": "#/definitions/RedemptionCodeDataResponse"
                 },
                 "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "RedemptionRecordListResponseDoc": {
+            "type": "object",
+            "required": [
+                "data",
+                "errorMsg"
+            ],
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "required": [
+                        "results",
+                        "total"
+                    ],
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RedemptionRecordResponse"
+                            }
+                        },
+                        "total": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "RedemptionRecordResponse": {
+            "type": "object",
+            "required": [
+                "balanceAfterNanousd",
+                "balanceBeforeNanousd",
+                "codeDescription",
+                "codeHint",
+                "codeID",
+                "codeStatus",
+                "createdAt",
+                "creditNanousd",
+                "creditUSD",
+                "durationDays",
+                "id",
+                "mode",
+                "planID",
+                "planName",
+                "refNo",
+                "rewardType",
+                "snapshotJSON",
+                "subscriptionID",
+                "userDisplayName",
+                "userID",
+                "userLabel",
+                "username"
+            ],
+            "properties": {
+                "balanceAfterNanousd": {
+                    "type": "integer",
+                    "x-nullable": true,
+                    "x-omitempty": false
+                },
+                "balanceBeforeNanousd": {
+                    "description": "BalanceBeforeNanousd / BalanceAfterNanousd 来自余额流水；订阅类兑换无流水时为 null。",
+                    "type": "integer",
+                    "x-nullable": true,
+                    "x-omitempty": false
+                },
+                "codeDescription": {
+                    "type": "string"
+                },
+                "codeHint": {
+                    "type": "string"
+                },
+                "codeID": {
+                    "type": "integer"
+                },
+                "codeStatus": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "creditNanousd": {
+                    "type": "integer"
+                },
+                "creditUSD": {
+                    "type": "number"
+                },
+                "durationDays": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "mode": {
+                    "type": "string"
+                },
+                "planID": {
+                    "type": "integer"
+                },
+                "planName": {
+                    "type": "string"
+                },
+                "refNo": {
+                    "type": "string"
+                },
+                "rewardType": {
+                    "type": "string"
+                },
+                "snapshotJSON": {
+                    "type": "string"
+                },
+                "subscriptionID": {
+                    "type": "integer"
+                },
+                "userDisplayName": {
+                    "type": "string"
+                },
+                "userID": {
+                    "type": "integer"
+                },
+                "userLabel": {
+                    "type": "string"
+                },
+                "username": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -6592,6 +6592,102 @@ definitions:
     - data
     - errorMsg
     type: object
+  RedemptionRecordListResponseDoc:
+    properties:
+      data:
+        properties:
+          results:
+            items:
+              $ref: '#/definitions/RedemptionRecordResponse'
+            type: array
+          total:
+            type: integer
+        required:
+        - results
+        - total
+        type: object
+      errorMsg:
+        type: string
+    required:
+    - data
+    - errorMsg
+    type: object
+  RedemptionRecordResponse:
+    properties:
+      balanceAfterNanousd:
+        type: integer
+        x-nullable: true
+        x-omitempty: false
+      balanceBeforeNanousd:
+        description: BalanceBeforeNanousd / BalanceAfterNanousd 来自余额流水；订阅类兑换无流水时为
+          null。
+        type: integer
+        x-nullable: true
+        x-omitempty: false
+      codeDescription:
+        type: string
+      codeHint:
+        type: string
+      codeID:
+        type: integer
+      codeStatus:
+        type: string
+      createdAt:
+        type: string
+      creditNanousd:
+        type: integer
+      creditUSD:
+        type: number
+      durationDays:
+        type: integer
+      id:
+        type: integer
+      mode:
+        type: string
+      planID:
+        type: integer
+      planName:
+        type: string
+      refNo:
+        type: string
+      rewardType:
+        type: string
+      snapshotJSON:
+        type: string
+      subscriptionID:
+        type: integer
+      userDisplayName:
+        type: string
+      userID:
+        type: integer
+      userLabel:
+        type: string
+      username:
+        type: string
+    required:
+    - balanceAfterNanousd
+    - balanceBeforeNanousd
+    - codeDescription
+    - codeHint
+    - codeID
+    - codeStatus
+    - createdAt
+    - creditNanousd
+    - creditUSD
+    - durationDays
+    - id
+    - mode
+    - planID
+    - planName
+    - refNo
+    - rewardType
+    - snapshotJSON
+    - subscriptionID
+    - userDisplayName
+    - userID
+    - userLabel
+    - username
+    type: object
   RedemptionResponse:
     properties:
       balanceTransactionID:
@@ -13798,6 +13894,68 @@ paths:
       summary: 管理员更新内置提示词
       tags:
       - admin-prompt-presets
+  /admin/redemptions:
+    get:
+      consumes:
+      - application/json
+      description: 管理员分页查看兑换码兑换明细，含奖励内容与余额变动，已删除兑换码的历史仍可查询
+      parameters:
+      - description: 页码
+        in: query
+        name: page
+        type: integer
+      - description: 每页数量
+        in: query
+        name: page_size
+        type: integer
+      - description: 搜索兑换流水号、兑换码摘要、兑换码备注
+        in: query
+        name: query
+        type: string
+      - description: 兑换码ID
+        in: query
+        name: code_id
+        type: integer
+      - description: 用户ID
+        in: query
+        name: user_id
+        type: integer
+      - description: 奖励类型(balance/subscription)
+        in: query
+        name: reward_type
+        type: string
+      - description: 兑换时间起点(RFC3339)
+        in: query
+        name: created_from
+        type: string
+      - description: 兑换时间终点(RFC3339)
+        in: query
+        name: created_to
+        type: string
+      - description: 排序方式
+        in: query
+        name: sort
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/RedemptionRecordListResponseDoc'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/AdminErrorDoc'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/AdminErrorDoc'
+      security:
+      - BearerAuth: []
+      summary: 管理员查询兑换记录
+      tags:
+      - admin
   /admin/settings:
     get:
       description: 按 namespace 分组返回全部动态配置项

--- a/backend/internal/application/admin/service.go
+++ b/backend/internal/application/admin/service.go
@@ -102,6 +102,7 @@ type usageStatisticsService interface {
 
 type orderLogService interface {
 	ListPaymentOrders(ctx context.Context, page int, pageSize int, filter billing.PaymentOrderListFilter) ([]domainbilling.PaymentOrder, int64, error)
+	ListRedemptions(ctx context.Context, page int, pageSize int, filter billing.RedemptionListFilter) ([]billing.RedemptionRecordView, int64, error)
 }
 
 type conversationEventService interface {

--- a/backend/internal/application/admin/service_logs.go
+++ b/backend/internal/application/admin/service_logs.go
@@ -55,6 +55,14 @@ func (s *Service) ListPaymentOrders(ctx context.Context, page int, pageSize int,
 	return s.orderLogService.ListPaymentOrders(ctx, page, pageSize, filter)
 }
 
+// ListRedemptions 查询管理员兑换记录。
+func (s *Service) ListRedemptions(ctx context.Context, page int, pageSize int, filter billing.RedemptionListFilter) ([]billing.RedemptionRecordView, int64, error) {
+	if s.orderLogService == nil {
+		return []billing.RedemptionRecordView{}, 0, nil
+	}
+	return s.orderLogService.ListRedemptions(ctx, page, pageSize, filter)
+}
+
 // ListConversationEventLogs 查询管理员对话事件。
 func (s *Service) ListConversationEventLogs(ctx context.Context, page int, pageSize int, filter appconversation.EventLogListFilter) ([]domainconversation.EventLog, int64, error) {
 	if s.conversationEventSvc == nil {

--- a/backend/internal/application/billing/service_model_identity_test.go
+++ b/backend/internal/application/billing/service_model_identity_test.go
@@ -397,6 +397,9 @@ func (r *billingRepositoryStub) MarkPaymentOrderPaidAndCreditBalance(context.Con
 func (r *billingRepositoryStub) ListRedemptionCodes(context.Context, repository.RedemptionCodeListFilter, int, int) ([]domainbilling.RedemptionCode, int64, error) {
 	panic("not used")
 }
+func (r *billingRepositoryStub) ListRedemptions(context.Context, repository.RedemptionListFilter, int, int) ([]repository.RedemptionRecord, int64, error) {
+	panic("not used")
+}
 func (r *billingRepositoryStub) GetRedemptionCodeByID(context.Context, uint) (*domainbilling.RedemptionCode, error) {
 	panic("not used")
 }

--- a/backend/internal/application/billing/service_redemption.go
+++ b/backend/internal/application/billing/service_redemption.go
@@ -51,6 +51,17 @@ type RedemptionCodeListInput struct {
 	PageSize     int
 }
 
+// RedemptionListFilter 描述管理员兑换记录筛选和排序条件。
+type RedemptionListFilter struct {
+	CodeID      uint
+	UserID      uint
+	RewardType  string
+	Query       string
+	CreatedFrom *time.Time
+	CreatedTo   *time.Time
+	Sort        string
+}
+
 // RedemptionCodeUpdateInput 定义管理员更新兑换码管理字段的入参。
 type RedemptionCodeUpdateInput struct {
 	Status            *string
@@ -106,9 +117,67 @@ type BatchDeleteData struct {
 	Results       []BatchDeleteResultView
 }
 
+// RedemptionRecordView 表示管理员兑换记录视图，带兑换码与余额流水上下文。
+// 应用层视图避免 transport 直接依赖仓储契约。
+type RedemptionRecordView struct {
+	Redemption      domainbilling.Redemption
+	CodeHint        string
+	CodeDescription string
+	CodeStatus      string
+	PlanName        string
+	// DurationDays 来自兑换时的快照，订阅类兑换表示套餐时长（天）。
+	DurationDays int
+	// BalanceAmountNanousd / BalanceAfterNanousd 来自余额流水；订阅类兑换无流水时为 nil。
+	BalanceAmountNanousd *int64
+	BalanceAfterNanousd  *int64
+}
+
+// redemptionSnapshotDurationDays 从兑换快照 JSON 解析套餐时长，解析失败按 0 处理。
+func redemptionSnapshotDurationDays(snapshotJSON string) int {
+	var payload struct {
+		DurationDays int `json:"duration_days"`
+	}
+	if err := json.Unmarshal([]byte(snapshotJSON), &payload); err != nil {
+		return 0
+	}
+	return payload.DurationDays
+}
+
+// ListRedemptions 查询管理员兑换记录列表。
+func (s *Service) ListRedemptions(ctx context.Context, page int, pageSize int, filter RedemptionListFilter) ([]RedemptionRecordView, int64, error) {
+	offset, limit := normalizePage(page, pageSize)
+	records, total, err := s.repo.ListRedemptions(ctx, repository.RedemptionListFilter{
+		CodeID:      filter.CodeID,
+		UserID:      filter.UserID,
+		RewardType:  strings.TrimSpace(filter.RewardType),
+		Query:       strings.TrimSpace(filter.Query),
+		CreatedFrom: filter.CreatedFrom,
+		CreatedTo:   filter.CreatedTo,
+		Sort:        strings.TrimSpace(filter.Sort),
+	}, offset, limit)
+	if err != nil {
+		return nil, 0, err
+	}
+	views := make([]RedemptionRecordView, 0, len(records))
+	for _, record := range records {
+		views = append(views, RedemptionRecordView{
+			Redemption:           record.Redemption,
+			CodeHint:             record.CodeHint,
+			CodeDescription:      record.CodeDescription,
+			CodeStatus:           record.CodeStatus,
+			PlanName:             record.PlanName,
+			DurationDays:         redemptionSnapshotDurationDays(record.Redemption.SnapshotJSON),
+			BalanceAmountNanousd: record.BalanceAmountNanousd,
+			BalanceAfterNanousd:  record.BalanceAfterNanousd,
+		})
+	}
+	return views, total, nil
+}
+
 // ListRedemptionCodes 查询管理员兑换码列表。
 func (s *Service) ListRedemptionCodes(ctx context.Context, input RedemptionCodeListInput) ([]RedemptionCodeView, int64, error) {
-	page, pageSize := normalizePage(input.Page, input.PageSize)
+	// normalizePage 返回的是 offset/limit，直接透传给仓储。
+	offset, limit := normalizePage(input.Page, input.PageSize)
 	mode := strings.TrimSpace(input.Mode)
 	status := strings.TrimSpace(input.Status)
 	availability := strings.TrimSpace(input.Availability)
@@ -144,7 +213,7 @@ func (s *Service) ListRedemptionCodes(ctx context.Context, input RedemptionCodeL
 		Status:       status,
 		Availability: availability,
 		Query:        query,
-	}, (page-1)*pageSize, pageSize)
+	}, offset, limit)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/backend/internal/infra/persistence/postgres/billing/repository.go
+++ b/backend/internal/infra/persistence/postgres/billing/repository.go
@@ -972,6 +972,112 @@ func (r *Repo) ListRedemptionCodes(ctx context.Context, filter repository.Redemp
 	return results, total, nil
 }
 
+// redemptionRecordRow 承载兑换记录与联表出的兑换码、套餐、余额流水上下文。
+type redemptionRecordRow struct {
+	ID                   uint
+	CodeID               uint
+	UserID               uint
+	Mode                 string
+	RewardType           string
+	CreditNanousd        int64
+	PlanID               uint
+	SubscriptionID       uint
+	BalanceTransactionID uint
+	RefNo                string
+	SnapshotJSON         string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	CodeHint             string
+	CodeDescription      string
+	CodeStatus           string
+	PlanName             string
+	BalanceAmountNanousd *int64
+	BalanceAfterNanousd  *int64
+}
+
+// ListRedemptions 分页查询兑换记录，联表补齐兑换码、套餐与余额流水上下文。
+// 兑换码为状态软删，已删除码的历史兑换仍可查询。
+func (r *Repo) ListRedemptions(ctx context.Context, filter repository.RedemptionListFilter, offset int, limit int) ([]repository.RedemptionRecord, int64, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	query := r.db.WithContext(ctx).Model(&model.Redemption{}).
+		Joins("LEFT JOIN billing_redemption_codes AS rc ON rc.id = billing_redemptions.code_id").
+		Joins("LEFT JOIN billing_plans AS rp ON rp.id = billing_redemptions.plan_id AND billing_redemptions.plan_id > 0").
+		Joins("LEFT JOIN billing_balance_transactions AS rt ON rt.id = billing_redemptions.balance_transaction_id AND billing_redemptions.balance_transaction_id > 0")
+	if filter.CodeID > 0 {
+		query = query.Where("billing_redemptions.code_id = ?", filter.CodeID)
+	}
+	if filter.UserID > 0 {
+		query = query.Where("billing_redemptions.user_id = ?", filter.UserID)
+	}
+	if rewardType := strings.TrimSpace(filter.RewardType); rewardType != "" {
+		query = query.Where("billing_redemptions.reward_type = ?", rewardType)
+	}
+	if keyword := strings.TrimSpace(filter.Query); keyword != "" {
+		like := "%" + strings.ToLower(keyword) + "%"
+		query = query.Where(
+			"LOWER(billing_redemptions.ref_no) LIKE ? OR LOWER(rc.code_hint) LIKE ? OR LOWER(rc.description) LIKE ?",
+			like,
+			like,
+			like,
+		)
+	}
+	if filter.CreatedFrom != nil {
+		query = query.Where("billing_redemptions.created_at >= ?", *filter.CreatedFrom)
+	}
+	if filter.CreatedTo != nil {
+		query = query.Where("billing_redemptions.created_at <= ?", *filter.CreatedTo)
+	}
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, translateError(err)
+	}
+	order := "billing_redemptions.created_at DESC, billing_redemptions.id DESC"
+	if strings.TrimSpace(filter.Sort) == "created_asc" {
+		order = "billing_redemptions.created_at ASC, billing_redemptions.id ASC"
+	}
+	rows := make([]redemptionRecordRow, 0)
+	if err := query.
+		Select("billing_redemptions.*, rc.code_hint AS code_hint, rc.description AS code_description, rc.status AS code_status, rp.name AS plan_name, rt.amount_nanousd AS balance_amount_nanousd, rt.balance_after_nanousd AS balance_after_nanousd").
+		Order(order).
+		Offset(offset).
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		return nil, 0, translateError(err)
+	}
+	results := make([]repository.RedemptionRecord, 0, len(rows))
+	for _, row := range rows {
+		results = append(results, repository.RedemptionRecord{
+			Redemption: domainbilling.Redemption{
+				ID:                   row.ID,
+				CodeID:               row.CodeID,
+				UserID:               row.UserID,
+				Mode:                 row.Mode,
+				RewardType:           row.RewardType,
+				CreditNanousd:        row.CreditNanousd,
+				PlanID:               row.PlanID,
+				SubscriptionID:       row.SubscriptionID,
+				BalanceTransactionID: row.BalanceTransactionID,
+				RefNo:                row.RefNo,
+				SnapshotJSON:         row.SnapshotJSON,
+				CreatedAt:            row.CreatedAt,
+				UpdatedAt:            row.UpdatedAt,
+			},
+			CodeHint:             row.CodeHint,
+			CodeDescription:      row.CodeDescription,
+			CodeStatus:           row.CodeStatus,
+			PlanName:             row.PlanName,
+			BalanceAmountNanousd: row.BalanceAmountNanousd,
+			BalanceAfterNanousd:  row.BalanceAfterNanousd,
+		})
+	}
+	return results, total, nil
+}
+
 // GetRedemptionCodeByID 查询单个未删除兑换码定义。
 func (r *Repo) GetRedemptionCodeByID(ctx context.Context, id uint) (*domainbilling.RedemptionCode, error) {
 	if id == 0 {

--- a/backend/internal/infra/persistence/postgres/billing/repository_redemptions_sqlite_test.go
+++ b/backend/internal/infra/persistence/postgres/billing/repository_redemptions_sqlite_test.go
@@ -1,0 +1,191 @@
+package billing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	domainbilling "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/billing"
+	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/models"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/repository"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func openRedemptionSQLiteTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file:billing_redemption_records?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("resolve sql db: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+
+	if err := db.AutoMigrate(&model.Redemption{}, &model.RedemptionCode{}, &model.BillingPlan{}, &model.BalanceTransaction{}); err != nil {
+		t.Fatalf("migrate redemption tables: %v", err)
+	}
+	return db
+}
+
+func TestListRedemptionsJoinsCodeAndBalanceContext(t *testing.T) {
+	db := openRedemptionSQLiteTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	usageCode := model.RedemptionCode{
+		CodeHash:    "hash-usage",
+		CodeHint:    "AAAA***0001",
+		Mode:        domainbilling.RedemptionCodeModeUsage,
+		RewardType:  domainbilling.RedemptionRewardTypeBalance,
+		Status:      domainbilling.RedemptionCodeStatusActive,
+		Description: "邀请返利",
+	}
+	deletedCode := model.RedemptionCode{
+		CodeHash:   "hash-period",
+		CodeHint:   "BBBB***0002",
+		Mode:       domainbilling.RedemptionCodeModePeriod,
+		RewardType: domainbilling.RedemptionRewardTypeSubscription,
+		Status:     domainbilling.RedemptionCodeStatusDeleted,
+	}
+	if err := db.Create(&usageCode).Error; err != nil {
+		t.Fatalf("create usage code: %v", err)
+	}
+	if err := db.Create(&deletedCode).Error; err != nil {
+		t.Fatalf("create deleted code: %v", err)
+	}
+	plan := model.BillingPlan{Code: "pro", Name: "Pro"}
+	if err := db.Create(&plan).Error; err != nil {
+		t.Fatalf("create plan: %v", err)
+	}
+	balanceTx := model.BalanceTransaction{
+		UserID:              7,
+		Type:                domainbilling.BalanceTransactionTypeRedemption,
+		AmountNanousd:       5_000_000_000,
+		BalanceAfterNanousd: 12_000_000_000,
+	}
+	if err := db.Create(&balanceTx).Error; err != nil {
+		t.Fatalf("create balance transaction: %v", err)
+	}
+
+	base := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	redemptions := []model.Redemption{
+		{
+			CodeID:               usageCode.ID,
+			UserID:               7,
+			Mode:                 domainbilling.RedemptionCodeModeUsage,
+			RewardType:           domainbilling.RedemptionRewardTypeBalance,
+			CreditNanousd:        5_000_000_000,
+			BalanceTransactionID: balanceTx.ID,
+			RefNo:                "redemption_7_1",
+		},
+		{
+			CodeID:         deletedCode.ID,
+			UserID:         8,
+			Mode:           domainbilling.RedemptionCodeModePeriod,
+			RewardType:     domainbilling.RedemptionRewardTypeSubscription,
+			PlanID:         plan.ID,
+			SubscriptionID: 33,
+			RefNo:          "redemption_8_1",
+		},
+		{
+			CodeID:     usageCode.ID,
+			UserID:     8,
+			Mode:       domainbilling.RedemptionCodeModeUsage,
+			RewardType: domainbilling.RedemptionRewardTypeBalance,
+			RefNo:      "redemption_8_2",
+		},
+	}
+	for index := range redemptions {
+		redemptions[index].CreatedAt = base.Add(time.Duration(index) * time.Minute)
+		if err := db.Create(&redemptions[index]).Error; err != nil {
+			t.Fatalf("create redemption %d: %v", index, err)
+		}
+	}
+
+	items, total, err := repo.ListRedemptions(ctx, repository.RedemptionListFilter{}, 0, 20)
+	if err != nil {
+		t.Fatalf("ListRedemptions() error = %v", err)
+	}
+	if total != 3 || len(items) != 3 {
+		t.Fatalf("ListRedemptions() = %d/%d, want 3/3", len(items), total)
+	}
+	if items[0].Redemption.RefNo != "redemption_8_2" {
+		t.Fatalf("default order first = %q, want redemption_8_2 (created desc)", items[0].Redemption.RefNo)
+	}
+
+	balanceItems, _, err := repo.ListRedemptions(ctx, repository.RedemptionListFilter{UserID: 7}, 0, 20)
+	if err != nil {
+		t.Fatalf("ListRedemptions(user) error = %v", err)
+	}
+	if len(balanceItems) != 1 {
+		t.Fatalf("ListRedemptions(user) = %d, want 1", len(balanceItems))
+	}
+	record := balanceItems[0]
+	if record.CodeHint != "AAAA***0001" || record.CodeDescription != "邀请返利" || record.CodeStatus != domainbilling.RedemptionCodeStatusActive {
+		t.Fatalf("joined code context = %+v", record)
+	}
+	if record.BalanceAmountNanousd == nil || *record.BalanceAmountNanousd != 5_000_000_000 {
+		t.Fatalf("BalanceAmountNanousd = %v, want 5e9", record.BalanceAmountNanousd)
+	}
+	if record.BalanceAfterNanousd == nil || *record.BalanceAfterNanousd != 12_000_000_000 {
+		t.Fatalf("BalanceAfterNanousd = %v, want 12e9", record.BalanceAfterNanousd)
+	}
+
+	deletedItems, _, err := repo.ListRedemptions(ctx, repository.RedemptionListFilter{CodeID: deletedCode.ID}, 0, 20)
+	if err != nil {
+		t.Fatalf("ListRedemptions(deleted code) error = %v", err)
+	}
+	if len(deletedItems) != 1 {
+		t.Fatalf("ListRedemptions(deleted code) = %d, want 1", len(deletedItems))
+	}
+	if deletedItems[0].CodeStatus != domainbilling.RedemptionCodeStatusDeleted {
+		t.Fatalf("deleted code status = %q, want deleted", deletedItems[0].CodeStatus)
+	}
+	if deletedItems[0].PlanName != "Pro" {
+		t.Fatalf("PlanName = %q, want Pro", deletedItems[0].PlanName)
+	}
+	if deletedItems[0].BalanceAmountNanousd != nil || deletedItems[0].BalanceAfterNanousd != nil {
+		t.Fatalf("subscription redemption balance context = %+v, want nil", deletedItems[0])
+	}
+
+	keywordItems, _, err := repo.ListRedemptions(ctx, repository.RedemptionListFilter{Query: "bbbb"}, 0, 20)
+	if err != nil {
+		t.Fatalf("ListRedemptions(query) error = %v", err)
+	}
+	if len(keywordItems) != 1 || keywordItems[0].Redemption.RefNo != "redemption_8_1" {
+		t.Fatalf("ListRedemptions(query bbbb) = %+v, want redemption_8_1", keywordItems)
+	}
+
+	// keyword(OR 条件)与其他 AND 筛选组合时必须整体括号，不能吞掉 user_id 条件。
+	comboItems, comboTotal, err := repo.ListRedemptions(ctx, repository.RedemptionListFilter{Query: "aaaa", UserID: 7}, 0, 20)
+	if err != nil {
+		t.Fatalf("ListRedemptions(query+user) error = %v", err)
+	}
+	if comboTotal != 1 || len(comboItems) != 1 || comboItems[0].Redemption.RefNo != "redemption_7_1" {
+		t.Fatalf("ListRedemptions(query aaaa + user 7) = %d/%d, want only redemption_7_1", len(comboItems), comboTotal)
+	}
+
+	rewardItems, _, err := repo.ListRedemptions(ctx, repository.RedemptionListFilter{RewardType: domainbilling.RedemptionRewardTypeSubscription}, 0, 20)
+	if err != nil {
+		t.Fatalf("ListRedemptions(rewardType) error = %v", err)
+	}
+	if len(rewardItems) != 1 || rewardItems[0].Redemption.RefNo != "redemption_8_1" {
+		t.Fatalf("ListRedemptions(subscription) = %d, want redemption_8_1", len(rewardItems))
+	}
+
+	from := base.Add(90 * time.Second)
+	rangedItems, _, err := repo.ListRedemptions(ctx, repository.RedemptionListFilter{CreatedFrom: &from, Sort: "created_asc"}, 0, 20)
+	if err != nil {
+		t.Fatalf("ListRedemptions(range) error = %v", err)
+	}
+	if len(rangedItems) != 1 || rangedItems[0].Redemption.RefNo != "redemption_8_2" {
+		t.Fatalf("ListRedemptions(range) = %d, want redemption_8_2", len(rangedItems))
+	}
+}

--- a/backend/internal/repository/billing.go
+++ b/backend/internal/repository/billing.go
@@ -40,6 +40,7 @@ type BillingRepository interface {
 	PatchRedemptionCode(ctx context.Context, id uint, patch RedemptionCodePatch) (*domainbilling.RedemptionCode, error)
 	DeleteRedemptionCode(ctx context.Context, id uint) error
 	RedeemCode(ctx context.Context, input RedemptionApplyInput) (*RedemptionApplyResult, error)
+	ListRedemptions(ctx context.Context, filter RedemptionListFilter, offset int, limit int) ([]RedemptionRecord, int64, error)
 	GetBillingMode(ctx context.Context) (string, error)
 	GetBillingPrepaidAmountNanousd(ctx context.Context) (int64, error)
 	GetNativeToolBillingEnabled(ctx context.Context) (bool, error)
@@ -74,6 +75,30 @@ type RedemptionCodePatch struct {
 	ExpiresAtSet      bool
 	ExpiresAt         *time.Time
 	Description       *string
+}
+
+// RedemptionListFilter 描述管理员兑换记录列表筛选条件。
+type RedemptionListFilter struct {
+	CodeID      uint
+	UserID      uint
+	RewardType  string
+	Query       string
+	CreatedFrom *time.Time
+	CreatedTo   *time.Time
+	Sort        string
+}
+
+// RedemptionRecord 表示带兑换码与余额流水上下文的兑换记录。
+// 兑换码删除为状态软删，历史记录始终可联表查询。
+type RedemptionRecord struct {
+	Redemption      domainbilling.Redemption
+	CodeHint        string
+	CodeDescription string
+	CodeStatus      string
+	PlanName        string
+	// BalanceAmountNanousd / BalanceAfterNanousd 来自余额流水；订阅类兑换无流水时为 nil。
+	BalanceAmountNanousd *int64
+	BalanceAfterNanousd  *int64
 }
 
 // RedemptionApplyInput 描述一次兑换需要在事务中完成的写入参数。

--- a/backend/internal/transport/http/admin/dto.go
+++ b/backend/internal/transport/http/admin/dto.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	appadmin "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/admin"
+	appbilling "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/billing"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/userview"
 	domainaudit "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/audit"
 	domainbilling "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/billing"
@@ -383,6 +384,33 @@ type PaymentOrderResponse struct {
 	UpdatedAt          time.Time  `json:"updatedAt"`
 }
 
+// RedemptionRecordResponse 兑换记录响应。
+type RedemptionRecordResponse struct {
+	ID              uint    `json:"id"`
+	CodeID          uint    `json:"codeID"`
+	CodeHint        string  `json:"codeHint"`
+	CodeDescription string  `json:"codeDescription"`
+	CodeStatus      string  `json:"codeStatus"`
+	UserID          uint    `json:"userID"`
+	Username        string  `json:"username"`
+	UserDisplayName string  `json:"userDisplayName"`
+	UserLabel       string  `json:"userLabel"`
+	Mode            string  `json:"mode"`
+	RewardType      string  `json:"rewardType"`
+	CreditNanousd   int64   `json:"creditNanousd"`
+	CreditUSD       float64 `json:"creditUSD"`
+	PlanID          uint    `json:"planID"`
+	PlanName        string  `json:"planName"`
+	DurationDays    int     `json:"durationDays"`
+	SubscriptionID  uint    `json:"subscriptionID"`
+	// BalanceBeforeNanousd / BalanceAfterNanousd 来自余额流水；订阅类兑换无流水时为 null。
+	BalanceBeforeNanousd *int64    `json:"balanceBeforeNanousd" extensions:"x-nullable,!x-omitempty"`
+	BalanceAfterNanousd  *int64    `json:"balanceAfterNanousd" extensions:"x-nullable,!x-omitempty"`
+	RefNo                string    `json:"refNo"`
+	SnapshotJSON         string    `json:"snapshotJSON"`
+	CreatedAt            time.Time `json:"createdAt"`
+}
+
 // ConversationEventResponse 对话事件响应。
 type ConversationEventResponse struct {
 	ID                uint       `json:"id"`
@@ -634,6 +662,15 @@ type PaymentOrderListResponseDoc struct {
 	Data     struct {
 		Total   int64                  `json:"total"`
 		Results []PaymentOrderResponse `json:"results"`
+	} `json:"data"`
+}
+
+// RedemptionRecordListResponseDoc 兑换记录分页响应。
+type RedemptionRecordListResponseDoc struct {
+	ErrorMsg string `json:"errorMsg"`
+	Data     struct {
+		Total   int64                      `json:"total"`
+		Results []RedemptionRecordResponse `json:"results"`
 	} `json:"data"`
 }
 
@@ -931,6 +968,38 @@ func toPaymentOrderResponse(item domainbilling.PaymentOrder, label appadmin.User
 		SnapshotJSON:       item.SnapshotJSON,
 		CreatedAt:          item.CreatedAt,
 		UpdatedAt:          item.UpdatedAt,
+	}
+}
+
+func toRedemptionRecordResponse(item appbilling.RedemptionRecordView, label appadmin.UserLabel) RedemptionRecordResponse {
+	var balanceBefore *int64
+	if item.BalanceAfterNanousd != nil && item.BalanceAmountNanousd != nil {
+		before := *item.BalanceAfterNanousd - *item.BalanceAmountNanousd
+		balanceBefore = &before
+	}
+	return RedemptionRecordResponse{
+		ID:                   item.Redemption.ID,
+		CodeID:               item.Redemption.CodeID,
+		CodeHint:             item.CodeHint,
+		CodeDescription:      item.CodeDescription,
+		CodeStatus:           item.CodeStatus,
+		UserID:               item.Redemption.UserID,
+		Username:             label.Username,
+		UserDisplayName:      label.DisplayName,
+		UserLabel:            label.Label,
+		Mode:                 item.Redemption.Mode,
+		RewardType:           item.Redemption.RewardType,
+		CreditNanousd:        item.Redemption.CreditNanousd,
+		CreditUSD:            float64(item.Redemption.CreditNanousd) / 1_000_000_000,
+		PlanID:               item.Redemption.PlanID,
+		PlanName:             item.PlanName,
+		DurationDays:         item.DurationDays,
+		SubscriptionID:       item.Redemption.SubscriptionID,
+		BalanceBeforeNanousd: balanceBefore,
+		BalanceAfterNanousd:  item.BalanceAfterNanousd,
+		RefNo:                item.Redemption.RefNo,
+		SnapshotJSON:         item.Redemption.SnapshotJSON,
+		CreatedAt:            item.Redemption.CreatedAt,
 	}
 }
 

--- a/backend/internal/transport/http/admin/handler.go
+++ b/backend/internal/transport/http/admin/handler.go
@@ -707,6 +707,70 @@ func (h *Handler) ListPaymentOrders(c *gin.Context) {
 	response.SuccessPage(c, total, orders)
 }
 
+// ListRedemptions godoc
+// @Summary 管理员查询兑换记录
+// @Description 管理员分页查看兑换码兑换明细，含奖励内容与余额变动，已删除兑换码的历史仍可查询
+// @Tags admin
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param page query int false "页码"
+// @Param page_size query int false "每页数量"
+// @Param query query string false "搜索兑换流水号、兑换码摘要、兑换码备注"
+// @Param code_id query int false "兑换码ID"
+// @Param user_id query int false "用户ID"
+// @Param reward_type query string false "奖励类型(balance/subscription)"
+// @Param created_from query string false "兑换时间起点(RFC3339)"
+// @Param created_to query string false "兑换时间终点(RFC3339)"
+// @Param sort query string false "排序方式"
+// @Success 200 {object} RedemptionRecordListResponseDoc
+// @Failure 400 {object} ErrorDoc
+// @Failure 500 {object} ErrorDoc
+// @Router /admin/redemptions [get]
+// ListRedemptions 查询兑换码兑换记录。
+func (h *Handler) ListRedemptions(c *gin.Context) {
+	page, pageSize := pageParams(c)
+	codeID, ok := parseOptionalUintQuery(c, "code_id")
+	if !ok {
+		return
+	}
+	userID, ok := parseOptionalUintQuery(c, "user_id")
+	if !ok {
+		return
+	}
+	createdFrom, ok := parseOptionalTimeQuery(c, "created_from")
+	if !ok {
+		return
+	}
+	createdTo, ok := parseOptionalTimeQuery(c, "created_to")
+	if !ok {
+		return
+	}
+	items, total, err := h.service.ListRedemptions(c.Request.Context(), page, pageSize, appbilling.RedemptionListFilter{
+		CodeID:      codeID,
+		UserID:      userID,
+		RewardType:  c.Query("reward_type"),
+		Query:       c.Query("query"),
+		CreatedFrom: createdFrom,
+		CreatedTo:   createdTo,
+		Sort:        c.Query("sort"),
+	})
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, "list redemptions failed")
+		return
+	}
+	userIDs := make([]uint, 0, len(items))
+	for _, item := range items {
+		userIDs = append(userIDs, item.Redemption.UserID)
+	}
+	userLabels := h.service.ResolveUserLabels(c.Request.Context(), userIDs)
+	records := make([]RedemptionRecordResponse, 0, len(items))
+	for _, item := range items {
+		records = append(records, toRedemptionRecordResponse(item, userLabels[item.Redemption.UserID]))
+	}
+	response.SuccessPage(c, total, records)
+}
+
 // ListConversationEvents godoc
 // @Summary 管理员查询对话事件
 // @Description 管理员分页查看对话运行轨迹、工具、MCP 与处理事件

--- a/backend/internal/transport/http/admin/router.go
+++ b/backend/internal/transport/http/admin/router.go
@@ -18,6 +18,7 @@ func (m *Module) RegisterRoutes(adminGroup *gin.RouterGroup) {
 	adminGroup.GET("/usage-statistics", m.Handler.GetUsageStatistics)
 	adminGroup.GET("/call-logs", m.Handler.ListUsageLogs)
 	adminGroup.GET("/payment-orders", m.Handler.ListPaymentOrders)
+	adminGroup.GET("/redemptions", m.Handler.ListRedemptions)
 	adminGroup.GET("/conversation-events", m.Handler.ListConversationEvents)
 	adminGroup.GET("/conversation-events/:id", m.Handler.GetConversationEvent)
 	adminGroup.POST("/conversation-events/cleanup", m.Handler.CleanupConversationRuns)

--- a/frontend/app/(admin)/admin/logs/page.tsx
+++ b/frontend/app/(admin)/admin/logs/page.tsx
@@ -1,5 +1,11 @@
+import { Suspense } from "react";
+
 import { AdminLogsPage as AdminLogsSection } from "@/features/admin/components/sections/logs/admin-logs";
 
 export default function AdminLogsPage() {
-  return <AdminLogsSection />;
+  return (
+    <Suspense fallback={null}>
+      <AdminLogsSection />
+    </Suspense>
+  );
 }

--- a/frontend/features/admin/api/admin.types.ts
+++ b/frontend/features/admin/api/admin.types.ts
@@ -9,6 +9,7 @@ import type {
   ImportOpenWebUIUsersResponse,
   PatchUserRequest,
   PaymentOrderResponse,
+  RedemptionRecordResponse,
   ResetUserPasswordRequest,
   ResetUserPasswordResponse,
   RevokeUserSessionsResponse,
@@ -68,6 +69,8 @@ export type AdminUsageLogDTO = Omit<UsageLogResponse, "billingAt">;
 
 export type AdminPaymentOrderDTO = PaymentOrderResponse;
 
+export type AdminRedemptionRecordDTO = RedemptionRecordResponse;
+
 export type AdminConversationEventDTO = ConversationEventResponse;
 
 export type ListAdminUsersResult = PagePayload<AdminUserDTO>;
@@ -76,6 +79,7 @@ export type ListAdminAuditLogsResult = PagePayload<AdminAuditLogDTO>;
 export type ListAdminSystemEventsResult = PagePayload<AdminSystemEventDTO>;
 export type ListAdminUsageLogsResult = PagePayload<AdminUsageLogDTO>;
 export type ListAdminPaymentOrdersResult = PagePayload<AdminPaymentOrderDTO>;
+export type ListAdminRedemptionsResult = PagePayload<AdminRedemptionRecordDTO>;
 export type ListAdminConversationEventsResult = PagePayload<AdminConversationEventDTO>;
 
 export type TikaRuntimeStatus =

--- a/frontend/features/admin/api/audit.ts
+++ b/frontend/features/admin/api/audit.ts
@@ -9,6 +9,7 @@ import type {
   AdminAuditLogDTO,
   AdminConversationEventDTO,
   AdminPaymentOrderDTO,
+  AdminRedemptionRecordDTO,
   AdminSystemEventDTO,
   AdminUsageLogDTO,
   AdminUserAuthEventDTO,
@@ -59,6 +60,16 @@ type ListAdminPaymentOrdersOptions = AdminPageOptions & {
   provider?: string;
   status?: string;
   userID?: number;
+  createdFrom?: string;
+  createdTo?: string;
+  sort?: string;
+};
+
+type ListAdminRedemptionsOptions = AdminPageOptions & {
+  query?: string;
+  codeID?: number;
+  userID?: number;
+  rewardType?: string;
   createdFrom?: string;
   createdTo?: string;
   sort?: string;
@@ -238,6 +249,31 @@ export async function listAdminPaymentOrders(
 
   const data = await authedRequest<PagePayload<AdminPaymentOrderDTO>>(
     `/api/v1/admin/payment-orders?${params.toString()}`,
+    { accessToken },
+    true,
+  );
+
+  return normalizeAdminPagePayload(data);
+}
+
+export async function listAdminRedemptions(
+  accessToken: string,
+  options: ListAdminRedemptionsOptions = {},
+): Promise<PagePayload<AdminRedemptionRecordDTO>> {
+  const { page, pageSize } = resolveAdminPage(options);
+  const params = new URLSearchParams();
+  params.set("page", String(page));
+  params.set("page_size", String(pageSize));
+  if (options.query?.trim()) params.set("query", options.query.trim());
+  if (options.codeID && options.codeID > 0) params.set("code_id", String(options.codeID));
+  if (options.userID && options.userID > 0) params.set("user_id", String(options.userID));
+  if (options.rewardType?.trim()) params.set("reward_type", options.rewardType.trim());
+  if (options.createdFrom?.trim()) params.set("created_from", options.createdFrom.trim());
+  if (options.createdTo?.trim()) params.set("created_to", options.createdTo.trim());
+  if (options.sort?.trim()) params.set("sort", options.sort.trim());
+
+  const data = await authedRequest<PagePayload<AdminRedemptionRecordDTO>>(
+    `/api/v1/admin/redemptions?${params.toString()}`,
     { accessToken },
     true,
   );

--- a/frontend/features/admin/components/sections/billing/billing-redemption.tsx
+++ b/frontend/features/admin/components/sections/billing/billing-redemption.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Check, CircleAlert, Copy, Download, Pencil, Plus, Trash2, X } from "lucide-react";
+import { Check, CircleAlert, Copy, Download, History, Pencil, Plus, Trash2, X } from "lucide-react";
 import { motion } from "motion/react";
 import { useLocale, useTranslations } from "next-intl";
 import { toast } from "sonner";
@@ -20,6 +20,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useVirtualTableRows, VirtualTablePaddingRow } from "@/components/ui/virtual-table";
 import { AdminDateTimePicker, adminDateTimeFormValue, adminDateTimeValueToISOString } from "@/features/admin/components/admin-date-time-picker";
 import { AdminBulkConfirmDialog } from "@/features/admin/components/bulk-confirm-dialog";
+import { RedemptionRecordsDialog } from "@/features/admin/components/sections/billing/redemption-records-dialog";
 import {
   batchDeleteAdminRedemptionCodes,
   createAdminRedemptionCodes,
@@ -158,6 +159,7 @@ export function BillingRedemptionSection({ plans, billingMode, loading }: Billin
   const stableRedemptionBulkAction = useDialogSnapshot(redemptionBulkAction);
   const [redemptionBulkPending, setRedemptionBulkPending] = React.useState(false);
   const [redemptionDeleteTarget, setRedemptionDeleteTarget] = React.useState<AdminRedemptionCodeDTO | null>(null);
+  const [redemptionRecordsTarget, setRedemptionRecordsTarget] = React.useState<AdminRedemptionCodeDTO | null>(null);
   const [createdRedemptionCodes, setCreatedRedemptionCodes] = React.useState<string[]>([]);
   const [redemptionStatusPendingID, setRedemptionStatusPendingID] = React.useState<number | null>(null);
 
@@ -865,7 +867,7 @@ export function BillingRedemptionSection({ plans, billingMode, loading }: Billin
               <TableHead className="w-[120px]">{t("redemption.columns.limit")}</TableHead>
               <TableHead className="w-[76px] text-center">{t("redemption.columns.status")}</TableHead>
               <TableHead className="w-[104px]">{t("redemption.columns.expiresAt")}</TableHead>
-              <TableHead stickyEnd className="w-[88px]" />
+              <TableHead stickyEnd className="w-[116px]" />
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -951,8 +953,19 @@ export function BillingRedemptionSection({ plans, billingMode, loading }: Billin
                       </div>
                     </TableCell>
                     <TableCell className="w-[104px] py-1.5 text-xs text-muted-foreground">{item.expiresAt ? formatDateTime(item.expiresAt, locale) : t("redemption.never")}</TableCell>
-                    <TableCell stickyEnd className="w-[88px] py-1.5 text-right">
+                    <TableCell stickyEnd className="w-[116px] py-1.5 text-right">
                       <div className="flex h-7 items-center justify-end">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-xs"
+                          className="h-7 w-7 text-muted-foreground shadow-none"
+                          onClick={() => setRedemptionRecordsTarget(item)}
+                          aria-label={t("redemption.viewRecords")}
+                          title={t("redemption.viewRecords")}
+                        >
+                          <History className="size-3.5 stroke-1" />
+                        </Button>
                         <Button
                           type="button"
                           variant="ghost"
@@ -1270,6 +1283,8 @@ export function BillingRedemptionSection({ plans, billingMode, loading }: Billin
         pendingLabel={t("redemption.deleting")}
         onConfirm={() => void deleteSingleRedemptionCode()}
       />
+
+      <RedemptionRecordsDialog code={redemptionRecordsTarget} onClose={() => setRedemptionRecordsTarget(null)} />
     </section>
   );
 }

--- a/frontend/features/admin/components/sections/billing/redemption-records-dialog.tsx
+++ b/frontend/features/admin/components/sections/billing/redemption-records-dialog.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useLocale, useTranslations } from "next-intl";
+import * as React from "react";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableEmptyRow,
+  TableHead,
+  TableHeader,
+  TableLoadingRow,
+  TableRow,
+} from "@/components/ui/table";
+import { TablePagination } from "@/components/ui/table-tools";
+import { listAdminRedemptions } from "@/features/admin/api";
+import type { AdminRedemptionRecordDTO } from "@/features/admin/api/admin.types";
+import type { AdminRedemptionCodeDTO } from "@/features/admin/api/billing.types";
+import { formatCreditUSD, formatDateTime } from "@/features/admin/model/billing-settings";
+import { resolveUserDisplayName } from "@/features/admin/model/log-display";
+import { resolveAdminErrorMessage } from "@/features/admin/utils/admin-error";
+import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
+
+const RECORDS_PAGE_SIZE = 10;
+
+function RedemptionRecordsDialogBody({ code }: { code: AdminRedemptionCodeDTO }) {
+  const locale = useLocale();
+  const tLogs = useTranslations("adminLogs");
+  const [records, setRecords] = React.useState<AdminRedemptionRecordDTO[]>([]);
+  const [total, setTotal] = React.useState(0);
+  const [page, setPage] = React.useState(1);
+  const [pageSize, setPageSize] = React.useState(RECORDS_PAGE_SIZE);
+  const [loading, setLoading] = React.useState(true);
+
+  const loadRecords = React.useCallback(async (nextPage = 1, nextPageSize = RECORDS_PAGE_SIZE) => {
+    setLoading(true);
+    try {
+      const token = await resolveAccessToken();
+      if (!token) {
+        toast.error(tLogs("toast.sessionExpired"), { description: tLogs("toast.signInAgain") });
+        return;
+      }
+      const data = await listAdminRedemptions(token, {
+        page: nextPage,
+        pageSize: nextPageSize,
+        codeID: code.id,
+      });
+      setRecords(data.results);
+      setTotal(data.total);
+      setPage(nextPage);
+      setPageSize(nextPageSize);
+    } catch (error) {
+      toast.error(tLogs("toast.redemptionsLoadFailed"), { description: resolveAdminErrorMessage(error) });
+    } finally {
+      setLoading(false);
+    }
+  }, [code.id, tLogs]);
+
+  React.useEffect(() => {
+    void loadRecords(1);
+  }, [loadRecords]);
+
+  const rewardLabel = (item: AdminRedemptionRecordDTO): string => {
+    if (item.rewardType === "subscription") {
+      const planName = item.planName.trim() || tLogs("redemptions.rewards.subscription");
+      return item.durationDays > 0
+        ? `${planName} · ${tLogs("redemptions.rewards.durationDays", { count: item.durationDays })}`
+        : planName;
+    }
+    return `${tLogs("redemptions.rewards.balance")} +${formatCreditUSD(item.creditUSD)}`;
+  };
+
+  return (
+    <div className="space-y-3">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead>{tLogs("columns.user")}</TableHead>
+            <TableHead>{tLogs("columns.reward")}</TableHead>
+            <TableHead>{tLogs("columns.balanceAfterRedemption")}</TableHead>
+            <TableHead>{tLogs("columns.time")}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {loading && records.length === 0 ? <TableLoadingRow colSpan={4} /> : null}
+          {records.map((item) => (
+            <TableRow key={item.id}>
+              <TableCell className="whitespace-nowrap text-muted-foreground">
+                {resolveUserDisplayName(item.userLabel, item.username, item.userID)}
+              </TableCell>
+              <TableCell className="whitespace-nowrap">{rewardLabel(item)}</TableCell>
+              <TableCell className="whitespace-nowrap font-medium tabular-nums text-foreground">
+                {typeof item.balanceAfterNanousd === "number"
+                  ? formatCreditUSD(item.balanceAfterNanousd / 1_000_000_000)
+                  : "-"}
+              </TableCell>
+              <TableCell className="whitespace-nowrap text-muted-foreground">
+                {formatDateTime(item.createdAt, locale)}
+              </TableCell>
+            </TableRow>
+          ))}
+          {!loading && records.length === 0 ? (
+            <TableEmptyRow colSpan={4}>{tLogs("redemptions.empty")}</TableEmptyRow>
+          ) : null}
+        </TableBody>
+      </Table>
+      {total > pageSize ? (
+        <TablePagination
+          loading={loading}
+          page={page}
+          pageCount={Math.max(1, Math.ceil(total / pageSize))}
+          pageSize={pageSize}
+          total={total}
+          onPageChange={(nextPage) => void loadRecords(nextPage, pageSize)}
+          onPageSizeChange={(nextPageSize) => void loadRecords(1, nextPageSize)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export function RedemptionRecordsDialog({
+  code,
+  onClose,
+}: {
+  code: AdminRedemptionCodeDTO | null;
+  onClose: () => void;
+}) {
+  const tLogs = useTranslations("adminLogs");
+
+  return (
+    <Dialog open={Boolean(code)} onOpenChange={(open) => !open && onClose()}>
+      {code ? (
+        <DialogContent className="flex max-h-[min(86vh,720px)] max-w-2xl flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
+          <DialogHeader className="shrink-0 px-4 py-4">
+            <DialogTitle>{tLogs("tabs.redemptions")}</DialogTitle>
+            <DialogDescription className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <span className="font-mono text-foreground/80">{code.codeHint}</span>
+              {code.description ? <span className="truncate">· {code.description}</span> : null}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4">
+            <RedemptionRecordsDialogBody key={code.id} code={code} />
+          </div>
+        </DialogContent>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/frontend/features/admin/components/sections/logs/admin-log-detail-sheet.tsx
+++ b/frontend/features/admin/components/sections/logs/admin-log-detail-sheet.tsx
@@ -85,6 +85,8 @@ export function LogDetailSheet({
         ? t("titles.usage")
         : detail?.kind === "order"
           ? t("titles.order")
+          : detail?.kind === "redemption"
+            ? t("titles.redemption")
           : detail?.kind === "conversation"
             ? t("titles.conversation")
         : detail?.kind === "system"
@@ -97,16 +99,21 @@ export function LogDetailSheet({
         ? `${detail.item.platformModelName || t("fallbacks.modelCall")} · ${formatDateTime(detail.item.createdAt, locale)}`
         : detail?.kind === "order"
           ? `${detail.item.orderNo || t("fallbacks.order")} · ${formatDateTime(detail.item.createdAt, locale)}`
+          : detail?.kind === "redemption"
+            ? `${detail.item.codeHint || t("fallbacks.redemption")} · ${formatDateTime(detail.item.createdAt, locale)}`
           : detail?.kind === "conversation"
             ? `${detail.item.eventType || detail.item.eventScope || t("fallbacks.conversationEvent")} · ${formatDateTime(detail.item.createdAt, locale)}`
       : detail?.kind === "system"
         ? `${detail.item.event || t("fallbacks.systemEvent")} · ${formatDateTime(detail.item.createdAt, locale)}`
         : `${detail?.item.action || t("fallbacks.auditEvent")} · ${formatDateTime(detail?.item.createdAt, locale)}`;
-  const requestID = detail && detail.kind !== "usage" && detail.kind !== "order" && detail.kind !== "conversation" ? detail.item.requestID : "";
+  const requestID =
+    detail && detail.kind !== "usage" && detail.kind !== "order" && detail.kind !== "redemption" && detail.kind !== "conversation"
+      ? detail.item.requestID
+      : "";
   const detailJSON =
     detail?.kind === "usage"
       ? detail.item.pricingSnapshotJSON
-      : detail?.kind === "order"
+      : detail?.kind === "order" || detail?.kind === "redemption"
         ? detail.item.snapshotJSON
         : detail?.kind === "conversation"
           ? detail.item.payloadJSON || detail.item.inputJSON || detail.item.outputJSON || detail.item.errorJSON
@@ -260,6 +267,73 @@ export function LogDetailSheet({
                 <DetailRow label={t("fields.interval")} value={`${detail.item.billingInterval || "-"} x ${detail.item.cycles || 0}`} />
                 <DetailRow label={t("fields.externalPaymentID")} value={detail.item.externalPaymentID || "-"} mono />
                 <DetailRow label={t("fields.externalCheckoutID")} value={detail.item.externalCheckoutID || "-"} mono />
+              </DetailBlock>
+            </>
+          ) : null}
+
+          {detail?.kind === "redemption" ? (
+            <>
+              <DetailBlock title={t("blocks.redemption")}>
+                <DetailRow label="ID" value={detail.item.id} mono />
+                <DetailRow label={t("fields.refNo")} value={detail.item.refNo || "-"} mono />
+                <DetailRow label={t("fields.redeemedAt")} value={formatDateTime(detail.item.createdAt, locale)} />
+              </DetailBlock>
+              <DetailBlock title={t("blocks.user")}>
+                <DetailRow label={t("fields.user")} value={resolveUserDisplayName(detail.item.userLabel, detail.item.username, detail.item.userID)} />
+                <DetailRow label={t("fields.userID")} value={detail.item.userID} mono />
+              </DetailBlock>
+              <DetailBlock title={t("blocks.redemptionCode")}>
+                <DetailRow label={t("fields.codeHint")} value={detail.item.codeHint || "-"} mono />
+                <DetailRow label={t("fields.codeID")} value={detail.item.codeID} mono />
+                <DetailRow label={t("fields.codeDescription")} value={detail.item.codeDescription || "-"} />
+                <DetailRow
+                  label={t("fields.codeStatus")}
+                  value={
+                    detail.item.codeStatus === "active" || detail.item.codeStatus === "inactive" || detail.item.codeStatus === "deleted"
+                      ? t(`codeStatus.${detail.item.codeStatus}`)
+                      : detail.item.codeStatus || "-"
+                  }
+                />
+              </DetailBlock>
+              <DetailBlock title={t("blocks.reward")}>
+                <DetailRow
+                  label={t("fields.rewardType")}
+                  value={detail.item.rewardType === "subscription" ? t("rewardTypes.subscription") : t("rewardTypes.balance")}
+                />
+                {detail.item.rewardType === "subscription" ? (
+                  <>
+                    <DetailRow label={t("fields.planName")} value={detail.item.planName || `#${detail.item.planID}`} />
+                    {detail.item.durationDays > 0 ? (
+                      <DetailRow
+                        label={t("fields.durationDays")}
+                        value={t("rewardDurationDays", { count: detail.item.durationDays })}
+                      />
+                    ) : null}
+                    <DetailRow label={t("fields.subscriptionID")} value={detail.item.subscriptionID || "-"} mono />
+                  </>
+                ) : (
+                  <>
+                    <DetailRow label={t("fields.credit")} value={formatTooltipUsageCost(detail.item.creditUSD, billingDisplay)} mono />
+                    <DetailRow
+                      label={t("fields.balanceBefore")}
+                      value={
+                        typeof detail.item.balanceBeforeNanousd === "number"
+                          ? formatUsageBalance(detail.item.balanceBeforeNanousd / 1_000_000_000, billingDisplay)
+                          : "-"
+                      }
+                      mono
+                    />
+                    <DetailRow
+                      label={t("fields.balanceAfterRedemption")}
+                      value={
+                        typeof detail.item.balanceAfterNanousd === "number"
+                          ? formatUsageBalance(detail.item.balanceAfterNanousd / 1_000_000_000, billingDisplay)
+                          : "-"
+                      }
+                      mono
+                    />
+                  </>
+                )}
               </DetailBlock>
             </>
           ) : null}

--- a/frontend/features/admin/components/sections/logs/admin-logs.tsx
+++ b/frontend/features/admin/components/sections/logs/admin-logs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Trash2 } from "lucide-react";
+import { useSearchParams } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import * as React from "react";
 
@@ -50,6 +51,7 @@ import { AdminDateRangeFilter } from "@/features/admin/components/admin-date-ran
 import { AdminDateTimePicker } from "@/features/admin/components/admin-date-time-picker";
 import { LogDetailSheet } from "@/features/admin/components/sections/logs/admin-log-detail-sheet";
 import { ModerationEventTable } from "@/features/admin/components/sections/logs/admin-moderation-events";
+import { RedemptionRecordTable } from "@/features/admin/components/sections/logs/admin-redemption-records";
 import {
   UsageLogCostCell,
   UsageLogModelCell,
@@ -939,10 +941,22 @@ function LogCleanupDialog({
   );
 }
 
+const LOG_TAB_VALUES = new Set(["audit", "usage", "auth", "orders", "redemptions", "conversation"]);
+
 export function AdminLogsPage() {
   const t = useTranslations("adminLogs");
   const { user } = useAuthSession();
   const isSuperAdmin = user?.role === "superadmin";
+  const searchParams = useSearchParams();
+  // 支持从其他管理页深链跳转（如兑换码管理的“查看兑换记录”）预选 tab 与兑换码筛选。
+  const [initialTab] = React.useState(() => {
+    const tabParam = searchParams.get("tab") ?? "";
+    return LOG_TAB_VALUES.has(tabParam) ? tabParam : "audit";
+  });
+  const [initialRedemptionCodeID] = React.useState(() => {
+    const parsed = Number.parseInt(searchParams.get("code_id") ?? "", 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  });
   const { detail, setDetail, conversationDetailLoading, openConversationDetail, closeDetail } = useAdminLogDetail();
   const [cleanupOpen, setCleanupOpen] = React.useState(false);
   const billingDisplay = useAdminBillingDisplayOptions();
@@ -980,12 +994,13 @@ export function AdminLogsPage() {
         </Button>
       </div>
 
-      <Tabs defaultValue="audit" className="space-y-3">
+      <Tabs defaultValue={initialTab} className="space-y-3">
         <TabsList variant="line">
           <TabsTrigger value="audit">{t("tabs.audit")}</TabsTrigger>
           <TabsTrigger value="usage">{t("tabs.usage")}</TabsTrigger>
           <TabsTrigger value="auth">{t("tabs.auth")}</TabsTrigger>
           <TabsTrigger value="orders">{t("tabs.orders")}</TabsTrigger>
+          <TabsTrigger value="redemptions">{t("tabs.redemptions")}</TabsTrigger>
           <TabsTrigger value="conversation">{t("tabs.conversation")}</TabsTrigger>
           {isSuperAdmin ? <TabsTrigger value="moderation">{t("tabs.moderation")}</TabsTrigger> : null}
         </TabsList>
@@ -1004,6 +1019,13 @@ export function AdminLogsPage() {
         </TabsContent>
         <TabsContent value="orders">
           <PaymentOrderTable key={cleanupRevisions.orders} onOpenDetail={(item) => setDetail({ kind: "order", item })} />
+        </TabsContent>
+        <TabsContent value="redemptions">
+          <RedemptionRecordTable
+            billingDisplay={billingDisplay}
+            initialCodeID={initialRedemptionCodeID}
+            onOpenDetail={(item) => setDetail({ kind: "redemption", item })}
+          />
         </TabsContent>
         <TabsContent value="conversation">
           <ConversationEventTable key={cleanupRevisions.conversation} onOpenDetail={(item) => void openConversationDetail(item)} />

--- a/frontend/features/admin/components/sections/logs/admin-redemption-records.tsx
+++ b/frontend/features/admin/components/sections/logs/admin-redemption-records.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { X } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableEmptyRow,
+  TableHead,
+  TableHeader,
+  TableLoadingRow,
+  TableRow,
+} from "@/components/ui/table";
+import { TablePagination, TableToolbar } from "@/components/ui/table-tools";
+import { useVirtualTableRows, VirtualTablePaddingRow } from "@/components/ui/virtual-table";
+import type { AdminRedemptionRecordDTO } from "@/features/admin/api/admin.types";
+import { AdminDateRangeFilter } from "@/features/admin/components/admin-date-range-filter";
+import {
+  REDEMPTION_SORT_OPTIONS,
+  type RedemptionSortValue,
+  useAdminRedemptions,
+} from "@/features/admin/hooks/use-admin-logs";
+import { formatDateTime, resolveUserDisplayName } from "@/features/admin/model/log-display";
+import { formatTooltipUsageCost, formatUsageBalance } from "@/features/admin/model/usage-log-billing";
+import type { BillingDisplayOptions } from "@/shared/lib/billing-display";
+
+// nanousd 转 USD，供余额展示复用现有格式化函数。
+function nanousdToUSD(value: number | null | undefined): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  return value / 1_000_000_000;
+}
+
+export function RedemptionRecordTable({
+  billingDisplay,
+  initialCodeID,
+  onOpenDetail,
+}: {
+  billingDisplay: BillingDisplayOptions;
+  initialCodeID?: number;
+  onOpenDetail: (item: AdminRedemptionRecordDTO) => void;
+}) {
+  const locale = useLocale();
+  const t = useTranslations("adminLogs");
+  const logs = useAdminRedemptions(initialCodeID);
+  const virtualRows = useVirtualTableRows(logs.records, {
+    enabled: logs.records.length > 100,
+    estimateSize: 40,
+  });
+  const rewardLabel = React.useCallback(
+    (item: AdminRedemptionRecordDTO) => {
+      if (item.rewardType === "subscription") {
+        const planName = item.planName.trim() || t("redemptions.rewards.subscription");
+        return item.durationDays > 0
+          ? `${planName} · ${t("redemptions.rewards.durationDays", { count: item.durationDays })}`
+          : planName;
+      }
+      return `${t("redemptions.rewards.balance")} +${formatTooltipUsageCost(item.creditUSD, billingDisplay)}`;
+    },
+    [billingDisplay, t],
+  );
+
+  return (
+    <div className="space-y-3">
+      <TableToolbar
+        query={logs.query}
+        onQueryChange={logs.setQuery}
+        queryPlaceholder={t("redemptions.searchPlaceholder")}
+        filters={[
+          {
+            key: "reward_type",
+            label: t("redemptions.filters.rewardType"),
+            value: logs.rewardTypeFilter,
+            onValueChange: logs.setRewardTypeFilter,
+            options: [
+              { label: t("redemptions.filters.all"), value: "" },
+              { label: t("redemptions.rewards.balance"), value: "balance" },
+              { label: t("redemptions.rewards.subscription"), value: "subscription" },
+            ],
+          },
+          ...(logs.codeIDFilter > 0
+            ? [
+                {
+                  key: "code",
+                  label: t("redemptions.filters.code"),
+                  active: true,
+                  content: (
+                    <div className="flex items-center gap-2 px-2 py-1.5 text-xs">
+                      <span className="font-mono text-muted-foreground">#{logs.codeIDFilter}</span>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        className="h-6 w-6 text-muted-foreground shadow-none"
+                        onClick={() => logs.setCodeIDFilter(0)}
+                        aria-label={t("redemptions.filters.clearCode")}
+                      >
+                        <X className="size-3.5 stroke-1" />
+                      </Button>
+                    </div>
+                  ),
+                },
+              ]
+            : []),
+          {
+            key: "created_range",
+            label: t("filters.timeRange"),
+            active: Boolean(logs.createdFromFilter || logs.createdToFilter),
+            content: (
+              <AdminDateRangeFilter
+                fromValue={logs.createdFromFilter}
+                toValue={logs.createdToFilter}
+                onFromChange={logs.setCreatedFromFilter}
+                onToChange={logs.setCreatedToFilter}
+                disabled={logs.loading}
+              />
+            ),
+          },
+        ]}
+        sort={{
+          value: logs.sortValue,
+          onValueChange: (value) => logs.setSortValue(value as RedemptionSortValue),
+          options: REDEMPTION_SORT_OPTIONS.map((item) => ({ label: t(item.labelKey), value: item.value })),
+        }}
+        loading={logs.loading}
+        onRefresh={() => void logs.loadRedemptions(logs.page, logs.pageSize)}
+      />
+
+      <Table
+        viewportRef={virtualRows.viewportRef}
+        viewportClassName={virtualRows.viewportClassName}
+        viewportStyle={virtualRows.viewportStyle}
+      >
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead className="w-[72px]">ID</TableHead>
+            <TableHead>{t("columns.user")}</TableHead>
+            <TableHead>{t("columns.code")}</TableHead>
+            <TableHead>{t("columns.reward")}</TableHead>
+            <TableHead>{t("columns.balanceAfterRedemption")}</TableHead>
+            <TableHead>{t("columns.time")}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {logs.loading && logs.records.length === 0 ? <TableLoadingRow colSpan={6} /> : null}
+          {logs.records.length > 0 ? <VirtualTablePaddingRow colSpan={6} height={virtualRows.paddingTop} /> : null}
+          {logs.records.length > 0 ? virtualRows.rows.map(({ item }) => {
+            const balanceAfterUSD = nanousdToUSD(item.balanceAfterNanousd);
+            return (
+              <TableRow key={item.id} className="cursor-pointer" onClick={() => onOpenDetail(item)}>
+                <TableCell className="font-mono text-xs text-foreground">{item.id}</TableCell>
+                <TableCell className="whitespace-nowrap text-muted-foreground">
+                  {resolveUserDisplayName(item.userLabel, item.username, item.userID)}
+                </TableCell>
+                <TableCell className="font-mono text-xs text-muted-foreground">
+                  <div
+                    className="max-w-[13rem] truncate"
+                    title={item.codeDescription ? `${item.codeHint} · ${item.codeDescription}` : item.codeHint || "-"}
+                  >
+                    {item.codeHint || "-"}
+                  </div>
+                </TableCell>
+                <TableCell className="whitespace-nowrap">
+                  {rewardLabel(item)}
+                </TableCell>
+                <TableCell className="whitespace-nowrap font-medium tabular-nums text-foreground">
+                  {balanceAfterUSD === null ? "-" : formatUsageBalance(balanceAfterUSD, billingDisplay)}
+                </TableCell>
+                <TableCell className="whitespace-nowrap text-muted-foreground">{formatDateTime(item.createdAt, locale)}</TableCell>
+              </TableRow>
+            );
+          }) : null}
+          {logs.records.length > 0 ? <VirtualTablePaddingRow colSpan={6} height={virtualRows.paddingBottom} /> : null}
+          {!logs.loading && logs.records.length === 0 ? <TableEmptyRow colSpan={6}>{t("redemptions.empty")}</TableEmptyRow> : null}
+        </TableBody>
+      </Table>
+
+      <TablePagination
+        loading={logs.loading}
+        page={logs.page}
+        pageCount={logs.pageCount}
+        pageSize={logs.pageSize}
+        total={logs.total}
+        onPageChange={(nextPage) => void logs.loadRedemptions(nextPage, logs.pageSize)}
+        onPageSizeChange={(nextPageSize) => void logs.loadRedemptions(1, nextPageSize)}
+      />
+    </div>
+  );
+}

--- a/frontend/features/admin/hooks/use-admin-logs-actions.ts
+++ b/frontend/features/admin/hooks/use-admin-logs-actions.ts
@@ -8,6 +8,7 @@ import type {
   AdminAuditLogDTO,
   AdminConversationEventDTO,
   AdminPaymentOrderDTO,
+  AdminRedemptionRecordDTO,
   AdminSystemEventDTO,
   AdminUsageLogDTO,
   AdminUserAuthEventDTO,
@@ -35,6 +36,7 @@ export type LogDetail =
   | { kind: "usage"; item: AdminUsageLogDTO }
   | { kind: "system"; item: AdminSystemEventDTO }
   | { kind: "order"; item: AdminPaymentOrderDTO }
+  | { kind: "redemption"; item: AdminRedemptionRecordDTO }
   | { kind: "conversation"; item: AdminConversationEventDTO };
 
 // cleanupDateToISOString 将日期输入转换为清理截止时间（当天 00:00 的 ISO 串），非法日期返回 null。

--- a/frontend/features/admin/hooks/use-admin-logs.ts
+++ b/frontend/features/admin/hooks/use-admin-logs.ts
@@ -7,6 +7,7 @@ import {
   listAdminAuditLogs,
   listAdminConversationEvents,
   listAdminPaymentOrders,
+  listAdminRedemptions,
   listAdminSystemEvents,
   listAdminUsageLogs,
   listAdminUserAuthEvents,
@@ -17,6 +18,7 @@ import type {
   AdminAuditLogDTO,
   AdminConversationEventDTO,
   AdminPaymentOrderDTO,
+  AdminRedemptionRecordDTO,
   AdminSystemEventDTO,
   AdminUsageLogDTO,
   AdminUserAuthEventDTO,
@@ -63,6 +65,11 @@ export const PAYMENT_ORDER_SORT_OPTIONS = [
   { labelKey: "sort.amountDesc", value: "amount_desc" },
 ] as const;
 
+export const REDEMPTION_SORT_OPTIONS = [
+  { labelKey: "sort.createdDesc", value: "created_desc" },
+  { labelKey: "sort.createdAsc", value: "created_asc" },
+] as const;
+
 export const CONVERSATION_EVENT_SORT_OPTIONS = [
   { labelKey: "sort.createdDesc", value: "created_desc" },
   { labelKey: "sort.createdAsc", value: "created_asc" },
@@ -75,6 +82,7 @@ export type SecurityLogSortValue = (typeof SECURITY_LOG_SORT_OPTIONS)[number]["v
 export type SystemEventSortValue = (typeof SYSTEM_EVENT_SORT_OPTIONS)[number]["value"];
 export type UsageLogSortValue = (typeof USAGE_LOG_SORT_OPTIONS)[number]["value"];
 export type PaymentOrderSortValue = (typeof PAYMENT_ORDER_SORT_OPTIONS)[number]["value"];
+export type RedemptionSortValue = (typeof REDEMPTION_SORT_OPTIONS)[number]["value"];
 export type ConversationEventSortValue = (typeof CONVERSATION_EVENT_SORT_OPTIONS)[number]["value"];
 
 const AUDIT_RESOURCE_VALUES = [
@@ -291,6 +299,28 @@ type UseAdminPaymentOrdersState = {
   sortValue: PaymentOrderSortValue;
   setSortValue: (value: PaymentOrderSortValue) => void;
   loadPaymentOrders: (page?: number, pageSize?: number) => Promise<void>;
+};
+
+type UseAdminRedemptionsState = {
+  records: AdminRedemptionRecordDTO[];
+  total: number;
+  page: number;
+  pageSize: number;
+  pageCount: number;
+  loading: boolean;
+  query: string;
+  setQuery: (value: string) => void;
+  rewardTypeFilter: string;
+  setRewardTypeFilter: (value: string) => void;
+  codeIDFilter: number;
+  setCodeIDFilter: (value: number) => void;
+  createdFromFilter: string;
+  setCreatedFromFilter: (value: string) => void;
+  createdToFilter: string;
+  setCreatedToFilter: (value: string) => void;
+  sortValue: RedemptionSortValue;
+  setSortValue: (value: RedemptionSortValue) => void;
+  loadRedemptions: (page?: number, pageSize?: number) => Promise<void>;
 };
 
 type UseAdminConversationEventsState = {
@@ -1015,6 +1045,116 @@ export function useAdminPaymentOrders(): UseAdminPaymentOrdersState {
     sortValue,
     setSortValue,
     loadPaymentOrders,
+  };
+}
+
+export function useAdminRedemptions(initialCodeID?: number): UseAdminRedemptionsState {
+  const t = useTranslations("adminLogs");
+  const [records, setRecords] = React.useState<AdminRedemptionRecordDTO[]>([]);
+  const [total, setTotal] = React.useState(0);
+  const [page, setPage] = React.useState(1);
+  const [pageSize, setPageSize] = React.useState(ADMIN_LOGS_PAGE_SIZE);
+  const [loading, setLoading] = React.useState(true);
+  const [query, setQueryState] = React.useState("");
+  const [debouncedQuery, setDebouncedQuery] = React.useState("");
+  const [rewardTypeFilter, setRewardTypeFilterState] = React.useState("");
+  const [codeIDFilter, setCodeIDFilterState] = React.useState(
+    initialCodeID && initialCodeID > 0 ? initialCodeID : 0,
+  );
+  const [createdFromFilter, setCreatedFromFilterState] = React.useState("");
+  const [createdToFilter, setCreatedToFilterState] = React.useState("");
+  const [sortValue, setSortValueState] = React.useState<RedemptionSortValue>("created_desc");
+  const requestSeqRef = React.useRef(0);
+
+  React.useEffect(() => {
+    const timer = window.setTimeout(() => setDebouncedQuery(query.trim()), 250);
+    return () => window.clearTimeout(timer);
+  }, [query]);
+
+  const loadRedemptions = React.useCallback(async (nextPage = 1, nextPageSize = pageSize) => {
+    const requestSeq = requestSeqRef.current + 1;
+    requestSeqRef.current = requestSeq;
+    setLoading(true);
+    try {
+      const token = await resolveAccessToken();
+      if (!token) {
+        toast.error(t("toast.sessionExpired"), { description: t("toast.signInAgain") });
+        return;
+      }
+      const data = await listAdminRedemptions(token, {
+        page: nextPage,
+        pageSize: nextPageSize,
+        query: /^\d+$/.test(debouncedQuery) ? undefined : debouncedQuery,
+        userID: parsePositiveInt(debouncedQuery),
+        codeID: codeIDFilter > 0 ? codeIDFilter : undefined,
+        rewardType: rewardTypeFilter,
+        createdFrom: toRFC3339DateRangeBound(createdFromFilter, "start"),
+        createdTo: toRFC3339DateRangeBound(createdToFilter, "end"),
+        sort: sortValue,
+      });
+      if (requestSeq !== requestSeqRef.current) return;
+      setRecords(data.results);
+      setTotal(data.total);
+      setPage(nextPage);
+      setPageSize(nextPageSize);
+    } catch (error) {
+      toast.error(t("toast.redemptionsLoadFailed"), { description: resolveAdminErrorMessage(error) });
+    } finally {
+      if (requestSeq === requestSeqRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [codeIDFilter, createdFromFilter, createdToFilter, debouncedQuery, pageSize, rewardTypeFilter, sortValue, t]);
+
+  React.useEffect(() => {
+    void loadRedemptions(1);
+  }, [loadRedemptions]);
+
+  const setQuery = React.useCallback((value: string) => {
+    setQueryState(value);
+    setPage(1);
+  }, []);
+  const setRewardTypeFilter = React.useCallback((value: string) => {
+    setRewardTypeFilterState(value);
+    setPage(1);
+  }, []);
+  const setCodeIDFilter = React.useCallback((value: number) => {
+    setCodeIDFilterState(value > 0 ? value : 0);
+    setPage(1);
+  }, []);
+  const setCreatedFromFilter = React.useCallback((value: string) => {
+    setCreatedFromFilterState(value);
+    setPage(1);
+  }, []);
+  const setCreatedToFilter = React.useCallback((value: string) => {
+    setCreatedToFilterState(value);
+    setPage(1);
+  }, []);
+  const setSortValue = React.useCallback((value: RedemptionSortValue) => {
+    setSortValueState(value);
+    setPage(1);
+  }, []);
+
+  return {
+    records,
+    total,
+    page,
+    pageSize,
+    pageCount: Math.max(1, Math.ceil(total / pageSize)),
+    loading,
+    query,
+    setQuery,
+    rewardTypeFilter,
+    setRewardTypeFilter,
+    codeIDFilter,
+    setCodeIDFilter,
+    createdFromFilter,
+    setCreatedFromFilter,
+    createdToFilter,
+    setCreatedToFilter,
+    sortValue,
+    setSortValue,
+    loadRedemptions,
   };
 }
 

--- a/frontend/i18n/messages/en-US/admin-billing.json
+++ b/frontend/i18n/messages/en-US/admin-billing.json
@@ -84,6 +84,7 @@
     "title": "Redemption codes",
     "create": "Create",
     "edit": "Edit",
+    "viewRecords": "View redemptions",
     "enable": "Enable",
     "disable": "Disable",
     "copySelected": "Copy",

--- a/frontend/i18n/messages/en-US/admin-logs.json
+++ b/frontend/i18n/messages/en-US/admin-logs.json
@@ -9,6 +9,7 @@
     "usage": "Model calls",
     "auth": "Auth security",
     "orders": "Order records",
+    "redemptions": "Redemptions",
     "conversation": "Conversation events",
     "moderation": "Moderation events",
     "system": "System events"
@@ -56,6 +57,7 @@
     "systemLoadFailed": "Failed to load system events",
     "usageLoadFailed": "Failed to load usage logs",
     "ordersLoadFailed": "Failed to load order records",
+    "redemptionsLoadFailed": "Failed to load redemption records",
     "conversationEventsLoadFailed": "Failed to load conversation events",
     "conversationEventDetailLoadFailed": "Failed to load conversation event details",
     "modelFilterLoadFailed": "Failed to load model filters"
@@ -117,7 +119,10 @@
     "amount": "Amount",
     "scope": "Scope",
     "tool": "Tool",
-    "runID": "Run ID"
+    "runID": "Run ID",
+    "code": "Code",
+    "reward": "Redeemed content",
+    "balanceAfterRedemption": "Balance after"
   },
   "audit": {
     "searchPlaceholder": "Search user ID, action, resource, request ID, IP, or detail",
@@ -266,6 +271,21 @@
       "failed": "Failed"
     }
   },
+  "redemptions": {
+    "searchPlaceholder": "Search user ID, redemption ref no., code hint, or note",
+    "empty": "No redemption records",
+    "filters": {
+      "all": "All",
+      "rewardType": "Reward type",
+      "code": "Code",
+      "clearCode": "Clear code filter"
+    },
+    "rewards": {
+      "balance": "Balance",
+      "subscription": "Subscription plan",
+      "durationDays": "{count} days"
+    }
+  },
   "conversation": {
     "searchPlaceholder": "Search user ID, run ID, event, stage, title, or tool name",
     "empty": "No conversation events",
@@ -304,6 +324,7 @@
       "auth": "Auth log detail",
       "usage": "Usage log detail",
       "order": "Order record detail",
+      "redemption": "Redemption record detail",
       "conversation": "Conversation event detail",
       "system": "System event detail"
     },
@@ -311,6 +332,7 @@
       "authEvent": "Auth event",
       "modelCall": "Model call",
       "order": "Order record",
+      "redemption": "Redemption record",
       "conversationEvent": "Conversation event",
       "systemEvent": "System event",
       "auditEvent": "Audit event"
@@ -326,8 +348,20 @@
       "usageBilling": "Usage billing",
       "order": "Order",
       "payment": "Payment",
+      "redemption": "Redemption",
+      "redemptionCode": "Redemption code",
+      "reward": "Reward",
       "conversationEvent": "Conversation event",
       "tool": "Tool"
+    },
+    "codeStatus": {
+      "active": "Active",
+      "inactive": "Inactive",
+      "deleted": "Deleted"
+    },
+    "rewardTypes": {
+      "balance": "Balance",
+      "subscription": "Subscription plan"
     },
     "fields": {
       "action": "Action",
@@ -372,6 +406,18 @@
       "eventScope": "Event scope",
       "stage": "Stage",
       "seq": "Seq",
+      "refNo": "Redemption ref no.",
+      "redeemedAt": "Redeemed at",
+      "codeHint": "Code",
+      "codeID": "Code ID",
+      "codeDescription": "Code note",
+      "codeStatus": "Code status",
+      "rewardType": "Reward type",
+      "planName": "Subscription plan",
+      "subscriptionID": "Subscription ID",
+      "balanceBefore": "Balance before redemption",
+      "balanceAfterRedemption": "Balance after redemption",
+      "durationDays": "Plan duration",
       "messageID": "Message ID",
       "toolName": "Tool name",
       "toolCallID": "Tool call ID",
@@ -384,6 +430,7 @@
       "failure": "Failed",
       "blocked": "Blocked"
     },
+    "rewardDurationDays": "{count} days",
     "rawUsageJsonTitle": "Raw Usage JSON",
     "jsonTitle": "Detail JSON",
     "loading": "Loading details",

--- a/frontend/i18n/messages/zh-CN/admin-billing.json
+++ b/frontend/i18n/messages/zh-CN/admin-billing.json
@@ -84,6 +84,7 @@
     "title": "兑换码",
     "create": "创建",
     "edit": "编辑",
+    "viewRecords": "查看兑换记录",
     "enable": "启用",
     "disable": "停用",
     "copySelected": "复制",

--- a/frontend/i18n/messages/zh-CN/admin-logs.json
+++ b/frontend/i18n/messages/zh-CN/admin-logs.json
@@ -9,6 +9,7 @@
     "usage": "模型调用",
     "auth": "认证安全",
     "orders": "订单记录",
+    "redemptions": "兑换记录",
     "conversation": "对话事件",
     "moderation": "审核事件",
     "system": "系统事件"
@@ -56,6 +57,7 @@
     "systemLoadFailed": "系统事件加载失败",
     "usageLoadFailed": "调用日志加载失败",
     "ordersLoadFailed": "订单记录加载失败",
+    "redemptionsLoadFailed": "兑换记录加载失败",
     "conversationEventsLoadFailed": "对话事件加载失败",
     "conversationEventDetailLoadFailed": "对话事件详情加载失败",
     "modelFilterLoadFailed": "模型筛选加载失败"
@@ -117,7 +119,10 @@
     "amount": "金额",
     "scope": "范围",
     "tool": "工具",
-    "runID": "运行 ID"
+    "runID": "运行 ID",
+    "code": "兑换码",
+    "reward": "兑换内容",
+    "balanceAfterRedemption": "兑换后余额"
   },
   "audit": {
     "searchPlaceholder": "搜索用户 ID、动作、资源、请求 ID、IP、详情",
@@ -266,6 +271,21 @@
       "failed": "支付失败"
     }
   },
+  "redemptions": {
+    "searchPlaceholder": "搜索用户 ID、兑换流水号、兑换码摘要、备注",
+    "empty": "暂无兑换记录",
+    "filters": {
+      "all": "全部",
+      "rewardType": "奖励类型",
+      "code": "兑换码",
+      "clearCode": "清除兑换码筛选"
+    },
+    "rewards": {
+      "balance": "余额",
+      "subscription": "订阅套餐",
+      "durationDays": "{count} 天"
+    }
+  },
   "conversation": {
     "searchPlaceholder": "搜索用户 ID、运行 ID、事件、阶段、标题、工具名",
     "empty": "暂无对话事件",
@@ -304,6 +324,7 @@
       "auth": "认证日志详情",
       "usage": "调用日志详情",
       "order": "订单记录详情",
+      "redemption": "兑换记录详情",
       "conversation": "对话事件详情",
       "system": "系统事件详情"
     },
@@ -311,6 +332,7 @@
       "authEvent": "认证事件",
       "modelCall": "模型调用",
       "order": "订单记录",
+      "redemption": "兑换记录",
       "conversationEvent": "对话事件",
       "systemEvent": "系统事件",
       "auditEvent": "审计事件"
@@ -326,8 +348,20 @@
       "usageBilling": "用量计费",
       "order": "订单",
       "payment": "支付",
+      "redemption": "兑换",
+      "redemptionCode": "兑换码",
+      "reward": "奖励",
       "conversationEvent": "对话事件",
       "tool": "工具"
+    },
+    "codeStatus": {
+      "active": "启用",
+      "inactive": "停用",
+      "deleted": "已删除"
+    },
+    "rewardTypes": {
+      "balance": "余额",
+      "subscription": "订阅套餐"
     },
     "fields": {
       "action": "动作",
@@ -372,6 +406,18 @@
       "eventScope": "事件范围",
       "stage": "阶段",
       "seq": "序号",
+      "refNo": "兑换流水号",
+      "redeemedAt": "兑换时间",
+      "codeHint": "兑换码",
+      "codeID": "兑换码 ID",
+      "codeDescription": "兑换码备注",
+      "codeStatus": "兑换码状态",
+      "rewardType": "奖励类型",
+      "planName": "订阅套餐",
+      "subscriptionID": "订阅 ID",
+      "balanceBefore": "兑换前余额",
+      "balanceAfterRedemption": "兑换后余额",
+      "durationDays": "套餐时长",
       "messageID": "消息 ID",
       "toolName": "工具名",
       "toolCallID": "工具调用 ID",
@@ -384,6 +430,7 @@
       "failure": "失败",
       "blocked": "阻断"
     },
+    "rewardDurationDays": "{count} 天",
     "rawUsageJsonTitle": "原始 Usage JSON",
     "jsonTitle": "详情 JSON",
     "loading": "正在加载详情",

--- a/packages/api-contract/src/types.generated.ts
+++ b/packages/api-contract/src/types.generated.ts
@@ -2916,6 +2916,40 @@ export interface RedemptionCodeResponseDoc {
   errorMsg: string;
 }
 
+export interface RedemptionRecordListResponseDoc {
+  data: {
+    results: RedemptionRecordResponse[];
+    total: number;
+  };
+  errorMsg: string;
+}
+
+export interface RedemptionRecordResponse {
+  balanceAfterNanousd: number | null;
+  /** BalanceBeforeNanousd / BalanceAfterNanousd 来自余额流水；订阅类兑换无流水时为 null。 */
+  balanceBeforeNanousd: number | null;
+  codeDescription: string;
+  codeHint: string;
+  codeID: number;
+  codeStatus: string;
+  createdAt: string;
+  creditNanousd: number;
+  creditUSD: number;
+  durationDays: number;
+  id: number;
+  mode: string;
+  planID: number;
+  planName: string;
+  refNo: string;
+  rewardType: string;
+  snapshotJSON: string;
+  subscriptionID: number;
+  userDisplayName: string;
+  userID: number;
+  userLabel: string;
+  username: string;
+}
+
 export interface RedemptionResponse {
   balanceTransactionID: number;
   codeID: number;
@@ -6693,6 +6727,41 @@ export namespace Admin {
     export type RequestBody = PatchPromptPresetRequest;
     export type RequestHeaders = {};
     export type ResponseBody = PromptPresetResponseDoc;
+  }
+
+  /**
+   * @description 管理员分页查看兑换码兑换明细，含奖励内容与余额变动，已删除兑换码的历史仍可查询
+   * @tags admin
+   * @name RedemptionsList
+   * @summary 管理员查询兑换记录
+   * @request GET:/admin/redemptions
+   * @secure
+   */
+  export namespace RedemptionsList {
+    export type RequestParams = {};
+    export type RequestQuery = {
+      /** 兑换码ID */
+      code_id?: number;
+      /** 兑换时间起点(RFC3339) */
+      created_from?: string;
+      /** 兑换时间终点(RFC3339) */
+      created_to?: string;
+      /** 页码 */
+      page?: number;
+      /** 每页数量 */
+      page_size?: number;
+      /** 搜索兑换流水号、兑换码摘要、兑换码备注 */
+      query?: string;
+      /** 奖励类型(balance/subscription) */
+      reward_type?: string;
+      /** 排序方式 */
+      sort?: string;
+      /** 用户ID */
+      user_id?: number;
+    };
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = RedemptionRecordListResponseDoc;
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #667.

The admin console only showed how many times each redemption code was used, with no per-redemption detail. This adds a full redemption record trail:

- New admin endpoint `GET /admin/redemptions` returning paginated redemption records joined with code context (hint, note, status), plan name, and balance transaction context (balance before/after). Records for soft-deleted codes remain queryable. Filters: keyword (ref no. / code hint / note), user ID, code ID, reward type, time range, sort by redemption time.
- New "Redemptions" tab in the admin log center, following the existing payment-orders table pattern (search, filters, pagination, detail sheet). Deep link `?tab=redemptions&code_id=` preselects the tab and code filter.
- Detail sheet shows redemption / user / code / reward blocks; balance rewards show credited amount and balance before/after, subscription rewards show plan name and duration (parsed from the redemption snapshot, so history reflects the entitlement at redemption time).
- Redemption code management rows get a history action that opens an in-place dialog listing that code's redemptions.
- Fixed a pre-existing pagination bug in `ListRedemptionCodes` where the offset returned by `normalizePage` was multiplied by page size again, skipping records from page 2 onward.
- Added `RedemptionRecordView` in the billing application layer so the transport layer does not depend on repository contracts (enforced by the layering test).

## Change type

- [x] Feature

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [x] Billing / payments
- [x] Admin console

## Verification

- `go build ./...` and `go test ./...` (backend, all green, including a new SQLite repository test covering joins, deleted-code history, keyword+filter combination, reward type, time range, and sorting)
- `pnpm lint` and `pnpm typecheck` (frontend)
- `pnpm api:generate` (Swagger and TypeScript contract regenerated and committed)
- Manual check of the logs tab, deep link, and the code-row dialog in both locales

## Screenshots, API examples, or logs

<!-- attach the redemption records tab + dialog screenshots -->

## Configuration, migration, and compatibility notes

- New admin-only endpoint `GET /admin/redemptions`; no database schema changes (reads existing tables via joins).
- `backend/docs/*` and `packages/api-contract/src/types.generated.ts` regenerated; `RedemptionRecordResponse` added to the API contract.

## Documentation

- [x] Documentation is not needed for this change.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.