### PR TITLE
fix: reconcile conversation run state with periodic snapshots to clear stuck sidebar spinners

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -9940,7 +9940,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Sends an authoritative snapshot followed by live user-scoped run state events",
+                "description": "Sends an authoritative snapshot followed by live user-scoped run state events; the snapshot is re-sent periodically for client-side reconciliation",
                 "produces": [
                     "text/event-stream"
                 ],

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -9933,7 +9933,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Sends an authoritative snapshot followed by live user-scoped run state events",
+                "description": "Sends an authoritative snapshot followed by live user-scoped run state events; the snapshot is re-sent periodically for client-side reconciliation",
                 "produces": [
                     "text/event-stream"
                 ],

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -15968,7 +15968,7 @@ paths:
   /conversation-runs/stream:
     get:
       description: Sends an authoritative snapshot followed by live user-scoped run
-        state events
+        state events; the snapshot is re-sent periodically for client-side reconciliation
       produces:
       - text/event-stream
       responses:

--- a/backend/internal/application/conversation/generation_active_stream.go
+++ b/backend/internal/application/conversation/generation_active_stream.go
@@ -52,6 +52,18 @@ func (s *Service) SubscribeActiveMessageGenerations(
 	return s.generationStreams.subscribeActive(ctx, userID)
 }
 
+// ListActiveMessageGenerations 返回用户当前活跃生成的权威快照。
+// 供长连接周期对账使用：增量事件丢失时客户端可据此自愈失效的运行状态。
+func (s *Service) ListActiveMessageGenerations(
+	ctx context.Context,
+	userID uint,
+) ([]ActiveMessageGeneration, error) {
+	if s == nil || s.generationStreams == nil || userID == 0 {
+		return []ActiveMessageGeneration{}, nil
+	}
+	return s.generationStreams.listActive(ctx, userID)
+}
+
 func (r *generationStreamRegistry) listActive(ctx context.Context, userID uint) ([]ActiveMessageGeneration, error) {
 	if r == nil || r.store == nil || userID == 0 {
 		return []ActiveMessageGeneration{}, nil

--- a/backend/internal/application/conversation/generation_stream_test.go
+++ b/backend/internal/application/conversation/generation_stream_test.go
@@ -355,6 +355,34 @@ func TestGenerationStreamRegistryActiveSubscriptionStartsWithSnapshotAndStreamsE
 	}
 }
 
+func TestServiceListActiveMessageGenerationsDelegatesToRegistry(t *testing.T) {
+	registry := newGenerationStreamRegistry(newTestGenerationStreamStore(), generationStreamOptions{
+		Retention:        time.Minute,
+		ActiveTTL:        time.Minute,
+		LeaseTTL:         time.Second,
+		LeaseRefresh:     100 * time.Millisecond,
+		MaxEvents:        8,
+		SubscriberBuffer: 4,
+	})
+	ctx := context.Background()
+	registry.register(ctx, "run_reconcile", 7, "conv_reconcile", func() {})
+	defer registry.finish(ctx, "run_reconcile")
+
+	svc := &Service{generationStreams: registry}
+	items, err := svc.ListActiveMessageGenerations(ctx, 7)
+	if err != nil || len(items) != 1 || items[0].RunID != "run_reconcile" || items[0].ConversationPublicID != "conv_reconcile" {
+		t.Fatalf("active snapshot = %+v err = %v, want registered run", items, err)
+	}
+	if items, err = svc.ListActiveMessageGenerations(ctx, 0); err != nil || len(items) != 0 {
+		t.Fatalf("zero user snapshot = %+v err = %v, want empty", items, err)
+	}
+
+	var nilService *Service
+	if items, err = nilService.ListActiveMessageGenerations(ctx, 7); err != nil || len(items) != 0 {
+		t.Fatalf("nil service snapshot = %+v err = %v, want empty", items, err)
+	}
+}
+
 func TestGenerationStreamStoreActiveLeaseExpires(t *testing.T) {
 	store := newTestGenerationStreamStore()
 	ctx := context.Background()

--- a/backend/internal/transport/http/conversation/handler_message_send.go
+++ b/backend/internal/transport/http/conversation/handler_message_send.go
@@ -662,7 +662,7 @@ func (h *Handler) CancelMessageGeneration(c *gin.Context) {
 
 // StreamActiveMessageGenerations godoc
 // @Summary Stream active conversation generations
-// @Description Sends an authoritative snapshot followed by live user-scoped run state events
+// @Description Sends an authoritative snapshot followed by live user-scoped run state events; the snapshot is re-sent periodically for client-side reconciliation
 // @Tags chat
 // @Produce text/event-stream
 // @Security BearerAuth
@@ -670,9 +670,10 @@ func (h *Handler) CancelMessageGeneration(c *gin.Context) {
 // @Failure 500 {object} ErrorDoc
 // @Router /conversation-runs/stream [get]
 func (h *Handler) StreamActiveMessageGenerations(c *gin.Context) {
+	userID := middleware.MustUserID(c)
 	snapshot, events, unsubscribe, err := h.service.SubscribeActiveMessageGenerations(
 		c.Request.Context(),
-		middleware.MustUserID(c),
+		userID,
 	)
 	if err != nil {
 		response.Error(c, http.StatusInternalServerError, "failed to subscribe to active conversation generations")
@@ -703,29 +704,41 @@ func (h *Handler) StreamActiveMessageGenerations(c *gin.Context) {
 		c.Writer.Flush()
 		return true
 	}
-
-	runs := make([]ActiveMessageGenerationResponse, 0, len(snapshot))
-	for _, item := range snapshot {
-		runs = append(runs, ActiveMessageGenerationResponse{
-			RunID:                item.RunID,
-			ConversationPublicID: item.ConversationPublicID,
-		})
+	writeSnapshot := func(items []appconversation.ActiveMessageGeneration) bool {
+		runs := make([]ActiveMessageGenerationResponse, 0, len(items))
+		for _, item := range items {
+			runs = append(runs, ActiveMessageGenerationResponse{
+				RunID:                item.RunID,
+				ConversationPublicID: item.ConversationPublicID,
+			})
+		}
+		return writeEvent(ActiveMessageGenerationEventResponse{Type: "snapshot", Runs: runs})
 	}
-	if !writeEvent(ActiveMessageGenerationEventResponse{Type: "snapshot", Runs: runs}) {
+
+	if !writeSnapshot(snapshot) {
 		return
 	}
 
-	keepalive := time.NewTicker(20 * time.Second)
-	defer keepalive.Stop()
+	// 周期重发权威快照兼作心跳：增量事件在断线间隙丢失时，客户端可在一个周期内对账清除失效运行。
+	snapshotTicker := time.NewTicker(20 * time.Second)
+	defer snapshotTicker.Stop()
 	for {
 		select {
 		case <-c.Request.Context().Done():
 			return
-		case <-keepalive.C:
-			if _, writeErr := c.Writer.Write([]byte(": keepalive\n\n")); writeErr != nil {
+		case <-snapshotTicker.C:
+			latest, listErr := h.service.ListActiveMessageGenerations(c.Request.Context(), userID)
+			if listErr != nil {
+				// 快照查询失败时退回注释帧，仅维持连接心跳。
+				if _, writeErr := c.Writer.Write([]byte(": keepalive\n\n")); writeErr != nil {
+					return
+				}
+				c.Writer.Flush()
+				continue
+			}
+			if !writeSnapshot(latest) {
 				return
 			}
-			c.Writer.Flush()
 		case event, ok := <-events:
 			if !ok {
 				return

--- a/frontend/features/chat/model/conversation-run-store.ts
+++ b/frontend/features/chat/model/conversation-run-store.ts
@@ -3,9 +3,15 @@ export type ConversationRunSnapshot = {
   conversationPublicID: string;
 };
 
+// local 记录连续缺席权威快照超过该时长后视为失效并移除。
+// 需大于「本地注册到服务端登记完成」的竞态窗口，小于用户可感知的卡死时长。
+const LOCAL_RUN_SNAPSHOT_MISS_TTL_MS = 15_000;
+
 type ConversationRunRecord = {
   conversationPublicID: string;
   status: "local" | "detached" | "server" | "settled";
+  // local 记录首次缺席权威快照的时间戳；再次命中快照后清除。
+  missingFromSnapshotSince?: number;
 };
 
 type Listener = () => void;
@@ -148,6 +154,7 @@ export class ConversationRunStore {
       }
     }
 
+    const now = Date.now();
     this.mutate(() => {
       for (const [runID, record] of this.records) {
         const serverOwner = snapshotRunOwners.get(runID);
@@ -169,7 +176,30 @@ export class ConversationRunStore {
           continue;
         }
         if (record.status === "detached" && serverOwner) {
-          this.records.set(runID, { ...record, status: "server" });
+          this.records.set(runID, {
+            conversationPublicID: record.conversationPublicID,
+            status: "server",
+          });
+          continue;
+        }
+        if (record.status === "local") {
+          if (serverOwner) {
+            if (record.missingFromSnapshotSince !== undefined) {
+              this.records.set(runID, {
+                conversationPublicID: record.conversationPublicID,
+                status: "local",
+              });
+            }
+            continue;
+          }
+          // 服务端从未登记该运行（提交失败、流挂死等）时，本地记录会持续缺席快照。
+          // 超时后移除，避免侧边栏加载指示永久卡住；竞态窗口内的缺席不受影响。
+          const missingSince = record.missingFromSnapshotSince ?? now;
+          if (now - missingSince >= LOCAL_RUN_SNAPSHOT_MISS_TTL_MS) {
+            this.records.delete(runID);
+          } else if (record.missingFromSnapshotSince === undefined) {
+            this.records.set(runID, { ...record, missingFromSnapshotSince: now });
+          }
         }
       }
 

--- a/packages/api-contract/src/types.generated.ts
+++ b/packages/api-contract/src/types.generated.ts
@@ -8015,7 +8015,7 @@ export namespace ConversationRuns {
   }
 
   /**
-   * @description Sends an authoritative snapshot followed by live user-scoped run state events
+   * @description Sends an authoritative snapshot followed by live user-scoped run state events; the snapshot is re-sent periodically for client-side reconciliation
    * @tags chat
    * @name StreamList
    * @summary Stream active conversation generations


### PR DESCRIPTION
## Summary

The sidebar conversation loading spinner occasionally kept spinning after a run
had already finished, and only a page refresh cleared it. Root cause: run state
relied entirely on incremental SSE events (`started` / `finished`), and the
authoritative snapshot was only sent once at connection time. Any lost terminal
event (network blip, tab backgrounding aborting the stream, submission failing
before the server registered the run, or a hung local stream) left a ghost
record in the frontend `ConversationRunStore` with no path to self-heal.

This change closes the loop with periodic reconciliation:

- Backend: `StreamActiveMessageGenerations` now re-sends the authoritative
  active-run snapshot on the existing 20s heartbeat tick instead of a bare
  keepalive comment frame, via a new `Service.ListActiveMessageGenerations`
  accessor. If the snapshot query fails, the handler falls back to the comment
  frame so the connection stays alive. No new connections or request cadence
  are introduced.
- Frontend: `ConversationRunStore.synchronize` now expires `local` records that
  stay absent from authoritative snapshots for over 15s
  (`missingFromSnapshotSince` timestamp, cleared on the next snapshot hit).
  A timestamp is used instead of a miss counter so reconnect bursts delivering
  several snapshots in quick succession cannot prematurely delete a run that is
  still inside the local-registration race window.

With this, every identified ghost-spinner scenario self-heals within one to two
snapshot cycles (~20–35s) without a refresh, while genuinely running
conversations are unaffected since they always appear in the snapshot.

## Change type

- [x] Bug fix

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [x] Conversations / streaming

## Verification

- `go test ./internal/application/conversation/ ./internal/transport/http/conversation/`
  (includes new `TestServiceListActiveMessageGenerationsDelegatesToRegistry`)
- `pnpm api:generate` (Swagger description updated for the stream endpoint)
- `pnpm lint` (biome) and `pnpm typecheck` (tsc) in `frontend/`

## Screenshots, API examples, or logs

SSE frame example — the 20s heartbeat now carries the authoritative snapshot:

    data: {"type":"snapshot","runs":[{"runID":"run_x","conversationPublicID":"conv_y"}]}

## Configuration, migration, and compatibility notes

No config, schema, or env changes. The SSE payload only re-uses the existing
`snapshot` event type that clients already handle on connect, so older clients
remain compatible. Generated Swagger docs and the API contract package were
regenerated for the endpoint description update.

## Documentation

- [x] Documentation is not needed for this change.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.