### PR TITLE
feat: add graceful shutdown draining with readiness flip and sse disconnect

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -69,6 +69,7 @@ import (
 	userrepo "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/postgres/user"
 	usersettingsrepo "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/persistence/postgres/usersettings"
 	platformruntime "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/runtime"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/shared/lifecycle"
 	platformhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http"
 	adminhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/admin"
 	announcementhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/announcement"
@@ -106,6 +107,8 @@ type App struct {
 	mediaArtifactClient    *mediaartifact.Client
 	moderationClient       *moderationclient.Client
 	backgroundCancel       context.CancelFunc
+	// shutdown 是进程关停排空信号：翻转就绪探针并断开订阅型长连接。
+	shutdown 				*lifecycle.Shutdown
 }
 
 type subscriptionGroupAdapter struct {
@@ -355,7 +358,8 @@ func NewApp() (*App, error) {
 	userService.SetAvatarFileValidator(conversationService)
 	authService.SetAvatarFileValidator(conversationService)
 	memoryService.SetCacheInvalidator(conversationService.InvalidateMemoryCache)
-	conversationHandler := conversationhttp.NewHandler(conversationService, runtimeCfg)
+	shutdownSignal := lifecycle.NewShutdown()
+	conversationHandler := conversationhttp.NewHandler(conversationService, runtimeCfg, shutdownSignal)
 	conversationModule := conversationhttp.NewModule(conversationHandler)
 	userHandler := userhttp.NewHandler(userService)
 	userModule := userhttp.NewModule(userHandler)
@@ -431,6 +435,7 @@ func NewApp() (*App, error) {
 		Settings:          settingsModule,
 		UserSettings:      userSettingsModule,
 		User:              userModule,
+		Shutdown:          shutdownSignal,
 		StartupLog: func(log *zap.Logger) {
 			if log == nil || bootstrapSuperAdmin == nil {
 				return
@@ -468,6 +473,7 @@ func NewApp() (*App, error) {
 		mediaArtifactClient:    mediaArtifactClient,
 		moderationClient:       moderationClient,
 		backgroundCancel:       backgroundCancel,
+		shutdown:               shutdownSignal,
 	}, nil
 }
 
@@ -502,14 +508,29 @@ func (a *App) Run() error {
 		a.logger.Info("server_shutting_down", zap.String("signal", sig.String()))
 	}
 
-	if a.backgroundCancel != nil {
-		a.backgroundCancel()
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// 阶段一：进入排空。就绪探针翻转为 503 引导负载均衡摘流，
+	// 订阅型 SSE（run 对账流、run 观看流）立即断开，客户端按既有逻辑重连。
+	a.shutdown.BeginDrain()
+
+	// 阶段二：排空 in-flight 请求。消息生成等有价值的流式请求在窗口内自然完成。
+	drainTimeout := httpTimeoutSeconds(a.cfg.HTTPShutdownTimeoutSeconds, 10)
+	ctx, cancel := context.WithTimeout(context.Background(), drainTimeout)
 	defer cancel()
 	if err := srv.Shutdown(ctx); err != nil {
-		a.logger.Error("server_shutdown_error", zap.Error(err))
-		return err
+		// 阶段三：排空超时，强断剩余连接。被打断的生成已有落盘与前端恢复兜底，
+		// 属预期内降级而非故障，进程仍以成功状态退出。
+		a.logger.Warn("server_drain_timeout_force_close",
+			zap.Duration("drain_timeout", drainTimeout),
+			zap.Error(err),
+		)
+		if closeErr := srv.Close(); closeErr != nil {
+			a.logger.Warn("server_force_close_error", zap.Error(closeErr))
+		}
+	}
+
+	// HTTP 排空完成后再停后台 worker；资源释放由 cli.Run 的 defer Close() 收尾。
+	if a.backgroundCancel != nil {
+		a.backgroundCancel()
 	}
 	a.logger.Info("server_stopped")
 	return nil

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -33,6 +33,9 @@ const (
 	defaultHTTPReadTimeoutSeconds       = 120
 	defaultHTTPIdleTimeoutSeconds       = 120
 	defaultHTTPMaxHeaderBytes           = 1 << 20
+	// defaultHTTPShutdownTimeoutSeconds 是优雅关停排空 in-flight 请求的默认窗口。
+	// 容器编排下应小于 terminationGracePeriodSeconds，为强断兜底与资源释放留余量。
+	defaultHTTPShutdownTimeoutSeconds = 10
 	// DefaultFileFullContextMaxBytes 是全文注入的默认提取文本大小上限（2 MiB）。
 	DefaultFileFullContextMaxBytes int64 = 2 * 1024 * 1024
 
@@ -237,6 +240,7 @@ type yamlConfig struct {
 		ReadTimeoutSeconds       int    `yaml:"read_timeout_seconds"`
 		IdleTimeoutSeconds       int    `yaml:"idle_timeout_seconds"`
 		MaxHeaderBytes           int    `yaml:"max_header_bytes"`
+		ShutdownTimeoutSeconds   int    `yaml:"shutdown_timeout_seconds"`
 	} `yaml:"server"`
 	Security struct {
 		JWTSecret              string `yaml:"jwt_secret"`
@@ -339,6 +343,7 @@ type Config struct {
 	HTTPReadTimeoutSeconds       int
 	HTTPIdleTimeoutSeconds       int
 	HTTPMaxHeaderBytes           int
+	HTTPShutdownTimeoutSeconds   int
 	JWTSecret                    string
 	DataEncryptionKey            string
 	SSRFProtectionEnabled        bool
@@ -578,6 +583,7 @@ func Load() Config {
 		HTTPReadTimeoutSeconds:       envOrInt("HTTP_READ_TIMEOUT_SECONDS", yc.Server.ReadTimeoutSeconds, defaultHTTPReadTimeoutSeconds),
 		HTTPIdleTimeoutSeconds:       envOrInt("HTTP_IDLE_TIMEOUT_SECONDS", yc.Server.IdleTimeoutSeconds, defaultHTTPIdleTimeoutSeconds),
 		HTTPMaxHeaderBytes:           envOrInt("HTTP_MAX_HEADER_BYTES", yc.Server.MaxHeaderBytes, defaultHTTPMaxHeaderBytes),
+		HTTPShutdownTimeoutSeconds:   envOrInt("HTTP_SHUTDOWN_TIMEOUT_SECONDS", yc.Server.ShutdownTimeoutSeconds, defaultHTTPShutdownTimeoutSeconds),
 		JWTSecret:                    envOr("JWT_SECRET", yc.Security.JWTSecret, defaultJWTSecret),
 		DataEncryptionKey:            envOr("DATA_ENCRYPTION_KEY", yc.Security.DataEncryptionKey, defaultDataEncryptionKey),
 		SSRFProtectionEnabled:        envOrBoolPtr("SSRF_PROTECTION_ENABLED", yc.Security.SSRFProtectionEnabled, false),

--- a/backend/internal/shared/lifecycle/lifecycle.go
+++ b/backend/internal/shared/lifecycle/lifecycle.go
@@ -1,0 +1,45 @@
+// Package lifecycle 提供进程级优雅关停的信号原语。
+package lifecycle
+
+import "sync"
+
+// Shutdown 是进程关停排空信号。
+// BeginDrain 触发后 Draining 返回 true 且 Done 通道关闭，供订阅型长连接与就绪探针感知排空。
+type Shutdown struct {
+	once sync.Once
+	done chan struct{}
+}
+
+// NewShutdown 创建未触发的关停信号。
+func NewShutdown() *Shutdown {
+	return &Shutdown{done: make(chan struct{})}
+}
+
+// BeginDrain 进入关停排空阶段，幂等且并发安全。
+func (s *Shutdown) BeginDrain() {
+	if s == nil {
+		return
+	}
+	s.once.Do(func() { close(s.done) })
+}
+
+// Draining 报告是否已进入关停排空阶段。
+func (s *Shutdown) Draining() bool {
+	if s == nil {
+		return false
+	}
+	select {
+	case <-s.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// Done 返回排空信号通道。nil 接收者返回 nil 通道，select 分支永不就绪。
+func (s *Shutdown) Done() <-chan struct{} {
+	if s == nil {
+		return nil
+	}
+	return s.done
+}

--- a/backend/internal/shared/lifecycle/lifecycle_test.go
+++ b/backend/internal/shared/lifecycle/lifecycle_test.go
@@ -1,0 +1,39 @@
+package lifecycle
+
+import "testing"
+
+func TestShutdownDrainLifecycle(t *testing.T) {
+	s := NewShutdown()
+	if s.Draining() {
+		t.Fatal("new shutdown must not be draining")
+	}
+	select {
+	case <-s.Done():
+		t.Fatal("done channel must block before BeginDrain")
+	default:
+	}
+
+	s.BeginDrain()
+	s.BeginDrain() // 幂等：重复触发不应 panic。
+	if !s.Draining() {
+		t.Fatal("expected draining after BeginDrain")
+	}
+	select {
+	case <-s.Done():
+	default:
+		t.Fatal("done channel must be closed after BeginDrain")
+	}
+}
+
+func TestShutdownNilReceiverIsSafe(t *testing.T) {
+	var s *Shutdown
+	s.BeginDrain()
+	if s.Draining() {
+		t.Fatal("nil shutdown must not report draining")
+	}
+	select {
+	case <-s.Done():
+		t.Fatal("nil shutdown done channel must never be ready")
+	default:
+	}
+}

--- a/backend/internal/transport/http/conversation/handler.go
+++ b/backend/internal/transport/http/conversation/handler.go
@@ -10,6 +10,7 @@ import (
 	appconversation "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/application/conversation"
 	model "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/domain/conversation"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/shared/lifecycle"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/shared/response"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/middleware"
 	"github.com/gin-gonic/gin"
@@ -17,8 +18,11 @@ import (
 
 // Handler 封装会话 HTTP 处理。
 type Handler struct {
-	service *appconversation.Service
-	cfg     *config.Runtime
+	service  *appconversation.Service
+	cfg      *config.Runtime
+	// shutdown 触发时订阅型长连接（run 对账流、run 观看流）立即退出，
+	// 让优雅关停不被常驻 SSE 拖到超时；客户端依靠既有重连逻辑恢复。
+	shutdown *lifecycle.Shutdown
 }
 
 func normalizeStreamEventPayload(eventType string, payload map[string]interface{}) map[string]interface{} {
@@ -47,10 +51,11 @@ func normalizeStreamEventPayload(eventType string, payload map[string]interface{
 }
 
 // NewHandler 创建处理器。
-func NewHandler(service *appconversation.Service, cfg *config.Runtime) *Handler {
+func NewHandler(service *appconversation.Service, cfg *config.Runtime, shutdown *lifecycle.Shutdown) *Handler {
 	return &Handler{
-		service: service,
-		cfg:     cfg,
+		service:  service,
+		cfg:      cfg,
+		shutdown: shutdown,
 	}
 }
 

--- a/backend/internal/transport/http/conversation/handler_message_send.go
+++ b/backend/internal/transport/http/conversation/handler_message_send.go
@@ -726,6 +726,9 @@ func (h *Handler) StreamActiveMessageGenerations(c *gin.Context) {
 		select {
 		case <-c.Request.Context().Done():
 			return
+		case <-h.shutdown.Done():
+			// 关停排空：订阅流立即退出，客户端按既有退避逻辑重连。
+			return
 		case <-snapshotTicker.C:
 			latest, listErr := h.service.ListActiveMessageGenerations(c.Request.Context(), userID)
 			if listErr != nil {
@@ -843,6 +846,9 @@ func (h *Handler) ResumeMessageGenerationStream(c *gin.Context) {
 	for {
 		select {
 		case <-c.Request.Context().Done():
+			return
+		case <-h.shutdown.Done():
+			// 关停排空：观看流立即退出，生成本体不受影响；客户端重连后经 Redis 重放续传。
 			return
 		case <-activeTicker.C:
 			if !isActive() {

--- a/backend/internal/transport/http/server.go
+++ b/backend/internal/transport/http/server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/infra/config"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/shared/buildinfo"
+	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/shared/lifecycle"
 	"github.com/DEEIX-AI/DEEIX-Chat/backend/internal/shared/response"
 	adminhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/admin"
 	announcementhttp "github.com/DEEIX-AI/DEEIX-Chat/backend/internal/transport/http/announcement"
@@ -69,6 +70,8 @@ type Modules struct {
 	User              *userhttp.Module
 	UserSettings      *usersettingshttp.Module
 	StartupLog        func(*zap.Logger)
+	// Shutdown 是进程关停排空信号；排空期间就绪探针返回 503，引导负载均衡摘除流量。
+	Shutdown 		  *lifecycle.Shutdown
 }
 
 // NewEngine 创建并注册 API 路由。
@@ -105,7 +108,7 @@ func NewEngine(cfg *config.Runtime, log *zap.Logger, modules Modules, hc HealthC
 		info := buildinfo.Snapshot()
 		c.JSON(http.StatusOK, gin.H{"status": "ok", "version": info.Version})
 	})
-	engine.GET("/readyz", readyzHandler(hc))
+	engine.GET("/readyz", readyzHandler(hc, modules.Shutdown))
 	if swaggerEnabled(snapshot.Env) {
 		engine.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	}
@@ -380,8 +383,13 @@ func isNextExportDataAsset(requestPath string) bool {
 	return strings.HasPrefix(fileName, "__next.") && strings.EqualFold(path.Ext(fileName), ".txt")
 }
 
-func readyzHandler(hc HealthChecker) gin.HandlerFunc {
+func readyzHandler(hc HealthChecker, shutdown *lifecycle.Shutdown) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// 排空期间立即返回未就绪，让负载均衡停止派发新流量；存量请求继续处理。
+		if shutdown.Draining() {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "draining"})
+			return
+		}
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
 		defer cancel()
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,6 +15,7 @@ server:
   read_timeout_seconds: 120
   idle_timeout_seconds: 120
   max_header_bytes: 1048576
+  shutdown_timeout_seconds: 10
 
 security:
   # Required. Replace both values with strong random secrets before deployment.

--- a/config.full.example.yaml
+++ b/config.full.example.yaml
@@ -20,6 +20,9 @@ server:
   read_timeout_seconds: 120
   idle_timeout_seconds: 120
   max_header_bytes: 1048576
+  # Graceful shutdown drain window for in-flight requests; keep below the
+  # orchestrator termination grace period (for example Kubernetes 30s).
+  shutdown_timeout_seconds: 10
 
 security:
   # Required. Replace both values with strong random secrets before deployment.

--- a/config.sqlite.example.yaml
+++ b/config.sqlite.example.yaml
@@ -15,6 +15,7 @@ server:
   read_timeout_seconds: 120
   idle_timeout_seconds: 120
   max_header_bytes: 1048576
+  shutdown_timeout_seconds: 10
 
 security:
   # Required. Replace both values with strong random secrets before deployment.


### PR DESCRIPTION
## Summary

Rolling restarts previously raced against long-lived SSE connections and in-flight generations: `srv.Shutdown` waited on persistent subscription streams until the timeout expired, then the process exited with an error while the load balancer kept routing new traffic to a dying instance.

This PR introduces a three-phase graceful shutdown built on a new `shared/lifecycle.Shutdown` drain signal:

1. **Begin drain** — `/readyz` immediately returns `503 {"status":"draining"}` so the load balancer stops routing new traffic, and subscription-style SSE streams (active-generation reconciliation stream, run watch stream) exit at once; clients recover through their existing reconnect/backoff logic, and watch streams resume via Redis replay.
2. **Drain in-flight requests** — valuable streaming work such as message generation completes naturally within a configurable window (`server.shutdown_timeout_seconds` / `HTTP_SHUTDOWN_TIMEOUT_SECONDS`, default 10s).
3. **Force close on timeout** — remaining connections are force-closed and logged as a warning instead of failing the process; interrupted generations are already covered by persistence and frontend resume logic, so this is an expected degradation, not an error.

Background workers are now cancelled after HTTP draining completes instead of before it, so in-flight requests keep their supporting workers during the drain window.

## Change type

- [x] Feature

## Affected areas

- [x] Backend / API
- [x] Conversations / streaming
- [x] Deployment / Docker / configuration

## Verification

- [x] `go build ./cmd/server && go vet ./...`
- [x] `go test ./...`
- [x] Manual: `make run`, open a chat with an active generation plus the run watch stream, send `SIGTERM`; confirm `/readyz` flips to 503, subscription SSE disconnects and reconnects, in-flight generation finishes within the drain window, and the process logs `server_stopped` and exits 0.
- [x] Manual: set `shutdown_timeout_seconds: 1` and interrupt a long generation; confirm `server_drain_timeout_force_close` is logged as a warning and the frontend resumes via the existing recovery path.

## Screenshots, API examples, or logs

During drain:

```text
GET /readyz -> 503 {"status": "draining"}
```

## Configuration, migration, and compatibility notes

- New optional config: `server.shutdown_timeout_seconds` (YAML) / `HTTP_SHUTDOWN_TIMEOUT_SECONDS` (env), default `10`. Added to all three example config files. Keep it below the orchestrator termination grace period (for example Kubernetes' 30s default).
- Behavior change: `/readyz` now returns 503 while draining. Readiness-based load balancers will remove the instance from rotation during shutdown, which is the intended effect; liveness (`/healthz`) is unchanged.
- Behavior change: a drain timeout no longer fails `Run()` — the server force-closes remaining connections and exits successfully.
- No API contract, DTO, or database changes; `pnpm api:generate` is not required.

## Documentation

- [x] Documentation was updated. (Example config files document the new key; no README change needed since per-timeout server keys are not individually listed there.)

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.