### PR TITLE
fix: unify frontend loading states and chart and preview polish

### DIFF
--- a/frontend/components/ui/chart.tsx
+++ b/frontend/components/ui/chart.tsx
@@ -367,6 +367,40 @@ function ChartInteractiveLegend({
   )
 }
 
+const STACKED_BAR_TOP_RADIUS: [number, number, number, number] = [4, 4, 0, 0]
+// Minimum rendered height of the column-top segment; slightly above the 4px
+// corner radius so the rounded cap stays visible for near-zero values.
+const STACKED_BAR_TOP_MIN_HEIGHT = 5
+
+// Rounds the top corners of the segment that is currently the visible top of
+// its own stacked column. A static per-series `radius` leaves square tops on
+// columns where the globally topmost series has no value.
+function createStackedBarTopRoundedShape(
+  isColumnTopSegment: (payload: unknown) => boolean
+): (props: RechartsPrimitive.BarShapeProps) => React.JSX.Element {
+  return (props) => {
+    if (!isColumnTopSegment(props.payload)) {
+      return <RechartsPrimitive.Rectangle {...props} radius={0} />
+    }
+    // A tiny top segment cannot fit the corner radius, so it would still look
+    // square. Keep its top edge in place and extend it downward over the
+    // segment below (the top segment paints last, so it wins), clamped to the
+    // stack baseline so the total column height never changes.
+    const maxHeight = Math.max(props.stackedBarStart - props.y, props.height)
+    const height = Math.min(
+      Math.max(props.height, STACKED_BAR_TOP_MIN_HEIGHT),
+      maxHeight
+    )
+    return (
+      <RechartsPrimitive.Rectangle
+        {...props}
+        height={height}
+        radius={STACKED_BAR_TOP_RADIUS}
+      />
+    )
+  }
+}
+
 // Helper to extract item config from a payload.
 function getPayloadConfigFromPayload(
   config: ChartConfig,
@@ -412,5 +446,6 @@ export {
   ChartLegendContent,
   ChartInteractiveLegend,
   ChartStyle,
+  createStackedBarTopRoundedShape,
 }
 export type { ChartInteractiveLegendItem }

--- a/frontend/features/admin/components/sections/statistics/admin-moderation-statistics.tsx
+++ b/frontend/features/admin/components/sections/statistics/admin-moderation-statistics.tsx
@@ -344,7 +344,7 @@ export function AdminModerationStatisticsSection() {
                 >
                   <defs>
                     <linearGradient id="fillModerationTrendMetric" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="var(--color-metricValue)" stopOpacity={0.3} />
+                      <stop offset="5%" stopColor="var(--color-metricValue)" stopOpacity={0.18} />
                       <stop offset="95%" stopColor="var(--color-metricValue)" stopOpacity={0.02} />
                     </linearGradient>
                   </defs>
@@ -385,9 +385,11 @@ export function AdminModerationStatisticsSection() {
                     fill="url(#fillModerationTrendMetric)"
                     fillOpacity={1}
                     stroke="var(--color-metricValue)"
-                    strokeWidth={2}
+                    strokeWidth={1.5}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
                     dot={false}
-                    activeDot={{ r: 3, strokeWidth: 2 }}
+                    activeDot={{ r: 2.5, strokeWidth: 1.5 }}
                     isAnimationActive
                     animationDuration={240}
                     animationEasing="ease-out"
@@ -398,10 +400,11 @@ export function AdminModerationStatisticsSection() {
                     dataKey="avgLatencyMS"
                     type="monotone"
                     stroke="var(--color-avgLatencyMS)"
-                    strokeWidth={1.5}
-                    strokeDasharray="4 4"
+                    strokeWidth={1}
+                    strokeDasharray="3 3"
+                    strokeLinecap="round"
                     dot={false}
-                    activeDot={{ r: 2.5, strokeWidth: 1.5 }}
+                    activeDot={{ r: 2, strokeWidth: 1 }}
                     isAnimationActive
                     animationDuration={240}
                     animationEasing="ease-out"

--- a/frontend/features/admin/components/sections/statistics/admin-statistics-charts.tsx
+++ b/frontend/features/admin/components/sections/statistics/admin-statistics-charts.tsx
@@ -8,6 +8,7 @@ import {
   ChartContainer,
   ChartInteractiveLegend,
   ChartTooltip,
+  createStackedBarTopRoundedShape,
   type ChartConfig,
   type ChartInteractiveLegendItem,
 } from "@/components/ui/chart";
@@ -268,7 +269,7 @@ export const StatisticsTrendChart = React.memo(function StatisticsTrendChart({
         >
         <defs>
           <linearGradient id="fillUsageTrendMetric" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="5%" stopColor="var(--color-metricValue)" stopOpacity={0.3} />
+            <stop offset="5%" stopColor="var(--color-metricValue)" stopOpacity={0.18} />
             <stop offset="95%" stopColor="var(--color-metricValue)" stopOpacity={0.02} />
           </linearGradient>
         </defs>
@@ -309,9 +310,11 @@ export const StatisticsTrendChart = React.memo(function StatisticsTrendChart({
           fill="url(#fillUsageTrendMetric)"
           fillOpacity={1}
           stroke="var(--color-metricValue)"
-          strokeWidth={2}
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
           dot={false}
-          activeDot={{ r: 3, strokeWidth: 2 }}
+          activeDot={{ r: 2.5, strokeWidth: 1.5 }}
           isAnimationActive
           animationDuration={CHART_ANIMATION_DURATION_MS}
           animationEasing="ease-out"
@@ -322,10 +325,11 @@ export const StatisticsTrendChart = React.memo(function StatisticsTrendChart({
           dataKey="avgLatencyMS"
           type="monotone"
           stroke="var(--color-avgLatencyMS)"
-          strokeWidth={1.5}
-          strokeDasharray="4 4"
+          strokeWidth={1}
+          strokeDasharray="3 3"
+          strokeLinecap="round"
           dot={false}
-          activeDot={{ r: 2.5, strokeWidth: 1.5 }}
+          activeDot={{ r: 2, strokeWidth: 1 }}
           isAnimationActive
           animationDuration={CHART_ANIMATION_DURATION_MS}
           animationEasing="ease-out"
@@ -366,6 +370,20 @@ type StatisticsStackedChartPoint = Record<string, unknown> & {
 
 function statisticsPeriodKey(value: string): string {
   return value.slice(0, 10);
+}
+
+function isStatisticsStackedChartPoint(value: unknown): value is StatisticsStackedChartPoint {
+  return typeof value === "object" && value !== null && "segments" in value && Array.isArray(value.segments);
+}
+
+// 返回该列在当前图例可见性下、数值大于 0 的最顶部分段 key，决定顶部圆角落在哪个分段。
+function stackedColumnTopSegmentKey(payload: unknown, hiddenSeries: ReadonlySet<string>): string | undefined {
+  if (!isStatisticsStackedChartPoint(payload)) return undefined;
+  for (let index = payload.segments.length - 1; index >= 0; index -= 1) {
+    const segment = payload.segments[index];
+    if (!hiddenSeries.has(segment.id) && segment.chartValue > 0) return segment.key;
+  }
+  return undefined;
 }
 
 function formatStackedMetricValue(
@@ -491,8 +509,17 @@ function StatisticsStackedTrendChart({
     () => series.map((item) => ({ id: item.id, label: item.label, title: item.fullLabel, color: item.color })),
     [series],
   );
-  const topVisibleSeriesID = React.useMemo(
-    () => [...series].reverse().find((item) => !hiddenSeries.has(item.id))?.id,
+  // 顶部圆角按每根柱当前可见的最顶部分段绘制，而不是固定给某个系列。
+  const seriesBarShapes = React.useMemo(
+    () =>
+      new Map(
+        series.map((item) => [
+          item.key,
+          createStackedBarTopRoundedShape(
+            (payload) => stackedColumnTopSegmentKey(payload, hiddenSeries) === item.key,
+          ),
+        ]),
+      ),
     [hiddenSeries, series],
   );
   if (loading) return <ChartLoadingSkeleton />;
@@ -545,7 +572,7 @@ function StatisticsStackedTrendChart({
               animationDuration={CHART_ANIMATION_DURATION_MS}
               animationEasing="ease-out"
               hide={hiddenSeries.has(item.id)}
-              radius={item.id === topVisibleSeriesID ? [4, 4, 0, 0] : 0}
+              shape={seriesBarShapes.get(item.key)}
             />
           ))}
         </BarChart>

--- a/frontend/features/chat/hooks/use-chat-artifacts.ts
+++ b/frontend/features/chat/hooks/use-chat-artifacts.ts
@@ -21,14 +21,15 @@ type ChatArtifactInlineLayout = "balanced" | "wide";
 const ARTIFACT_INLINE_BREAKPOINT = 768;
 const ARTIFACT_WIDE_BREAKPOINT = 1280;
 const ARTIFACT_MIN_RATIO = 1 / 3;
-const ARTIFACT_MAX_RATIO = 1 / 2;
+const ARTIFACT_MAX_RATIO = 3 / 4;
+const ARTIFACT_BALANCED_RATIO = 1 / 2;
 
 function resolveInlineLayout(viewportWidth: number): ChatArtifactInlineLayout {
   return viewportWidth >= ARTIFACT_WIDE_BREAKPOINT ? "wide" : "balanced";
 }
 
 function resolveDefaultRatio(layout: ChatArtifactInlineLayout): number {
-  return layout === "wide" ? ARTIFACT_MIN_RATIO : ARTIFACT_MAX_RATIO;
+  return layout === "wide" ? ARTIFACT_MIN_RATIO : ARTIFACT_BALANCED_RATIO;
 }
 
 function clampArtifactRatio(value: number): number {

--- a/frontend/features/knowledge-bases/components/knowledge-base-detail.tsx
+++ b/frontend/features/knowledge-bases/components/knowledge-base-detail.tsx
@@ -202,7 +202,7 @@ function KnowledgeBaseFileList({
   return (
     <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3 md:px-5">
       {loading ? (
-        <div className="flex justify-center py-16">
+        <div className="flex h-full items-center justify-center text-muted-foreground">
           <Spinner className="size-4" />
         </div>
       ) : files.length > 0 ? (

--- a/frontend/features/knowledge-bases/hooks/use-knowledge-bases-page.ts
+++ b/frontend/features/knowledge-bases/hooks/use-knowledge-bases-page.ts
@@ -106,6 +106,18 @@ export function useKnowledgeBasesPage(mode: KnowledgeBaseMode) {
   const [bulkDeleteFiles, setBulkDeleteFiles] = React.useState(false);
   const [bulkDeleting, setBulkDeleting] = React.useState(false);
   const [previewTarget, setPreviewTarget] = React.useState<KnowledgeBasePreviewTarget | null>(null);
+
+  // 选中知识库变化时在渲染期同步复位文件列表,使切换后的首帧即为加载态。
+  const [filesSelectedID, setFilesSelectedID] = React.useState(selectedID);
+  if (filesSelectedID !== selectedID) {
+    setFilesSelectedID(selectedID);
+    setFiles([]);
+    setFilesTotal(0);
+    setFilesPage(1);
+    setFilesLoading(Boolean(selectedID));
+    setFilesLoadingMore(false);
+  }
+
   const itemsRequestVersionRef = React.useRef(0);
   const filesRequestVersionRef = React.useRef(0);
   const availableFilesRequestVersionRef = React.useRef(0);

--- a/frontend/features/layouts/components/navigation/nav-projects.tsx
+++ b/frontend/features/layouts/components/navigation/nav-projects.tsx
@@ -74,6 +74,7 @@ import {
 import { useChatSession } from "@/features/chat";
 import { ProjectDialog, type ProjectDraft } from "@/features/layouts/components/navigation/project-dialog";
 import { SidebarConversationItem } from "@/features/layouts/components/navigation/sidebar-conversation-item";
+import { SidebarConversationSkeleton } from "@/features/layouts/components/navigation/sidebar-conversation-skeleton";
 import { useLayoutActiveConversation } from "@/features/layouts/hooks/use-layout-active-conversation";
 import { useLayoutProjectConversations } from "@/features/layouts/hooks/use-layout-project-conversations";
 import { useLayoutSidebarNavigation } from "@/features/layouts/hooks/use-layout-sidebar-navigation";
@@ -86,6 +87,7 @@ import { useLocalizedErrorMessage } from "@/i18n/use-localized-error";
 import { cn } from "@/lib/utils";
 import { CollapsibleMotionContent } from "@/shared/components/collapsible-motion-content";
 import { DeleteFilesOption } from "@/shared/components/delete-files-option";
+import { LoadingReveal } from "@/shared/components/loading-reveal";
 import { useDialogSnapshot } from "@/shared/hooks/use-dialog-snapshot";
 import { useStoredBoolean } from "@/shared/hooks/use-stored-boolean";
 
@@ -398,6 +400,7 @@ export function NavProjects() {
   const { requestNewConversation } = useChatSession();
   const items = useSidebarConversationField("items");
   const projects = useSidebarConversationField("projects");
+  const loadingInitial = useSidebarConversationField("loadingInitial");
   const lastChange = useSidebarConversationField("lastChange");
   const createProject = useSidebarConversationField("createProject");
   const updateProject = useSidebarConversationField("updateProject");
@@ -684,38 +687,7 @@ export function NavProjects() {
     }
   }, [conversationDeleteTarget]);
 
-  if (projects.length === 0) {
-    return (
-      <>
-        <div className="relative z-10 group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:opacity-0">
-          <Collapsible open={projectsOpen} onOpenChange={setProjectsOpen}>
-            <SidebarGroup className="px-2 py-2">
-              <ProjectGroupHeader
-                title={t("title")}
-                createLabel={t("create")}
-                contentID={projectsContentID}
-                open={projectsOpen}
-                onCreate={() => setDraft({
-                  name: "",
-                  systemPrompt: "",
-                  mcpDefaultMode: "inherit",
-                  defaultMCPToolIDs: [],
-                  defaultSkillIDs: [],
-                  defaultKnowledgeBaseIDs: [],
-                })}
-                onOpenChange={setProjectsOpen}
-                toggleLabel={projectsOpen ? t("collapseSection") : t("expandSection")}
-              />
-              <CollapsibleMotionContent id={projectsContentID} open={projectsOpen}>
-                <div className="px-2 py-1 text-xs text-sidebar-foreground/55">{t("empty")}</div>
-              </CollapsibleMotionContent>
-            </SidebarGroup>
-          </Collapsible>
-        </div>
-        <ProjectDialog draft={draft} setDraft={setDraft} onOpenChange={(open) => !open && closeDraft()} onSubmit={commitDraft} />
-      </>
-    );
-  }
+  const showInitialSkeleton = loadingInitial && projects.length === 0;
 
   return (
     <>
@@ -739,242 +711,258 @@ export function NavProjects() {
               toggleLabel={projectsOpen ? t("collapseSection") : t("expandSection")}
             />
             <CollapsibleMotionContent id={projectsContentID} open={projectsOpen}>
-              <DndContext
-                sensors={projectSortSensors}
-                collisionDetection={closestCenter}
-                onDragStart={onProjectDragStart}
-                onDragEnd={(event) => void onProjectDragEnd(event)}
-                onDragCancel={onProjectDragCancel}
+              <LoadingReveal
+                loading={showInitialSkeleton}
+                skeleton={
+                  <SidebarConversationSkeleton
+                    count={2}
+                    widths={["66%", "52%"]}
+                    prefix="sidebar-projects"
+                  />
+                }
+                className="min-h-0"
               >
-                <SortableContext items={projectIDs} strategy={verticalListSortingStrategy}>
-                  <SidebarMenu className="gap-0.5">
-                    {projects.map((project) => {
-                      const expanded = expandedProjectIDs.has(project.publicID);
-                      const conversationState = projectConversationState[project.publicID];
-                      const conversationLoading = expanded && (!conversationState || conversationState.loading);
-                      const hasActiveChild = Boolean(conversationState?.items.some((item) => item.publicID === activeConversationID));
-                      const active =
-                        ((pathname === "/recent" || pathname === "/chat") && activeProjectID === project.publicID) ||
-                        activeConversationProjectID === project.publicID ||
-                        hasActiveChild;
-                      const rowHovered = hoveredProjectRowID === project.publicID;
-                      const rowFocused = focusedProjectRowID === project.publicID;
-                      const createHovered = hoveredProjectCreateID === project.publicID;
-                      const menuHovered = hoveredProjectMenuID === project.publicID;
-                      const menuOpen = openProjectMenuID === project.publicID;
-                      const rowDragging = draggingProjectID === project.publicID;
-                      const canSortProjects = projects.length >= 2;
-                      const projectActionPaddingClassName = canSortProjects ? "pr-24" : "pr-16";
-                      const projectCreateActionClassName = canSortProjects ? "right-16" : "right-8";
-                      const projectMenuActionClassName = canSortProjects ? "right-8" : "right-0";
-                      const showProjectActions = isMobile || (!rowDragging && (rowHovered || rowFocused || menuHovered || menuOpen));
-                      const projectConversationContentID = `sidebar-project-${project.publicID}-conversations`;
-                      return (
-                        <ProjectSortableItem
-                          key={project.publicID}
-                          projectID={project.publicID}
-                          disabled={!canSortProjects || savingProjectOrder}
-                        >
-                          {({ attributes, isDragging, listeners }) => (
-                            <>
-                              <div
-                                className="group/project-row relative"
-                                onFocus={(event) => {
-                                  setFocusedProjectRowID(
-                                    event.target instanceof HTMLElement && event.target.matches(":focus-visible")
-                                      ? project.publicID
-                                      : null,
-                                  );
-                                }}
-                                onBlur={(event) => {
-                                  const nextTarget = event.relatedTarget;
-                                  if (!(nextTarget instanceof Node) || !event.currentTarget.contains(nextTarget)) {
-                                    setFocusedProjectRowID(null);
-                                  }
-                                }}
-                              >
-                                <ProjectDragHandle
-                                  attributes={attributes}
-                                  disabled={savingProjectOrder}
-                                  hidden={!canSortProjects}
-                                  label={t("dragToReorder", { name: project.name || t("untitled") })}
-                                  listeners={listeners}
-                                  visible={isMobile || rowHovered || rowFocused || isDragging}
-                                />
-                                <ProjectTreeButton
-                                  active={active}
-                                  actionPaddingClassName={projectActionPaddingClassName}
-                                  contentID={projectConversationContentID}
-                                  expanded={expanded}
-                                  name={project.name}
-                                  onHoverChange={(hovered) => setHoveredProjectRowID(hovered ? project.publicID : null)}
-                                  onToggleExpanded={() => toggleProjectExpanded(project.publicID)}
-                                />
-                                <ProjectInlineAction
-                                  label={t("newChatInProject")}
-                                  visible={showProjectActions}
-                                  className={projectCreateActionClassName}
-                                  onHoverChange={(hovered) => setHoveredProjectCreateID(hovered ? project.publicID : null)}
-                                  onClick={() => startProjectConversation(project.publicID)}
-                                >
-                                  <PlusIcon aria-hidden size={16} strokeWidth={1.6} animate={createHovered ? "default" : undefined} />
-                                </ProjectInlineAction>
-                                <DropdownMenu
-                                  modal={false}
-                                  open={menuOpen}
-                                  onOpenChange={(open) => setOpenProjectMenuID(open ? project.publicID : null)}
-                                >
-                                  <DropdownMenuTrigger asChild>
-                                    <ProjectInlineAction
-                                      label={t("menu")}
-                                      visible={showProjectActions}
-                                      className={projectMenuActionClassName}
-                                      onHoverChange={(hovered) => setHoveredProjectMenuID(hovered ? project.publicID : null)}
-                                    >
-                                      <Ellipsis aria-hidden size={16} strokeWidth={1.4} animate={menuHovered ? "pulse" : undefined} />
-                                    </ProjectInlineAction>
-                                  </DropdownMenuTrigger>
-                                  <DropdownMenuContent align="end" className="w-max min-w-36 max-w-[calc(100vw-2rem)]">
-                                    <DropdownMenuItem
-                                      onSelect={(event) => {
-                                        event.preventDefault();
-                                        setDraft({
-                                          publicID: project.publicID,
-                                          name: project.name,
-                                          systemPrompt: project.systemPrompt ?? "",
-                                          mcpDefaultMode: project.mcpDefaultMode ?? "inherit",
-                                          defaultMCPToolIDs: project.defaultMCPToolIDs ?? [],
-                                          defaultSkillIDs: project.defaultSkillIDs ?? [],
-                                          defaultKnowledgeBaseIDs: project.defaultKnowledgeBaseIDs ?? [],
-                                        });
-                                      }}
-                                    >
-                                      <DropdownMenuItemIcon icon={PencilLine} className="text-current" />
-                                      {t("edit")}
-                                    </DropdownMenuItem>
-                                    <DropdownMenuSeparator />
-                                    <DropdownMenuItem
-                                      variant="destructive"
-                                      onSelect={(event) => {
-                                        event.preventDefault();
-                                        setDeleteTarget({ publicID: project.publicID, name: project.name });
-                                      }}
-                                    >
-                                      <DropdownMenuItemIcon icon={Trash} className="text-current" />
-                                      {t("delete")}
-                                    </DropdownMenuItem>
-                                  </DropdownMenuContent>
-                                </DropdownMenu>
-                              </div>
-                              <AnimatePresence initial={false}>
-                                {expanded ? (
-                                  <motion.div
-                                    key={`${project.publicID}-conversations`}
-                                    id={projectConversationContentID}
-                                    initial={{ height: 0, opacity: 0, "--mask-stop": "0%", y: 6 }}
-                                    animate={{ height: "auto", opacity: 1, "--mask-stop": "100%", y: 0 }}
-                                    exit={{ height: 0, opacity: 0, "--mask-stop": "0%", y: 6 }}
-                                    transition={PROJECT_TREE_ACCORDION_TRANSITION}
-                                    style={PROJECT_TREE_ACCORDION_MASK_STYLE}
+                {projects.length === 0 ? (
+                  <div className="px-2 py-1 text-xs text-sidebar-foreground/55">{t("empty")}</div>
+                ) : (
+                  <DndContext
+                    sensors={projectSortSensors}
+                    collisionDetection={closestCenter}
+                    onDragStart={onProjectDragStart}
+                    onDragEnd={(event) => void onProjectDragEnd(event)}
+                    onDragCancel={onProjectDragCancel}
+                  >
+                    <SortableContext items={projectIDs} strategy={verticalListSortingStrategy}>
+                      <SidebarMenu className="gap-0.5">
+                        {projects.map((project) => {
+                          const expanded = expandedProjectIDs.has(project.publicID);
+                          const conversationState = projectConversationState[project.publicID];
+                          const conversationLoading = expanded && (!conversationState || conversationState.loading);
+                          const hasActiveChild = Boolean(conversationState?.items.some((item) => item.publicID === activeConversationID));
+                          const active =
+                            ((pathname === "/recent" || pathname === "/chat") && activeProjectID === project.publicID) ||
+                            activeConversationProjectID === project.publicID ||
+                            hasActiveChild;
+                          const rowHovered = hoveredProjectRowID === project.publicID;
+                          const rowFocused = focusedProjectRowID === project.publicID;
+                          const createHovered = hoveredProjectCreateID === project.publicID;
+                          const menuHovered = hoveredProjectMenuID === project.publicID;
+                          const menuOpen = openProjectMenuID === project.publicID;
+                          const rowDragging = draggingProjectID === project.publicID;
+                          const canSortProjects = projects.length >= 2;
+                          const projectActionPaddingClassName = canSortProjects ? "pr-24" : "pr-16";
+                          const projectCreateActionClassName = canSortProjects ? "right-16" : "right-8";
+                          const projectMenuActionClassName = canSortProjects ? "right-8" : "right-0";
+                          const showProjectActions = isMobile || (!rowDragging && (rowHovered || rowFocused || menuHovered || menuOpen));
+                          const projectConversationContentID = `sidebar-project-${project.publicID}-conversations`;
+                          return (
+                            <ProjectSortableItem
+                              key={project.publicID}
+                              projectID={project.publicID}
+                              disabled={!canSortProjects || savingProjectOrder}
+                            >
+                              {({ attributes, isDragging, listeners }) => (
+                                <>
+                                  <div
+                                    className="group/project-row relative"
+                                    onFocus={(event) => {
+                                      setFocusedProjectRowID(
+                                        event.target instanceof HTMLElement && event.target.matches(":focus-visible")
+                                          ? project.publicID
+                                          : null,
+                                      );
+                                    }}
+                                    onBlur={(event) => {
+                                      const nextTarget = event.relatedTarget;
+                                      if (!(nextTarget instanceof Node) || !event.currentTarget.contains(nextTarget)) {
+                                        setFocusedProjectRowID(null);
+                                      }
+                                    }}
                                   >
-                                    <SidebarMenuSub className="mx-0 w-full translate-x-0 gap-0.5 border-l-0 px-0 py-0.5">
-                                      {conversationLoading ? (
-                                        <SidebarMenuSubItem>
-                                          <div className="flex h-7 w-full items-center gap-2 rounded-md pl-8 pr-2 text-xs text-muted-foreground">
-                                            <Spinner className="size-3.5" />
-                                            <span>{tRecent("loadingMore")}</span>
-                                          </div>
-                                        </SidebarMenuSubItem>
-                                      ) : null}
+                                    <ProjectDragHandle
+                                      attributes={attributes}
+                                      disabled={savingProjectOrder}
+                                      hidden={!canSortProjects}
+                                      label={t("dragToReorder", { name: project.name || t("untitled") })}
+                                      listeners={listeners}
+                                      visible={isMobile || rowHovered || rowFocused || isDragging}
+                                    />
+                                    <ProjectTreeButton
+                                      active={active}
+                                      actionPaddingClassName={projectActionPaddingClassName}
+                                      contentID={projectConversationContentID}
+                                      expanded={expanded}
+                                      name={project.name}
+                                      onHoverChange={(hovered) => setHoveredProjectRowID(hovered ? project.publicID : null)}
+                                      onToggleExpanded={() => toggleProjectExpanded(project.publicID)}
+                                    />
+                                    <ProjectInlineAction
+                                      label={t("newChatInProject")}
+                                      visible={showProjectActions}
+                                      className={projectCreateActionClassName}
+                                      onHoverChange={(hovered) => setHoveredProjectCreateID(hovered ? project.publicID : null)}
+                                      onClick={() => startProjectConversation(project.publicID)}
+                                    >
+                                      <PlusIcon aria-hidden size={16} strokeWidth={1.6} animate={createHovered ? "default" : undefined} />
+                                    </ProjectInlineAction>
+                                    <DropdownMenu
+                                      modal={false}
+                                      open={menuOpen}
+                                      onOpenChange={(open) => setOpenProjectMenuID(open ? project.publicID : null)}
+                                    >
+                                      <DropdownMenuTrigger asChild>
+                                        <ProjectInlineAction
+                                          label={t("menu")}
+                                          visible={showProjectActions}
+                                          className={projectMenuActionClassName}
+                                          onHoverChange={(hovered) => setHoveredProjectMenuID(hovered ? project.publicID : null)}
+                                        >
+                                          <Ellipsis aria-hidden size={16} strokeWidth={1.4} animate={menuHovered ? "pulse" : undefined} />
+                                        </ProjectInlineAction>
+                                      </DropdownMenuTrigger>
+                                      <DropdownMenuContent align="end" className="w-max min-w-36 max-w-[calc(100vw-2rem)]">
+                                        <DropdownMenuItem
+                                          onSelect={(event) => {
+                                            event.preventDefault();
+                                            setDraft({
+                                              publicID: project.publicID,
+                                              name: project.name,
+                                              systemPrompt: project.systemPrompt ?? "",
+                                              mcpDefaultMode: project.mcpDefaultMode ?? "inherit",
+                                              defaultMCPToolIDs: project.defaultMCPToolIDs ?? [],
+                                              defaultSkillIDs: project.defaultSkillIDs ?? [],
+                                              defaultKnowledgeBaseIDs: project.defaultKnowledgeBaseIDs ?? [],
+                                            });
+                                          }}
+                                        >
+                                          <DropdownMenuItemIcon icon={PencilLine} className="text-current" />
+                                          {t("edit")}
+                                        </DropdownMenuItem>
+                                        <DropdownMenuSeparator />
+                                        <DropdownMenuItem
+                                          variant="destructive"
+                                          onSelect={(event) => {
+                                            event.preventDefault();
+                                            setDeleteTarget({ publicID: project.publicID, name: project.name });
+                                          }}
+                                        >
+                                          <DropdownMenuItemIcon icon={Trash} className="text-current" />
+                                          {t("delete")}
+                                        </DropdownMenuItem>
+                                      </DropdownMenuContent>
+                                    </DropdownMenu>
+                                  </div>
+                                  <AnimatePresence initial={false}>
+                                    {expanded ? (
+                                      <motion.div
+                                        key={`${project.publicID}-conversations`}
+                                        id={projectConversationContentID}
+                                        initial={{ height: 0, opacity: 0, "--mask-stop": "0%", y: 6 }}
+                                        animate={{ height: "auto", opacity: 1, "--mask-stop": "100%", y: 0 }}
+                                        exit={{ height: 0, opacity: 0, "--mask-stop": "0%", y: 6 }}
+                                        transition={PROJECT_TREE_ACCORDION_TRANSITION}
+                                        style={PROJECT_TREE_ACCORDION_MASK_STYLE}
+                                      >
+                                        <SidebarMenuSub className="mx-0 w-full translate-x-0 gap-0.5 border-l-0 px-0 py-0.5">
+                                          {conversationLoading ? (
+                                            <SidebarMenuSubItem>
+                                              <div className="flex h-7 w-full items-center gap-2 rounded-md pl-8 pr-2 text-xs text-muted-foreground">
+                                                <Spinner className="size-3.5" />
+                                                <span>{tRecent("loadingMore")}</span>
+                                              </div>
+                                            </SidebarMenuSubItem>
+                                          ) : null}
 
-                                      {conversationState?.error ? (
-                                        <SidebarMenuSubItem>
-                                          <Button
-                                            type="button"
-                                            variant="ghost"
-                                            size="sm"
-                                            className="w-full min-w-0 justify-start pl-8 pr-2 text-left text-xs font-normal text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-                                            onClick={() => void loadProjectConversations(project.publicID, true)}
-                                          >
-                                            <span className="truncate">{tRecent("loadMoreFailed")}</span>
-                                            <span className="ml-auto shrink-0 underline underline-offset-4">{tRecent("retry")}</span>
-                                          </Button>
-                                        </SidebarMenuSubItem>
-                                      ) : null}
+                                          {conversationState?.error ? (
+                                            <SidebarMenuSubItem>
+                                              <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="sm"
+                                                className="w-full min-w-0 justify-start pl-8 pr-2 text-left text-xs font-normal text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                                                onClick={() => void loadProjectConversations(project.publicID, true)}
+                                              >
+                                                <span className="truncate">{tRecent("loadMoreFailed")}</span>
+                                                <span className="ml-auto shrink-0 underline underline-offset-4">{tRecent("retry")}</span>
+                                              </Button>
+                                            </SidebarMenuSubItem>
+                                          ) : null}
 
-                                      {conversationState?.loaded && conversationState.items.length === 0 ? (
-                                        <SidebarMenuSubItem>
-                                          <div className="w-full rounded-md py-1 pl-8 pr-2 text-xs text-sidebar-foreground/55">
-                                            {tRecent("empty")}
-                                          </div>
-                                        </SidebarMenuSubItem>
-                                      ) : null}
+                                          {conversationState?.loaded && conversationState.items.length === 0 ? (
+                                            <SidebarMenuSubItem>
+                                              <div className="w-full rounded-md py-1 pl-8 pr-2 text-xs text-sidebar-foreground/55">
+                                                {tRecent("empty")}
+                                              </div>
+                                            </SidebarMenuSubItem>
+                                          ) : null}
 
-                                      {conversationState?.items.map((conversation) => {
-                                        const title = conversation.title || tRecent("untitled");
-                                        return (
-                                          <SidebarConversationItem
-                                            key={conversation.publicID}
-                                            active={activeConversationID === conversation.publicID}
-                                            item={{
-                                              publicID: conversation.publicID,
-                                              title,
-                                              url: `/chat?conversation_id=${conversation.publicID}`,
-                                              shareActive:
-                                                conversation.shareStatus === "active" && Boolean(conversation.shareID?.trim()),
-                                              labelsJSON: conversation.labelsJSON,
-                                            }}
-                                            starAction={{
-                                              label: conversation.isStarred ? tRecent("row.unstar") : tRecent("row.star"),
-                                              icon: conversation.isStarred ? StarOff : Star,
-                                              onSelect: (targetPublicID) => {
-                                                void setStarByPublicID(targetPublicID, !conversation.isStarred);
-                                              },
-                                            }}
-                                            projectMenu={{
-                                              label: tRecent("row.moveToProject"),
-                                              unassignedLabel: tRecent("projects.unassigned"),
-                                              currentProjectID: conversation.projectID,
-                                              projects,
-                                              onSelect: (targetPublicID, targetProjectID) => {
-                                                void setProjectByPublicID(targetPublicID, targetProjectID);
-                                              },
-                                            }}
-                                            isTransferring={false}
-                                            isRenaming={conversationRenameTarget?.publicID === conversation.publicID}
-                                            renameValue={
-                                              conversationRenameTarget?.publicID === conversation.publicID ? renameValue : title
-                                            }
-                                            rowClassName="w-full"
-                                            linkClassName="pl-8"
-                                            onRenameValueChange={setRenameValue}
-                                            onRenameCommit={onRenameConversationCommit}
-                                            onRenameCancel={onRenameConversationCancel}
-                                            onAutoRename={onAutoRenameConversation}
-                                            isAutoRenaming={autoRenamingConversationID === conversation.publicID}
-                                            onManageLabels={() => setLabelsTarget(conversation)}
-                                            onRename={onRenameConversation}
-                                            onArchive={onArchiveConversation}
-                                            onShare={(publicID, shareTitle) => setShareTarget({ publicID, title: shareTitle })}
-                                            onExport={onExportConversation}
-                                            onDelete={onDeleteConversation}
-                                            onNavigate={onNavigate}
-                                            menuTriggerID={`project-conversation-menu-trigger-${conversation.publicID}`}
-                                          />
-                                        );
-                                      })}
-                                    </SidebarMenuSub>
-                                  </motion.div>
-                                ) : null}
-                              </AnimatePresence>
-                            </>
-                          )}
-                        </ProjectSortableItem>
-                      );
-                    })}
-                  </SidebarMenu>
-                </SortableContext>
-              </DndContext>
+                                          {conversationState?.items.map((conversation) => {
+                                            const title = conversation.title || tRecent("untitled");
+                                            return (
+                                              <SidebarConversationItem
+                                                key={conversation.publicID}
+                                                active={activeConversationID === conversation.publicID}
+                                                item={{
+                                                  publicID: conversation.publicID,
+                                                  title,
+                                                  url: `/chat?conversation_id=${conversation.publicID}`,
+                                                  shareActive:
+                                                    conversation.shareStatus === "active" && Boolean(conversation.shareID?.trim()),
+                                                  labelsJSON: conversation.labelsJSON,
+                                                }}
+                                                starAction={{
+                                                  label: conversation.isStarred ? tRecent("row.unstar") : tRecent("row.star"),
+                                                  icon: conversation.isStarred ? StarOff : Star,
+                                                  onSelect: (targetPublicID) => {
+                                                    void setStarByPublicID(targetPublicID, !conversation.isStarred);
+                                                  },
+                                                }}
+                                                projectMenu={{
+                                                  label: tRecent("row.moveToProject"),
+                                                  unassignedLabel: tRecent("projects.unassigned"),
+                                                  currentProjectID: conversation.projectID,
+                                                  projects,
+                                                  onSelect: (targetPublicID, targetProjectID) => {
+                                                    void setProjectByPublicID(targetPublicID, targetProjectID);
+                                                  },
+                                                }}
+                                                isTransferring={false}
+                                                isRenaming={conversationRenameTarget?.publicID === conversation.publicID}
+                                                renameValue={
+                                                  conversationRenameTarget?.publicID === conversation.publicID ? renameValue : title
+                                                }
+                                                rowClassName="w-full"
+                                                linkClassName="pl-8"
+                                                onRenameValueChange={setRenameValue}
+                                                onRenameCommit={onRenameConversationCommit}
+                                                onRenameCancel={onRenameConversationCancel}
+                                                onAutoRename={onAutoRenameConversation}
+                                                isAutoRenaming={autoRenamingConversationID === conversation.publicID}
+                                                onManageLabels={() => setLabelsTarget(conversation)}
+                                                onRename={onRenameConversation}
+                                                onArchive={onArchiveConversation}
+                                                onShare={(publicID, shareTitle) => setShareTarget({ publicID, title: shareTitle })}
+                                                onExport={onExportConversation}
+                                                onDelete={onDeleteConversation}
+                                                onNavigate={onNavigate}
+                                                menuTriggerID={`project-conversation-menu-trigger-${conversation.publicID}`}
+                                              />
+                                            );
+                                          })}
+                                        </SidebarMenuSub>
+                                      </motion.div>
+                                    ) : null}
+                                  </AnimatePresence>
+                                </>
+                              )}
+                            </ProjectSortableItem>
+                          );
+                        })}
+                      </SidebarMenu>
+                    </SortableContext>
+                  </DndContext>
+                )}
+              </LoadingReveal>
             </CollapsibleMotionContent>
           </SidebarGroup>
         </Collapsible>

--- a/frontend/features/settings/components/sections/subscription/subscription-trend.tsx
+++ b/frontend/features/settings/components/sections/subscription/subscription-trend.tsx
@@ -5,7 +5,12 @@ import { Activity, BadgeDollarSign, Braces, Timer } from "lucide-react";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import { useTranslations } from "next-intl";
 
-import { ChartContainer, ChartInteractiveLegend, ChartTooltip } from "@/components/ui/chart";
+import {
+  ChartContainer,
+  ChartInteractiveLegend,
+  ChartTooltip,
+  createStackedBarTopRoundedShape,
+} from "@/components/ui/chart";
 import type { ChartConfig, ChartInteractiveLegendItem } from "@/components/ui/chart";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -91,6 +96,26 @@ const CHART_ANIMATION_DURATION_MS = 240;
 const MAX_DAILY_MODEL_SERIES = 10;
 const OTHER_MODEL_KEY = "__other_models__";
 const OTHER_MODEL_COLOR = "#64748b";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+// 返回该列当前可见、数值大于 0 的最顶部模型分段 key，决定顶部圆角落在哪个分段。
+function dailyColumnTopSegmentKey(
+  payload: unknown,
+  modelSeries: ModelSeries[],
+  hiddenSeries: ReadonlySet<string>,
+): string | undefined {
+  if (!isRecord(payload)) return undefined;
+  for (let index = modelSeries.length - 1; index >= 0; index -= 1) {
+    const model = modelSeries[index];
+    if (hiddenSeries.has(model.platformModelName)) continue;
+    const value = payload[model.key];
+    if (typeof value === "number" && value > 0) return model.key;
+  }
+  return undefined;
+}
 
 function useHiddenUsageSeries() {
   const [hiddenSeries, setHiddenSeries] = React.useState<Set<string>>(() => new Set());
@@ -420,8 +445,17 @@ function DailyUsageChart({
       : [{ id: "totalTokens", label: "Tokens", color: "var(--chart-1)" }],
     [modelSeries],
   );
-  const topVisibleModelName = React.useMemo(
-    () => [...modelSeries].reverse().find((item) => !hiddenSeries.has(item.platformModelName))?.platformModelName,
+  // 顶部圆角按每根柱当前可见的最顶部分段绘制，而不是固定给某个系列。
+  const modelBarShapes = React.useMemo(
+    () =>
+      new Map(
+        modelSeries.map((model) => [
+          model.key,
+          createStackedBarTopRoundedShape(
+            (payload) => dailyColumnTopSegmentKey(payload, modelSeries, hiddenSeries) === model.key,
+          ),
+        ]),
+      ),
     [hiddenSeries, modelSeries],
   );
 
@@ -466,7 +500,7 @@ function DailyUsageChart({
                     fill={model.color}
                     maxBarSize={42}
                     hide={hiddenSeries.has(model.platformModelName)}
-                    radius={model.platformModelName === topVisibleModelName ? [4, 4, 0, 0] : 0}
+                    shape={modelBarShapes.get(model.key)}
                     isAnimationActive
                     animationDuration={CHART_ANIMATION_DURATION_MS}
                     animationEasing="ease-out"

--- a/frontend/shared/components/file-preview/preview-dialog.tsx
+++ b/frontend/shared/components/file-preview/preview-dialog.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useLocalizedErrorMessage } from "@/i18n/use-localized-error";
+import { cn } from "@/lib/utils";
 import { formatBytes, resolveFileExtension, resolveFilePreviewKind } from "@/shared/lib/file-display";
 import { fetchFileContent, type FileContentResult } from "@/shared/api/file";
 import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
@@ -32,7 +33,12 @@ type PreviewState =
       contentType: string;
     };
 
-type PreviewSourceProps = {
+type PreviewViewerLoadingProps = {
+  showLoading?: boolean;
+  onLoadingChange?: (loading: boolean) => void;
+};
+
+type PreviewSourceProps = PreviewViewerLoadingProps & {
   source: string;
 };
 
@@ -51,7 +57,7 @@ type PreviewTextProps = {
 };
 
 function PreviewRendererFallback() {
-  return <PreviewLoading className="min-h-[320px]" />;
+  return <PreviewLoading className="min-h-[180px] sm:min-h-[320px]" />;
 }
 
 const PreviewDocx = dynamic<PreviewSourceProps>(
@@ -222,14 +228,17 @@ export function FilePreviewDialog({
   const t = useTranslations("files.previewDialog");
   const activeFile = open ? file : null;
   const { state, download } = useFilePreviewDialog(activeFile, loadContent);
+  const [viewerLoading, setViewerLoading] = React.useState(false);
+  const previewKind = state.status === "ready" ? state.kind : null;
+  const showLoadingOverlay = Boolean(activeFile) && (state.status === "loading" || viewerLoading);
+
+  React.useEffect(() => {
+    setViewerLoading(false);
+  }, [activeFile?.fileID, state.status, previewKind]);
 
   const previewBody = React.useMemo(() => {
     if (!open || !file) {
       return null;
-    }
-
-    if (state.status === "loading") {
-      return <PreviewLoading className="min-h-[180px] sm:min-h-[320px]" />;
     }
 
     if (state.status === "error") {
@@ -259,16 +268,23 @@ export function FilePreviewDialog({
       return <PreviewMedia kind={kind} source={objectURL} alt={file.fileName} contentType={contentType} />;
     }
     if (kind === "pdf") {
-      return <PreviewPdf source={objectURL} />;
+      return <PreviewPdf source={objectURL} showLoading={false} onLoadingChange={setViewerLoading} />;
     }
     if (kind === "docx") {
-      return <PreviewDocx source={objectURL} />;
+      return <PreviewDocx source={objectURL} showLoading={false} onLoadingChange={setViewerLoading} />;
     }
     if (kind === "spreadsheet") {
-      return <PreviewSheet source={objectURL} />;
+      return <PreviewSheet source={objectURL} showLoading={false} onLoadingChange={setViewerLoading} />;
     }
     if (kind === "native") {
-      return <PreviewDocument source={objectURL} contentType={contentType} />;
+      return (
+        <PreviewDocument
+          source={objectURL}
+          contentType={contentType}
+          showLoading={false}
+          onLoadingChange={setViewerLoading}
+        />
+      );
     }
     if (kind === "markdown" || kind === "code" || kind === "text") {
       return <PreviewText kind={kind} content={textContent ?? ""} />;
@@ -320,7 +336,17 @@ export function FilePreviewDialog({
 
         <div className="min-h-0 flex-1 overflow-hidden">
           <div className="h-full max-h-[calc(68dvh-64px)] overflow-auto sm:max-h-[calc(92vh-72px)]">
-            <div className="px-3 py-3 sm:px-5 sm:py-5">{previewBody}</div>
+            <div
+              className={cn(
+                "relative px-3 py-3 sm:px-5 sm:py-5",
+                showLoadingOverlay && "min-h-[180px] sm:min-h-[320px]",
+              )}
+            >
+              {previewBody}
+              {showLoadingOverlay ? (
+                <PreviewLoading className="pointer-events-none absolute inset-0 z-10" />
+              ) : null}
+            </div>
           </div>
         </div>
       </DialogContent>


### PR DESCRIPTION
## Summary

Three groups of frontend polish in one focused pass:

**Loading-state fixes.** Loading feedback was inconsistent and occasionally
contradictory across the app:
- Sidebar "Projects" section flashed "no projects" during the initial fetch
  while "Starred"/"Recent" showed skeletons; it now uses the same
  `LoadingReveal` + skeleton pattern (and the duplicated empty-branch header
  markup was merged away).
- Switching knowledge bases flashed the previous KB's file list or empty state
  before the spinner appeared, because the loading flag was only set in an
  effect (after paint). State is now reset synchronously during render, so the
  first frame after a switch is always the spinner.
- The knowledge base file-list spinner was pinned near the top (`py-16`); it is
  now centered on both axes like the files page.
- The shared file preview dialog stacked three uncoordinated loading states
  (content fetch, dynamic chunk load, document parse) with different heights,
  causing visible spinner swaps and dialog jumps. Heavy viewers
  (pdf/docx/sheet/native) now hoist their internal loading via
  `showLoading={false}` + `onLoadingChange`, and the dialog renders a single
  continuous overlay with stable min-height. Benefits all consumers
  (knowledge bases, platform files dialog, chat attachments, chat input).

**Chart polish.** Stacked bar columns now round the top corners of whichever
segment is actually the visible top of each column (respecting legend
visibility and near-zero segments) via a new `createStackedBarTopRoundedShape`
helper in `components/ui/chart.tsx`; line/area charts get thinner strokes,
rounded caps, softer gradient opacity, and smaller active dots across admin
statistics, moderation statistics, and subscription trend charts.

**Artifact preview width.** The chat artifact panel can now be dragged up to
75% of the workspace (previously capped at 50%). The default widths are
unchanged (1/2 balanced, 1/3 wide); only the drag ceiling was raised, with the
default decoupled into `ARTIFACT_BALANCED_RATIO`.

## Change type

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Frontend / UI
- [x] Admin console

## Verification

- [x] `pnpm typecheck` — passes
- [x] `biome lint` on all touched files — no issues
- [x] Manual check recommended: switch between knowledge bases (empty ↔
      non-empty), open a PDF preview, drag the artifact divider to the new 75%
      limit, and review stacked bars with some series hidden via legend.

## Screenshots, API examples, or logs

UI-only changes; behavior is the absence of loading flicker/jumps and the new
stacked-bar rounded tops.

## Configuration, migration, and compatibility notes

No API, configuration, or URL changes. `FilePreviewDialog`'s public props are
unchanged; viewer components' new behavior is opt-in via existing
`showLoading`/`onLoadingChange` props.

## Documentation

- [x] Documentation is not needed for this change.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.