### PR TITLE
fix: harden markdown links and stream value parsing

### DIFF
--- a/backend/internal/infra/cache/redis/conversation_cache.go
+++ b/backend/internal/infra/cache/redis/conversation_cache.go
@@ -240,13 +240,7 @@ func (c *conversationCache) ClaimTimedOutFileProcessingMessages(ctx context.Cont
 		}
 		return nil, err
 	}
-	messages := make([]repository.FileProcessingMessage, 0, len(claimed))
-	for _, msg := range claimed {
-		parsed := parseFileProcessingMessage(msg)
-		parsed.Reclaimed = true
-		messages = append(messages, parsed)
-	}
-	return messages, nil
+	return c.decodeFileProcessingMessages(ctx, consumerName, claimed, true)
 }
 
 // ReadFileProcessingMessages 阻塞读取未处理消息（最多 1 条，5s 超时）。
@@ -269,21 +263,97 @@ func (c *conversationCache) ReadFileProcessingMessages(ctx context.Context, cons
 	}
 	messages := make([]repository.FileProcessingMessage, 0)
 	for _, stream := range streams {
-		for _, msg := range stream.Messages {
-			messages = append(messages, parseFileProcessingMessage(msg))
+		parsed, parseErr := c.decodeFileProcessingMessages(ctx, consumerName, stream.Messages, false)
+		if parseErr != nil {
+			return nil, parseErr
 		}
+		messages = append(messages, parsed...)
 	}
 	return messages, nil
 }
 
-func parseFileProcessingMessage(msg redis.XMessage) repository.FileProcessingMessage {
+func (c *conversationCache) decodeFileProcessingMessages(
+	ctx context.Context,
+	consumerName string,
+	messages []redis.XMessage,
+	reclaimed bool,
+) ([]repository.FileProcessingMessage, error) {
+	parsedMessages := make([]repository.FileProcessingMessage, 0, len(messages))
+	for _, msg := range messages {
+		parsed, err := parseFileProcessingMessage(msg)
+		if err != nil {
+			quarantined, quarantineErr := c.deadLetterInvalidFileProcessingMessage(ctx, consumerName, msg, err)
+			if quarantineErr != nil {
+				return nil, fmt.Errorf("dead-letter invalid file processing message %q: %w", msg.ID, quarantineErr)
+			}
+			if !quarantined {
+				return nil, fmt.Errorf("dead-letter invalid file processing message %q: message ownership lost", msg.ID)
+			}
+			continue
+		}
+		parsed.Reclaimed = reclaimed
+		parsedMessages = append(parsedMessages, parsed)
+	}
+	return parsedMessages, nil
+}
+
+func parseFileProcessingMessage(msg redis.XMessage) (repository.FileProcessingMessage, error) {
+	userID, err := strconv.ParseUint(strings.TrimSpace(getStringVal(msg.Values["user_id"])), 10, strconv.IntSize)
+	if err != nil || userID == 0 {
+		if err == nil {
+			err = errors.New("must be greater than zero")
+		}
+		return repository.FileProcessingMessage{}, fmt.Errorf("invalid user_id: %w", err)
+	}
+
+	retry, err := strconv.Atoi(strings.TrimSpace(getStringVal(msg.Values["retry"])))
+	if err != nil || retry < 0 {
+		if err == nil {
+			err = errors.New("must not be negative")
+		}
+		return repository.FileProcessingMessage{}, fmt.Errorf("invalid retry: %w", err)
+	}
+
+	lastError := ""
+	if rawLastError, ok := msg.Values["last_error"]; ok {
+		lastError = getStringVal(rawLastError)
+	}
+
 	return repository.FileProcessingMessage{
 		ID:        msg.ID,
-		UserID:    uint(getInt64Val(msg.Values["user_id"])),
+		UserID:    uint(userID),
 		FileID:    strings.TrimSpace(getStringVal(msg.Values["file_id"])),
-		Retry:     int(getInt64Val(msg.Values["retry"])),
-		LastError: getStringVal(msg.Values["last_error"]),
+		Retry:     retry,
+		LastError: lastError,
+	}, nil
+}
+
+func (c *conversationCache) deadLetterInvalidFileProcessingMessage(
+	ctx context.Context,
+	consumerName string,
+	message redis.XMessage,
+	parseErr error,
+) (bool, error) {
+	lastError := "invalid queue message: " + parseErr.Error()
+	if rawLastError, ok := message.Values["last_error"]; ok {
+		if previousError := strings.TrimSpace(getStringVal(rawLastError)); previousError != "" {
+			lastError += "; previous error: " + previousError
+		}
 	}
+
+	return fileProcessingScriptResult(deadLetterFileProcessingMessageScript.Run(
+		ctx,
+		c.client,
+		[]string{fileProcessingStreamName, fileProcessingDLQName},
+		fileProcessingGroupName,
+		consumerName,
+		message.ID,
+		getStringVal(message.Values["user_id"]),
+		getStringVal(message.Values["file_id"]),
+		getStringVal(message.Values["retry"]),
+		truncateStr(lastError, 255),
+		fileProcessingDLQMaxLen,
+	).Result())
 }
 
 // RenewFileProcessingMessageLease 刷新执行中消息的空闲时间，避免长任务被其他 worker 重复认领。

--- a/backend/internal/infra/llm/anthropic.go
+++ b/backend/internal/infra/llm/anthropic.go
@@ -1354,11 +1354,7 @@ func applyAnthropicStreamEvent(
 }
 
 func anthropicContentBlockIndex(parsed map[string]interface{}) int {
-	index := int(toInt64(parsed["index"]))
-	if index < 0 {
-		return 0
-	}
-	return index
+	return streamToolCallIndex(parsed["index"], 0)
 }
 
 func upsertAnthropicStreamToolCall(result *GenerateOutput, index int, item ToolCall) ToolCall {

--- a/backend/internal/infra/llm/client.go
+++ b/backend/internal/infra/llm/client.go
@@ -27,6 +27,8 @@ const (
 	defaultReadTimeoutMS       = 120000 // 非流式/首字节超时 120s（含 LLM 推理）
 	defaultStreamIdleTimeoutMS = 60000  // 流式 chunk 间隔超时 60s
 	maxUpstreamBodyBytes       = 64 * 1024 * 1024
+	// maxStreamToolCallIndex 防止异常稀疏的上游索引触发无界切片扩容。
+	maxStreamToolCallIndex = 1024
 )
 
 const upstreamRequestIDHeaderTemplate = "${DEEIX_UPSTREAM_REQUEST_ID}"
@@ -1432,6 +1434,17 @@ func toInt64(raw interface{}) int64 {
 	default:
 		return 0
 	}
+}
+
+func streamToolCallIndex(raw interface{}, fallback int) int {
+	if fallback < 0 || fallback > maxStreamToolCallIndex {
+		fallback = 0
+	}
+	index, err := strconv.Atoi(strings.TrimSpace(getString(raw)))
+	if err != nil || index < 0 || index > maxStreamToolCallIndex {
+		return fallback
+	}
+	return index
 }
 
 func normalizeJSONString(raw interface{}) string {

--- a/backend/internal/infra/llm/openai_chat_completions.go
+++ b/backend/internal/infra/llm/openai_chat_completions.go
@@ -306,10 +306,7 @@ func mergeChatStreamToolCalls(parsed map[string]interface{}, result *GenerateOut
 	}
 	for fallbackIndex, raw := range items {
 		payload := asMap(raw)
-		index := int(toInt64(payload["index"]))
-		if index < 0 {
-			index = fallbackIndex
-		}
+		index := streamToolCallIndex(payload["index"], fallbackIndex)
 		for len(result.ToolCalls) <= index {
 			result.ToolCalls = append(result.ToolCalls, ToolCall{Status: "requested"})
 		}

--- a/frontend/shared/components/markdown/streamdown-components.tsx
+++ b/frontend/shared/components/markdown/streamdown-components.tsx
@@ -109,7 +109,11 @@ function resolveLinkKind(href: string): ResolvedLinkKind {
 
   try {
     const targetURL = new URL(href, currentOrigin);
-    if (targetURL.protocol === "javascript:") {
+    if (
+      targetURL.protocol === "javascript:" ||
+      targetURL.protocol === "data:" ||
+      targetURL.protocol === "vbscript:"
+    ) {
       return "invalid";
     }
     if (targetURL.origin === currentOrigin) {


### PR DESCRIPTION
## Summary

Harden untrusted Markdown links and backend stream value parsing.

- Reject `javascript:`, `data:`, and `vbscript:` links in the custom Markdown link resolver while preserving normal anchors, HTTP links, and supported special links.
- Parse Redis file-processing `user_id` and `retry` values using target-width integer types with explicit range validation.
- Atomically move malformed file-processing messages to the existing dead-letter queue instead of leaving poison messages pending indefinitely.
- Preserve existing queue error context when recording malformed messages.
- Add a shared bounded tool-call index parser for Anthropic and OpenAI-compatible streaming responses.
- Fall back to safe positional indices when upstream tool-call indices are missing, invalid, negative, or excessively large.
- Prevent unsafe integer narrowing and abnormal sparse slice allocation from untrusted upstream values.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [x] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [x] Files / RAG / extraction
- [x] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm --dir frontend exec biome check shared/components/markdown/streamdown-components.tsx`
- [x] `pnpm --filter @deeix/web typecheck`
- [x] `go test ./internal/infra/cache/redis ./internal/infra/llm ./internal/application/processing`
- [x] `pnpm --filter @deeix/api check`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Not applicable. This change affects validation and failure handling without introducing visual UI changes or modifying public API payloads.

## Configuration, migration, and compatibility notes

- No database migration or configuration change is required.
- No public API contract is changed.
- Valid Redis queue messages and valid provider stream events retain their existing behavior.
- Malformed Redis messages are now quarantined in the existing dead-letter queue.
- Invalid or excessive provider tool-call indices now use a safe fallback.
- `data:` anchor links are blocked; Markdown image handling is unaffected.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including Markdown link handling, Redis file-processing queues, and provider stream parsing.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.