### PR TITLE
fix: preserve multiline web text when pasting into chat

### DIFF
--- a/frontend/features/chat/utils/markdown-paste.ts
+++ b/frontend/features/chat/utils/markdown-paste.ts
@@ -89,13 +89,33 @@ function resolveVSCodeCodePaste(clipboardData: DataTransfer): ClipboardMarkdownP
   }
 }
 
-function containsBlockHTML(html: string): boolean {
-  const document = new DOMParser().parseFromString(html, "text/html");
-  return Boolean(document.body.querySelector(HTML_BLOCK_SELECTOR));
+function containsBlockHTML(root: ParentNode): boolean {
+  return Boolean(root.querySelector(HTML_BLOCK_SELECTOR));
 }
 
 function normalizeText(value: string): string {
   return value.replace(/\r\n?/g, "\n").trim();
+}
+
+function normalizeTextFlow(value: string): string {
+  return normalizeText(value).replace(/\s+/g, " ");
+}
+
+function containsMarkdownFormatting(root: ParentNode): boolean {
+  return Boolean(
+    root.querySelector(
+      "a[href], b, blockquote, code, del, em, h1, h2, h3, h4, h5, h6, hr, i, img[src], ol, pre, s, strike, strong, table, ul",
+    ),
+  );
+}
+
+function losesSourceLineBreaks(markdown: string, plainText: string): boolean {
+  const markdownLines = normalizeText(markdown).split("\n");
+  const sourceLines = normalizeText(plainText).split("\n");
+  return (
+    markdownLines.length < sourceLines.length ||
+    markdownLines.filter((line) => line.trim()).length < sourceLines.filter((line) => line.trim()).length
+  );
 }
 
 function resolveRichTextMarkdownPaste(clipboardData: DataTransfer): ClipboardMarkdownPaste | null {
@@ -105,18 +125,32 @@ function resolveRichTextMarkdownPaste(clipboardData: DataTransfer): ClipboardMar
     return null;
   }
 
-  const markdown = turndownService.turndown(html).trim();
+  const body = new DOMParser().parseFromString(html, "text/html").body;
+  if (!containsMarkdownFormatting(body)) {
+    return null;
+  }
+
+  const markdown = turndownService.turndown(body).trim();
+  if (!markdown) {
+    return null;
+  }
+
   const normalizedMarkdown = normalizeText(markdown);
+  const normalizedPlainText = normalizeText(plainText);
+  const normalizedEscapedPlainText = normalizeText(turndownService.escape(plainText));
+  const normalizedMarkdownFlow = normalizeTextFlow(markdown);
   if (
-    !markdown ||
-    normalizedMarkdown === normalizeText(plainText) ||
-    normalizedMarkdown === normalizeText(turndownService.escape(plainText))
+    normalizedMarkdown === normalizedPlainText ||
+    normalizedMarkdown === normalizedEscapedPlainText ||
+    normalizedMarkdownFlow === normalizeTextFlow(plainText) ||
+    normalizedMarkdownFlow === normalizeTextFlow(normalizedEscapedPlainText) ||
+    losesSourceLineBreaks(markdown, plainText)
   ) {
     return null;
   }
 
   return {
-    block: containsBlockHTML(html),
+    block: containsBlockHTML(body),
     markdown,
   };
 }


### PR DESCRIPTION
## Summary

Fixes #677.

Prevent external webpage text from being escaped or losing line breaks when pasted into the chat composer.

The composer previously preferred `text/html` and converted it through Turndown. For code editors and syntax-highlighted webpages, the HTML representation may not contain the same line structure as `text/plain`. Turndown could therefore collapse multiple lines and escape identifiers such as `max_tokens` into `max\_tokens`.

This change introduces a fidelity-first paste policy:

- use native `text/plain` when the copied HTML contains no meaningful Markdown formatting;
- fall back to native text when HTML-to-Markdown conversion loses source lines;
- avoid overriding native paste when conversion only changes escaping or whitespace;
- continue preserving links, emphasis, lists, tables, code blocks, and other meaningful rich-text formatting;
- preserve the existing VS Code fenced-code behavior;
- preserve the existing DEEIX code-block plain-text clipboard marker;
- parse clipboard HTML once and reuse the parsed document.

The implementation is content-based and does not introduce website-specific rules or code-text heuristics.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] Verified multiline syntax-highlighted web text preserves underscores and line breaks.
- [x] Verified literal options such as `--disable-auto-update` remain unchanged.
- [x] Verified bold text, links, and lists still convert to Markdown.
- [x] `pnpm --dir frontend check`
- [x] `pnpm build`
- [x] `git diff --check`

## Screenshots, API examples, or logs

No layout changes.

Before:

```text
"model": "moonshotai/kimi-k3", "max\_tokens": 16384, "seed": 0, "stream": stream, "temperature": 1, "reasoning\_effort": "max"
```

After:

```text
"model": "moonshotai/kimi-k3",
"max_tokens": 16384,
"seed": 0,
"stream": stream,
"temperature": 1,
"reasoning_effort": "max"
```

## Configuration, migration, and compatibility notes

- No configuration or migration is required.
- No API or data contract changes are introduced.
- Native browser paste remains the source of truth for literal text.
- Existing rich-text, VS Code, and internal code-copy behavior remains supported.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains unchanged.
- [x] Clipboard HTML continues to be parsed in a detached document and is never mounted or executed.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior is documented in this pull request.
- [x] Generated artifacts are included only when explicitly required.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.