### PR TITLE
fix: correct admin redemption filters and control styling

### DIFF
--- a/frontend/features/admin/components/admin-date-range-filter.tsx
+++ b/frontend/features/admin/components/admin-date-range-filter.tsx
@@ -76,13 +76,15 @@ export function AdminDateRangeFilter({
             variant="outline"
             className={cn(
               ADMIN_DATE_PICKER_TRIGGER_CLASSNAME,
-              "px-2.5 h-7",
+              "h-7 px-2",
               triggerClassName,
               !selectedRange?.from && "text-muted-foreground",
             )}
             disabled={disabled}
           >
-            <CalendarIcon className="size-3 opacity-70" />
+            <span aria-hidden="true" className="flex size-3 shrink-0 items-center justify-center">
+              <CalendarIcon className="size-3 opacity-70" />
+            </span>
             <span className="min-w-0 truncate text-[11px]">{triggerLabel}</span>
           </Button>
         </PopoverTrigger>

--- a/frontend/features/admin/components/sections/announcements/admin-announcements.tsx
+++ b/frontend/features/admin/components/sections/announcements/admin-announcements.tsx
@@ -597,6 +597,7 @@ export function AdminAnnouncementsPage() {
                   toValue={toDateRangeValue(form.expiresAt)}
                   disabled={saving}
                   placeholder={t("fields.alwaysActive")}
+                  triggerClassName="h-8 px-3"
                   onFromChange={(value) => setForm((current) => ({ ...current, startsAt: dateRangeBoundaryValue(value, "start") }))}
                   onToChange={(value) => setForm((current) => ({ ...current, expiresAt: dateRangeBoundaryValue(value, "end") }))}
                 />

--- a/frontend/features/admin/components/sections/logs/admin-redemption-records.tsx
+++ b/frontend/features/admin/components/sections/logs/admin-redemption-records.tsx
@@ -5,6 +5,7 @@ import { useLocale, useTranslations } from "next-intl";
 import * as React from "react";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Table,
   TableBody,
@@ -34,6 +35,74 @@ function nanousdToUSD(value: number | null | undefined): number | null {
     return null;
   }
   return value / 1_000_000_000;
+}
+
+function RedemptionIDFilter({
+  value,
+  placeholder,
+  clearLabel,
+  onValueChange,
+}: {
+  value: number;
+  placeholder: string;
+  clearLabel: string;
+  onValueChange: (value: number) => void;
+}) {
+  const [draft, setDraft] = React.useState(value > 0 ? String(value) : "");
+
+  React.useEffect(() => {
+    setDraft(value > 0 ? String(value) : "");
+  }, [value]);
+
+  const commit = React.useCallback(() => {
+    const parsed = /^\d+$/.test(draft) ? Number.parseInt(draft, 10) : 0;
+    const nextValue = Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 0;
+
+    setDraft(nextValue > 0 ? String(nextValue) : "");
+    if (nextValue !== value) {
+      onValueChange(nextValue);
+    }
+  }, [draft, onValueChange, value]);
+
+  const clear = React.useCallback(() => {
+    setDraft("");
+    if (value > 0) {
+      onValueChange(0);
+    }
+  }, [onValueChange, value]);
+
+  return (
+    <div className="relative">
+      <Input
+        value={draft}
+        inputMode="numeric"
+        pattern="[0-9]*"
+        placeholder={placeholder}
+        className="h-7 pr-7 pl-2 text-[11px] tabular-nums"
+        onChange={(event) => setDraft(event.target.value.replace(/\D/g, ""))}
+        onBlur={commit}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            event.currentTarget.blur();
+          }
+        }}
+      />
+      {draft ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="absolute top-1/2 right-1 h-5 w-5 -translate-y-1/2 text-muted-foreground shadow-none"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={clear}
+          aria-label={clearLabel}
+        >
+          <X className="size-3 stroke-1" />
+        </Button>
+      ) : null}
+    </div>
+  );
 }
 
 export function RedemptionRecordTable({
@@ -83,30 +152,32 @@ export function RedemptionRecordTable({
               { label: t("redemptions.rewards.subscription"), value: "subscription" },
             ],
           },
-          ...(logs.codeIDFilter > 0
-            ? [
-                {
-                  key: "code",
-                  label: t("redemptions.filters.code"),
-                  active: true,
-                  content: (
-                    <div className="flex items-center gap-2 px-2 py-1.5 text-xs">
-                      <span className="font-mono text-muted-foreground">#{logs.codeIDFilter}</span>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-xs"
-                        className="h-6 w-6 text-muted-foreground shadow-none"
-                        onClick={() => logs.setCodeIDFilter(0)}
-                        aria-label={t("redemptions.filters.clearCode")}
-                      >
-                        <X className="size-3.5 stroke-1" />
-                      </Button>
-                    </div>
-                  ),
-                },
-              ]
-            : []),
+          {
+            key: "code_id",
+            label: t("redemptions.filters.codeID"),
+            active: logs.codeIDFilter > 0,
+            content: (
+              <RedemptionIDFilter
+                value={logs.codeIDFilter}
+                placeholder={t("redemptions.filters.codeIDPlaceholder")}
+                clearLabel={t("redemptions.filters.clearCodeID")}
+                onValueChange={logs.setCodeIDFilter}
+              />
+            ),
+          },
+          {
+            key: "user_id",
+            label: t("redemptions.filters.userID"),
+            active: logs.userIDFilter > 0,
+            content: (
+              <RedemptionIDFilter
+                value={logs.userIDFilter}
+                placeholder={t("redemptions.filters.userIDPlaceholder")}
+                clearLabel={t("redemptions.filters.clearUserID")}
+                onValueChange={logs.setUserIDFilter}
+              />
+            ),
+          },
           {
             key: "created_range",
             label: t("filters.timeRange"),

--- a/frontend/features/admin/hooks/use-admin-logs.ts
+++ b/frontend/features/admin/hooks/use-admin-logs.ts
@@ -314,6 +314,8 @@ type UseAdminRedemptionsState = {
   setRewardTypeFilter: (value: string) => void;
   codeIDFilter: number;
   setCodeIDFilter: (value: number) => void;
+  userIDFilter: number;
+  setUserIDFilter: (value: number) => void;
   createdFromFilter: string;
   setCreatedFromFilter: (value: string) => void;
   createdToFilter: string;
@@ -1061,6 +1063,7 @@ export function useAdminRedemptions(initialCodeID?: number): UseAdminRedemptions
   const [codeIDFilter, setCodeIDFilterState] = React.useState(
     initialCodeID && initialCodeID > 0 ? initialCodeID : 0,
   );
+  const [userIDFilter, setUserIDFilterState] = React.useState(0);
   const [createdFromFilter, setCreatedFromFilterState] = React.useState("");
   const [createdToFilter, setCreatedToFilterState] = React.useState("");
   const [sortValue, setSortValueState] = React.useState<RedemptionSortValue>("created_desc");
@@ -1084,8 +1087,8 @@ export function useAdminRedemptions(initialCodeID?: number): UseAdminRedemptions
       const data = await listAdminRedemptions(token, {
         page: nextPage,
         pageSize: nextPageSize,
-        query: /^\d+$/.test(debouncedQuery) ? undefined : debouncedQuery,
-        userID: parsePositiveInt(debouncedQuery),
+        query: debouncedQuery,
+        userID: userIDFilter > 0 ? userIDFilter : undefined,
         codeID: codeIDFilter > 0 ? codeIDFilter : undefined,
         rewardType: rewardTypeFilter,
         createdFrom: toRFC3339DateRangeBound(createdFromFilter, "start"),
@@ -1104,7 +1107,7 @@ export function useAdminRedemptions(initialCodeID?: number): UseAdminRedemptions
         setLoading(false);
       }
     }
-  }, [codeIDFilter, createdFromFilter, createdToFilter, debouncedQuery, pageSize, rewardTypeFilter, sortValue, t]);
+  }, [codeIDFilter, createdFromFilter, createdToFilter, debouncedQuery, pageSize, rewardTypeFilter, sortValue, t, userIDFilter]);
 
   React.useEffect(() => {
     void loadRedemptions(1);
@@ -1120,6 +1123,10 @@ export function useAdminRedemptions(initialCodeID?: number): UseAdminRedemptions
   }, []);
   const setCodeIDFilter = React.useCallback((value: number) => {
     setCodeIDFilterState(value > 0 ? value : 0);
+    setPage(1);
+  }, []);
+  const setUserIDFilter = React.useCallback((value: number) => {
+    setUserIDFilterState(value > 0 ? value : 0);
     setPage(1);
   }, []);
   const setCreatedFromFilter = React.useCallback((value: string) => {
@@ -1148,6 +1155,8 @@ export function useAdminRedemptions(initialCodeID?: number): UseAdminRedemptions
     setRewardTypeFilter,
     codeIDFilter,
     setCodeIDFilter,
+    userIDFilter,
+    setUserIDFilter,
     createdFromFilter,
     setCreatedFromFilter,
     createdToFilter,

--- a/frontend/i18n/messages/en-US/admin-logs.json
+++ b/frontend/i18n/messages/en-US/admin-logs.json
@@ -272,13 +272,17 @@
     }
   },
   "redemptions": {
-    "searchPlaceholder": "Search user ID, redemption ref no., code hint, or note",
+    "searchPlaceholder": "Search redemption ref no., code hint, or note",
     "empty": "No redemption records",
     "filters": {
       "all": "All",
       "rewardType": "Reward type",
-      "code": "Code",
-      "clearCode": "Clear code filter"
+      "codeID": "Code ID",
+      "codeIDPlaceholder": "Enter code ID",
+      "userID": "User ID",
+      "userIDPlaceholder": "Enter user ID",
+      "clearCodeID": "Clear code ID",
+      "clearUserID": "Clear user ID"
     },
     "rewards": {
       "balance": "Balance",

--- a/frontend/i18n/messages/zh-CN/admin-logs.json
+++ b/frontend/i18n/messages/zh-CN/admin-logs.json
@@ -272,13 +272,17 @@
     }
   },
   "redemptions": {
-    "searchPlaceholder": "搜索用户 ID、兑换流水号、兑换码摘要、备注",
+    "searchPlaceholder": "搜索兑换流水号、兑换码摘要或备注",
     "empty": "暂无兑换记录",
     "filters": {
       "all": "全部",
       "rewardType": "奖励类型",
-      "code": "兑换码",
-      "clearCode": "清除兑换码筛选"
+      "codeID": "兑换码 ID",
+      "codeIDPlaceholder": "输入兑换码 ID",
+      "userID": "用户 ID",
+      "userIDPlaceholder": "输入用户 ID",
+      "clearCodeID": "清除兑换码 ID",
+      "clearUserID": "清除用户 ID"
     },
     "rewards": {
       "balance": "余额",
@@ -450,7 +454,7 @@
     "detailImageAlt": "审核图片 {index}",
     "imageLoadFailed": "部分隔离图片加载失败",
     "filters": {
-      "all": "所有"
+      "all": "全部"
     },
     "results": {
       "passed": "通过",

--- a/frontend/shared/components/model-option-icon.tsx
+++ b/frontend/shared/components/model-option-icon.tsx
@@ -1,7 +1,15 @@
 import { ModelIcon } from "@/shared/components/model-icon";
 
-export function ModelOptionIcon({ iconUrl, label }: { iconUrl?: string | null; label: string }) {
+export function ModelOptionIcon({
+  iconUrl,
+  label,
+  size = 16,
+}: {
+  iconUrl?: string | null;
+  label: string;
+  size?: number;
+}) {
   return (
-    <ModelIcon iconUrl={iconUrl} label={label} className="self-center" />
+    <ModelIcon iconUrl={iconUrl} label={label} size={size} className="self-center" />
   );
 }

--- a/frontend/shared/components/model-select.tsx
+++ b/frontend/shared/components/model-select.tsx
@@ -176,19 +176,19 @@ function ModelSelectIcon({
   fallbackValue: string;
 }) {
   if (!option) {
-    return <ModelOptionIcon iconUrl={null} label="" />;
+    return <ModelOptionIcon iconUrl={null} label="" size={14} />;
   }
 
   if (!option.iconUrl && option.value === fallbackValue) {
     return (
-      <span className="inline-flex size-4 shrink-0 items-center justify-center self-center text-foreground">
-        <Sparkles className="size-4" strokeWidth={1.8} />
+      <span className="inline-flex size-3.5 shrink-0 items-center justify-center self-center text-muted-foreground">
+        <Sparkles className="size-3.5 stroke-1" />
         <span className="sr-only">{option.label}</span>
       </span>
     );
   }
 
-  return <ModelOptionIcon iconUrl={option.iconUrl} label={option.label} />;
+  return <ModelOptionIcon iconUrl={option.iconUrl} label={option.label} size={14} />;
 }
 
 export function ModelSelect({


### PR DESCRIPTION
## Summary

- Stop interpreting numeric redemption search text as a user ID.
- Keep the redemption search field scoped to reference numbers, code hints, and notes.
- Add explicit exact-match filters for redemption code IDs and user IDs.
- Preserve existing `code_id` deep-link filtering behavior.
- Align compact filter inputs and date range controls through shared component styling.
- Prevent icon-aware button padding from shifting date range controls.
- Preserve standard sizing for the announcement date range field.
- Normalize compact model selector icons to 14px.
- Use the standard muted color and stroke width for the “All models” icon.
- Standardize the Chinese moderation filter label from “所有” to “全部”.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [x] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `git diff --check`
- [ ] Not run; reason:

## Screenshots, API examples, or logs

- Verified the redemption filter popover, date range alignment, moderation labels, and compact model selector styling locally.

## Configuration, migration, and compatibility notes

- No database migration or configuration change is required.
- No backend API contract was changed.
- The implementation reuses the existing `code_id`, `user_id`, and free-text query parameters.
- Existing redemption code deep links remain compatible.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped to the existing admin-only redemption log endpoint.
- [x] Security-sensitive behavior was reviewed for the affected admin billing filters.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior and compatibility notes are documented.
- [x] Generated artifacts are included only when explicitly required.
- [x] Build output, caches, local configuration, and environment files are not committed.