### PR TITLE
fix: prevent post generation blank space and stale run indicators

### DIFF
--- a/frontend/features/chat/components/sections/chat-area.tsx
+++ b/frontend/features/chat/components/sections/chat-area.tsx
@@ -53,14 +53,34 @@ function ScrollToLiveUser({
   viewportRef: React.RefObject<HTMLDivElement | null>;
 }): null {
   const handledScrollKeyRef = React.useRef("");
-  const followWhenOverflowingRef = React.useRef(false);
+  const waitingForOverflowRef = React.useRef(false);
+  const userTookOverRef = React.useRef(false);
   const { scrollToEnd, scrollToMessage } = useMessageScroller();
   const scrollable = useMessageScrollerScrollable();
 
   React.useLayoutEffect(() => {
     if (!scrollKey) {
+      const previousScrollKey = handledScrollKeyRef.current;
+      const preserveScrollPosition = userTookOverRef.current;
       handledScrollKeyRef.current = "";
-      followWhenOverflowingRef.current = false;
+      waitingForOverflowRef.current = false;
+      userTookOverRef.current = false;
+      if (!previousScrollKey) {
+        return;
+      }
+
+      const viewport = viewportRef.current;
+      const previousScrollTop = viewport?.scrollTop ?? 0;
+      // scrollToMessage may add an internal spacer while keeping the live user
+      // message at the top. Releasing the live anchor through the public API
+      // clears that spacer when the run reaches a terminal state.
+      scrollToEnd({ behavior: "auto" });
+      if (viewport && preserveScrollPosition) {
+        viewport.scrollTop = Math.min(
+          previousScrollTop,
+          Math.max(0, viewport.scrollHeight - viewport.clientHeight),
+        );
+      }
       return;
     }
     if (handledScrollKeyRef.current === scrollKey) {
@@ -68,11 +88,15 @@ function ScrollToLiveUser({
     }
 
     handledScrollKeyRef.current = scrollKey;
+    waitingForOverflowRef.current = true;
+    userTookOverRef.current = false;
     let secondFrameID: number | null = null;
     const firstFrameID = window.requestAnimationFrame(() => {
       secondFrameID = window.requestAnimationFrame(() => {
+        if (userTookOverRef.current) {
+          return;
+        }
         const reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
-        followWhenOverflowingRef.current = true;
         scrollToMessage(scrollKey, {
           align: "start",
           behavior: reducedMotion ? "auto" : "smooth",
@@ -85,13 +109,18 @@ function ScrollToLiveUser({
         window.cancelAnimationFrame(secondFrameID);
       }
     };
-  }, [scrollKey, scrollToMessage]);
+  }, [scrollKey, scrollToEnd, scrollToMessage, viewportRef]);
 
   React.useLayoutEffect(() => {
-    if (!scrollKey || !scrollable.end || !followWhenOverflowingRef.current) {
+    if (
+      !scrollKey ||
+      !scrollable.end ||
+      !waitingForOverflowRef.current ||
+      userTookOverRef.current
+    ) {
       return;
     }
-    followWhenOverflowingRef.current = false;
+    waitingForOverflowRef.current = false;
     scrollToEnd({ behavior: "auto" });
   }, [scrollKey, scrollToEnd, scrollable.end]);
 
@@ -101,7 +130,8 @@ function ScrollToLiveUser({
       return;
     }
     const stopFollowing = () => {
-      followWhenOverflowingRef.current = false;
+      waitingForOverflowRef.current = false;
+      userTookOverRef.current = true;
     };
     const stopFollowingFromKeyboard = (event: KeyboardEvent) => {
       if (["ArrowDown", "ArrowUp", "End", "Home", "PageDown", "PageUp", " "].includes(event.key)) {
@@ -698,7 +728,7 @@ export function ChatArea({
       ) : null}
 
       <div className="relative min-h-0 flex-1 overflow-hidden">
-        <MessageScrollerProvider>
+        <MessageScrollerProvider autoScroll={Boolean(liveUserScrollKey)}>
           <MessageScroller>
             <ScrollToLiveUser
               scrollKey={liveUserScrollKey}

--- a/frontend/features/chat/hooks/use-chat-message-submit.ts
+++ b/frontend/features/chat/hooks/use-chat-message-submit.ts
@@ -352,7 +352,7 @@ export function useChatMessageSubmit({
       let targetBranchScope = plan.targetBranchScope;
       const wasConversationMode = showConversationLayout || visibleMessageCount > 0;
       const createdAt = new Date().toISOString();
-      let sentSuccessfully = false;
+      let terminalResultReceived = false;
       let shouldKeepConversationLayout = false;
       const streamAbortController = new AbortController();
       let targetConversationID = queuedSubmission?.conversationPublicID ?? conversationIDRef.current;
@@ -551,7 +551,7 @@ export function useChatMessageSubmit({
           signal: streamAbortController.signal,
         });
 
-        sentSuccessfully = true;
+        terminalResultReceived = true;
         const assistantMessageSucceeded = (completed.assistantMessage.status || "success") === "success";
         const completedBranchScope: BranchScope = {
           conversationScopeKey: targetConversationScopeKey,
@@ -735,7 +735,14 @@ export function useChatMessageSubmit({
           activeStreamsRef.current.delete(clientRunID);
         }
         activeGenerationRunsRef?.current.delete(clientRunID);
-        onConversationRunDetached?.(clientRunID);
+        if (terminalResultReceived) {
+          // A resolved stream already has an authoritative terminal result.
+          // Settle locally as a fallback even if the final SSE callback was
+          // missed; only uncertain disconnects should remain detached.
+          onConversationRunFinished?.(clientRunID);
+        } else {
+          onConversationRunDetached?.(clientRunID);
+        }
         if (
           branchRunIsVisible(
             targetBranchScope,
@@ -744,7 +751,7 @@ export function useChatMessageSubmit({
             visibleBranchScopePathRef.current,
             visibleMessagesRef.current,
           ) &&
-          !sentSuccessfully &&
+          !terminalResultReceived &&
           !wasConversationMode &&
           !shouldKeepConversationLayout
         ) {
@@ -765,6 +772,7 @@ export function useChatMessageSubmit({
       modelOptions,
       onConversationCreated,
       onConversationRunDetached,
+      onConversationRunFinished,
       onConversationRunStarted,
       options,
       prependNewConversation,


### PR DESCRIPTION
## Summary

- Clear the temporary message scroller spacer when generation reaches a terminal state.
- Preserve the current viewport position when the user manually takes over scrolling.
- Keep automatic bottom following scoped to active generation only.
- Settle completed conversation runs immediately when a terminal result is received.
- Keep runs detached only when the stream ends without a confirmed terminal result.
- Prevent completed conversations from retaining stale running indicators in the sidebar.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`

## Screenshots, API examples, or logs

Not included. The changes affect scroll lifecycle and client-side conversation run state.

## Configuration, migration, and compatibility notes

No configuration, database, API contract, or deployment changes are required.

The existing interrupted-stream recovery behavior remains unchanged. Only streams with a confirmed terminal result are settled immediately.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.