### PR TITLE
fix: resolve active session locations

### DIFF
--- a/backend/internal/application/auth/service.go
+++ b/backend/internal/application/auth/service.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/netip"
 	"net/url"
 	"sort"
 	"strings"
@@ -642,9 +643,36 @@ func (s *Service) resolveSessionAuditContext(
 
 	enriched, err := s.geoResolver.Lookup(ctx, normalized.ClientIP)
 	if err != nil {
+		s.warnGeoLookupFailure("audit_context", normalized.ClientIP, err)
 		return normalized
 	}
 	return mergeSessionAuditContext(normalized, enriched)
+}
+
+func (s *Service) warnGeoLookupFailure(stage string, rawIP string, err error) {
+	if err == nil {
+		return
+	}
+	clientIP, parseErr := netip.ParseAddr(strings.TrimSpace(rawIP))
+	if parseErr != nil ||
+		!clientIP.IsGlobalUnicast() ||
+		clientIP.IsPrivate() ||
+		clientIP.IsLoopback() ||
+		clientIP.IsLinkLocalUnicast() {
+		return
+	}
+	reason := "lookup_failed"
+	if errors.Is(err, context.Canceled) {
+		reason = "request_canceled"
+	} else if errors.Is(err, context.DeadlineExceeded) {
+		reason = "timeout"
+	}
+	s.warn(
+		"session_geo_lookup_failed",
+		zap.String("stage", stage),
+		zap.String("reason", reason),
+		zap.String("error_type", fmt.Sprintf("%T", err)),
+	)
 }
 
 // mergeSessionAuditContext 将 enriched 中的地理信息补填到 base 中，仅覆盖 base 的空字段。
@@ -681,24 +709,31 @@ func mergeSessionAuditContext(
 	return result
 }
 
-func sessionActivityInputFromSnapshot(snapshot sessionAuditSnapshot, lastSeenAt time.Time) repository.UpdateSessionActivityInput {
-	return repository.UpdateSessionActivityInput{
-		LastSeenAt:   &lastSeenAt,
-		ClientIP:     &snapshot.ClientIP,
-		UserAgent:    &snapshot.UserAgent,
-		DeviceName:   &snapshot.DeviceName,
-		BrowserName:  &snapshot.BrowserName,
-		OSName:       &snapshot.OSName,
-		DeviceType:   &snapshot.DeviceType,
-		GeoSource:    &snapshot.GeoSource,
-		GeoAccuracy:  &snapshot.GeoAccuracy,
-		CountryCode:  &snapshot.CountryCode,
-		RegionName:   &snapshot.RegionName,
-		CityName:     &snapshot.CityName,
-		TimezoneName: &snapshot.TimezoneName,
-		IPLatitude:   &snapshot.IPLatitude,
-		IPLongitude:  &snapshot.IPLongitude,
+func sessionActivityInputFromSnapshot(
+	snapshot sessionAuditSnapshot,
+	lastSeenAt time.Time,
+	includeGeo bool,
+) repository.UpdateSessionActivityInput {
+	input := repository.UpdateSessionActivityInput{
+		LastSeenAt:  &lastSeenAt,
+		ClientIP:    &snapshot.ClientIP,
+		UserAgent:   &snapshot.UserAgent,
+		DeviceName:  &snapshot.DeviceName,
+		BrowserName: &snapshot.BrowserName,
+		OSName:      &snapshot.OSName,
+		DeviceType:  &snapshot.DeviceType,
 	}
+	if includeGeo {
+		input.GeoSource = &snapshot.GeoSource
+		input.GeoAccuracy = &snapshot.GeoAccuracy
+		input.CountryCode = &snapshot.CountryCode
+		input.RegionName = &snapshot.RegionName
+		input.CityName = &snapshot.CityName
+		input.TimezoneName = &snapshot.TimezoneName
+		input.IPLatitude = &snapshot.IPLatitude
+		input.IPLongitude = &snapshot.IPLongitude
+	}
+	return input
 }
 
 // UpdateProfile 更新当前用户资料。
@@ -1116,8 +1151,9 @@ func (s *Service) Refresh(
 		return nil, err
 	}
 
-	sessionSnapshot := buildSessionAuditSnapshot(normalizedAuditCtx)
-	if err = s.repo.TouchSessionActivity(ctx, userItem.ID, claims.SessionID, sessionActivityInputFromSnapshot(sessionSnapshot, now)); err != nil {
+	sessionSnapshot := buildSessionAuditSnapshotForSession(session, normalizedAuditCtx)
+	includeGeo := sessionClientIPChanged(session, normalizedAuditCtx) || sessionAuditContextHasGeo(normalizedAuditCtx)
+	if err = s.repo.TouchSessionActivity(ctx, userItem.ID, claims.SessionID, sessionActivityInputFromSnapshot(sessionSnapshot, now, includeGeo)); err != nil {
 		return nil, err
 	}
 
@@ -1237,9 +1273,11 @@ func (s *Service) ValidateAccessSession(
 	}
 
 	now := time.Now()
-	sessionSnapshot := buildSessionAuditSnapshot(auditCtx)
+	normalizedAuditCtx := auditCtx.Normalize()
+	sessionSnapshot := buildSessionAuditSnapshotForSession(session, normalizedAuditCtx)
 	if shouldTouchSessionActivity(session, sessionSnapshot, now) {
-		if err = s.repo.TouchSessionActivity(ctx, userID, strings.TrimSpace(sessionID), sessionActivityInputFromSnapshot(sessionSnapshot, now)); err != nil {
+		includeGeo := sessionClientIPChanged(session, normalizedAuditCtx) || sessionAuditContextHasGeo(normalizedAuditCtx)
+		if err = s.repo.TouchSessionActivity(ctx, userID, strings.TrimSpace(sessionID), sessionActivityInputFromSnapshot(sessionSnapshot, now, includeGeo)); err != nil {
 			return err
 		}
 	}
@@ -1318,6 +1356,7 @@ func (s *Service) ensureSessionGeoResolved(
 
 	enriched, err := s.geoResolver.Lookup(ctx, session.ClientIP)
 	if err != nil {
+		s.warnGeoLookupFailure("active_session_enrichment", session.ClientIP, err)
 		return session, err
 	}
 	merged := mergeSessionAuditContext(

--- a/backend/internal/application/auth/service_test.go
+++ b/backend/internal/application/auth/service_test.go
@@ -12,7 +12,8 @@ import (
 
 type validateAccessSessionRepo struct {
 	repository.AuthRepository
-	session *domainuser.Session
+	session     *domainuser.Session
+	touchInputs []repository.UpdateSessionActivityInput
 }
 
 func (r *validateAccessSessionRepo) GetSessionByUserAndSessionID(_ context.Context, userID uint, sessionID string) (*domainuser.Session, error) {
@@ -22,8 +23,48 @@ func (r *validateAccessSessionRepo) GetSessionByUserAndSessionID(_ context.Conte
 	return r.session, nil
 }
 
-func (r *validateAccessSessionRepo) TouchSessionActivity(_ context.Context, _ uint, _ string, _ repository.UpdateSessionActivityInput) error {
+func (r *validateAccessSessionRepo) TouchSessionActivity(_ context.Context, _ uint, _ string, input repository.UpdateSessionActivityInput) error {
+	r.touchInputs = append(r.touchInputs, input)
 	return nil
+}
+
+func (r *validateAccessSessionRepo) ListActiveSessionsByUserID(_ context.Context, userID uint, _ time.Time) ([]domainuser.Session, error) {
+	if r.session == nil || r.session.UserID != userID {
+		return nil, nil
+	}
+	return []domainuser.Session{*r.session}, nil
+}
+
+type validateAccessSessionGeoResolver struct {
+	result requestmeta.SessionAuditContext
+	err    error
+	inputs []string
+}
+
+func (r *validateAccessSessionGeoResolver) Lookup(_ context.Context, rawIP string) (requestmeta.SessionAuditContext, error) {
+	r.inputs = append(r.inputs, rawIP)
+	return r.result, r.err
+}
+
+func newValidateAccessSessionWithGeo(now time.Time) *domainuser.Session {
+	latitude := 31.2304
+	longitude := 121.4737
+	return &domainuser.Session{
+		SessionID:    "session-id",
+		UserID:       1,
+		ClientIP:     "203.0.113.10",
+		GeoSource:    "geoip_api",
+		GeoAccuracy:  "ip",
+		CountryCode:  "CN",
+		RegionName:   "Shanghai",
+		CityName:     "Shanghai",
+		TimezoneName: "Asia/Shanghai",
+		IPLatitude:   &latitude,
+		IPLongitude:  &longitude,
+		CreatedAt:    now.Add(-30 * time.Minute),
+		LastSeenAt:   &now,
+		ExpiresAt:    now.Add(24 * time.Hour),
+	}
 }
 
 func TestNormalizeAppearancePreferencesAllowsFontSize(t *testing.T) {
@@ -140,5 +181,147 @@ func TestValidateAccessSessionRejectsTokenBeforeSessionCreation(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("expected access token issued before session creation to be rejected")
+	}
+}
+
+func TestValidateAccessSessionDoesNotOverwriteStoredGeoForSameIP(t *testing.T) {
+	now := time.Now()
+	lastSeenAt := now.Add(-2 * time.Minute)
+	session := newValidateAccessSessionWithGeo(now)
+	session.LastSeenAt = &lastSeenAt
+	repo := &validateAccessSessionRepo{session: session}
+	resolver := &validateAccessSessionGeoResolver{}
+	service := &Service{repo: repo, geoResolver: resolver}
+
+	err := service.ValidateAccessSession(
+		context.Background(),
+		1,
+		"session-id",
+		session.CreatedAt.Add(time.Minute),
+		requestmeta.SessionAuditContext{ClientIP: "203.0.113.10"},
+	)
+	if err != nil {
+		t.Fatalf("expected session validation to succeed, got %v", err)
+	}
+	if len(resolver.inputs) != 0 {
+		t.Fatalf("expected no GeoIP lookup for unchanged IP, got %d", len(resolver.inputs))
+	}
+	if len(repo.touchInputs) != 1 {
+		t.Fatalf("expected one activity update, got %d", len(repo.touchInputs))
+	}
+	input := repo.touchInputs[0]
+	if input.GeoSource != nil || input.GeoAccuracy != nil || input.CountryCode != nil ||
+		input.RegionName != nil || input.CityName != nil || input.TimezoneName != nil ||
+		input.IPLatitude != nil || input.IPLongitude != nil {
+		t.Fatalf("expected same-IP activity updates to leave stored location untouched, got %+v", input)
+	}
+}
+
+func TestValidateAccessSessionUpdatesExplicitGeoForSameIP(t *testing.T) {
+	now := time.Now()
+	session := newValidateAccessSessionWithGeo(now)
+	repo := &validateAccessSessionRepo{session: session}
+	service := &Service{repo: repo}
+
+	err := service.ValidateAccessSession(
+		context.Background(),
+		1,
+		"session-id",
+		session.CreatedAt.Add(time.Minute),
+		requestmeta.SessionAuditContext{
+			ClientIP:     session.ClientIP,
+			GeoSource:    "proxy_header_trusted",
+			GeoAccuracy:  "ip",
+			CountryCode:  "CN",
+			RegionName:   "Jiangsu",
+			CityName:     "Nanjing",
+			TimezoneName: "Asia/Shanghai",
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected session validation to succeed, got %v", err)
+	}
+	if len(repo.touchInputs) != 1 {
+		t.Fatalf("expected one activity update, got %d", len(repo.touchInputs))
+	}
+	input := repo.touchInputs[0]
+	if input.GeoSource == nil || *input.GeoSource != "proxy_header_trusted" ||
+		input.RegionName == nil || *input.RegionName != "Jiangsu" ||
+		input.CityName == nil || *input.CityName != "Nanjing" {
+		t.Fatalf("expected explicit request location to update the session, got %+v", input)
+	}
+}
+
+func TestValidateAccessSessionInvalidatesGeoWhenClientIPChanges(t *testing.T) {
+	now := time.Now()
+	session := newValidateAccessSessionWithGeo(now)
+	repo := &validateAccessSessionRepo{session: session}
+	resolver := &validateAccessSessionGeoResolver{}
+	service := &Service{repo: repo, geoResolver: resolver}
+
+	err := service.ValidateAccessSession(
+		context.Background(),
+		1,
+		"session-id",
+		session.CreatedAt.Add(time.Minute),
+		requestmeta.SessionAuditContext{ClientIP: "198.51.100.20"},
+	)
+	if err != nil {
+		t.Fatalf("expected session validation to succeed, got %v", err)
+	}
+	if len(resolver.inputs) != 0 {
+		t.Fatalf("expected access validation not to perform external GeoIP lookups, got %#v", resolver.inputs)
+	}
+	if len(repo.touchInputs) != 1 {
+		t.Fatalf("expected one activity update, got %d", len(repo.touchInputs))
+	}
+	input := repo.touchInputs[0]
+	if input.ClientIP == nil || *input.ClientIP != "198.51.100.20" ||
+		input.CountryCode == nil || *input.CountryCode != "" ||
+		input.RegionName == nil || *input.RegionName != "" ||
+		input.CityName == nil || *input.CityName != "" ||
+		input.IPLatitude == nil || *input.IPLatitude != nil ||
+		input.IPLongitude == nil || *input.IPLongitude != nil {
+		t.Fatalf("expected stale location to be invalidated for the new IP, got %+v", input)
+	}
+}
+
+func TestListCurrentActiveSessionsResolvesMissingGeo(t *testing.T) {
+	now := time.Now()
+	session := newValidateAccessSessionWithGeo(now)
+	session.ClientIP = "198.51.100.20"
+	session.GeoSource = ""
+	session.GeoAccuracy = ""
+	session.CountryCode = ""
+	session.RegionName = ""
+	session.CityName = ""
+	session.TimezoneName = ""
+	session.IPLatitude = nil
+	session.IPLongitude = nil
+	repo := &validateAccessSessionRepo{session: session}
+	resolver := &validateAccessSessionGeoResolver{
+		result: requestmeta.SessionAuditContext{
+			GeoSource:    "geoip_api",
+			GeoAccuracy:  "ip",
+			CountryCode:  "US",
+			RegionName:   "California",
+			CityName:     "San Francisco",
+			TimezoneName: "America/Los_Angeles",
+		},
+	}
+	service := &Service{repo: repo, geoResolver: resolver}
+
+	results, err := service.ListCurrentActiveSessions(context.Background(), 1, "session-id")
+	if err != nil {
+		t.Fatalf("expected active sessions to load, got %v", err)
+	}
+	if len(resolver.inputs) != 1 || resolver.inputs[0] != "198.51.100.20" {
+		t.Fatalf("expected one lazy lookup for the missing location, got %#v", resolver.inputs)
+	}
+	if len(results) != 1 || results[0].CountryCode != "US" || results[0].CityName != "San Francisco" {
+		t.Fatalf("expected the active session to contain the resolved location, got %+v", results)
+	}
+	if len(repo.touchInputs) != 1 || repo.touchInputs[0].CountryCode == nil || *repo.touchInputs[0].CountryCode != "US" {
+		t.Fatalf("expected the resolved location to be persisted, got %+v", repo.touchInputs)
 	}
 }

--- a/backend/internal/application/auth/session_metadata.go
+++ b/backend/internal/application/auth/session_metadata.go
@@ -48,6 +48,85 @@ func buildSessionAuditSnapshot(auditCtx requestmeta.SessionAuditContext) session
 	return snapshot
 }
 
+// buildSessionAuditSnapshotForSession 合并请求元数据与会话最近一次有效元数据。
+// 同一 IP 下的空字段不得覆盖已有值，不同 IP 之间不得沿用地理信息。
+func buildSessionAuditSnapshotForSession(
+	session *domainuser.Session,
+	auditCtx requestmeta.SessionAuditContext,
+) sessionAuditSnapshot {
+	snapshot := buildSessionAuditSnapshot(auditCtx)
+	if session == nil {
+		return snapshot
+	}
+
+	currentIP := strings.TrimSpace(session.ClientIP)
+	if snapshot.ClientIP == "" {
+		snapshot.ClientIP = currentIP
+	}
+	if snapshot.UserAgent == "" {
+		snapshot.UserAgent = strings.TrimSpace(session.UserAgent)
+	}
+	if snapshot.DeviceName == "" {
+		snapshot.DeviceName = strings.TrimSpace(session.DeviceName)
+	}
+	if snapshot.BrowserName == "" {
+		snapshot.BrowserName = strings.TrimSpace(session.BrowserName)
+	}
+	if snapshot.OSName == "" {
+		snapshot.OSName = strings.TrimSpace(session.OSName)
+	}
+	if snapshot.DeviceType == "" || snapshot.DeviceType == "unknown" {
+		snapshot.DeviceType = strings.TrimSpace(session.DeviceType)
+	}
+	if snapshot.ClientIP != currentIP {
+		return snapshot
+	}
+
+	if snapshot.GeoSource == "" {
+		snapshot.GeoSource = strings.TrimSpace(session.GeoSource)
+	}
+	if snapshot.GeoAccuracy == "" {
+		snapshot.GeoAccuracy = strings.TrimSpace(session.GeoAccuracy)
+	}
+	if snapshot.CountryCode == "" {
+		snapshot.CountryCode = strings.TrimSpace(session.CountryCode)
+	}
+	if snapshot.RegionName == "" {
+		snapshot.RegionName = strings.TrimSpace(session.RegionName)
+	}
+	if snapshot.CityName == "" {
+		snapshot.CityName = strings.TrimSpace(session.CityName)
+	}
+	if snapshot.TimezoneName == "" {
+		snapshot.TimezoneName = strings.TrimSpace(session.TimezoneName)
+	}
+	if snapshot.IPLatitude == nil {
+		snapshot.IPLatitude = session.IPLatitude
+	}
+	if snapshot.IPLongitude == nil {
+		snapshot.IPLongitude = session.IPLongitude
+	}
+	return snapshot
+}
+
+func sessionClientIPChanged(session *domainuser.Session, auditCtx requestmeta.SessionAuditContext) bool {
+	if session == nil {
+		return false
+	}
+	incomingIP := strings.TrimSpace(auditCtx.ClientIP)
+	return incomingIP != "" && incomingIP != strings.TrimSpace(session.ClientIP)
+}
+
+func sessionAuditContextHasGeo(auditCtx requestmeta.SessionAuditContext) bool {
+	normalized := auditCtx.Normalize()
+	return normalized.CountryCode != "" ||
+		normalized.RegionName != "" ||
+		normalized.CityName != "" ||
+		normalized.TimezoneName != "" ||
+		normalized.IPLatitude != nil ||
+		normalized.IPLongitude != nil
+}
+
 func resolveBrowserName(userAgent string) string {
 	switch ua := strings.TrimSpace(userAgent); {
 	case ua == "":


### PR DESCRIPTION
## Summary

Closes #695.

Fix active sessions remaining in the "Unknown location" state even when the correct client IP has already been recorded.

- Preserve existing device and geolocation metadata when requests from the same IP do not include replacement values.
- Clear stale geolocation metadata when the session IP changes.
- Lazily resolve and persist missing geolocation when active sessions are queried.
- Add structured GeoIP failure diagnostics without logging raw client IP addresses.
- Add regression coverage for same-IP updates, IP changes, explicit proxy metadata, and lazy location resolution.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [ ] Frontend / UI
- [x] Backend / API
- [x] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd backend && go test ./...`
- [x] `cd backend && go vet ./internal/application/auth/...`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Not applicable. This is a backend session metadata fix with no UI or public API contract changes.

## Configuration, migration, and compatibility notes

- No database migration is required.
- No new environment variables or deployment changes are required.
- Existing `TRUSTED_PROXIES` and GeoIP configuration continue to apply.
- Existing sessions with missing location metadata are resolved when the active session list is queried.
- Nginx does not require a GeoIP module. It only needs to forward the real client IP correctly.
- If GeoIP is disabled or unavailable, the session remains usable and continues to display an unknown location.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, trusted proxy metadata, GeoIP resolution, and operational logging.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.