### PR TITLE
fix: stabilize MCP and knowledge base popovers

### DIFF
--- a/frontend/features/chat/components/sections/chat-input.tsx
+++ b/frontend/features/chat/components/sections/chat-input.tsx
@@ -1023,6 +1023,7 @@ function ChatInputComponent({
                   selectedToolIDs={selectedToolIDs}
                   defaultToolIDs={defaultToolIDs}
                   maxSelectedTools={maxSelectedTools}
+                  placementPreference={isConversationMode ? "top" : "bottom"}
                   disabled={loading || uploading || toolsLoading}
                   onSelectedToolsChange={onSelectedToolsChange}
                   onDefaultToolsChange={onDefaultToolsChange}
@@ -1032,6 +1033,7 @@ function ChatInputComponent({
               {!isMediaMode ? (
                 <ChatKnowledgeBases
                   selectedIDs={selectedKnowledgeBaseIDs}
+                  placementPreference={isConversationMode ? "top" : "bottom"}
                   disabled={loading || uploading}
                   available={ragAvailable}
                   unavailableReason={ragAvailabilityReason}

--- a/frontend/features/chat/components/sections/chat-knowledge-bases.tsx
+++ b/frontend/features/chat/components/sections/chat-knowledge-bases.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BookOpen, Check, Search } from "lucide-react";
+import { BookOpen, Check } from "lucide-react";
 import { useTranslations } from "next-intl";
 import * as React from "react";
 import { toast } from "sonner";
@@ -19,12 +19,14 @@ const MAX_SELECTED_KNOWLEDGE_BASES = 8;
 
 export function ChatKnowledgeBases({
   selectedIDs,
+  placementPreference,
   disabled,
   available,
   unavailableReason,
   onChange,
 }: {
   selectedIDs: string[];
+  placementPreference: "top" | "bottom";
   disabled: boolean;
   available: boolean | null;
   unavailableReason: string;
@@ -199,8 +201,31 @@ export function ChatKnowledgeBases({
         </TooltipContent>
       </Tooltip>
 
-      <PopoverContent side="bottom" align="start" sideOffset={8} className="w-[min(22rem,calc(100vw-2rem))] p-1.5">
-        <div className="flex items-center justify-between gap-3 px-2 pb-1.5 text-[11px] font-medium text-foreground/70">
+      <PopoverContent
+        side={placementPreference}
+        align="start"
+        sideOffset={8}
+        avoidCollisions={false}
+        collisionPadding={8}
+        data-knowledge-bases-popover-content
+        className="flex max-h-[var(--radix-popover-content-available-height)] w-[min(20rem,calc(100vw-1rem))] flex-col p-1.5"
+        onPointerDown={(event) => event.stopPropagation()}
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
+        onPointerDownOutside={(event) => {
+          const target = event.target as HTMLElement | null;
+          if (target?.closest("[data-knowledge-bases-popover-content]")) {
+            event.preventDefault();
+          }
+        }}
+        onFocusOutside={(event) => {
+          const target = event.target as HTMLElement | null;
+          if (target?.closest("[data-knowledge-bases-popover-content]")) {
+            event.preventDefault();
+          }
+        }}
+      >
+        <div className="flex h-7 shrink-0 items-center justify-between gap-3 px-2 text-[11px] font-medium text-foreground/70">
           <span>{t("knowledgeBases")}</span>
           {selectedIDs.length > 0 ? (
             <button
@@ -213,22 +238,22 @@ export function ChatKnowledgeBases({
           ) : null}
         </div>
         {available === false ? (
-          <p className="mb-1.5 rounded-md bg-muted/55 px-2 py-2 text-[11px] leading-4 text-muted-foreground">
+          <p className="mx-1 mb-1 shrink-0 rounded-md bg-muted/45 px-2.5 py-2 text-[11px] leading-4 text-muted-foreground dark:bg-muted/35">
             {unavailableDescription}
           </p>
         ) : null}
-        <div className="relative mx-1 mb-1.5">
-          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" strokeWidth={1.7} />
+        <div className="mx-1 mb-1 shrink-0">
           <Input
             value={query}
             placeholder={t("searchKnowledgeBases")}
-            className="h-8 pl-8 text-xs"
+            className="h-7 border-0 bg-muted/45 px-2.5 text-xs shadow-none dark:bg-muted/35"
             onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => event.stopPropagation()}
           />
         </div>
-        <div className="max-h-64 space-y-0.5 overflow-y-auto">
+        <div className="min-h-0 max-h-72 space-y-0.5 overflow-y-auto px-0.5">
           {loading && items.length === 0 ? (
-            <div className="flex items-center justify-center py-8"><Spinner className="size-4" /></div>
+            <div className="flex items-center justify-center py-6"><Spinner className="size-4" /></div>
           ) : filteredItems.length > 0 ? filteredItems.map((item) => {
             const selected = selectedSet.has(item.publicID);
             const ready = item.readyFileCount > 0;
@@ -236,8 +261,10 @@ export function ChatKnowledgeBases({
               <button
                 key={item.publicID}
                 type="button"
-                className="flex min-h-10 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-45"
+                data-selected={selected}
+                className="flex h-7 w-full items-center gap-1.5 rounded-md px-1.5 text-left text-foreground/80 transition-colors hover:bg-accent hover:text-accent-foreground data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-45"
                 disabled={available === false || (!ready && !selected)}
+                aria-pressed={selected}
                 onClick={() => {
                   if (selected) {
                     onChange(selectedIDs.filter((id) => id !== item.publicID));
@@ -250,25 +277,28 @@ export function ChatKnowledgeBases({
                   onChange([...selectedIDs, item.publicID]);
                 }}
               >
-                <BookOpen className="size-4 shrink-0 text-muted-foreground" strokeWidth={1.6} />
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-xs font-medium">{item.name}</span>
-                  <span className="block truncate text-[11px] text-muted-foreground">
-                    {ready
-                      ? t("knowledgeBaseReadyFiles", { count: item.readyFileCount })
-                      : t("knowledgeBaseNotReady")}
-                  </span>
+                <span className="flex min-w-0 flex-1 items-center gap-1.5">
+                  {selected ? (
+                    <Check className="size-3.5 shrink-0 text-primary" strokeWidth={1.8} />
+                  ) : (
+                    <BookOpen className="size-3.5 shrink-0 text-muted-foreground" strokeWidth={1.6} />
+                  )}
+                  <span className="truncate text-xs font-medium text-current" title={item.name}>{item.name}</span>
                 </span>
-                <Check className={cn("size-3.5 shrink-0", selected ? "opacity-100" : "opacity-0")} strokeWidth={1.8} />
+                <span className="shrink-0 text-[10px] leading-none tabular-nums text-muted-foreground">
+                  {ready
+                    ? t("knowledgeBaseReadyFiles", { count: item.readyFileCount })
+                    : t("knowledgeBaseNotReady")}
+                </span>
               </button>
             );
           }) : (
-            <p className="px-2 py-8 text-center text-xs text-muted-foreground">{t("knowledgeBaseEmpty")}</p>
+            <p className="px-2 py-6 text-center text-xs text-muted-foreground">{t("knowledgeBaseEmpty")}</p>
           )}
           {page * 50 < total ? (
             <button
               type="button"
-              className="flex h-8 w-full items-center justify-center rounded-md text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none"
+              className="flex h-7 w-full items-center justify-center rounded-md text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none"
               disabled={loadingMore}
               onClick={() => void loadCatalog(query.trim(), page + 1)}
             >

--- a/frontend/features/chat/components/sections/chat-mcp.tsx
+++ b/frontend/features/chat/components/sections/chat-mcp.tsx
@@ -33,6 +33,7 @@ type ChatMCPProps = {
   selectedToolIDs: number[];
   defaultToolIDs: number[];
   maxSelectedTools: number;
+  placementPreference: "top" | "bottom";
   disabled: boolean;
   onSelectedToolsChange: (toolIDs: number[]) => void;
   onDefaultToolsChange: (toolIDs: number[]) => void | Promise<void>;
@@ -55,7 +56,7 @@ function MCPToolRowAction({
       aria-label={label}
       title={label}
       className={cn(
-        "flex size-8 shrink-0 items-center justify-center rounded-md text-foreground/45 outline-none transition-[background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground",
+        "flex size-7 shrink-0 items-center justify-center rounded-md text-foreground/35 outline-none transition-[background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground",
         className,
       )}
     >
@@ -151,6 +152,7 @@ export function ChatMCP({
   selectedToolIDs,
   defaultToolIDs,
   maxSelectedTools,
+  placementPreference,
   disabled,
   onSelectedToolsChange,
   onDefaultToolsChange,
@@ -315,11 +317,13 @@ export function ChatMCP({
         </TooltipContent>
       </Tooltip>
       <PopoverContent
-        side="bottom"
+        side={placementPreference}
         align="start"
         sideOffset={8}
+        avoidCollisions={false}
+        collisionPadding={8}
         data-mcp-tools-popover-content
-        className="w-[22rem] p-1.5"
+        className="flex max-h-[var(--radix-popover-content-available-height)] w-[min(20rem,calc(100vw-1rem))] flex-col p-1.5"
         onPointerDown={(event) => event.stopPropagation()}
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}
@@ -336,7 +340,7 @@ export function ChatMCP({
           }
         }}
       >
-        <div className="flex items-center justify-between gap-3 px-2 pb-1.5 text-[11px] font-medium text-foreground/70">
+        <div className="flex h-7 shrink-0 items-center justify-between gap-3 px-2 text-[11px] font-medium text-foreground/70">
           <span>{tComposer("mcpTools")}</span>
           {selectedToolCount > 0 ? (
             <button
@@ -348,18 +352,16 @@ export function ChatMCP({
             </button>
           ) : null}
         </div>
-        <div
-          className="px-1 py-1"
-        >
+        <div className="mx-1 mb-1 shrink-0">
           <Input
             value={search}
             onChange={(event) => setSearch(event.target.value)}
             onKeyDown={(event) => event.stopPropagation()}
-            className="border-border/60 bg-transparent dark:bg-transparent"
+            className="h-7 border-0 bg-muted/45 px-2.5 text-xs shadow-none dark:bg-muted/35"
             placeholder={tComposer("searchToolsPlaceholder")}
           />
         </div>
-        <div className="max-h-72 overflow-y-auto px-0.5 pt-1">
+        <div className="min-h-0 max-h-72 overflow-y-auto px-0.5">
           {filteredToolGroups.map((group) => {
             const groupState = toolSelectionState(group.tools);
             const expanded = hasSearch || expandedServerKeys.has(group.key);
@@ -370,15 +372,14 @@ export function ChatMCP({
             const allDefault = group.tools.length > 0 && defaultCount === group.tools.length;
             const hasDefault = defaultCount > 0;
             return (
-              <div key={group.key} className="mb-1">
+              <div key={group.key} className="mb-0.5 last:mb-0">
                 <div
                   data-interactive={groupInteractive}
-                  data-selected={groupState.selectedCount > 0}
-                  className="group/server flex h-8 items-center gap-2 rounded-md px-2 text-[11px] font-medium text-foreground/65 transition-colors data-[interactive=true]:bg-accent data-[interactive=true]:text-accent-foreground"
+                  className="group/server flex h-7 items-center gap-1.5 rounded-md px-1.5 text-foreground/80 transition-colors data-[interactive=true]:bg-accent data-[interactive=true]:text-accent-foreground"
                 >
                   <Checkbox
                     checked={groupState.allSelected ? true : groupState.partiallySelected ? "indeterminate" : false}
-                    className="shrink-0"
+                    className="size-3 rounded-[3px] [&_svg]:size-2.5"
                     aria-label={tComposer("mcpToggleServerTools", { server: group.serverName })}
                     onCheckedChange={(nextChecked) => toggleToolGroup(group.tools, nextChecked === true)}
                   />
@@ -391,62 +392,64 @@ export function ChatMCP({
                     onFocus={() => setFocusedRowKey(groupRowKey)}
                     onBlur={() => setFocusedRowKey((current) => (current === groupRowKey ? null : current))}
                   >
-                    <span className="flex min-w-0 flex-1 items-center gap-1.5">
-                      <span className="min-w-0 truncate text-xs font-semibold text-current">{group.serverName}</span>
-                      <span className="shrink-0 text-[10px] leading-none text-foreground/45 transition-colors group-data-[interactive=true]/server:text-accent-foreground/75">
-                        |
-                      </span>
-                      <span className="shrink-0 text-[10px] leading-none text-foreground/45 transition-colors group-data-[interactive=true]/server:text-accent-foreground/75">
-                        {tComposer("mcpServerToolCount", { selected: groupState.selectedCount, total: group.tools.length })}
-                      </span>
+                    <span className="flex min-w-0 flex-1 items-center gap-2">
+                      <span className="min-w-0 flex-1 truncate text-xs font-medium text-current">{group.serverName}</span>
                       {overLimit ? (
                         <span className="min-w-0 truncate text-[10px] leading-none text-amber-600 dark:text-amber-400">
                           {tComposer("mcpServerLimitHint", { limit: selectionLimit })}
                         </span>
                       ) : null}
+                      <span
+                        title={tComposer("mcpServerToolCount", { selected: groupState.selectedCount, total: group.tools.length })}
+                        className="shrink-0 text-[10px] leading-none tabular-nums text-muted-foreground transition-colors group-data-[interactive=true]/server:text-accent-foreground/75"
+                      >
+                        {groupState.selectedCount}/{group.tools.length}
+                      </span>
                     </span>
                   </button>
-                  <Tooltip disableHoverableContent>
-                    <TooltipTrigger asChild>
-                      <MCPToolRowAction
-                        label={allDefault
-                          ? tComposer("mcpUnsetDefaultServerTools", { server: group.serverName })
-                          : tComposer("mcpSetDefaultServerTools", { server: group.serverName })}
-                        className={cn("-mr-2", hasDefault && "text-amber-500 hover:text-amber-500 focus-visible:text-amber-500")}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          toggleDefaultToolGroup(group.tools);
-                        }}
+                  <div className="-mr-0.5 flex shrink-0 items-center gap-0">
+                    <Tooltip disableHoverableContent>
+                      <TooltipTrigger asChild>
+                        <MCPToolRowAction
+                          label={allDefault
+                            ? tComposer("mcpUnsetDefaultServerTools", { server: group.serverName })
+                            : tComposer("mcpSetDefaultServerTools", { server: group.serverName })}
+                          className={cn(hasDefault && "text-amber-500 hover:text-amber-500 focus-visible:text-amber-500")}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            toggleDefaultToolGroup(group.tools);
+                          }}
+                        >
+                          <Star
+                            className="size-3.5"
+                            strokeWidth={1.8}
+                            fill={allDefault ? "currentColor" : "none"}
+                          />
+                        </MCPToolRowAction>
+                      </TooltipTrigger>
+                      <TooltipContent
+                        side="right"
+                        align="center"
+                        sideOffset={6}
+                        className="text-xs data-[state=closed]:[animation-duration:60ms] data-[state=open]:[animation-duration:90ms]"
                       >
-                        <Star
-                          className="size-3.5"
-                          strokeWidth={1.8}
-                          fill={allDefault ? "currentColor" : "none"}
-                        />
-                      </MCPToolRowAction>
-                    </TooltipTrigger>
-                    <TooltipContent
-                      side="right"
-                      align="center"
-                      sideOffset={6}
-                      className="text-xs data-[state=closed]:[animation-duration:60ms] data-[state=open]:[animation-duration:90ms]"
+                        {allDefault
+                          ? tComposer("mcpDefaultServerToolsEnabled")
+                          : tComposer("mcpDefaultServerToolsDisabled")}
+                      </TooltipContent>
+                    </Tooltip>
+                    <button
+                      type="button"
+                      className="flex size-7 shrink-0 items-center justify-center rounded-md text-foreground/35 outline-none transition-[background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground"
+                      aria-label={expanded ? tComposer("mcpCollapseServerTools", { server: group.serverName }) : tComposer("mcpExpandServerTools", { server: group.serverName })}
+                      onClick={() => toggleServerExpanded(group.key)}
                     >
-                      {allDefault
-                        ? tComposer("mcpDefaultServerToolsEnabled")
-                        : tComposer("mcpDefaultServerToolsDisabled")}
-                    </TooltipContent>
-                  </Tooltip>
-                  <button
-                    type="button"
-                    className="-mr-2 flex size-8 shrink-0 items-center justify-center rounded-md text-foreground/45 outline-none transition-[background-color,color] duration-150 hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground"
-                    aria-label={expanded ? tComposer("mcpCollapseServerTools", { server: group.serverName }) : tComposer("mcpExpandServerTools", { server: group.serverName })}
-                    onClick={() => toggleServerExpanded(group.key)}
-                  >
-                    <ChevronDown
-                      className={cn("size-3.5 shrink-0 transition-transform duration-200", expanded && "rotate-180")}
-                      strokeWidth={1.7}
-                    />
-                  </button>
+                      <ChevronDown
+                        className={cn("size-3.5 shrink-0 transition-transform duration-200", expanded && "rotate-180")}
+                        strokeWidth={1.7}
+                      />
+                    </button>
+                  </div>
                 </div>
                 <AnimatePresence initial={false}>
                   {expanded ? (
@@ -458,7 +461,7 @@ export function ChatMCP({
                       transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
                       className="overflow-hidden"
                     >
-                      <div className="mt-1 space-y-1 border-l border-border/60 ml-2 pl-3">
+                      <div className="ml-2.5 mt-0.5 space-y-0.5 border-l border-border/50 pl-2">
                         {group.visibleTools.map((tool) => {
                           const checked = selectedToolIDSet.has(tool.id);
                           const isDefault = defaultToolIDSet.has(tool.id);
@@ -470,12 +473,11 @@ export function ChatMCP({
                             <div
                               key={tool.id}
                               data-interactive={toolInteractive}
-                              data-selected={checked}
-                              className="group/tool flex h-8 items-center gap-2 rounded-md px-2 text-[11px] font-medium text-foreground/65 transition-colors data-[interactive=true]:bg-accent data-[interactive=true]:text-accent-foreground"
+                              className="group/tool flex h-7 items-center gap-1.5 rounded-md px-1.5 text-[11px] font-medium text-foreground/70 transition-colors data-[interactive=true]:bg-accent data-[interactive=true]:text-accent-foreground"
                             >
                               <Checkbox
                                 checked={checked}
-                                className="shrink-0"
+                                className="size-3 rounded-[3px] [&_svg]:size-2.5"
                                 aria-label={tComposer("mcpToggleTool", { tool: label })}
                                 onCheckedChange={(nextChecked) => toggleTool(tool.id, nextChecked === true)}
                               />
@@ -505,7 +507,7 @@ export function ChatMCP({
                                   </Tooltip>
                                 ) : null}
                               </button>
-                              <div className="-mr-2 flex shrink-0 items-center gap-0">
+                              <div className="-mr-0.5 flex shrink-0 items-center gap-0">
                                 {tool.priceNanousd > 0 ? (
                                   <Tooltip disableHoverableContent>
                                     <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary

- Keep chat resource popovers anchored to the intended side:
  - Open below the composer on the new conversation page.
  - Open above the composer in existing conversations.
- Constrain expanded content to the available viewport height and scroll internally instead of repositioning the whole popover.
- Prevent the knowledge base popover from closing when users focus the search field or interact with its content.
- Unify MCP and knowledge base search fields at a compact `h-7` height.
- Refine the MCP tool list with compact rows, smaller checkboxes, aligned action columns, and concise selection counts.
- Refine the knowledge base list into a single-line left-right layout with aligned status text and clear selected states.

Closes #696.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [x] Files / RAG / extraction
- [ ] Model routing / providers
- [x] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm typecheck`
- [x] `git diff --check`
- [ ] Production build and browser visual verification were not run.

## Screenshots, API examples, or logs

Not included.

## Configuration, migration, and compatibility notes

No configuration changes, database migrations, API contract changes, or deployment updates are required.

Existing MCP selection, default tool, knowledge base search, pagination, RAG availability, and selection-limit behavior remain unchanged.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.