### PR TITLE
fix: preserve long reasoning during stream recovery

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -10110,7 +10110,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "boolean",
-                        "description": "是否返回可替换当前正文的权威文本快照",
+                        "description": "是否返回正文与当前思考轮次的权威内容快照",
                         "name": "snapshot",
                         "in": "query"
                     }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -10103,7 +10103,7 @@
                     },
                     {
                         "type": "boolean",
-                        "description": "是否返回可替换当前正文的权威文本快照",
+                        "description": "是否返回正文与当前思考轮次的权威内容快照",
                         "name": "snapshot",
                         "in": "query"
                     }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -16190,7 +16190,7 @@ paths:
         in: query
         name: after
         type: integer
-      - description: 是否返回可替换当前正文的权威文本快照
+      - description: 是否返回正文与当前思考轮次的权威内容快照
         in: query
         name: snapshot
         type: boolean

--- a/backend/internal/application/conversation/generation_stream.go
+++ b/backend/internal/application/conversation/generation_stream.go
@@ -86,9 +86,9 @@ func (s *Service) SubscribeMessageGeneration(
 	userID uint,
 	runID string,
 	afterSeq int64,
-	includeTextSnapshot bool,
+	includeSnapshots bool,
 ) ([]GenerationStreamEvent, <-chan GenerationStreamEvent, func(), bool) {
-	return s.generationStreams.subscribe(ctx, userID, normalizeRunID(runID), afterSeq, includeTextSnapshot)
+	return s.generationStreams.subscribe(ctx, userID, normalizeRunID(runID), afterSeq, includeSnapshots)
 }
 
 // FinishMessageGeneration 标记生成流结束，并在短期恢复窗口后释放事件缓存。
@@ -323,6 +323,7 @@ func (r *generationStreamRegistry) publish(ctx context.Context, runID string, pa
 	if streamString(persisted["type"]) == "delta" {
 		appendInput.TextDelta = streamString(persisted["delta"])
 	}
+	appendInput.UpstreamThink = generationStreamUpstreamThinkAppend(actual)
 	record, err := r.append(ctx, r.store, runID, appendInput)
 	if err == nil && record.Seq > 0 {
 		actual["seq"] = record.Seq
@@ -356,12 +357,12 @@ func (r *generationStreamRegistry) subscribe(
 	userID uint,
 	runID string,
 	afterSeq int64,
-	includeTextSnapshot bool,
+	includeSnapshots bool,
 ) ([]GenerationStreamEvent, <-chan GenerationStreamEvent, func(), bool) {
 	if runID == "" {
 		return nil, nil, nil, false
 	}
-	return r.subscribeStore(ctx, r.store, userID, runID, afterSeq, includeTextSnapshot)
+	return r.subscribeStore(ctx, r.store, userID, runID, afterSeq, includeSnapshots)
 }
 
 func (r *generationStreamRegistry) subscribeStore(
@@ -370,7 +371,7 @@ func (r *generationStreamRegistry) subscribeStore(
 	userID uint,
 	runID string,
 	afterSeq int64,
-	includeTextSnapshot bool,
+	includeSnapshots bool,
 ) ([]GenerationStreamEvent, <-chan GenerationStreamEvent, func(), bool) {
 	if store == nil || !r.authorized(ctx, store, runID, userID) {
 		return nil, nil, nil, false
@@ -381,16 +382,30 @@ func (r *generationStreamRegistry) subscribeStore(
 	}
 	textSnapshot := repository.GenerationStreamTextSnapshot{}
 	hasTextSnapshot := false
-	if includeTextSnapshot {
-		// Read the snapshot after the retained window. Events appended in between
-		// are read again from cursor; visible deltas already covered by the snapshot
-		// are filtered by snapshot seq while non-text events remain replayable.
+	upstreamThinkSnapshot := repository.GenerationStreamUpstreamThinkSnapshot{}
+	hasUpstreamThinkSnapshot := false
+	if includeSnapshots {
+		// Read checkpoints after the retained window. Events appended in between
+		// are read again from cursor; deltas already covered by a checkpoint are
+		// filtered by its seq while non-content events remain replayable.
 		textSnapshot, hasTextSnapshot, err = store.GetGenerationStreamTextSnapshot(ctx, runID)
 		if err != nil {
 			return nil, nil, nil, false
 		}
+		upstreamThinkSnapshot, hasUpstreamThinkSnapshot, err = store.GetGenerationStreamUpstreamThinkSnapshot(ctx, runID)
+		if err != nil {
+			return nil, nil, nil, false
+		}
 	}
-	replay, cursor, terminal, safe := retainedStreamEvents(retained, afterSeq, textSnapshot, hasTextSnapshot, includeTextSnapshot)
+	replay, cursor, terminal, safe := retainedStreamEvents(
+		retained,
+		afterSeq,
+		textSnapshot,
+		hasTextSnapshot,
+		upstreamThinkSnapshot,
+		hasUpstreamThinkSnapshot,
+		includeSnapshots,
+	)
 	if !safe {
 		return nil, nil, nil, false
 	}
@@ -401,7 +416,7 @@ func (r *generationStreamRegistry) subscribeStore(
 	}
 
 	readCtx, cancel := context.WithCancel(ctx)
-	go r.readStoreEvents(readCtx, store, runID, cursor, afterSeq, textSnapshot.Seq, events)
+	go r.readStoreEvents(readCtx, store, runID, cursor, afterSeq, textSnapshot.Seq, upstreamThinkSnapshot.Seq, events)
 	return replay, events, cancel, true
 }
 
@@ -412,6 +427,7 @@ func (r *generationStreamRegistry) readStoreEvents(
 	cursor string,
 	afterSeq int64,
 	textSnapshotSeq int64,
+	upstreamThinkSnapshotSeq int64,
 	out chan<- GenerationStreamEvent,
 ) {
 	defer close(out)
@@ -440,6 +456,9 @@ func (r *generationStreamRegistry) readStoreEvents(
 				continue
 			}
 			if streamString(event.Payload["type"]) == "delta" && event.Seq <= textSnapshotSeq {
+				continue
+			}
+			if streamString(event.Payload["type"]) == "upstream_think_delta" && event.Seq <= upstreamThinkSnapshotSeq {
 				continue
 			}
 			afterSeq = event.Seq
@@ -624,14 +643,17 @@ func retainedStreamEvents(
 	afterSeq int64,
 	textSnapshot repository.GenerationStreamTextSnapshot,
 	hasTextSnapshot bool,
-	includeTextSnapshot bool,
+	upstreamThinkSnapshot repository.GenerationStreamUpstreamThinkSnapshot,
+	hasUpstreamThinkSnapshot bool,
+	includeSnapshots bool,
 ) ([]GenerationStreamEvent, string, bool, bool) {
-	replay := make([]GenerationStreamEvent, 0)
+	replay := make([]GenerationStreamEvent, 0, len(records)+2)
 	cursor := "0-0"
 	terminal := false
-	snapshotPending := includeTextSnapshot && hasTextSnapshot
+	textSnapshotPending := includeSnapshots && hasTextSnapshot
+	upstreamThinkSnapshotPending := includeSnapshots && hasUpstreamThinkSnapshot
 	appendTextSnapshot := func() {
-		if !snapshotPending {
+		if !textSnapshotPending {
 			return
 		}
 		replay = append(replay, GenerationStreamEvent{
@@ -643,7 +665,27 @@ func retainedStreamEvents(
 				"replace": true,
 			},
 		})
-		snapshotPending = false
+		textSnapshotPending = false
+	}
+	appendUpstreamThinkSnapshot := func() {
+		if !upstreamThinkSnapshotPending {
+			return
+		}
+		replay = append(replay, GenerationStreamEvent{
+			Seq:     upstreamThinkSnapshot.Seq,
+			Payload: generationStreamUpstreamThinkSnapshotPayload(upstreamThinkSnapshot),
+		})
+		upstreamThinkSnapshotPending = false
+	}
+	appendSnapshotsBefore := func(seq int64) {
+		for (textSnapshotPending && textSnapshot.Seq < seq) ||
+			(upstreamThinkSnapshotPending && upstreamThinkSnapshot.Seq < seq) {
+			if textSnapshotPending && (!upstreamThinkSnapshotPending || textSnapshot.Seq <= upstreamThinkSnapshot.Seq) {
+				appendTextSnapshot()
+				continue
+			}
+			appendUpstreamThinkSnapshot()
+		}
 	}
 	for _, record := range records {
 		if strings.TrimSpace(record.ID) != "" {
@@ -653,19 +695,25 @@ func retainedStreamEvents(
 		if !ok {
 			continue
 		}
-		if snapshotPending && event.Seq > textSnapshot.Seq {
-			appendTextSnapshot()
-		}
+		appendSnapshotsBefore(event.Seq)
 		if isTerminalStreamPayload(event.Payload) {
 			terminal = true
 		}
 		if streamString(event.Payload["type"]) == "delta" {
 			// A text delta without a cumulative checkpoint cannot be replayed
 			// safely once the bounded event window has trimmed older chunks.
-			if includeTextSnapshot && !hasTextSnapshot {
+			if includeSnapshots && !hasTextSnapshot {
 				return nil, cursor, terminal, false
 			}
-			if includeTextSnapshot && event.Seq <= textSnapshot.Seq {
+			if includeSnapshots && event.Seq <= textSnapshot.Seq {
+				continue
+			}
+		}
+		if streamString(event.Payload["type"]) == "upstream_think_delta" {
+			if includeSnapshots && !hasUpstreamThinkSnapshot && upstreamThinkPayloadHasContent(event.Payload) {
+				return nil, cursor, terminal, false
+			}
+			if includeSnapshots && event.Seq <= upstreamThinkSnapshot.Seq {
 				continue
 			}
 		}
@@ -673,8 +721,66 @@ func retainedStreamEvents(
 			replay = append(replay, event)
 		}
 	}
+	if textSnapshotPending && upstreamThinkSnapshotPending {
+		if textSnapshot.Seq <= upstreamThinkSnapshot.Seq {
+			appendTextSnapshot()
+		} else {
+			appendUpstreamThinkSnapshot()
+		}
+	}
 	appendTextSnapshot()
+	appendUpstreamThinkSnapshot()
 	return replay, cursor, terminal, true
+}
+
+func generationStreamUpstreamThinkAppend(payload map[string]interface{}) *repository.GenerationStreamUpstreamThinkAppend {
+	if streamString(payload["type"]) != "upstream_think_delta" {
+		return nil
+	}
+	delta, _ := payload["delta"].(string)
+	contentMarkdown, hasContent := payload["contentMarkdown"].(string)
+	roundID := strings.TrimSpace(streamString(payload["roundID"]))
+	metadata := map[string]interface{}{"type": "upstream_think_delta"}
+	for _, key := range []string{"status", "title", "summary", "stage", "eventID", "startedAt", "endedAt", "kind"} {
+		if value, ok := payload[key]; ok {
+			metadata[key] = value
+		}
+	}
+	if roundID != "" {
+		metadata["roundID"] = roundID
+	}
+	metadataJSON, err := marshalStreamPayload(metadata)
+	if err != nil {
+		return nil
+	}
+	return &repository.GenerationStreamUpstreamThinkAppend{
+		RoundID:         roundID,
+		Delta:           delta,
+		ContentMarkdown: contentMarkdown,
+		Replace:         hasContent,
+		MetadataJSON:    metadataJSON,
+	}
+}
+
+func generationStreamUpstreamThinkSnapshotPayload(snapshot repository.GenerationStreamUpstreamThinkSnapshot) map[string]interface{} {
+	payload := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(snapshot.MetadataJSON), &payload); err != nil || payload == nil {
+		payload = map[string]interface{}{}
+	}
+	payload["type"] = "upstream_think_delta"
+	payload["seq"] = snapshot.Seq
+	payload["contentMarkdown"] = snapshot.ContentMarkdown
+	if strings.TrimSpace(streamString(payload["roundID"])) == "" && snapshot.RoundID != "" {
+		payload["roundID"] = snapshot.RoundID
+	}
+	delete(payload, "delta")
+	return payload
+}
+
+func upstreamThinkPayloadHasContent(payload map[string]interface{}) bool {
+	_, hasDelta := payload["delta"].(string)
+	_, hasContent := payload["contentMarkdown"].(string)
+	return hasDelta || hasContent
 }
 
 func decodeStreamRecord(record repository.GenerationStreamMessage) (GenerationStreamEvent, bool) {

--- a/backend/internal/application/conversation/generation_stream_test.go
+++ b/backend/internal/application/conversation/generation_stream_test.go
@@ -171,6 +171,139 @@ func TestGenerationStreamRegistryKeepsNonTextReplayInSequenceOrder(t *testing.T)
 	}
 }
 
+func TestGenerationStreamRegistryOrdersTextAndUpstreamThinkingSnapshots(t *testing.T) {
+	registry := newGenerationStreamRegistry(newTestGenerationStreamStore(), generationStreamOptions{
+		Retention:        time.Minute,
+		ActiveTTL:        time.Minute,
+		MaxEvents:        8,
+		SubscriberBuffer: 4,
+	})
+	ctx := context.Background()
+	runID := EnsureMessageGenerationRunID("")
+	registry.register(ctx, runID, 7, "conv_test", func() {})
+	defer registry.finish(ctx, runID)
+	registry.publish(ctx, runID, map[string]interface{}{"type": "file_proc", "message": "preparing"})
+	registry.publish(ctx, runID, map[string]interface{}{
+		"type":    "upstream_think_delta",
+		"status":  "streaming",
+		"roundID": " round_1 ",
+		"delta":   "thought",
+	})
+	registry.publish(ctx, runID, map[string]interface{}{"type": "delta", "delta": "answer"})
+	registry.publish(ctx, runID, map[string]interface{}{"type": "usage", "output_tokens": 1})
+
+	replay, _, unsubscribe, ok := registry.subscribe(ctx, 7, runID, 0, true)
+	if !ok {
+		t.Fatal("expected subscription")
+	}
+	defer unsubscribe()
+	if len(replay) != 4 ||
+		replay[0].Seq != 1 || replay[0].Payload["type"] != "file_proc" ||
+		replay[1].Seq != 2 || replay[1].Payload["type"] != "upstream_think_delta" ||
+		replay[1].Payload["contentMarkdown"] != "thought" || replay[1].Payload["roundID"] != "round_1" ||
+		replay[2].Seq != 3 || replay[2].Payload["type"] != "delta" || replay[2].Payload["replace"] != true ||
+		replay[3].Seq != 4 || replay[3].Payload["type"] != "usage" {
+		t.Fatalf("unexpected ordered snapshot replay: %+v", replay)
+	}
+}
+
+func TestGenerationStreamRegistryUpstreamThinkingSnapshotTracksTerminalMetadata(t *testing.T) {
+	registry := newGenerationStreamRegistry(newTestGenerationStreamStore(), generationStreamOptions{
+		Retention:        time.Minute,
+		ActiveTTL:        time.Minute,
+		MaxEvents:        8,
+		SubscriberBuffer: 4,
+	})
+	ctx := context.Background()
+	runID := EnsureMessageGenerationRunID("")
+	registry.register(ctx, runID, 7, "conv_test", func() {})
+	defer registry.finish(ctx, runID)
+	registry.publish(ctx, runID, map[string]interface{}{
+		"type":    "upstream_think_delta",
+		"status":  "streaming",
+		"roundID": "round_1",
+		"delta":   "thought",
+	})
+	registry.publish(ctx, runID, map[string]interface{}{
+		"type":    "upstream_think_delta",
+		"status":  "completed",
+		"roundID": "round_1",
+	})
+
+	replay, _, unsubscribe, ok := registry.subscribe(ctx, 7, runID, 0, true)
+	if !ok {
+		t.Fatal("expected subscription")
+	}
+	defer unsubscribe()
+	if len(replay) != 1 || replay[0].Seq != 2 ||
+		replay[0].Payload["type"] != "upstream_think_delta" ||
+		replay[0].Payload["contentMarkdown"] != "thought" ||
+		replay[0].Payload["status"] != "completed" {
+		t.Fatalf("unexpected terminal upstream-thinking snapshot: %+v", replay)
+	}
+}
+
+func TestGenerationStreamRegistryRestoresCompleteUpstreamThinkingBeyondReplayWindow(t *testing.T) {
+	store := newTestGenerationStreamStore()
+	registry := newGenerationStreamRegistry(store, generationStreamOptions{
+		Retention:        time.Minute,
+		ActiveTTL:        time.Minute,
+		MaxEvents:        generationStreamMaxEvents,
+		SubscriberBuffer: 4,
+	})
+	ctx := context.Background()
+	runID := EnsureMessageGenerationRunID("")
+	registry.register(ctx, runID, 7, "conv_test", func() {})
+	defer registry.finish(ctx, runID)
+
+	var expected strings.Builder
+	for i := 0; i < generationStreamMaxEvents+100; i++ {
+		delta := fmt.Sprintf("thought-%04d\n", i)
+		expected.WriteString(delta)
+		registry.publish(ctx, runID, map[string]interface{}{
+			"type":      "upstream_think_delta",
+			"status":    "streaming",
+			"stage":     "think",
+			"roundID":   "round_1",
+			"eventID":   "event_1",
+			"startedAt": "2026-08-31T00:00:00Z",
+			"delta":     delta,
+		})
+	}
+
+	replay, events, unsubscribe, ok := registry.subscribe(ctx, 7, runID, 0, true)
+	if !ok {
+		t.Fatal("expected subscription")
+	}
+	defer unsubscribe()
+	if len(replay) != 1 {
+		t.Fatalf("expected one upstream-thinking checkpoint, got %d events", len(replay))
+	}
+	checkpoint := replay[0]
+	if checkpoint.Payload["type"] != "upstream_think_delta" ||
+		checkpoint.Payload["contentMarkdown"] != expected.String() ||
+		checkpoint.Payload["roundID"] != "round_1" ||
+		checkpoint.Seq != generationStreamMaxEvents+100 {
+		t.Fatalf("unexpected upstream-thinking checkpoint: %+v", checkpoint)
+	}
+
+	registry.publish(ctx, runID, map[string]interface{}{
+		"type":    "upstream_think_delta",
+		"status":  "streaming",
+		"roundID": "round_1",
+		"eventID": "event_1",
+		"delta":   "continued",
+	})
+	select {
+	case event := <-events:
+		if event.Payload["type"] != "upstream_think_delta" || event.Payload["delta"] != "continued" {
+			t.Fatalf("unexpected live upstream-thinking event: %+v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for live upstream-thinking event")
+	}
+}
+
 func TestGenerationStreamRegistryRejectsTextReplayWithoutSnapshot(t *testing.T) {
 	store := newTestGenerationStreamStore()
 	registry := newGenerationStreamRegistry(store, generationStreamOptions{
@@ -562,15 +695,19 @@ type testGenerationStreamStore struct {
 }
 
 type testGenerationStream struct {
-	userID         uint
-	conversationID string
-	canceled       bool
-	activeUntil    time.Time
-	nextSeq        int64
-	events         []repository.GenerationStreamMessage
-	textContent    strings.Builder
-	textSeq        int64
-	expiresAt      time.Time
+	userID                uint
+	conversationID        string
+	canceled              bool
+	activeUntil           time.Time
+	nextSeq               int64
+	events                []repository.GenerationStreamMessage
+	textContent           strings.Builder
+	textSeq               int64
+	upstreamThinkContent  strings.Builder
+	upstreamThinkSeq      int64
+	upstreamThinkRoundID  string
+	upstreamThinkMetadata string
+	expiresAt             time.Time
 }
 
 func newTestGenerationStreamStore() *testGenerationStreamStore {
@@ -672,11 +809,45 @@ func (s *testGenerationStreamStore) AppendGenerationStreamEvent(_ context.Contex
 		_, _ = item.textContent.WriteString(input.TextDelta)
 		item.textSeq = item.nextSeq
 	}
+	if input.UpstreamThink != nil {
+		roundID := strings.TrimSpace(input.UpstreamThink.RoundID)
+		if roundID == "" {
+			roundID = item.upstreamThinkRoundID
+		}
+		if roundID != "" && item.upstreamThinkRoundID != "" && roundID != item.upstreamThinkRoundID {
+			item.upstreamThinkContent.Reset()
+		}
+		if input.UpstreamThink.Replace {
+			item.upstreamThinkContent.Reset()
+			_, _ = item.upstreamThinkContent.WriteString(input.UpstreamThink.ContentMarkdown)
+		} else {
+			_, _ = item.upstreamThinkContent.WriteString(input.UpstreamThink.Delta)
+		}
+		item.upstreamThinkSeq = item.nextSeq
+		item.upstreamThinkRoundID = roundID
+		item.upstreamThinkMetadata = input.UpstreamThink.MetadataJSON
+	}
 	if maxEvents > 0 && int64(len(item.events)) > maxEvents {
 		item.events = append([]repository.GenerationStreamMessage(nil), item.events[len(item.events)-int(maxEvents):]...)
 	}
 	item.expiresAt = time.Now().Add(ttl)
 	return record, nil
+}
+
+func (s *testGenerationStreamStore) GetGenerationStreamUpstreamThinkSnapshot(_ context.Context, runID string) (repository.GenerationStreamUpstreamThinkSnapshot, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cleanupLocked()
+	item, ok := s.items[runID]
+	if !ok || item.upstreamThinkSeq <= 0 {
+		return repository.GenerationStreamUpstreamThinkSnapshot{}, false, nil
+	}
+	return repository.GenerationStreamUpstreamThinkSnapshot{
+		Seq:             item.upstreamThinkSeq,
+		RoundID:         item.upstreamThinkRoundID,
+		ContentMarkdown: item.upstreamThinkContent.String(),
+		MetadataJSON:    item.upstreamThinkMetadata,
+	}, true, nil
 }
 
 func (s *testGenerationStreamStore) GetGenerationStreamTextSnapshot(_ context.Context, runID string) (repository.GenerationStreamTextSnapshot, bool, error) {
@@ -730,6 +901,10 @@ func (s *testGenerationStreamStore) ResetGenerationStreamEvents(_ context.Contex
 		item.events = nil
 		item.textContent.Reset()
 		item.textSeq = 0
+		item.upstreamThinkContent.Reset()
+		item.upstreamThinkSeq = 0
+		item.upstreamThinkRoundID = ""
+		item.upstreamThinkMetadata = ""
 	}
 	return nil
 }

--- a/backend/internal/infra/cache/memory/generation_stream.go
+++ b/backend/internal/infra/cache/memory/generation_stream.go
@@ -10,17 +10,21 @@ import (
 )
 
 type generationStream struct {
-	ownerID         uint
-	conversationID  string
-	ownerExpiresAt  time.Time
-	activeExpiresAt time.Time
-	cancelExpiresAt time.Time
-	eventsExpiresAt time.Time
-	seq             int64
-	events          []repository.GenerationStreamMessage
-	textContent     strings.Builder
-	textSeq         int64
-	notify          chan struct{}
+	ownerID               uint
+	conversationID        string
+	ownerExpiresAt        time.Time
+	activeExpiresAt       time.Time
+	cancelExpiresAt       time.Time
+	eventsExpiresAt       time.Time
+	seq                   int64
+	events                []repository.GenerationStreamMessage
+	textContent           strings.Builder
+	textSeq               int64
+	upstreamThinkContent  strings.Builder
+	upstreamThinkSeq      int64
+	upstreamThinkRoundID  string
+	upstreamThinkMetadata string
+	notify                chan struct{}
 }
 
 func (c *Cache) RegisterGenerationStream(ctx context.Context, runID string, userID uint, conversationPublicID string, ttl time.Duration) error {
@@ -126,6 +130,24 @@ func (c *Cache) AppendGenerationStreamEvent(ctx context.Context, runID string, i
 		_, _ = stream.textContent.WriteString(input.TextDelta)
 		stream.textSeq = stream.seq
 	}
+	if input.UpstreamThink != nil {
+		roundID := strings.TrimSpace(input.UpstreamThink.RoundID)
+		if roundID == "" {
+			roundID = stream.upstreamThinkRoundID
+		}
+		if roundID != "" && stream.upstreamThinkRoundID != "" && roundID != stream.upstreamThinkRoundID {
+			stream.upstreamThinkContent.Reset()
+		}
+		if input.UpstreamThink.Replace {
+			stream.upstreamThinkContent.Reset()
+			_, _ = stream.upstreamThinkContent.WriteString(input.UpstreamThink.ContentMarkdown)
+		} else {
+			_, _ = stream.upstreamThinkContent.WriteString(input.UpstreamThink.Delta)
+		}
+		stream.upstreamThinkSeq = stream.seq
+		stream.upstreamThinkRoundID = roundID
+		stream.upstreamThinkMetadata = input.UpstreamThink.MetadataJSON
+	}
 	if maxEvents <= 0 {
 		maxEvents = 1024
 	}
@@ -137,6 +159,22 @@ func (c *Cache) AppendGenerationStreamEvent(ctx context.Context, runID string, i
 	c.notifyGenerationStreamsLocked()
 	c.maybeSweepLocked(time.Now())
 	return record, nil
+}
+
+func (c *Cache) GetGenerationStreamUpstreamThinkSnapshot(ctx context.Context, runID string) (repository.GenerationStreamUpstreamThinkSnapshot, bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	stream := c.streams[strings.TrimSpace(runID)]
+	now := time.Now()
+	if stream == nil || stream.eventsExpired(now) || stream.upstreamThinkSeq <= 0 {
+		return repository.GenerationStreamUpstreamThinkSnapshot{}, false, nil
+	}
+	return repository.GenerationStreamUpstreamThinkSnapshot{
+		Seq:             stream.upstreamThinkSeq,
+		RoundID:         stream.upstreamThinkRoundID,
+		ContentMarkdown: stream.upstreamThinkContent.String(),
+		MetadataJSON:    stream.upstreamThinkMetadata,
+	}, true, nil
 }
 
 func (c *Cache) GetGenerationStreamTextSnapshot(ctx context.Context, runID string) (repository.GenerationStreamTextSnapshot, bool, error) {
@@ -224,6 +262,10 @@ func (c *Cache) ResetGenerationStreamEvents(ctx context.Context, runID string) e
 	stream.events = nil
 	stream.textContent.Reset()
 	stream.textSeq = 0
+	stream.upstreamThinkContent.Reset()
+	stream.upstreamThinkSeq = 0
+	stream.upstreamThinkRoundID = ""
+	stream.upstreamThinkMetadata = ""
 	// Keep seq monotonic so any in-flight afterSeq cursors stay valid.
 	stream.notifyLocked()
 	return nil

--- a/backend/internal/infra/cache/memory/generation_stream_test.go
+++ b/backend/internal/infra/cache/memory/generation_stream_test.go
@@ -89,6 +89,59 @@ func TestGenerationStreamTextSnapshotLifecycle(t *testing.T) {
 	}
 }
 
+func TestGenerationStreamUpstreamThinkSnapshotLifecycle(t *testing.T) {
+	cache := New()
+	ctx := context.Background()
+	runID := "run_memory_upstream_think_snapshot"
+	if err := cache.RegisterGenerationStream(ctx, runID, 7, "conv_test", time.Minute); err != nil {
+		t.Fatal(err)
+	}
+
+	updates := []*repository.GenerationStreamUpstreamThinkAppend{
+		{RoundID: "round_1", Delta: "思考", MetadataJSON: `{"type":"upstream_think_delta","roundID":"round_1"}`},
+		{RoundID: "round_1", ContentMarkdown: "完整思考", Replace: true, MetadataJSON: `{"type":"upstream_think_delta","roundID":"round_1"}`},
+		{RoundID: "round_1", Delta: "继续", MetadataJSON: `{"type":"upstream_think_delta","roundID":"round_1"}`},
+	}
+	for _, update := range updates {
+		if _, err := cache.AppendGenerationStreamEvent(ctx, runID, repository.GenerationStreamAppend{
+			PayloadJSON:   `{"type":"upstream_think_delta"}`,
+			UpstreamThink: update,
+		}, 2, time.Minute); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	snapshot, ok, err := cache.GetGenerationStreamUpstreamThinkSnapshot(ctx, runID)
+	if err != nil || !ok {
+		t.Fatalf("snapshot ok=%v err=%v", ok, err)
+	}
+	if snapshot.ContentMarkdown != "完整思考继续" || snapshot.RoundID != "round_1" || snapshot.Seq != 3 {
+		t.Fatalf("unexpected snapshot: %+v", snapshot)
+	}
+
+	if _, err := cache.AppendGenerationStreamEvent(ctx, runID, repository.GenerationStreamAppend{
+		PayloadJSON: `{"type":"upstream_think_delta"}`,
+		UpstreamThink: &repository.GenerationStreamUpstreamThinkAppend{
+			RoundID:      "round_2",
+			Delta:        "下一轮",
+			MetadataJSON: `{"type":"upstream_think_delta","roundID":"round_2"}`,
+		},
+	}, 2, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, ok, err = cache.GetGenerationStreamUpstreamThinkSnapshot(ctx, runID)
+	if err != nil || !ok || snapshot.ContentMarkdown != "下一轮" || snapshot.RoundID != "round_2" || snapshot.Seq != 4 {
+		t.Fatalf("unexpected snapshot after round change: snapshot=%+v ok=%v err=%v", snapshot, ok, err)
+	}
+
+	if err := cache.ResetGenerationStreamEvents(ctx, runID); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot, ok, err = cache.GetGenerationStreamUpstreamThinkSnapshot(ctx, runID); err != nil || ok {
+		t.Fatalf("snapshot survived reset: snapshot=%+v ok=%v err=%v", snapshot, ok, err)
+	}
+}
+
 func TestGenerationStreamClearActiveMarksInactive(t *testing.T) {
 	cache := New()
 	ctx := context.Background()

--- a/backend/internal/infra/cache/redis/conversation_cache.go
+++ b/backend/internal/infra/cache/redis/conversation_cache.go
@@ -50,9 +50,9 @@ type fileQueueConfig struct {
 }
 
 // appendGenerationStreamEventScript keeps the event sequence, bounded replay
-// window, and cumulative visible-text checkpoint consistent in one Redis
-// round trip. Key TTLs are initialized only when a value is first created;
-// FinishMessageGeneration shortens them to the post-run retention window.
+// window, and cumulative visible-text/upstream-thinking checkpoints consistent
+// in one Redis round trip. Key TTLs are initialized only when a value is first
+// created; FinishMessageGeneration shortens them to the post-run retention window.
 var appendGenerationStreamEventScript = redis.NewScript(`
 local events_missing = redis.call("EXISTS", KEYS[2]) == 0
 local has_text_delta = ARGV[4] ~= ""
@@ -60,10 +60,38 @@ local text_missing = false
 if has_text_delta then
 	text_missing = redis.call("EXISTS", KEYS[3]) == 0
 end
+local has_think_update = ARGV[5] == "1"
+local think_content_missing = false
+local think_meta_missing = false
+if has_think_update then
+	think_content_missing = redis.call("EXISTS", KEYS[5]) == 0
+	think_meta_missing = redis.call("EXISTS", KEYS[6]) == 0
+end
 local seq = redis.call("INCR", KEYS[1])
 if has_text_delta then
 	redis.call("APPEND", KEYS[3], ARGV[4])
 	redis.call("SET", KEYS[4], tostring(seq), "KEEPTTL")
+end
+if has_think_update then
+	local previous_round = redis.call("HGET", KEYS[6], "round") or ""
+	local next_round = ARGV[8]
+	if next_round == "" then
+		next_round = previous_round
+	end
+	if next_round ~= "" and previous_round ~= "" and next_round ~= previous_round then
+		redis.call("DEL", KEYS[5])
+		think_content_missing = true
+	end
+	if ARGV[6] == "1" then
+		redis.call("SET", KEYS[5], ARGV[7], "KEEPTTL")
+	else
+		redis.call("APPEND", KEYS[5], ARGV[7])
+	end
+	redis.call("HSET", KEYS[6],
+		"seq", tostring(seq),
+		"round", next_round,
+		"metadata", ARGV[9]
+	)
 end
 local id = redis.call(
 	"XADD",
@@ -84,8 +112,27 @@ if has_text_delta and text_missing then
 	redis.call("PEXPIRE", KEYS[3], ARGV[3])
 	redis.call("PEXPIRE", KEYS[4], ARGV[3])
 end
+if has_think_update and think_content_missing then
+	redis.call("PEXPIRE", KEYS[5], ARGV[3])
+end
+if has_think_update and think_meta_missing then
+	redis.call("PEXPIRE", KEYS[6], ARGV[3])
+end
 
 return {id, tostring(seq)}
+`)
+
+var getGenerationStreamUpstreamThinkSnapshotScript = redis.NewScript(`
+if redis.call("EXISTS", KEYS[1]) == 0 or redis.call("EXISTS", KEYS[2]) == 0 then
+	return {"0"}
+end
+return {
+	"1",
+	redis.call("GET", KEYS[1]) or "",
+	redis.call("HGET", KEYS[2], "seq") or "",
+	redis.call("HGET", KEYS[2], "round") or "",
+	redis.call("HGET", KEYS[2], "metadata") or ""
+}
 `)
 
 var renewFileProcessingLeaseScript = redis.NewScript(`
@@ -792,7 +839,7 @@ func (c *conversationCache) IsGenerationStreamCanceled(ctx context.Context, runI
 	return count > 0, nil
 }
 
-// AppendGenerationStreamEvent 原子追加生成事件，并同步维护可见文本快照。
+// AppendGenerationStreamEvent 原子追加生成事件，并同步维护正文与当前思考轮次快照。
 func (c *conversationCache) AppendGenerationStreamEvent(ctx context.Context, runID string, input repository.GenerationStreamAppend, maxEvents int64, ttl time.Duration) (repository.GenerationStreamMessage, error) {
 	if c.client == nil {
 		return repository.GenerationStreamMessage{}, nil
@@ -803,6 +850,22 @@ func (c *conversationCache) AppendGenerationStreamEvent(ctx context.Context, run
 	if ttl <= 0 {
 		ttl = time.Minute
 	}
+	hasUpstreamThink := "0"
+	upstreamThinkReplace := "0"
+	upstreamThinkContent := ""
+	upstreamThinkRoundID := ""
+	upstreamThinkMetadata := ""
+	if input.UpstreamThink != nil {
+		hasUpstreamThink = "1"
+		if input.UpstreamThink.Replace {
+			upstreamThinkReplace = "1"
+			upstreamThinkContent = input.UpstreamThink.ContentMarkdown
+		} else {
+			upstreamThinkContent = input.UpstreamThink.Delta
+		}
+		upstreamThinkRoundID = input.UpstreamThink.RoundID
+		upstreamThinkMetadata = input.UpstreamThink.MetadataJSON
+	}
 	result, err := appendGenerationStreamEventScript.Run(
 		ctx,
 		c.client,
@@ -811,11 +874,18 @@ func (c *conversationCache) AppendGenerationStreamEvent(ctx context.Context, run
 			generationStreamEventsKey(runID),
 			generationStreamTextKey(runID),
 			generationStreamTextSeqKey(runID),
+			generationStreamUpstreamThinkContentKey(runID),
+			generationStreamUpstreamThinkMetaKey(runID),
 		},
 		input.PayloadJSON,
 		maxEvents,
 		ttl.Milliseconds(),
 		input.TextDelta,
+		hasUpstreamThink,
+		upstreamThinkReplace,
+		upstreamThinkContent,
+		upstreamThinkRoundID,
+		upstreamThinkMetadata,
 	).Result()
 	if err != nil {
 		return repository.GenerationStreamMessage{}, err
@@ -830,6 +900,41 @@ func (c *conversationCache) AppendGenerationStreamEvent(ctx context.Context, run
 		return repository.GenerationStreamMessage{}, errors.New("invalid generation stream append metadata")
 	}
 	return repository.GenerationStreamMessage{ID: id, Seq: seq, PayloadJSON: input.PayloadJSON}, nil
+}
+
+// GetGenerationStreamUpstreamThinkSnapshot 原子读取当前思考轮次的完整恢复快照。
+func (c *conversationCache) GetGenerationStreamUpstreamThinkSnapshot(ctx context.Context, runID string) (repository.GenerationStreamUpstreamThinkSnapshot, bool, error) {
+	if c.client == nil {
+		return repository.GenerationStreamUpstreamThinkSnapshot{}, false, nil
+	}
+	result, err := getGenerationStreamUpstreamThinkSnapshotScript.Run(
+		ctx,
+		c.client,
+		[]string{
+			generationStreamUpstreamThinkContentKey(runID),
+			generationStreamUpstreamThinkMetaKey(runID),
+		},
+	).Result()
+	if err != nil {
+		return repository.GenerationStreamUpstreamThinkSnapshot{}, false, err
+	}
+	values, ok := result.([]interface{})
+	if !ok || len(values) == 0 || getStringVal(values[0]) != "1" {
+		return repository.GenerationStreamUpstreamThinkSnapshot{}, false, nil
+	}
+	if len(values) != 5 {
+		return repository.GenerationStreamUpstreamThinkSnapshot{}, false, nil
+	}
+	seq := getInt64Val(values[2])
+	if seq <= 0 {
+		return repository.GenerationStreamUpstreamThinkSnapshot{}, false, nil
+	}
+	return repository.GenerationStreamUpstreamThinkSnapshot{
+		Seq:             seq,
+		RoundID:         getStringVal(values[3]),
+		ContentMarkdown: getStringVal(values[1]),
+		MetadataJSON:    getStringVal(values[4]),
+	}, true, nil
 }
 
 // GetGenerationStreamTextSnapshot 原子读取完整可见文本及其最后事件序号。
@@ -926,6 +1031,8 @@ func (c *conversationCache) ResetGenerationStreamEvents(ctx context.Context, run
 		generationStreamEventsKey(runID),
 		generationStreamTextKey(runID),
 		generationStreamTextSeqKey(runID),
+		generationStreamUpstreamThinkContentKey(runID),
+		generationStreamUpstreamThinkMetaKey(runID),
 	).Err()
 }
 
@@ -939,6 +1046,8 @@ func (c *conversationCache) ExpireGenerationStream(ctx context.Context, runID st
 	pipe.Expire(ctx, generationStreamSeqKey(runID), ttl)
 	pipe.Expire(ctx, generationStreamTextKey(runID), ttl)
 	pipe.Expire(ctx, generationStreamTextSeqKey(runID), ttl)
+	pipe.Expire(ctx, generationStreamUpstreamThinkContentKey(runID), ttl)
+	pipe.Expire(ctx, generationStreamUpstreamThinkMetaKey(runID), ttl)
 	pipe.Expire(ctx, generationStreamOwnerKey(runID), ttl)
 	pipe.Expire(ctx, generationStreamConversationKey(runID), ttl)
 	pipe.Expire(ctx, generationStreamCancelKey(runID), ttl)
@@ -980,6 +1089,14 @@ func generationStreamTextKey(runID string) string {
 
 func generationStreamTextSeqKey(runID string) string {
 	return generationStreamKeyPrefix + strings.TrimSpace(runID) + ":text_seq"
+}
+
+func generationStreamUpstreamThinkContentKey(runID string) string {
+	return generationStreamKeyPrefix + strings.TrimSpace(runID) + ":upstream_think"
+}
+
+func generationStreamUpstreamThinkMetaKey(runID string) string {
+	return generationStreamKeyPrefix + strings.TrimSpace(runID) + ":upstream_think_meta"
 }
 
 func generationStreamOwnerKey(runID string) string {

--- a/backend/internal/repository/conversation_cache.go
+++ b/backend/internal/repository/conversation_cache.go
@@ -42,15 +42,34 @@ type GenerationStreamMessage struct {
 
 // GenerationStreamAppend 是一次原子追加所需的数据。
 // TextDelta 仅在可见文本 delta 事件中设置，用于同步维护完整恢复快照。
+// UpstreamThink 仅在上游思考事件中设置，用于维护当前思考轮次的完整恢复快照。
 type GenerationStreamAppend struct {
-	PayloadJSON string
-	TextDelta   string
+	PayloadJSON   string
+	TextDelta     string
+	UpstreamThink *GenerationStreamUpstreamThinkAppend
+}
+
+// GenerationStreamUpstreamThinkAppend 描述上游思考快照的原子更新。
+type GenerationStreamUpstreamThinkAppend struct {
+	RoundID         string
+	Delta           string
+	ContentMarkdown string
+	Replace         bool
+	MetadataJSON    string
 }
 
 // GenerationStreamTextSnapshot 是生成期间可恢复的完整可见文本及其事件序号。
 type GenerationStreamTextSnapshot struct {
 	Seq     int64
 	Content string
+}
+
+// GenerationStreamUpstreamThinkSnapshot 是当前思考轮次的完整内容及其最后事件序号。
+type GenerationStreamUpstreamThinkSnapshot struct {
+	Seq             int64
+	RoundID         string
+	ContentMarkdown string
+	MetadataJSON    string
 }
 
 // FileProcessingQueueRepository 封装文件处理队列缓存能力。
@@ -86,6 +105,7 @@ type GenerationStreamCacheRepository interface {
 	IsGenerationStreamCanceled(ctx context.Context, runID string) (bool, error)
 	AppendGenerationStreamEvent(ctx context.Context, runID string, input GenerationStreamAppend, maxEvents int64, ttl time.Duration) (GenerationStreamMessage, error)
 	GetGenerationStreamTextSnapshot(ctx context.Context, runID string) (GenerationStreamTextSnapshot, bool, error)
+	GetGenerationStreamUpstreamThinkSnapshot(ctx context.Context, runID string) (GenerationStreamUpstreamThinkSnapshot, bool, error)
 	ListGenerationStreamEvents(ctx context.Context, runID string, limit int64) ([]GenerationStreamMessage, error)
 	ReadGenerationStreamEvents(ctx context.Context, runID string, afterID string, block time.Duration, limit int64) ([]GenerationStreamMessage, error)
 	// ResetGenerationStreamEvents clears retained events while keeping owner metadata so

--- a/backend/internal/transport/http/conversation/handler_message_send.go
+++ b/backend/internal/transport/http/conversation/handler_message_send.go
@@ -765,7 +765,7 @@ func (h *Handler) StreamActiveMessageGenerations(c *gin.Context) {
 // @Security BearerAuth
 // @Param run_id path string true "运行 ID"
 // @Param after query int false "已接收的最后事件序号"
-// @Param snapshot query bool false "是否返回可替换当前正文的权威文本快照"
+// @Param snapshot query bool false "是否返回正文与当前思考轮次的权威内容快照"
 // @Success 200 {string} string "NDJSON stream"
 // @Failure 404 {object} ErrorDoc
 // @Router /conversation-runs/{run_id}/stream [get]
@@ -780,13 +780,13 @@ func (h *Handler) ResumeMessageGenerationStream(c *gin.Context) {
 		afterSeq = 0
 	}
 	userID := middleware.MustUserID(c)
-	includeTextSnapshot, _ := strconv.ParseBool(strings.TrimSpace(c.Query("snapshot")))
+	includeSnapshots, _ := strconv.ParseBool(strings.TrimSpace(c.Query("snapshot")))
 	replay, events, unsubscribe, ok := h.service.SubscribeMessageGeneration(
 		c.Request.Context(),
 		userID,
 		runID,
 		afterSeq,
-		includeTextSnapshot,
+		includeSnapshots,
 	)
 	if !ok {
 		h.service.MarkMessageGenerationInterrupted(c.Request.Context(), userID, runID)

--- a/frontend/features/chat/hooks/use-chat-data.ts
+++ b/frontend/features/chat/hooks/use-chat-data.ts
@@ -436,7 +436,7 @@ export function useChatData(
               ...prev,
               messages: prev.messages.map((message) =>
                 message.runID === pendingRunID && message.role === "assistant" && message.status === "pending"
-                  ? { ...message, processTrace: event.trace }
+                  ? { ...message, processTrace: event.trace ?? message.processTrace }
                   : message,
               ),
             }));

--- a/packages/api-contract/src/types.generated.ts
+++ b/packages/api-contract/src/types.generated.ts
@@ -8185,7 +8185,7 @@ export namespace ConversationRuns {
     export type RequestQuery = {
       /** 已接收的最后事件序号 */
       after?: number;
-      /** 是否返回可替换当前正文的权威文本快照 */
+      /** 是否返回正文与当前思考轮次的权威内容快照 */
       snapshot?: boolean;
     };
     export type RequestBody = never;


### PR DESCRIPTION
## Summary

Closes #701.

- Preserve complete in-progress reasoning when a conversation is refreshed or revisited.
- Add a cumulative snapshot for the active upstream reasoning round while keeping the replay stream bounded.
- Atomically update and read reasoning content metadata and sequence state in Redis.
- Keep the memory cache behavior aligned with Redis including round transitions expiration and reset handling.
- Replay answer and reasoning snapshots in sequence order without duplicating covered events.
- Preserve the existing process trace when an oversized compacted stream event does not include a complete trace.
- Track terminal reasoning metadata even when the terminal event contains no additional text.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `go test ./internal/application/conversation ./internal/infra/cache/memory ./internal/infra/cache/redis -count=1`
- [x] `go test -race ./internal/application/conversation ./internal/infra/cache/memory -count=1`
- [x] `go vet ./internal/application/conversation ./internal/infra/cache/memory ./internal/infra/cache/redis ./internal/repository ./internal/transport/http/conversation`
- [x] `go test ./... -run '^$' -count=1`
- [x] `pnpm exec biome lint features/chat/hooks/use-chat-data.ts`
- [x] `pnpm typecheck`
- [x] `git diff --check`

## Screenshots API examples or logs

Not applicable. This change corrects stream recovery behavior without changing the visual design.

## Configuration migration and compatibility notes

- No database migration is required.
- No configuration or deployment changes are required.
- No breaking API request or response changes are introduced.
- The existing `snapshot=true` recovery option now restores both visible answer content and the current reasoning round.
- The retained event window remains bounded at 1024 events.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets tokens credentials local config or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed including stream ownership replay authorization and cache expiration.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior deployment steps API contracts or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches build output `.pyc` files `.env` files and local storage data are not committed.