### PR TITLE
feat: improve chat composer focus behavior

### DIFF
--- a/frontend/features/chat/components/app-chat-area.tsx
+++ b/frontend/features/chat/components/app-chat-area.tsx
@@ -150,6 +150,7 @@ export function AppChatArea() {
   const upsertConversation = useSidebarConversationField("upsertConversation");
   const {
     cancelResumedGeneration,
+    conversationPublicID: messageDataConversationID,
     loading,
     loadingOlder,
     errorMsg,
@@ -709,9 +710,13 @@ export function AppChatArea() {
 
   const composerSending = temporaryMode ? temporaryRuntime.sending : generating;
   const composerConversationMode = temporaryMode ? temporaryRuntime.messages.length > 0 : isConversationMode;
+  const composerLoading =
+    !temporaryMode &&
+    Boolean(conversationID) &&
+    (loading || messageDataConversationID !== conversationID);
   const chatInputProps = {
     draft,
-    loading: temporaryMode ? false : loading,
+    loading: composerLoading,
     sending: composerSending,
     uploading: temporaryMode ? false : uploading,
     isConversationMode: composerConversationMode,
@@ -741,6 +746,7 @@ export function AppChatArea() {
     modelLoading: modelsLoading,
     dropActive: fileDragActive,
     temporaryMode,
+    autoFocusKey: conversationID ?? `${conversationKey}:${newConversationRevision}`,
     onDraftChange: setDraft,
     onModelChange: setSelectedPlatformModelName,
     onModelCatalogRefresh: refreshModelCatalogForComposer,

--- a/frontend/features/chat/components/sections/chat-input.tsx
+++ b/frontend/features/chat/components/sections/chat-input.tsx
@@ -130,6 +130,7 @@ type ChatInputProps = {
   modelDisabled?: boolean;
   dropActive?: boolean;
   temporaryMode?: boolean;
+  autoFocusKey: string;
   onDraftChange: (value: string) => void;
   onModelChange: (platformModelName: string) => void;
   onModelCatalogRefresh?: () => void | Promise<void>;
@@ -286,6 +287,7 @@ function ChatInputComponent({
   modelDisabled = false,
   dropActive = false,
   temporaryMode = false,
+  autoFocusKey,
   onDraftChange,
   onModelChange,
   onModelCatalogRefresh,
@@ -341,6 +343,7 @@ function ChatInputComponent({
   const inputGroupRef = React.useRef<HTMLDivElement | null>(null);
   const inputGroupMeasureRef = React.useRef<HTMLDivElement | null>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const lastAutoFocusKeyRef = React.useRef("");
   const markdownPreviewRef = React.useRef<HTMLDivElement | null>(null);
   const attachmentScrollFadeRef = useScrollFadeFallbackRef<HTMLDivElement>();
   const composingRef = React.useRef(false);
@@ -388,6 +391,21 @@ function ChatInputComponent({
       setMarkdownPreview(false);
     }
   }, [hasDraftText]);
+
+  React.useEffect(() => {
+    if (loading || lastAutoFocusKeyRef.current === autoFocusKey) {
+      return;
+    }
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+    lastAutoFocusKeyRef.current = autoFocusKey;
+    if (window.matchMedia("(pointer: coarse)").matches) {
+      return;
+    }
+    textarea.focus({ preventScroll: true });
+  }, [autoFocusKey, loading]);
 
   React.useLayoutEffect(() => {
     const node = inputGroupMeasureRef.current;
@@ -865,7 +883,7 @@ function ChatInputComponent({
           <InputGroupTextarea
             ref={textareaRef}
             value={draft}
-            disabled={loading || uploading}
+            disabled={loading}
             readOnly={speechInput.active}
             placeholder={dropActive ? tChat("attachments.dropTitle") : speechInput.placeholder}
             rows={1}


### PR DESCRIPTION
## Summary

- Automatically focus the chat composer when opening the chat page.
- Restore focus after creating a new conversation or switching between conversations.
- Wait for the target conversation data to become ready before focusing to avoid loading-state races.
- Keep the textarea available while pasted attachments upload so typing is not interrupted.
- Avoid automatic focus on coarse-pointer devices to prevent unexpectedly opening the mobile keyboard.

Closes #703.

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] `pnpm check`
- [x] `git diff --check`

## Screenshots, API examples, or logs

Not applicable.

## Configuration, migration, and compatibility notes

No configuration changes, database migrations, API contract changes, or deployment changes are required.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.