### PR TITLE
fix: clear stale conversation run indicators after completion

### DIFF
--- a/frontend/features/chat/components/app-chat-area.tsx
+++ b/frontend/features/chat/components/app-chat-area.tsx
@@ -160,7 +160,6 @@ export function AppChatArea() {
     reload,
     replaceMessage,
     resumingActivityLabel,
-    resumingConversationID,
     resumingRunID,
   } = useChatData(conversationID, {
     activeGenerationRunsRef,
@@ -490,15 +489,6 @@ export function AppChatArea() {
     resumingActivityLabel,
     resumingRunID,
   });
-  React.useEffect(() => {
-    const normalizedConversationID = resumingConversationID.trim();
-    const normalizedRunID = resumingRunID.trim();
-    if (!normalizedConversationID || !normalizedRunID) {
-      return;
-    }
-    registerConversationRun(normalizedRunID, normalizedConversationID);
-    return () => detachConversationRun(normalizedRunID);
-  }, [detachConversationRun, registerConversationRun, resumingConversationID, resumingRunID]);
   const generating = sending;
   const uploadDropDisabled = loading || uploading;
   const onStopActiveMessage = React.useCallback(() => {

--- a/frontend/features/chat/hooks/use-chat-data.ts
+++ b/frontend/features/chat/hooks/use-chat-data.ts
@@ -26,11 +26,6 @@ type ActiveResumeStream = {
   accessToken: string | null;
 };
 
-type ResumingRun = {
-  conversationPublicID: string;
-  runID: string;
-};
-
 export function useChatData(
   conversationID: string | null,
   {
@@ -55,8 +50,7 @@ export function useChatData(
     hasOlder: false,
   });
   const [reloadToken, setReloadToken] = React.useState(0);
-  const [resumingRun, setResumingRun] = React.useState<ResumingRun | null>(null);
-  const resumingRunID = resumingRun?.runID ?? "";
+  const [resumingRunID, setResumingRunID] = React.useState("");
   const [resumingActivityLabel, setResumingActivityLabel] = React.useState("");
   const stateRef = React.useRef(state);
   stateRef.current = state;
@@ -261,7 +255,7 @@ export function useChatData(
 
     active.controller.abort();
     clearResumeCheckpoint(active.runID);
-    setResumingRun(null);
+    setResumingRunID("");
 
     const token = active.accessToken ?? (await resolveAccessToken());
     if (!token) {
@@ -306,7 +300,7 @@ export function useChatData(
       !pendingRunID ||
       pendingRunIsActive
     ) {
-      setResumingRun(null);
+      setResumingRunID("");
       setResumingActivityLabel("");
       return;
     }
@@ -333,7 +327,7 @@ export function useChatData(
       runID: pendingRunID,
       accessToken: null,
     };
-    setResumingRun({ conversationPublicID: conversationID, runID: pendingRunID });
+    setResumingRunID(pendingRunID);
     setResumingActivityLabel("");
 
     async function resume() {
@@ -512,7 +506,7 @@ export function useChatData(
       } catch (error) {
         if (!controller.signal.aborted && error instanceof Error && error.name !== "AbortError") {
           clearResumeCheckpoint(pendingRunID);
-          setResumingRun(null);
+          setResumingRunID("");
           setResumingActivityLabel("");
           reload();
         }
@@ -521,7 +515,7 @@ export function useChatData(
           activeResumeStreamRef.current = null;
         }
         if (!controller.signal.aborted && !closed) {
-          setResumingRun(null);
+          setResumingRunID("");
           setResumingActivityLabel("");
         }
       }
@@ -571,7 +565,6 @@ export function useChatData(
     reload,
     replaceMessage,
     resumingActivityLabel,
-    resumingConversationID: resumingRun?.conversationPublicID ?? "",
     resumingRunID,
   };
 }

--- a/frontend/features/chat/model/conversation-run-store.ts
+++ b/frontend/features/chat/model/conversation-run-store.ts
@@ -115,7 +115,7 @@ export class ConversationRunStore {
       }
       if (
         existing?.conversationPublicID === conversationID &&
-        (existing.status === "local" || existing.status === "server")
+        existing.status === "server"
       ) {
         return;
       }
@@ -184,12 +184,10 @@ export class ConversationRunStore {
         }
         if (record.status === "local") {
           if (serverOwner) {
-            if (record.missingFromSnapshotSince !== undefined) {
-              this.records.set(runID, {
-                conversationPublicID: record.conversationPublicID,
-                status: "local",
-              });
-            }
+            this.records.set(runID, {
+              conversationPublicID: record.conversationPublicID,
+              status: "server",
+            });
             continue;
           }
           // 服务端从未登记该运行（提交失败、流挂死等）时，本地记录会持续缺席快照。


### PR DESCRIPTION
## Summary

Fixes #705.

Prevents sidebar conversation run indicators from remaining active after message generation has already completed.

The recovery stream previously registered an existing server-side run as a new local run. A stale pending message could therefore recreate the global running state after completion.

This change:

- separates message stream recovery from global run ownership;
- removes the redundant recovery conversation state and registration effect;
- keeps actual local submissions and authoritative server SSE events as the only run-state sources;
- promotes locally submitted runs to server-confirmed state after a `started` event or authoritative snapshot;
- clears server-confirmed runs on the next empty snapshot when completion events are lost under unstable networks;
- preserves the grace period for newly submitted runs that the server has not acknowledged yet.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- [x] Temporary run-state regression tests — 6/6 passed
- [x] Weak-network tests reproduced 2 failures before the fix and passed after the fix
- [x] `pnpm --filter @deeix/web lint`
- [x] `pnpm --filter @deeix/web typecheck`
- [x] `pnpm --filter @deeix/web build`

Temporary test files were removed after verification and are not included in the pull request.

## Screenshots, API examples, or logs

Not applicable. This change corrects conversation run-state synchronization without changing the visible UI.

## Configuration, migration, and compatibility notes

No configuration, environment variable, API contract, database migration, or deployment changes are required.

The existing active-run SSE protocol and periodic authoritative snapshots remain unchanged.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.