### PR TITLE
feat: support disabling knowledge bases from the admin console

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -13803,6 +13803,30 @@ const docTemplate = `{
                 }
             }
         },
+        "/settings/feature-policy": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "settings"
+                ],
+                "summary": "查询用户侧功能开关策略",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Envelope"
+                        }
+                    }
+                }
+            }
+        },
         "/settings/login-page": {
             "get": {
                 "produces": [

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -13796,6 +13796,30 @@
                 }
             }
         },
+        "/settings/feature-policy": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "settings"
+                ],
+                "summary": "查询用户侧功能开关策略",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Envelope"
+                        }
+                    }
+                }
+            }
+        },
         "/settings/login-page": {
             "get": {
                 "produces": [

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -18658,6 +18658,20 @@ paths:
       summary: 查询聊天上下文策略
       tags:
       - settings
+  /settings/feature-policy:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/Envelope'
+      security:
+      - BearerAuth: []
+      summary: 查询用户侧功能开关策略
+      tags:
+      - settings
   /settings/login-page:
     get:
       produces:

--- a/backend/internal/application/conversation/service_file_context.go
+++ b/backend/internal/application/conversation/service_file_context.go
@@ -273,6 +273,10 @@ func (s *Service) resolveKnowledgeBaseRAGFiles(
 	if len(publicIDs) == 0 {
 		return nil, nil
 	}
+	if !s.cfg.Snapshot().KnowledgeBaseEnabled {
+		// 知识库功能已被后台关闭：静默忽略引用，保证存量会话仍可正常发送。
+		return nil, nil
+	}
 	if !ragAvailable || s.knowledgeBaseResolver == nil || s.ragSvc == nil {
 		return nil, ErrKnowledgeBaseUnavailable
 	}

--- a/backend/internal/application/conversation/service_file_context_test.go
+++ b/backend/internal/application/conversation/service_file_context_test.go
@@ -88,6 +88,7 @@ func TestBindAttachmentMessageRolesPrefersUserOwnership(t *testing.T) {
 
 func TestResolveKnowledgeBaseRAGFilesFiltersAndDeduplicatesReadyFiles(t *testing.T) {
 	service := &Service{
+		cfg:    config.NewRuntime(config.Config{KnowledgeBaseEnabled: true}),
 		ragSvc: &apprag.Service{},
 		knowledgeBaseResolver: knowledgeBaseResolverStub{resolveFiles: func(context.Context, uint, []string) ([]domainknowledgebase.KnowledgeBase, []model.FileObject, error) {
 			return []domainknowledgebase.KnowledgeBase{{PublicID: "kb-one", ReadyFileCount: 1}}, []model.FileObject{
@@ -109,6 +110,7 @@ func TestResolveKnowledgeBaseRAGFilesFiltersAndDeduplicatesReadyFiles(t *testing
 
 func TestResolveKnowledgeBaseRAGFilesMapsUnavailableReference(t *testing.T) {
 	service := &Service{
+		cfg:    config.NewRuntime(config.Config{KnowledgeBaseEnabled: true}),
 		ragSvc: &apprag.Service{},
 		knowledgeBaseResolver: knowledgeBaseResolverStub{resolveFiles: func(context.Context, uint, []string) ([]domainknowledgebase.KnowledgeBase, []model.FileObject, error) {
 			return nil, nil, domainknowledgebase.ErrReferenceUnavailable
@@ -118,6 +120,25 @@ func TestResolveKnowledgeBaseRAGFilesMapsUnavailableReference(t *testing.T) {
 	_, err := service.resolveKnowledgeBaseRAGFiles(context.Background(), 11, []string{"missing"}, true)
 	if !errors.Is(err, ErrInvalidKnowledgeBaseReference) {
 		t.Fatalf("resolveKnowledgeBaseRAGFiles() error = %v, want ErrInvalidKnowledgeBaseReference", err)
+	}
+}
+
+func TestResolveKnowledgeBaseRAGFilesSkipsWhenFeatureDisabled(t *testing.T) {
+	service := &Service{
+		cfg:    config.NewRuntime(config.Config{KnowledgeBaseEnabled: false}),
+		ragSvc: &apprag.Service{},
+		knowledgeBaseResolver: knowledgeBaseResolverStub{resolveFiles: func(context.Context, uint, []string) ([]domainknowledgebase.KnowledgeBase, []model.FileObject, error) {
+			t.Fatal("resolver should not be called when knowledge base feature is disabled")
+			return nil, nil, nil
+		}},
+	}
+
+	files, err := service.resolveKnowledgeBaseRAGFiles(context.Background(), 11, []string{"kb-one"}, true)
+	if err != nil {
+		t.Fatalf("resolveKnowledgeBaseRAGFiles() error = %v", err)
+	}
+	if files != nil {
+		t.Fatalf("resolved files = %#v, want nil when feature disabled", files)
 	}
 }
 

--- a/backend/internal/application/conversation/service_message_send.go
+++ b/backend/internal/application/conversation/service_message_send.go
@@ -556,6 +556,11 @@ func (s *Service) sendMessageInternal(
 	if imageProcessing.Routed {
 		fileContextPlan = withoutCurrentImageAttachments(fileContextPlan)
 	}
+	if !cfg.KnowledgeBaseEnabled {
+		// 知识库功能已被后台关闭：视同未选择知识库，检索与后续“知识库未命中/不可用”的
+		// 判定、提示一并跳过，避免存量引用阻塞发送或注入误导性提示。
+		input.KnowledgeBaseIDs = nil
+	}
 	knowledgeBaseFiles, err := s.resolveKnowledgeBaseRAGFiles(
 		ctx,
 		input.UserID,

--- a/backend/internal/application/conversation/service_project.go
+++ b/backend/internal/application/conversation/service_project.go
@@ -487,6 +487,9 @@ func (s *Service) validateConversationProjectDefaults(
 			return ErrInvalidConversationProject
 		}
 	}
+	if knowledgeBaseSelectionChanged && len(knowledgeBaseIDs) > 0 && !s.cfg.Snapshot().KnowledgeBaseEnabled {
+		return ErrInvalidConversationProject
+	}
 	if knowledgeBaseSelectionChanged && len(knowledgeBaseIDs) > 8 {
 		return ErrInvalidConversationProject
 	}

--- a/backend/internal/application/conversation/service_temporary_context.go
+++ b/backend/internal/application/conversation/service_temporary_context.go
@@ -17,11 +17,15 @@ func (s *Service) prepareTemporaryKnowledgeContext(
 	if len(input.KnowledgeBaseIDs) == 0 {
 		return userContextInput{}, nil, nil
 	}
+	cfg := s.cfg.Snapshot()
+	if !cfg.KnowledgeBaseEnabled {
+		// 知识库功能已被后台关闭：静默忽略引用，临时聊天继续按无知识库处理。
+		return userContextInput{}, nil, nil
+	}
 	if s.embeddingSvc == nil || s.ragSvc == nil || s.knowledgeBaseResolver == nil {
 		return userContextInput{}, nil, ErrKnowledgeBaseUnavailable
 	}
 
-	cfg := s.cfg.Snapshot()
 	capability := s.resolveChatFileCapability(ctx)
 	files, err := s.resolveKnowledgeBaseRAGFiles(
 		ctx,

--- a/backend/internal/application/settings/runtime_settings.go
+++ b/backend/internal/application/settings/runtime_settings.go
@@ -162,6 +162,10 @@ func (r *RuntimeSettings) applyItem(cfg *config.Config, item domainsettings.Syst
 	case "chat:model_option_denied_paths":
 		cfg.ModelOptionDeniedPaths = item.Value
 
+		// 知识库配置
+	case "knowledgebase:enabled":
+		cfg.KnowledgeBaseEnabled = toBool(item.Value, cfg.KnowledgeBaseEnabled)
+
 		// 存储配置
 	case "storage:user_storage_quota_bytes":
 		cfg.UserStorageQuotaBytes = toInt64(item.Value, cfg.UserStorageQuotaBytes)

--- a/backend/internal/application/settings/seed.go
+++ b/backend/internal/application/settings/seed.go
@@ -77,6 +77,9 @@ func defaultSettings() []domainsettings.SystemSetting {
 		{Namespace: "chat", Key: "model_option_allowed_paths", Value: config.DefaultModelOptionAllowedPathsJSON(), ValueType: "json", Description: "模型 options 白名单路径 JSON，default 对所有协议生效"},
 		{Namespace: "chat", Key: "model_option_denied_paths", Value: config.DefaultModelOptionDeniedPathsJSON(), ValueType: "json", Description: "模型 options 黑名单路径 JSON，default 对所有协议生效"},
 
+		// 知识库配置
+		{Namespace: "knowledgebase", Key: "enabled", Value: "true", ValueType: "bool", Description: "是否启用知识库功能；关闭后隐藏用户侧入口并拒绝知识库请求"},
+
 		// 存储配置
 		{Namespace: "storage", Key: "user_storage_quota_bytes", Value: "104857600", ValueType: "int", Description: "用户总存储配额（管理页面按 MB 输入，内部以字节保存），0表示不限制"},
 		{Namespace: "storage", Key: "max_upload_file_bytes", Value: "20971520", ValueType: "int", Description: "默认附件大小上限（管理页面按 MB 输入，内部以字节保存）"},

--- a/backend/internal/application/settings/service.go
+++ b/backend/internal/application/settings/service.go
@@ -341,14 +341,15 @@ func csvSet(raw string) map[string]struct{} {
 
 // validNamespaces 合法的 namespace 集合。
 var validNamespaces = map[string]bool{
-	"auth":    true,
-	"billing": true,
-	"chat":    true,
-	"storage": true,
-	"file":    true,
-	"extract": true,
-	"mcp":     true,
-	"circuit": true,
+	"auth":          true,
+	"billing":       true,
+	"chat":          true,
+	"storage":       true,
+	"file":          true,
+	"extract":       true,
+	"mcp":           true,
+	"circuit":       true,
+	"knowledgebase": true,
 }
 
 // IsValidNamespace 判断 namespace 是否允许被动态配置。

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -439,6 +439,8 @@ type Config struct {
 	ModelOptionPolicyMode        string
 	ModelOptionAllowedPaths      string
 	ModelOptionDeniedPaths       string
+	// 知识库配置
+	KnowledgeBaseEnabled bool
 	// 存储配置
 	UserStorageQuotaBytes int64
 	MaxUploadFileBytes    int64
@@ -677,6 +679,7 @@ func Load() Config {
 		ModelOptionPolicyMode:             "allowlist",
 		ModelOptionAllowedPaths:           DefaultModelOptionAllowedPathsJSON(),
 		ModelOptionDeniedPaths:            DefaultModelOptionDeniedPathsJSON(),
+		KnowledgeBaseEnabled:              true,
 		UserStorageQuotaBytes:             104857600,
 		MaxUploadFileBytes:                20971520,
 		MaxMessageFiles:                   10,

--- a/backend/internal/transport/http/knowledgebase/handler.go
+++ b/backend/internal/transport/http/knowledgebase/handler.go
@@ -32,6 +32,16 @@ func NewHandler(service *appknowledgebase.Service, cfg *config.Runtime) *Handler
 
 const multipartUploadOverheadBytes = 1 << 20
 
+// requireKnowledgeBaseEnabled 在知识库功能被后台关闭时拒绝用户侧请求。
+func (h *Handler) requireKnowledgeBaseEnabled(c *gin.Context) {
+	if h.cfg.Snapshot().KnowledgeBaseEnabled {
+		c.Next()
+		return
+	}
+	response.ErrorWithCode(c, http.StatusForbidden, "knowledge_base.disabled", "knowledge base feature is disabled")
+	c.Abort()
+}
+
 // ListVisible godoc
 // @Summary 查询当前用户可用知识库
 // @Tags knowledge-bases

--- a/backend/internal/transport/http/knowledgebase/router.go
+++ b/backend/internal/transport/http/knowledgebase/router.go
@@ -2,21 +2,22 @@ package knowledgebase
 
 import "github.com/gin-gonic/gin"
 
-// RegisterRoutes 注册知识库用户侧路由。
+// RegisterRoutes 注册知识库用户侧路由；知识库功能关闭时统一拒绝。
 func (m *Module) RegisterRoutes(authRequired *gin.RouterGroup) {
-	authRequired.GET("/knowledge-bases", m.Handler.ListVisible)
-	authRequired.GET("/knowledge-bases/mine", m.Handler.ListMine)
-	authRequired.POST("/knowledge-bases/mine", m.Handler.CreateMine)
-	authRequired.PATCH("/knowledge-bases/mine/:id", m.Handler.PatchMine)
-	authRequired.DELETE("/knowledge-bases/mine/:id", m.Handler.DeleteMine)
-	authRequired.GET("/knowledge-bases/:id", m.Handler.GetVisible)
-	authRequired.GET("/knowledge-bases/:id/files", m.Handler.ListVisibleFiles)
-	authRequired.POST("/knowledge-bases/:id/files/processing/statuses", m.Handler.GetVisibleFileProcessingStatuses)
-	authRequired.POST("/knowledge-bases/:id/files/processing/snapshot", m.Handler.GetVisibleFileProcessingSnapshot)
-	authRequired.GET("/knowledge-bases/:id/files/:file_id/content", m.Handler.GetVisibleFileContent)
-	authRequired.GET("/knowledge-bases/mine/:id/available-files", m.Handler.ListAvailableMineFiles)
-	authRequired.POST("/knowledge-bases/mine/:id/files", m.Handler.AddMineFiles)
-	authRequired.DELETE("/knowledge-bases/mine/:id/files/:file_id", m.Handler.RemoveMineFile)
+	group := authRequired.Group("", m.Handler.requireKnowledgeBaseEnabled)
+	group.GET("/knowledge-bases", m.Handler.ListVisible)
+	group.GET("/knowledge-bases/mine", m.Handler.ListMine)
+	group.POST("/knowledge-bases/mine", m.Handler.CreateMine)
+	group.PATCH("/knowledge-bases/mine/:id", m.Handler.PatchMine)
+	group.DELETE("/knowledge-bases/mine/:id", m.Handler.DeleteMine)
+	group.GET("/knowledge-bases/:id", m.Handler.GetVisible)
+	group.GET("/knowledge-bases/:id/files", m.Handler.ListVisibleFiles)
+	group.POST("/knowledge-bases/:id/files/processing/statuses", m.Handler.GetVisibleFileProcessingStatuses)
+	group.POST("/knowledge-bases/:id/files/processing/snapshot", m.Handler.GetVisibleFileProcessingSnapshot)
+	group.GET("/knowledge-bases/:id/files/:file_id/content", m.Handler.GetVisibleFileContent)
+	group.GET("/knowledge-bases/mine/:id/available-files", m.Handler.ListAvailableMineFiles)
+	group.POST("/knowledge-bases/mine/:id/files", m.Handler.AddMineFiles)
+	group.DELETE("/knowledge-bases/mine/:id/files/:file_id", m.Handler.RemoveMineFile)
 }
 
 // RegisterAdminRoutes 注册知识库管理员路由。

--- a/backend/internal/transport/http/settings/dto.go
+++ b/backend/internal/transport/http/settings/dto.go
@@ -112,6 +112,11 @@ type ChatContextPolicyResponse struct {
 	ContextCompactEnabled bool `json:"contextCompactEnabled"`
 }
 
+// FeaturePolicyResponse 返回用户侧功能开关策略。
+type FeaturePolicyResponse struct {
+	KnowledgeBaseEnabled bool `json:"knowledgeBaseEnabled"`
+}
+
 // ── mapping 函数 ─────────────────────────────────────────────────────────────
 
 func toAppPatchItems(items []PatchItem) []appsettings.PatchItem {

--- a/backend/internal/transport/http/settings/handler.go
+++ b/backend/internal/transport/http/settings/handler.go
@@ -271,6 +271,18 @@ func (h *Handler) GetChatContextPolicy(c *gin.Context) {
 	response.Success(c, ChatContextPolicyResponse{ContextCompactEnabled: cfg.ContextCompactEnabled})
 }
 
+// GetFeaturePolicy godoc
+// @Summary 查询用户侧功能开关策略
+// @Tags settings
+// @Produce json
+// @Security BearerAuth
+// @Success 200 {object} response.Envelope
+// @Router /settings/feature-policy [get]
+func (h *Handler) GetFeaturePolicy(c *gin.Context) {
+	cfg := h.runtime.Snapshot()
+	response.Success(c, FeaturePolicyResponse{KnowledgeBaseEnabled: cfg.KnowledgeBaseEnabled})
+}
+
 // Patch godoc
 // @Summary 批量更新配置项
 // @Description 批量更新动态配置并清除缓存，下次读取自动刷新

--- a/backend/internal/transport/http/settings/router.go
+++ b/backend/internal/transport/http/settings/router.go
@@ -17,6 +17,7 @@ func (m *Module) RegisterRoutes(api *gin.RouterGroup) {
 	api.GET("/settings/model-option-policy", m.Handler.GetModelOptionPolicy)
 	api.GET("/settings/mcp-policy", m.Handler.GetMCPPolicy)
 	api.GET("/settings/chat-context-policy", m.Handler.GetChatContextPolicy)
+	api.GET("/settings/feature-policy", m.Handler.GetFeaturePolicy)
 }
 
 // RegisterAdminRoutes 注册 settings 管理路由（由管理员中间件保护）。

--- a/frontend/app/(project)/knowledges/page.tsx
+++ b/frontend/app/(project)/knowledges/page.tsx
@@ -1,6 +1,21 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import * as React from "react";
+
 import { AppKnowledgeBases } from "@/features/knowledge-bases/components/app-knowledge-bases";
+import { useFeaturePolicy } from "@/shared/hooks/use-feature-policy";
 
 export default function Page() {
+  const router = useRouter();
+  const { knowledgeBaseEnabled, loaded } = useFeaturePolicy();
+
+  React.useEffect(() => {
+    if (loaded && !knowledgeBaseEnabled) router.replace("/");
+  }, [knowledgeBaseEnabled, loaded, router]);
+
+  if (!loaded || !knowledgeBaseEnabled) return null;
+
   return (
     <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden md:-mx-4 md:-mb-4">
       <AppKnowledgeBases />

--- a/frontend/features/chat/components/sections/chat-knowledge-bases.tsx
+++ b/frontend/features/chat/components/sections/chat-knowledge-bases.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 import { listVisibleKnowledgeBases } from "@/shared/api/knowledge-bases";
 import type { KnowledgeBaseDTO } from "@/shared/api/knowledge-bases.types";
 import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
+import { useFeaturePolicy } from "@/shared/hooks/use-feature-policy";
 
 const MAX_SELECTED_KNOWLEDGE_BASES = 8;
 
@@ -33,6 +34,7 @@ export function ChatKnowledgeBases({
   onChange: (ids: string[]) => void;
 }) {
   const t = useTranslations("chat.composer");
+  const { knowledgeBaseEnabled } = useFeaturePolicy();
   const [open, setOpen] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
   const [loadingMore, setLoadingMore] = React.useState(false);
@@ -158,6 +160,8 @@ export function ChatKnowledgeBases({
       unavailableDescription = t("knowledgeBaseUnavailableVectorStore");
       break;
   }
+
+  if (!knowledgeBaseEnabled) return null;
 
   return (
     <Popover open={open} onOpenChange={(nextOpen) => {

--- a/frontend/features/knowledge-bases/components/admin-knowledge-bases.tsx
+++ b/frontend/features/knowledge-bases/components/admin-knowledge-bases.tsx
@@ -3,10 +3,12 @@
 import { BookOpen, FolderOpen, HardDrive, MoreHorizontal, PencilLine, Plus, Trash2 } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import * as React from "react";
+import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Field, FieldLabel } from "@/components/ui/field";
 import {
   Dialog,
   DialogContent,
@@ -22,6 +24,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
 import {
   Table,
   TableBody,
@@ -33,9 +36,14 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TableToolbar } from "@/components/ui/table-tools";
+import { listAdminSettingsByNamespace, patchAdminSettings } from "@/features/admin/api";
+import { resolveAdminErrorMessage } from "@/features/admin/utils/admin-error";
 import { AdminPlatformFilesDialog } from "@/features/knowledge-bases/components/admin-platform-files-dialog";
 import { KnowledgeBaseDetail } from "@/features/knowledge-bases/components/knowledge-base-detail";
 import { useKnowledgeBasesPage } from "@/features/knowledge-bases/hooks/use-knowledge-bases-page";
+import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
+import { SettingsFieldRow, SettingsPage, SettingsSection } from "@/shared/components/settings-layout";
+import { overrideFeaturePolicy } from "@/shared/hooks/use-feature-policy";
 
 type KnowledgeBasesPageModel = ReturnType<typeof useKnowledgeBasesPage>;
 
@@ -56,168 +64,223 @@ export function AdminKnowledgeBases({ page }: { page: KnowledgeBasesPageModel })
     setDetailOpen(true);
   }, [list]);
 
+  const [featureEnabled, setFeatureEnabled] = React.useState<boolean | null>(null);
+  const [featureSaving, setFeatureSaving] = React.useState(false);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const token = await resolveAccessToken();
+        if (!token) return;
+        const settings = await listAdminSettingsByNamespace(token, "knowledgebase");
+        if (cancelled) return;
+        setFeatureEnabled((settings.find((item) => item.key === "enabled")?.value ?? "true") !== "false");
+      } catch {
+        // 读取失败时保持未知态：开关维持禁用，避免在错误状态下误操作。
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const toggleFeature = React.useCallback(async (next: boolean) => {
+    const previous = featureEnabled;
+    setFeatureSaving(true);
+    setFeatureEnabled(next);
+    try {
+      const token = await resolveAccessToken();
+      if (!token) throw new Error("missing access token");
+      await patchAdminSettings(token, {
+        items: [{ namespace: "knowledgebase", key: "enabled", value: String(next) }],
+      });
+      overrideFeaturePolicy({ knowledgeBaseEnabled: next });
+      toast.success(t(next ? "featureToggle.enabledToast" : "featureToggle.disabledToast"));
+    } catch (error) {
+      setFeatureEnabled(previous);
+      toast.error(resolveAdminErrorMessage(error, t("featureToggle.saveFailed")));
+    } finally {
+      setFeatureSaving(false);
+    }
+  }, [featureEnabled, t]);
+
   return (
-    <div className="min-w-0 flex-1 space-y-3 overflow-y-auto pb-10">
-      <div className="flex h-10 items-center px-1">
-        <h3 className="text-sm font-semibold">{t("adminTitle")}</h3>
-      </div>
-
-      <TableToolbar
-        query={list.query}
-        onQueryChange={list.changeQuery}
-        queryPlaceholder={t("searchPlaceholder")}
-        sort={{
-          value: list.sortKey,
-          onValueChange: (value) => list.changeSort(value as typeof list.sortKey),
-          options: [
-            { value: "default", label: t("sort.default") },
-            { value: "updated", label: t("sort.updated") },
-            { value: "created", label: t("sort.created") },
-            { value: "name", label: t("sort.name") },
-            { value: "files", label: t("sort.files") },
-          ],
-        }}
-        selectedCount={list.selectedIDs.length}
-        bulkActions={[{
-          key: "delete",
-          label: t("bulkDeleteAction"),
-          icon: <Trash2 className="size-3.5 stroke-1" />,
-          onClick: list.requestBulkDelete,
-          disabled: list.bulkDeleting,
-        }]}
-        loading={list.loading || list.bulkDeleting}
-        onRefresh={list.refresh}
-      >
-        <Button
-          type="button"
-          size="sm"
-          variant="outline"
-          className="h-7 gap-1 px-2 text-xs shadow-none"
-          onClick={() => setPlatformFilesOpen(true)}
+    <SettingsPage className="min-w-0 flex-1 overflow-y-auto">
+      <SettingsSection title={t("title")}>
+        <SettingsFieldRow
+          title={t("featureToggle.label")}
+          description={t("featureToggle.description")}
+          controlClassName="items-end"
         >
-          <HardDrive className="size-3.5 stroke-1" />
-          {t("localFiles")}
-        </Button>
-        <Button type="button" size="sm" className="h-7 gap-1 px-2 text-xs" onClick={list.create}>
-          <Plus className="size-3.5 stroke-1" />
-          {t("create")}
-        </Button>
-      </TableToolbar>
+          <Switch
+            checked={featureEnabled ?? true}
+            disabled={featureSaving || featureEnabled === null}
+            onCheckedChange={(checked) => void toggleFeature(checked)}
+            aria-label={t("featureToggle.label")}
+          />
+        </SettingsFieldRow>
 
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-[44px] py-1.5 text-center">
-              <div className="flex h-7 items-center justify-center">
-                <Checkbox
-                  checked={
-                    list.items.length > 0 && list.selectedIDs.length === list.items.length
-                      ? true
-                      : list.selectedIDs.length > 0
-                        ? "indeterminate"
-                        : false
-                  }
-                  onCheckedChange={(checked) => checked ? list.selectAll() : list.clearSelection()}
-                  aria-label={t("selectAll")}
-                />
-              </div>
-            </TableHead>
-            <TableHead className="min-w-[260px]">{t("columns.name")}</TableHead>
-            <TableHead className="w-[112px] text-center">{t("columns.sources")}</TableHead>
-            <TableHead className="w-[88px] text-center">{t("columns.status")}</TableHead>
-            <TableHead className="w-[160px]">{t("columns.updated")}</TableHead>
-            <TableHead stickyEnd className="w-[56px]" />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {list.loading && list.items.length === 0 ? <TableLoadingRow colSpan={6} /> : null}
-          {!list.loading && list.items.length === 0 ? (
-            <TableEmptyRow colSpan={6}>{list.query.trim() ? t("searchEmpty") : t("empty")}</TableEmptyRow>
-          ) : null}
-          {list.items.map((item) => (
-            <TableRow
-              key={item.publicID}
-              interactive
-              selected={detail.selected?.publicID === item.publicID && detailOpen}
-              tone={!item.enabled ? "muted" : undefined}
-              onClick={() => openDetail(item.publicID)}
-            >
-              <TableCell className="w-[44px] py-1.5 text-center" onClick={(event) => event.stopPropagation()}>
-                <div className="flex h-7 items-center justify-center">
-                  <Checkbox
-                    checked={selectedIDs.has(item.publicID)}
-                    onCheckedChange={(checked) => list.toggleSelection(item.publicID, checked === true)}
-                    aria-label={t("selectKnowledgeBase")}
-                  />
-                </div>
-              </TableCell>
-              <TableCell className="max-w-[460px] py-1.5">
-                <div className="flex min-w-0 items-center gap-2.5">
-                  <BookOpen className="size-4 shrink-0 text-muted-foreground" strokeWidth={1.4} />
-                  <div className="min-w-0">
-                    <p className="truncate font-medium text-foreground">{item.name}</p>
-                    <p className="truncate text-[11px] leading-4 text-muted-foreground">
-                      {item.description || t("adminDefaultDescription")}
-                    </p>
-                  </div>
-                </div>
-              </TableCell>
-              <TableCell className="py-1.5 text-center">
-                <span className="tabular-nums text-foreground">{item.readyFileCount}</span>
-                <span className="text-muted-foreground"> / {item.fileCount}</span>
-              </TableCell>
-              <TableCell className="py-1.5 text-center">
-                <Badge variant="secondary" className="border-0 font-normal shadow-none">
-                  {item.enabled ? t("enabled") : t("disabled")}
-                </Badge>
-              </TableCell>
-              <TableCell className="py-1.5 text-muted-foreground">
-                {dateFormatter.format(new Date(item.updatedAt))}
-              </TableCell>
-              <TableCell stickyEnd className="w-[56px] py-1.5 text-right" onClick={(event) => event.stopPropagation()}>
-                <div className="flex h-7 items-center justify-end">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button type="button" size="icon-xs" variant="ghost" className="text-muted-foreground shadow-none" aria-label={t("moreActions")}>
-                        <MoreHorizontal className="size-3.5 stroke-1" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem onClick={() => openDetail(item.publicID)}>
-                        <FolderOpen className="size-3.5 stroke-1" />
-                        {t("manage")}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => list.edit(item)}>
-                        <PencilLine className="size-3.5 stroke-1" />
-                        {t("editTitle")}
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem variant="destructive" onClick={() => list.requestDelete(item)}>
-                        <Trash2 className="size-3.5 stroke-1" />
-                        {t("delete")}
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-      {list.hasMore ? (
-        <div className="flex justify-center">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 text-xs text-muted-foreground"
-            disabled={list.loadingMore}
-            onClick={() => void list.loadMore()}
+        <Field className="gap-2">
+          <FieldLabel>{t("adminTitle")}</FieldLabel>
+          <TableToolbar
+            query={list.query}
+            onQueryChange={list.changeQuery}
+            queryPlaceholder={t("searchPlaceholder")}
+            sort={{
+              value: list.sortKey,
+              onValueChange: (value) => list.changeSort(value as typeof list.sortKey),
+              options: [
+                { value: "default", label: t("sort.default") },
+                { value: "updated", label: t("sort.updated") },
+                { value: "created", label: t("sort.created") },
+                { value: "name", label: t("sort.name") },
+                { value: "files", label: t("sort.files") },
+              ],
+            }}
+            selectedCount={list.selectedIDs.length}
+            bulkActions={[{
+              key: "delete",
+              label: t("bulkDeleteAction"),
+              icon: <Trash2 className="size-3.5 stroke-1" />,
+              onClick: list.requestBulkDelete,
+              disabled: list.bulkDeleting,
+            }]}
+            loading={list.loading || list.bulkDeleting}
+            onRefresh={list.refresh}
           >
-            {list.loadingMore ? <Spinner className="size-3" /> : t("loadMore")}
-          </Button>
-        </div>
-      ) : null}
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 gap-1 px-2 text-xs shadow-none"
+              onClick={() => setPlatformFilesOpen(true)}
+            >
+              <HardDrive className="size-3.5 stroke-1" />
+              {t("localFiles")}
+            </Button>
+            <Button type="button" size="sm" className="h-7 gap-1 px-2 text-xs" onClick={list.create}>
+              <Plus className="size-3.5 stroke-1" />
+              {t("create")}
+            </Button>
+          </TableToolbar>
+
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[44px] py-1.5 text-center">
+                  <div className="flex h-7 items-center justify-center">
+                    <Checkbox
+                      checked={
+                        list.items.length > 0 && list.selectedIDs.length === list.items.length
+                          ? true
+                          : list.selectedIDs.length > 0
+                            ? "indeterminate"
+                            : false
+                      }
+                      onCheckedChange={(checked) => checked ? list.selectAll() : list.clearSelection()}
+                      aria-label={t("selectAll")}
+                    />
+                  </div>
+                </TableHead>
+                <TableHead className="min-w-[260px]">{t("columns.name")}</TableHead>
+                <TableHead className="w-[112px] text-center">{t("columns.sources")}</TableHead>
+                <TableHead className="w-[88px] text-center">{t("columns.status")}</TableHead>
+                <TableHead className="w-[160px]">{t("columns.updated")}</TableHead>
+                <TableHead stickyEnd className="w-[56px]" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {list.loading && list.items.length === 0 ? <TableLoadingRow colSpan={6} /> : null}
+              {!list.loading && list.items.length === 0 ? (
+                <TableEmptyRow colSpan={6}>{list.query.trim() ? t("searchEmpty") : t("empty")}</TableEmptyRow>
+              ) : null}
+              {list.items.map((item) => (
+                <TableRow
+                  key={item.publicID}
+                  interactive
+                  selected={detail.selected?.publicID === item.publicID && detailOpen}
+                  tone={!item.enabled ? "muted" : undefined}
+                  onClick={() => openDetail(item.publicID)}
+                >
+                  <TableCell className="w-[44px] py-1.5 text-center" onClick={(event) => event.stopPropagation()}>
+                    <div className="flex h-7 items-center justify-center">
+                      <Checkbox
+                        checked={selectedIDs.has(item.publicID)}
+                        onCheckedChange={(checked) => list.toggleSelection(item.publicID, checked === true)}
+                        aria-label={t("selectKnowledgeBase")}
+                      />
+                    </div>
+                  </TableCell>
+                  <TableCell className="max-w-[460px] py-1.5">
+                    <div className="flex min-w-0 items-center gap-2.5">
+                      <BookOpen className="size-4 shrink-0 text-muted-foreground" strokeWidth={1.4} />
+                      <div className="min-w-0">
+                        <p className="truncate font-medium text-foreground">{item.name}</p>
+                        <p className="truncate text-[11px] leading-4 text-muted-foreground">
+                          {item.description || t("adminDefaultDescription")}
+                        </p>
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell className="py-1.5 text-center">
+                    <span className="tabular-nums text-foreground">{item.readyFileCount}</span>
+                    <span className="text-muted-foreground"> / {item.fileCount}</span>
+                  </TableCell>
+                  <TableCell className="py-1.5 text-center">
+                    <Badge variant="secondary" className="border-0 font-normal shadow-none">
+                      {item.enabled ? t("enabled") : t("disabled")}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="py-1.5 text-muted-foreground">
+                    {dateFormatter.format(new Date(item.updatedAt))}
+                  </TableCell>
+                  <TableCell stickyEnd className="w-[56px] py-1.5 text-right" onClick={(event) => event.stopPropagation()}>
+                    <div className="flex h-7 items-center justify-end">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button type="button" size="icon-xs" variant="ghost" className="text-muted-foreground shadow-none" aria-label={t("moreActions")}>
+                            <MoreHorizontal className="size-3.5 stroke-1" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={() => openDetail(item.publicID)}>
+                            <FolderOpen className="size-3.5 stroke-1" />
+                            {t("manage")}
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => list.edit(item)}>
+                            <PencilLine className="size-3.5 stroke-1" />
+                            {t("editTitle")}
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem variant="destructive" onClick={() => list.requestDelete(item)}>
+                            <Trash2 className="size-3.5 stroke-1" />
+                            {t("delete")}
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          {list.hasMore ? (
+            <div className="flex justify-center">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs text-muted-foreground"
+                disabled={list.loadingMore}
+                onClick={() => void list.loadMore()}
+              >
+                {list.loadingMore ? <Spinner className="size-3" /> : t("loadMore")}
+              </Button>
+            </div>
+          ) : null}
+        </Field>
+      </SettingsSection>
 
       <Dialog open={detailOpen} onOpenChange={setDetailOpen}>
         <DialogContent className="flex h-[min(78dvh,720px)] max-h-[min(78dvh,720px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-[920px]">
@@ -252,6 +315,6 @@ export function AdminKnowledgeBases({ page }: { page: KnowledgeBasesPageModel })
         </DialogContent>
       </Dialog>
       <AdminPlatformFilesDialog open={platformFilesOpen} onOpenChange={setPlatformFilesOpen} />
-    </div>
+    </SettingsPage>
   );
 }

--- a/frontend/features/layouts/components/navigation/nav-main.tsx
+++ b/frontend/features/layouts/components/navigation/nav-main.tsx
@@ -22,6 +22,7 @@ import {
   filterConversationSearchResults,
   NAVIGATION_SEARCH_PAGE_SIZE,
 } from "@/features/layouts/model/navigation-search";
+import { useFeaturePolicy } from "@/shared/hooks/use-feature-policy";
 
 export function NavMain({
   onCreateConversation,
@@ -29,6 +30,7 @@ export function NavMain({
   onCreateConversation: () => void;
 }) {
   const t = useTranslations("common.navigation");
+  const { knowledgeBaseEnabled } = useFeaturePolicy();
   const isMobile = useSidebarIsMobile();
   const { setOpenMobile } = useSidebarActions();
   const state = useSidebarVisualState();
@@ -74,7 +76,9 @@ export function NavMain({
         </SidebarMenu>
 
         <SidebarMenu className="mt-4 gap-0.5">
-          {NAVIGATION_ITEMS.filter((item) => item.group === "secondary").map((item) => (
+          {NAVIGATION_ITEMS.filter(
+            (item) => item.group === "secondary" && (knowledgeBaseEnabled || item.id !== "knowledgeBases"),
+          ).map((item) => (
             <NavMainItem
               key={item.id}
               item={item}

--- a/frontend/features/layouts/components/navigation/project-dialog.tsx
+++ b/frontend/features/layouts/components/navigation/project-dialog.tsx
@@ -32,6 +32,7 @@ import type { SkillSummaryDTO } from "@/shared/api/skills.types";
 import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
 import { ModelSelect, type ModelSelectOption } from "@/shared/components/model-select";
 import { useDialogSnapshot } from "@/shared/hooks/use-dialog-snapshot";
+import { useFeaturePolicy } from "@/shared/hooks/use-feature-policy";
 import { resolveModelOptionIconUrl, resolveModelOptionLabel } from "@/shared/lib/model-option-display";
 import {
   hasMultipleImageAttachmentProcessors,
@@ -244,6 +245,7 @@ export function ProjectDialog({
   onSubmit: () => void | Promise<void>;
 }) {
   const t = useTranslations("recent.projects");
+  const { knowledgeBaseEnabled } = useFeaturePolicy();
   const [submitting, setSubmitting] = React.useState(false);
   const [catalogLoading, setCatalogLoading] = React.useState(false);
   const [modelCatalogLoading, setModelCatalogLoading] = React.useState(false);
@@ -394,7 +396,7 @@ export function ProjectDialog({
     onError: handleCatalogLoadError,
   });
   const knowledgeBaseCatalog = usePaginatedProjectCatalog({
-    open,
+    open: open && knowledgeBaseEnabled,
     selectedIDs: draft?.defaultKnowledgeBaseIDs.slice(0, 8) ?? [],
     loadPage: listVisibleKnowledgeBases,
     getID: getKnowledgeBaseID,
@@ -600,31 +602,33 @@ export function ProjectDialog({
                   }}
                 />
 
-                <ProjectDefaultSelector
-                  icon={BookOpen}
-                  label={t("selectKnowledgeBases")}
-                  description={t("knowledgeBaseDefaultsDescription")}
-                  emptyLabel={t("knowledgeBaseDefaultsEmpty")}
-                  searchPlaceholder={t("searchKnowledgeBases")}
-                  options={knowledgeBaseCatalog.items.map((item) => ({
-                    id: item.publicID,
-                    label: item.name,
-                    detail: `${item.scope === "builtin" ? t("builtinKnowledgeBase") : t("personalKnowledgeBase")} · ${t("knowledgeBaseFileCount", { count: item.readyFileCount })}`,
-                    disabled: item.readyFileCount === 0,
-                  }))}
-                  selectedIDs={stableDraft?.defaultKnowledgeBaseIDs ?? []}
-                  selectionLimit={8}
-                  loading={knowledgeBaseCatalog.loading && knowledgeBaseCatalog.items.length === 0}
-                  searching={knowledgeBaseCatalog.loading}
-                  loadingMore={knowledgeBaseCatalog.loadingMore}
-                  hasMore={knowledgeBaseCatalog.hasMore}
-                  disabled={submitting}
-                  onQueryChange={knowledgeBaseCatalog.setQuery}
-                  onLoadMore={knowledgeBaseCatalog.loadMore}
-                  onChange={(defaultKnowledgeBaseIDs) => {
-                    setDraft((current) => current ? { ...current, defaultKnowledgeBaseIDs } : current);
-                  }}
-                />
+                {knowledgeBaseEnabled ? (
+                  <ProjectDefaultSelector
+                    icon={BookOpen}
+                    label={t("selectKnowledgeBases")}
+                    description={t("knowledgeBaseDefaultsDescription")}
+                    emptyLabel={t("knowledgeBaseDefaultsEmpty")}
+                    searchPlaceholder={t("searchKnowledgeBases")}
+                    options={knowledgeBaseCatalog.items.map((item) => ({
+                      id: item.publicID,
+                      label: item.name,
+                      detail: `${item.scope === "builtin" ? t("builtinKnowledgeBase") : t("personalKnowledgeBase")} · ${t("knowledgeBaseFileCount", { count: item.readyFileCount })}`,
+                      disabled: item.readyFileCount === 0,
+                    }))}
+                    selectedIDs={stableDraft?.defaultKnowledgeBaseIDs ?? []}
+                    selectionLimit={8}
+                    loading={knowledgeBaseCatalog.loading && knowledgeBaseCatalog.items.length === 0}
+                    searching={knowledgeBaseCatalog.loading}
+                    loadingMore={knowledgeBaseCatalog.loadingMore}
+                    hasMore={knowledgeBaseCatalog.hasMore}
+                    disabled={submitting}
+                    onQueryChange={knowledgeBaseCatalog.setQuery}
+                    onLoadMore={knowledgeBaseCatalog.loadMore}
+                    onChange={(defaultKnowledgeBaseIDs) => {
+                      setDraft((current) => current ? { ...current, defaultKnowledgeBaseIDs } : current);
+                    }}
+                  />
+                ) : null}
               </div>
             </div>
           </div>

--- a/frontend/i18n/messages/en-US/knowledge-bases.json
+++ b/frontend/i18n/messages/en-US/knowledge-bases.json
@@ -2,6 +2,13 @@
   "title": "Knowledge bases",
   "adminTitle": "Built-in knowledge bases",
   "adminDefaultDescription": "Built-in knowledge available to every user",
+  "featureToggle": {
+    "label": "Enable knowledge bases",
+    "description": "When disabled, user-facing knowledge base entries are hidden and requests are rejected. Existing data and bindings are preserved.",
+    "enabledToast": "Knowledge bases enabled",
+    "disabledToast": "Knowledge bases disabled; user-facing entries are now hidden",
+    "saveFailed": "Failed to save knowledge base toggle"
+  },
   "create": "New",
   "localFiles": "Local sources",
   "localFilesTitle": "Local sources",

--- a/frontend/i18n/messages/zh-CN/knowledge-bases.json
+++ b/frontend/i18n/messages/zh-CN/knowledge-bases.json
@@ -2,6 +2,13 @@
   "title": "知识库",
   "adminTitle": "内置知识库",
   "adminDefaultDescription": "面向所有用户提供的内置知识内容",
+  "featureToggle": {
+    "label": "启用知识库",
+    "description": "关闭后将隐藏用户侧的知识库入口并拒绝相关请求，重新开启后配置与数据保持不变。",
+    "enabledToast": "已开启知识库功能",
+    "disabledToast": "已关闭知识库功能，用户侧入口将隐藏",
+    "saveFailed": "知识库开关保存失败"
+  },
   "create": "新建",
   "localFiles": "本地资料",
   "localFilesTitle": "本地资料",

--- a/frontend/shared/api/settings.ts
+++ b/frontend/shared/api/settings.ts
@@ -16,6 +16,10 @@ export type ChatContextPolicy = {
   contextCompactEnabled: boolean;
 };
 
+export type FeaturePolicy = {
+  knowledgeBaseEnabled: boolean;
+};
+
 export async function getModelOptionPolicy(accessToken: string): Promise<ModelOptionPolicy> {
   const data = await authedRequest<ModelOptionPolicyResponse>(
     "/api/v1/settings/model-option-policy",
@@ -44,6 +48,14 @@ export async function getMCPPolicy(accessToken: string): Promise<MCPPolicy> {
 export async function getChatContextPolicy(accessToken: string): Promise<ChatContextPolicy> {
   return authedRequest<ChatContextPolicy>(
     "/api/v1/settings/chat-context-policy",
+    { accessToken },
+    true,
+  );
+}
+
+export async function getFeaturePolicy(accessToken: string): Promise<FeaturePolicy> {
+  return authedRequest<FeaturePolicy>(
+    "/api/v1/settings/feature-policy",
     { accessToken },
     true,
   );

--- a/frontend/shared/hooks/use-feature-policy.ts
+++ b/frontend/shared/hooks/use-feature-policy.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import * as React from "react";
+
+import { type FeaturePolicy, getFeaturePolicy } from "@/shared/api/settings";
+import { resolveAccessToken } from "@/shared/auth/resolve-access-token";
+
+const DEFAULT_FEATURE_POLICY: FeaturePolicy = { knowledgeBaseEnabled: true };
+
+let cachedFeaturePolicy: FeaturePolicy | null = null;
+let inflightFeaturePolicy: Promise<void> | null = null;
+const featurePolicyListeners = new Set<() => void>();
+
+function setCachedFeaturePolicy(policy: FeaturePolicy) {
+  cachedFeaturePolicy = policy;
+  for (const listener of featurePolicyListeners) listener();
+}
+
+/** 管理端修改功能开关成功后调用，让当前标签页内的消费方立即生效。 */
+export function overrideFeaturePolicy(patch: Partial<FeaturePolicy>) {
+  setCachedFeaturePolicy({ ...(cachedFeaturePolicy ?? DEFAULT_FEATURE_POLICY), ...patch });
+}
+
+function loadFeaturePolicy(): Promise<void> {
+  inflightFeaturePolicy ??= (async () => {
+    try {
+      const token = await resolveAccessToken();
+      if (!token) {
+        setCachedFeaturePolicy(DEFAULT_FEATURE_POLICY);
+        return;
+      }
+      setCachedFeaturePolicy(await getFeaturePolicy(token));
+    } catch {
+      // 拉取失败按默认全部开启处理（fail-open），避免误伤正常部署或阻塞路由守卫。
+      setCachedFeaturePolicy(DEFAULT_FEATURE_POLICY);
+    } finally {
+      inflightFeaturePolicy = null;
+    }
+  })();
+  return inflightFeaturePolicy;
+}
+
+function subscribeFeaturePolicy(listener: () => void): () => void {
+  featurePolicyListeners.add(listener);
+  return () => featurePolicyListeners.delete(listener);
+}
+
+function getFeaturePolicySnapshot(): FeaturePolicy | null {
+  return cachedFeaturePolicy;
+}
+
+/**
+ * 读取后台功能开关策略（会话级缓存，首次挂载时拉取一次，缓存更新时全量通知）。
+ * 加载完成前返回默认全开，`loaded` 用于需要等待确定结果的场景（如路由守卫）。
+ */
+export function useFeaturePolicy(): FeaturePolicy & { loaded: boolean } {
+  const policy = React.useSyncExternalStore(
+    subscribeFeaturePolicy,
+    getFeaturePolicySnapshot,
+    getFeaturePolicySnapshot,
+  );
+
+  React.useEffect(() => {
+    if (!cachedFeaturePolicy) void loadFeaturePolicy();
+  }, []);
+
+  return policy ? { ...policy, loaded: true } : { ...DEFAULT_FEATURE_POLICY, loaded: false };
+}

--- a/packages/api-contract/src/types.generated.ts
+++ b/packages/api-contract/src/types.generated.ts
@@ -9567,6 +9567,22 @@ export namespace Settings {
   /**
    * No description
    * @tags settings
+   * @name FeaturePolicyList
+   * @summary 查询用户侧功能开关策略
+   * @request GET:/settings/feature-policy
+   * @secure
+   */
+  export namespace FeaturePolicyList {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = Envelope;
+  }
+
+  /**
+   * No description
+   * @tags settings
    * @name LoginPageList
    * @summary 查询公开登录页配置
    * @request GET:/settings/login-page


### PR DESCRIPTION
## Summary

Closes #713.

Knowledge bases could not be turned off: deployments that don't need the feature still showed the knowledge base picker in the chat composer and the entry in the sidebar.

This PR adds a master switch (admin console → Knowledge bases → "Enable knowledge bases", default **on**). The toggle is enforced on both sides:

**Backend**
- New runtime setting `knowledgebase:enabled` (seeded `true`; existing deployments keep their current behavior). Admin PATCH applies it immediately without a restart.
- New authenticated endpoint `GET /api/v1/settings/feature-policy` returning `{ knowledgeBaseEnabled }` for the frontend.
- When disabled, all user-facing `/knowledge-bases*` routes are rejected with `403 knowledge_base.disabled` (admin management routes stay available).
- The message-send pipeline treats stale knowledge base references in existing conversations / temporary chats / project defaults as "no knowledge bases selected", so old conversations keep working without misleading "no evidence found" notices; saving project defaults with knowledge base ids is rejected while disabled.

**Frontend**
- New `useFeaturePolicy()` hook: session-level cache via `useSyncExternalStore`, fail-open to enabled when the policy fetch is unavailable, and same-tab reactive updates right after the admin toggles the switch.
- When disabled, the chat composer knowledge base button, the sidebar entry, and the project dialog section are hidden; `/knowledges` redirects to `/`.
- The admin knowledge bases page is restructured onto the shared `SettingsPage` / `SettingsSection` / `SettingsFieldRow` layout so the switch matches the MCP tools page pattern.

Knowledge base data is never deleted by the switch; re-enabling restores everything as-is.

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [x] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [x] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- `go build ./...` and `go test ./...` (backend) — passed, including the new `TestResolveKnowledgeBaseRAGFilesSkipsWhenFeatureDisabled`
- `pnpm --filter @deeix/web check` (Biome + tsc) — passed
- Manual testing in local dev: toggling the switch hides/restores the composer button, sidebar entry, and project dialog section in the same tab without a refresh; `/knowledges` redirects while disabled; sending in a conversation that still references a knowledge base proceeds without knowledge base retrieval or notices

## Screenshots, API examples, or logs

`GET /api/v1/settings/feature-policy` → `200 { "knowledgeBaseEnabled": true }`
`GET /api/v1/knowledge-bases` while disabled → `403 { "code": "knowledge_base.disabled" }`

## Configuration, migration, and compatibility notes

- New settings row `knowledgebase:enabled` (bool, default `true`) is seeded on startup; seeding only inserts missing keys, so an admin's choice survives restarts and upgrades. No schema migration.
- API contract: adds `FeaturePolicyResponse` / the feature-policy endpoint; Swagger docs and `packages/api-contract/src/types.generated.ts` are regenerated in this PR.
- Fully backward compatible: with the switch on (default), behavior is unchanged.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.