### PR TITLE
feat: show usage balance and lifetime spend as cards and hide top-up without payment providers

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -16073,7 +16073,9 @@ const docTemplate = `{
                 "periodUsedNanousd",
                 "periodUsedUSD",
                 "plan",
-                "subscriptionEntitlements"
+                "subscriptionEntitlements",
+                "totalSpentNanousd",
+                "totalSpentUSD"
             ],
             "properties": {
                 "account": {
@@ -16130,6 +16132,12 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/SubscriptionEntitlementResponse"
                     }
+                },
+                "totalSpentNanousd": {
+                    "type": "integer"
+                },
+                "totalSpentUSD": {
+                    "type": "number"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -16066,7 +16066,9 @@
                 "periodUsedNanousd",
                 "periodUsedUSD",
                 "plan",
-                "subscriptionEntitlements"
+                "subscriptionEntitlements",
+                "totalSpentNanousd",
+                "totalSpentUSD"
             ],
             "properties": {
                 "account": {
@@ -16123,6 +16125,12 @@
                     "items": {
                         "$ref": "#/definitions/SubscriptionEntitlementResponse"
                     }
+                },
+                "totalSpentNanousd": {
+                    "type": "integer"
+                },
+                "totalSpentUSD": {
+                    "type": "number"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1080,6 +1080,10 @@ definitions:
         items:
           $ref: '#/definitions/SubscriptionEntitlementResponse'
         type: array
+      totalSpentNanousd:
+        type: integer
+      totalSpentUSD:
+        type: number
     required:
     - account
     - mode
@@ -1093,6 +1097,8 @@ definitions:
     - periodUsedUSD
     - plan
     - subscriptionEntitlements
+    - totalSpentNanousd
+    - totalSpentUSD
     type: object
   BillingOverviewResponseDoc:
     properties:

--- a/backend/internal/application/billing/service.go
+++ b/backend/internal/application/billing/service.go
@@ -2662,6 +2662,12 @@ func (s *Service) GetBillingOverview(ctx context.Context, userID uint, now time.
 			return nil, accountErr
 		}
 		overview.Account = toBillingAccountView(account)
+		// 按量计费模式返回账户累计消费(不限时间的计费流水合计),供订阅页「累计花费」卡片展示。
+		totalSpentNanousd, totalErr := s.repo.SumTotalBilledNanousd(ctx, userID)
+		if totalErr != nil {
+			return nil, totalErr
+		}
+		overview.TotalSpentNanousd = totalSpentNanousd
 		return overview, nil
 	}
 	if mode != "period" {

--- a/backend/internal/application/billing/service_model_identity_test.go
+++ b/backend/internal/application/billing/service_model_identity_test.go
@@ -442,6 +442,9 @@ func (r *billingRepositoryStub) ListDailyUsageByUser(context.Context, uint, time
 func (r *billingRepositoryStub) SumBillableNanousd(context.Context, uint, time.Time, time.Time) (int64, error) {
 	return 0, nil
 }
+func (r *billingRepositoryStub) SumTotalBilledNanousd(context.Context, uint) (int64, error) {
+	return 0, nil
+}
 
 func TestRecordUsageWithAuthorizationUsesBillingAtForPeriod(t *testing.T) {
 	billingAt := time.Date(2026, 6, 30, 23, 59, 58, 0, time.UTC)

--- a/backend/internal/application/billing/view.go
+++ b/backend/internal/application/billing/view.go
@@ -42,6 +42,7 @@ type BillingOverview struct {
 	PeriodUsedNanousd        int64
 	PeriodRemainingNanousd   int64
 	Account                  *BillingAccountView
+	TotalSpentNanousd        int64
 	SubscriptionEntitlements []SubscriptionEntitlementView
 }
 

--- a/backend/internal/infra/persistence/postgres/billing/repository.go
+++ b/backend/internal/infra/persistence/postgres/billing/repository.go
@@ -2195,6 +2195,20 @@ func (r *Repo) SumBillableNanousd(ctx context.Context, userID uint, startAt time
 	return total, nil
 }
 
+// SumTotalBilledNanousd 统计用户不限时间的累计计费金额(仅付费模型流水,不含充值与兑换入账)。
+func (r *Repo) SumTotalBilledNanousd(ctx context.Context, userID uint) (int64, error) {
+	var total int64
+	err := r.db.WithContext(ctx).
+		Model(&model.UsageLedger{}).
+		Select("COALESCE(SUM(billed_nanousd), 0)").
+		Where("user_id = ? AND is_free_model = ?", userID, false).
+		Scan(&total).Error
+	if err != nil {
+		return 0, translateError(err)
+	}
+	return total, nil
+}
+
 func toDomainModelPricing(item model.ModelPricing) domainbilling.ModelPricing {
 	return domainbilling.ModelPricing{
 		ID:                          item.ID,

--- a/backend/internal/infra/persistence/postgres/billing/repository_sqlite_test.go
+++ b/backend/internal/infra/persistence/postgres/billing/repository_sqlite_test.go
@@ -994,6 +994,74 @@ func TestAddPeriodUsageAndSettleOverageUsesBillingAtForPeriodBoundary(t *testing
 	}
 }
 
+func TestSumTotalBilledNanousdAggregatesLifetimePaidUsage(t *testing.T) {
+	db := openBillingSQLiteTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	// 跨年份的付费流水应全部计入;免费模型流水与其他用户流水应排除。
+	ledgers := []model.UsageLedger{
+		{
+			UserID:              1,
+			PlatformModelName:   "gpt-early",
+			BillingAt:           time.Date(2025, 1, 2, 8, 0, 0, 0, time.UTC),
+			UsageDate:           time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			BilledCurrency:      "USD",
+			BilledNanousd:       800,
+			PricingSnapshotJSON: `{}`,
+		},
+		{
+			UserID:              1,
+			PlatformModelName:   "gpt-recent",
+			BillingAt:           time.Date(2026, 8, 1, 8, 0, 0, 0, time.UTC),
+			UsageDate:           time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			BilledCurrency:      "USD",
+			BilledNanousd:       500,
+			PricingSnapshotJSON: `{}`,
+		},
+		{
+			UserID:              1,
+			PlatformModelName:   "gpt-free",
+			IsFreeModel:         true,
+			BillingAt:           time.Date(2026, 8, 2, 8, 0, 0, 0, time.UTC),
+			UsageDate:           time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC),
+			BilledCurrency:      "USD",
+			BilledNanousd:       300,
+			PricingSnapshotJSON: `{}`,
+		},
+		{
+			UserID:              2,
+			PlatformModelName:   "gpt-other-user",
+			BillingAt:           time.Date(2026, 8, 3, 8, 0, 0, 0, time.UTC),
+			UsageDate:           time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC),
+			BilledCurrency:      "USD",
+			BilledNanousd:       900,
+			PricingSnapshotJSON: `{}`,
+		},
+	}
+	for i := range ledgers {
+		if err := db.Create(&ledgers[i]).Error; err != nil {
+			t.Fatalf("create usage ledger %d: %v", i, err)
+		}
+	}
+
+	total, err := repo.SumTotalBilledNanousd(ctx, 1)
+	if err != nil {
+		t.Fatalf("SumTotalBilledNanousd() error = %v", err)
+	}
+	if total != 1300 {
+		t.Fatalf("total = %d, want 1300", total)
+	}
+
+	empty, err := repo.SumTotalBilledNanousd(ctx, 3)
+	if err != nil {
+		t.Fatalf("SumTotalBilledNanousd() empty user error = %v", err)
+	}
+	if empty != 0 {
+		t.Fatalf("empty user total = %d, want 0", empty)
+	}
+}
+
 func TestValidateRedeemableCodeAllowsUsageCodeInPeriodModeOnly(t *testing.T) {
 	db := openBillingSQLiteTestDB(t)
 	now := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)

--- a/backend/internal/repository/billing.go
+++ b/backend/internal/repository/billing.go
@@ -55,6 +55,7 @@ type BillingRepository interface {
 	ListMonthlyUsageByUser(ctx context.Context, userID uint, limit int) ([]domainbilling.UsageMonthlySummary, error)
 	ListDailyUsageByUser(ctx context.Context, userID uint, startDate time.Time, endDate time.Time) ([]domainbilling.UsageDailySummary, error)
 	SumBillableNanousd(ctx context.Context, userID uint, startAt time.Time, endAt time.Time) (int64, error)
+	SumTotalBilledNanousd(ctx context.Context, userID uint) (int64, error)
 }
 
 // RedemptionCodeListFilter 描述管理员兑换码列表筛选条件。

--- a/backend/internal/transport/http/billing/dto.go
+++ b/backend/internal/transport/http/billing/dto.go
@@ -360,6 +360,8 @@ type BillingOverviewResponse struct {
 	PeriodRemainingUSD       float64                           `json:"periodRemainingUSD"`
 	PeriodRemainingNanousd   int64                             `json:"periodRemainingNanousd"`
 	Account                  *BillingAccountResponse           `json:"account" extensions:"x-nullable,!x-omitempty"`
+	TotalSpentUSD            float64                           `json:"totalSpentUSD"`
+	TotalSpentNanousd        int64                             `json:"totalSpentNanousd"`
 	SubscriptionEntitlements []SubscriptionEntitlementResponse `json:"subscriptionEntitlements"`
 }
 
@@ -867,6 +869,8 @@ func toBillingOverviewResponse(item *appbilling.BillingOverview) BillingOverview
 		PeriodRemainingUSD:       nanousdToUSD(item.PeriodRemainingNanousd),
 		PeriodRemainingNanousd:   item.PeriodRemainingNanousd,
 		Account:                  toBillingAccountViewResponse(item.Account),
+		TotalSpentUSD:            nanousdToUSD(item.TotalSpentNanousd),
+		TotalSpentNanousd:        item.TotalSpentNanousd,
 		SubscriptionEntitlements: toSubscriptionEntitlementResponses(item.SubscriptionEntitlements),
 	}
 }

--- a/frontend/features/settings/components/sections/subscription/settings-subscription.tsx
+++ b/frontend/features/settings/components/sections/subscription/settings-subscription.tsx
@@ -348,6 +348,8 @@ export function SettingsSubscription() {
     [billingOverview?.subscriptionEntitlements],
   );
   const paymentDisabled = paymentProviders.length === 0;
+  // 配置未加载时先不渲染充值入口,避免"置灰→消失"的闪现;确认无渠道后保持隐藏。
+  const topUpVisible = billingConfig !== null && paymentProviders.length > 0;
   const currentPlan = React.useMemo(() => {
     if (billingOverview?.plan) return billingOverview.plan;
     return billingPlans.find((plan) => viewer?.subscriptionPlanID === plan.id || viewer?.subscriptionTier === plan.code) ?? null;
@@ -420,6 +422,7 @@ export function SettingsSubscription() {
         redemptionLoading={redemptionLoading}
         topUpLoading={topUpLoading}
         paymentDisabled={paymentDisabled}
+        topUpVisible={topUpVisible}
         billingPlans={billingPlans}
         billingOverview={billingOverview}
         currentPlan={currentPlan}
@@ -460,6 +463,7 @@ export function SettingsSubscription() {
       <section className="space-y-6 px-0.5 md:space-y-7 xl:space-y-8 xl:px-1">
         <Separator />
         <SubscriptionActivityHeatmap accessToken={accessToken} />
+        <Separator />
         <SubscriptionTrend
           dailyUsage={dailyUsage}
           monthlyUsage={monthlyUsage}

--- a/frontend/features/settings/components/sections/subscription/subscription-summary.tsx
+++ b/frontend/features/settings/components/sections/subscription/subscription-summary.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Banknote, Check, Ticket } from "lucide-react";
+import { Banknote, Check, Coins, Ticket, Wallet } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
@@ -96,6 +96,18 @@ function ActionRow({
   );
 }
 
+function AccountMetricTile({ label, value, icon }: { label: string; value: string; icon: React.ReactNode }) {
+  return (
+    <div className="min-w-0 rounded-md bg-muted/35 px-3 py-3.5 md:px-4 md:py-4">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <span className="text-foreground/55">{icon}</span>
+        <span>{label}</span>
+      </div>
+      <p className="mt-2 truncate text-base font-semibold tabular-nums text-foreground md:text-lg">{value}</p>
+    </div>
+  );
+}
+
 function ValueRow({
   title,
   value,
@@ -176,6 +188,7 @@ type SubscriptionSummaryProps = {
   redemptionLoading: boolean;
   topUpLoading: boolean;
   paymentDisabled: boolean;
+  topUpVisible: boolean;
   billingPlans: BillingPlanDTO[];
   billingOverview: BillingOverviewData["overview"] | null;
   currentPlan: BillingPlanDTO | null;
@@ -219,6 +232,7 @@ export function SubscriptionSummary({
   redemptionLoading,
   topUpLoading,
   paymentDisabled,
+  topUpVisible,
   billingPlans,
   billingOverview,
   currentPlan,
@@ -348,10 +362,12 @@ export function SubscriptionSummary({
             title={t("periodOverage.title")}
             value={t("periodOverage.balance", { value: formatAccountBalance(billingAccount?.balanceUSD ?? 0, billingDisplay) })}
             action={
-              <Button type="button" variant="outline" disabled={billingLoading || topUpLoading || paymentDisabled} onClick={onOpenTopUpDialog}>
-                <Banknote className="size-3.5" />
-                {t("usageBilling.topUp")}
-              </Button>
+              topUpVisible ? (
+                <Button type="button" variant="outline" disabled={billingLoading || topUpLoading} onClick={onOpenTopUpDialog}>
+                  <Banknote className="size-3.5" />
+                  {t("usageBilling.topUp")}
+                </Button>
+              ) : null
             }
           />
         </section>
@@ -359,22 +375,37 @@ export function SubscriptionSummary({
 
       {billingMode === "usage" ? (
         <section className="space-y-6 px-0.5 md:space-y-7 xl:space-y-8 xl:px-1">
-          <ActionRow
-            title={t("usageBilling.title")}
-            value={t("usageBilling.balance", { value: formatAccountBalance(billingAccount?.balanceUSD ?? 0, billingDisplay) })}
-            action={
-              <div className="flex items-center gap-2">
-                <Button type="button" variant="outline" disabled={billingLoading || redemptionLoading} onClick={onOpenRedemptionDialog}>
-                  <Ticket className="size-3.5" />
-                  {t("redemption.open")}
-                </Button>
-                <Button type="button" variant="outline" disabled={billingLoading || topUpLoading || paymentDisabled} onClick={onOpenTopUpDialog}>
-                  <Banknote className="size-3.5" />
-                  {t("usageBilling.topUp")}
-                </Button>
-              </div>
-            }
-          />
+          <div className="space-y-4 md:space-y-5">
+            <ActionRow
+              title={t("usageBilling.title")}
+              action={
+                <div className="flex items-center gap-2">
+                  <Button type="button" variant="outline" disabled={billingLoading || redemptionLoading} onClick={onOpenRedemptionDialog}>
+                    <Ticket className="size-3.5" />
+                    {t("redemption.open")}
+                  </Button>
+                  {topUpVisible ? (
+                    <Button type="button" variant="outline" disabled={billingLoading || topUpLoading} onClick={onOpenTopUpDialog}>
+                      <Banknote className="size-3.5" />
+                      {t("usageBilling.topUp")}
+                    </Button>
+                  ) : null}
+                </div>
+              }
+            />
+            <div className="grid grid-cols-2 gap-2 text-xs">
+              <AccountMetricTile
+                label={t("usageBilling.balanceLabel")}
+                value={formatAccountBalance(billingAccount?.balanceUSD ?? 0, billingDisplay)}
+                icon={<Wallet className="size-4" />}
+              />
+              <AccountMetricTile
+                label={t("usageBilling.totalSpentLabel")}
+                value={formatAccountBalance(billingOverview?.totalSpentUSD ?? 0, billingDisplay)}
+                icon={<Coins className="size-4" />}
+              />
+            </div>
+          </div>
         </section>
       ) : null}
 

--- a/frontend/features/settings/components/sections/subscription/subscription-trend.tsx
+++ b/frontend/features/settings/components/sections/subscription/subscription-trend.tsx
@@ -142,12 +142,12 @@ function MetricTile({ label, value, icon }: { label: string; value: string; icon
   );
 }
 
-function UsageTrendMetricTiles({ stats, billingDisplay }: { stats: UsageTrendStats; billingDisplay: BillingDisplayOptions }) {
+function UsageTrendMetricTiles({ view, stats, billingDisplay }: { view: UsageTrendView; stats: UsageTrendStats; billingDisplay: BillingDisplayOptions }) {
   const t = useTranslations("settings.subscriptionPage.usageTrend.metrics");
   return (
     <div className="grid grid-cols-2 gap-2 text-xs md:grid-cols-4">
       <MetricTile
-        label={t("totalCost")}
+        label={t(view === "daily" ? "periodCost" : "yearCost")}
         value={formatUsageSummaryCost(stats.totalBilled, billingDisplay)}
         icon={<BadgeDollarSign className="size-4" />}
       />
@@ -691,7 +691,7 @@ export function SubscriptionTrend({
           </TabsList>
         </Tabs>
       </div>
-      <UsageTrendMetricTiles stats={trendStats} billingDisplay={billingDisplay} />
+      <UsageTrendMetricTiles view={view} stats={trendStats} billingDisplay={billingDisplay} />
       {view === "daily" ? (
         <DailyUsageChart items={dailyUsage} loading={loading} billingDisplay={billingDisplay} />
       ) : (

--- a/frontend/i18n/messages/en-US/settings.json
+++ b/frontend/i18n/messages/en-US/settings.json
@@ -496,7 +496,8 @@
     },
     "usageBilling": {
       "title": "Usage billing",
-      "balance": "Account balance {value}",
+      "balanceLabel": "Account balance",
+      "totalSpentLabel": "Total spent",
       "topUp": "Top up"
     },
     "selfMode": {
@@ -532,7 +533,8 @@
       "otherModels": "Other",
       "empty": "No usage data.",
       "metrics": {
-        "totalCost": "Total cost",
+        "periodCost": "Period cost",
+        "yearCost": "12-month cost",
         "totalTokens": "Total tokens",
         "totalCalls": "Total calls",
         "averageLatency": "Average latency"

--- a/frontend/i18n/messages/zh-CN/settings.json
+++ b/frontend/i18n/messages/zh-CN/settings.json
@@ -496,7 +496,8 @@
     },
     "usageBilling": {
       "title": "按量付费",
-      "balance": "账户余额 {value}",
+      "balanceLabel": "账户余额",
+      "totalSpentLabel": "累计花费",
       "topUp": "充值"
     },
     "selfMode": {
@@ -532,7 +533,8 @@
       "otherModels": "其他",
       "empty": "暂无用量数据。",
       "metrics": {
-        "totalCost": "总费用",
+        "periodCost": "本周期费用",
+        "yearCost": "近 12 个月费用",
         "totalTokens": "总 Tokens",
         "totalCalls": "总调用",
         "averageLatency": "平均耗时"

--- a/frontend/shared/components/markdown/streamdown-components.tsx
+++ b/frontend/shared/components/markdown/streamdown-components.tsx
@@ -26,7 +26,8 @@ import { MarkdownFootnotesContext } from "./streamdown-html";
 import { StreamdownCheckIcon, StreamdownCopyIcon } from "./streamdown-icons";
 import { sanitizeHTMLStyle } from "./streamdown-style";
 
-const DEFAULT_CODE_BLOCK_LANGUAGE = "markdown";
+// 未标注语言的围栏统一按纯文本处理:标签如实显示 text,避免内容被错误地按 Markdown 语法高亮。
+const DEFAULT_CODE_BLOCK_LANGUAGE = "text";
 const CODE_BLOCK_ACTION_BUTTON_CLASSNAME =
   "size-5 cursor-pointer rounded-none p-1 text-muted-foreground transition-all hover:bg-foreground/[0.04] hover:text-foreground focus-visible:bg-foreground/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35 disabled:cursor-not-allowed disabled:opacity-50";
 

--- a/frontend/shared/lib/artifact-preview.ts
+++ b/frontend/shared/lib/artifact-preview.ts
@@ -84,6 +84,9 @@ function hasSVGDocumentRoot(code: string): boolean {
   return SVG_ROOT_RE.test(code.slice(cursor));
 }
 
+// 未标注语言的围栏在渲染层会被归一化为纯文本语言,这些语言下按内容嗅探 HTML/SVG 预览能力。
+const CONTENT_SNIFF_LANGUAGES = ["", "text", "txt", "plaintext", "plain", "markdown"];
+
 export function resolveArtifactPreviewKind(language: string, code: string): ArtifactPreviewKind | null {
   const normalized = normalizeLanguage(language);
   if (["html", "htm", "xhtml"].includes(normalized)) return "html";
@@ -91,11 +94,11 @@ export function resolveArtifactPreviewKind(language: string, code: string): Arti
   if (["js", "javascript", "mjs", "cjs"].includes(normalized)) return "javascript";
   if (["svg", "svg+xml", "image/svg+xml"].includes(normalized)) return "svg";
   if (
-    ["", "markdown", "xml", "text/xml", "application/xml"].includes(normalized) &&
+    [...CONTENT_SNIFF_LANGUAGES, "xml", "text/xml", "application/xml"].includes(normalized) &&
     hasSVGDocumentRoot(code)
   ) {
     return "svg";
   }
-  if ((!normalized || normalized === "markdown") && HTML_LIKE_RE.test(code)) return "html";
+  if (CONTENT_SNIFF_LANGUAGES.includes(normalized) && HTML_LIKE_RE.test(code)) return "html";
   return null;
 }

--- a/packages/api-contract/src/types.generated.ts
+++ b/packages/api-contract/src/types.generated.ts
@@ -440,6 +440,8 @@ export interface BillingOverviewResponse {
   periodUsedUSD: number;
   plan: BillingPlanResponse | null;
   subscriptionEntitlements: SubscriptionEntitlementResponse[];
+  totalSpentNanousd: number;
+  totalSpentUSD: number;
 }
 
 export interface BillingOverviewResponseDoc {


### PR DESCRIPTION
## Summary

Closes #714.

On the subscription settings page in usage billing mode, the account balance was a single line of small text that didn't match the card style of the usage trend area, there was no way to see lifetime spend (trend metrics only cover the selected time range), and the top-up button stayed visible (grayed out) even when no payment provider was configured.

**Backend**
- `GET /api/v1/billing/overview` now returns `totalSpentUSD` / `totalSpentNanousd`: the account's lifetime billed total (usage ledger sum, excludes top-ups and redemptions), computed in usage mode via a new `SumTotalBilledNanousd` repository query (covered by a new SQLite test).

**Frontend**
- Usage billing section now shows two metric cards — "Account balance" and "Total spent" — reusing the usage trend tile style (`rounded-md bg-muted/35` with large tabular numerals). The redeem / top-up actions stay in the section header row.
- The top-up button is hidden (not disabled) when no payment provider is configured, in both the usage billing section and the period-mode overage row. It is also not rendered until the billing config has loaded, so it never flashes from disabled to hidden. The redeem button remains available since redemption codes don't depend on payment providers.
- To avoid two tiles both reading as "total cost", the usage trend cost metric is now scoped per view: "Period cost" (daily view, current billing cycle) and "12-month cost" (monthly view). The new lifetime card is labeled "Total spent".
- Added the missing separator between the activity overview and the usage trend sections to match the page's section rhythm.

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [x] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [x] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- `go build ./...` and `go test ./...` (backend) — passed, including the new `TestSumTotalBilledNanousdAggregatesLifetimePaidUsage`
- `pnpm --filter @deeix/web check` and `pnpm --filter @deeix/api-contract check` — passed
- Manual testing in local dev: balance and total spent render as cards in usage mode with USD display; top-up button hidden with no providers configured and shown when providers exist; trend cost label switches between daily / monthly views

## Screenshots, API examples, or logs

<!-- TODO: add before/after screenshots of the usage billing section (cards + hidden top-up). -->

`GET /api/v1/billing/overview` (usage mode) → `200 { "overview": { "mode": "usage", "account": { ... }, "totalSpentUSD": 16.383155, "totalSpentNanousd": 16383155000, ... } }`

## Configuration, migration, and compatibility notes

- API contract: `BillingOverviewResponse` gains `totalSpentUSD` / `totalSpentNanousd` (additive, backward compatible). Swagger docs and `packages/api-contract/src/types.generated.ts` are regenerated in this PR.
- No schema migration: the lifetime total is an indexed aggregate over the existing usage ledger (`user_id` index), computed only in usage mode.
- No configuration changes. Deployments with payment providers configured see no behavior change to top-up.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.