### PR TITLE
fix: keep the persisted new-conversation draft when starting a new chat

### DIFF
--- a/frontend/features/chat/components/app-chat-area.tsx
+++ b/frontend/features/chat/components/app-chat-area.tsx
@@ -283,7 +283,6 @@ export function AppChatArea() {
     appendAttachmentsForKey,
   } = useChatComposerState(conversationID, {
     preserveDrafts: preserveConversationDrafts,
-    resetToken: newConversationRevision,
     storageScope: user?.publicID ?? "",
     transient: temporaryMode,
   });

--- a/frontend/features/chat/hooks/use-chat-composer-state.ts
+++ b/frontend/features/chat/hooks/use-chat-composer-state.ts
@@ -266,16 +266,16 @@ export function resolveConversationComposerKey(conversationID: string | null): s
   return conversationID?.trim() || NEW_CONVERSATION_COMPOSER_KEY;
 }
 
+// 新对话草稿与历史会话草稿同属一个 store（key 为 __new__），"新对话"按钮只切换会话 key，
+// 不删除已持久化的条目；切回新对话时由 hydration 从 storage 恢复，提交时由 setDraft("") 写空清除。
 export function useChatComposerState(
   conversationID: string | null,
   {
     preserveDrafts = true,
-    resetToken = 0,
     storageScope = "",
     transient = false,
   }: {
     preserveDrafts?: boolean;
-    resetToken?: number;
     storageScope?: string;
     transient?: boolean;
   } = {},
@@ -336,19 +336,6 @@ export function useChatComposerState(
     window.addEventListener("storage", handleStorage);
     return () => window.removeEventListener("storage", handleStorage);
   }, []);
-
-  React.useEffect(() => {
-    if (resetToken <= 0 || conversationID) {
-      return;
-    }
-    discardPendingPersistence(conversationKey);
-    if (!transient && storageKey) {
-      ComposerStorageOps.removeEntry(storageKey, conversationKey);
-    }
-    setHydratedConversationKey(conversationKey);
-    setHydratedStorageKey(storageKey);
-    setState(createEmptyComposerState(conversationKey));
-  }, [conversationID, conversationKey, discardPendingPersistence, resetToken, storageKey, transient]);
 
   useIsomorphicLayoutEffect(() => {
     const previousStorageKey = activeStorageKeyRef.current;


### PR DESCRIPTION
## Summary

Closes [#722](https://github.com/DEEIX-AI/DEEIX-Chat/issues/722).

Clicking the sidebar "New chat" button deleted the persisted new-conversation draft from localStorage and emptied the input, from any page. The draft store already keeps a `__new__` entry alongside per-conversation entries and restores it on reload, so the button was destroying data the persistence layer is designed to keep, and doing so across tabs.

Root cause: `useChatComposerState` accepted `newConversationRevision` as a `resetToken` and ran an effect that, whenever `resetToken > 0` and no conversation was active, called `removeEntry(storageKey, "__new__")` and reset the composer state. Two problems with it:

- It made "New chat" a destructive action on the new-conversation draft, inconsistent with `chat.preserve_conversation_drafts` and with how history-conversation drafts behave.
- Unlike every other consumer of `resetToken` (`use-chat-runtime`, `use-chat-model-options`, `use-chat-composer-selection`), it had no previous-token guard, so it also fired on mount and whenever `storageKey` changed. Once the button had been clicked once in a session, simply navigating back to `/chat` (sidebar link, browser back, returning from settings) or the user session resolving asynchronously wiped the draft with no click at all. A hard reload survived only because the revision counter restarts at 0.

Fix: remove the effect and the `resetToken` option from `useChatComposerState`, and stop passing it from `AppChatArea`. No replacement logic is needed:

- Clicking "New chat" while already on a blank new conversation leaves the key unchanged, so the draft stays.
- Clicking it from a history or locally created conversation changes the key from that conversation to `__new__`; the existing hydration layout effect restores the persisted draft.
- Submitting clears the draft at submit time (`use-chat-message-submit.ts`) while the key is still `__new__`, so the entry is deleted and nothing stale is left behind.
- `preserveDrafts=false` still removes entries through the existing `!persistenceEnabled` branch.

`newConversationRevision` still drives what the button genuinely has to reset: collapsing the conversation layout, resetting branch selection, and returning the model and tool/skill/knowledge-base selection to their defaults. Those hooks are unchanged.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [x] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- `pnpm --filter @deeix/web check` (biome lint + tsc)
- The frontend has no test runner, so the hook was exercised in a throwaway jsdom + React 19.2.8 harness outside the repository, running the pre-fix and fixed hook side by side (not committed):
  - Pre-fix: an in-place `resetToken` bump deletes the persisted `__new__` entry; mounting with `resetToken > 0` deletes it with no interaction.
  - Fixed: the draft survives unmount/remount; switching to a conversation and back restores it; a late-arriving `storageScope` does not wipe it; `setDraft("")` at submit removes the entry with nothing stale on remount; `preserveDrafts=false` still clears the entry.
- Manual: type in a new conversation, open a second tab on `/chat` (draft visible after reload), click "New chat" in the first tab, reload the second tab. Draft remains in both. Repeat from a history conversation and from a settings page.

## Screenshots, API examples, or logs

Not applicable; no visual change beyond the draft no longer disappearing.

## Configuration, migration, and compatibility notes

No API, configuration, or storage schema changes. The localStorage key format (`deeix-chat:chat-composer:v2:<user>` with a `__new__` entry) is unchanged; existing drafts are read as before.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.