### PR TITLE
fix: open the starred "all conversations" dialog with the same preview layout as sidebar search

### DIFF
--- a/frontend/features/layouts/components/navigation/nav-starred.tsx
+++ b/frontend/features/layouts/components/navigation/nav-starred.tsx
@@ -39,6 +39,7 @@ import { NavigationSearch } from "@/features/layouts/components/navigation/navig
 import { SidebarConversationItem } from "@/features/layouts/components/navigation/sidebar-conversation-item";
 import { SidebarConversationSkeleton } from "@/features/layouts/components/navigation/sidebar-conversation-skeleton";
 import { useLayoutActiveConversation } from "@/features/layouts/hooks/use-layout-active-conversation";
+import { useLayoutSearchPreview } from "@/features/layouts/hooks/use-layout-search-preview";
 import { useLayoutSidebarListFlip } from "@/features/layouts/hooks/use-layout-sidebar-list-flip";
 import { useLayoutSidebarNavigation } from "@/features/layouts/hooks/use-layout-sidebar-navigation";
 import { filterConversationSearchResults } from "@/features/layouts/model/navigation-search";
@@ -97,6 +98,7 @@ export function NavStarred() {
   const [renameValue, setRenameValue] = React.useState("");
   const [autoRenamingPublicID, setAutoRenamingPublicID] = React.useState<string | null>(null);
   const [starredOpen, setStarredOpen] = useStoredBoolean(STARRED_OPEN_STORAGE_KEY, true);
+  const searchPreview = useLayoutSearchPreview(showAllStarredDialog);
   const listContainerRef = React.useRef<HTMLDivElement | null>(null);
   const deleteFilesID = React.useId();
   const starredContentID = React.useId();
@@ -409,6 +411,13 @@ export function NavStarred() {
         loading={dialogLoading}
         loadingText={t("starredSearch.loading")}
         emptyText={t("starredSearch.empty")}
+        showPreviewPane
+        previewConversationID={searchPreview.preview.conversationID}
+        previewMessages={searchPreview.preview.messages}
+        previewLoading={searchPreview.preview.loading}
+        previewLoadFailed={searchPreview.preview.loadFailed}
+        onPreviewChange={searchPreview.selectPreview}
+        onPreviewRetry={searchPreview.retryPreview}
         onSelect={onSelectSearchResult}
       />
 

--- a/frontend/features/layouts/components/navigation/navigation-search.tsx
+++ b/frontend/features/layouts/components/navigation/navigation-search.tsx
@@ -338,11 +338,7 @@ export function NavigationSearch({
       }}
       className={cn(
         "h-auto w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] overflow-hidden rounded-lg border border-border/60 bg-background p-0 transition-[max-width] duration-200 ease-out sm:w-full",
-        previewPaneEnabled
-          ? "md:max-w-5xl"
-          : previewPaneAvailable
-            ? "sm:max-w-xl lg:max-w-2xl"
-            : "sm:max-w-xl lg:max-w-2xl",
+        previewPaneEnabled ? "md:max-w-5xl" : "sm:max-w-xl lg:max-w-2xl",
       )}
     >
       <CommandInput


### PR DESCRIPTION
## Summary

Fixes #723.

Both the sidebar search button and the "All conversations" button under the starred section render the same `NavigationSearch` component, but only `nav-main.tsx` passed the preview-pane props. `previewPaneAvailable` therefore stayed `false` for the starred dialog, which forced it onto the narrow single-column branch (`max-w-2xl`, 280px list, no footer) while the sidebar search opened as the wide two-column layout (`max-w-5xl`, results + message preview, keyboard-hint footer with the compact/preview toggle). The starred dialog has used `NavigationSearch` since v0.1.0 and was missed when dd5e4f8e added the preview pane.

Approach: reuse the existing `useLayoutSearchPreview` hook in `NavStarred` and pass the same `showPreviewPane` / `preview*` / `onPreview*` prop set that `nav-main.tsx` already passes. No changes to `NavigationSearch` behavior; the preview-pane preference (`deeix.navigation-search.preview.open`) is shared, so toggling it in either dialog applies to both. Mobile and non-hover devices keep the compact layout in both dialogs as before.

Also collapses a dead ternary in `navigation-search.tsx` whose two branches returned the same class string. No behavior change.

Intentionally unchanged: the starred dialog still filters the fully loaded starred set on the client (ID / title / labels / model) without message-body search or pagination, and each dialog's description text continues to describe its own search scope.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Configuration / deployment
- [ ] Security hardening
- [ ] Other

## Affected areas

- [x] Frontend / UI
- [ ] Backend / API
- [ ] Authentication / authorization
- [ ] Conversations / streaming
- [ ] Files / RAG / extraction
- [ ] Model routing / providers
- [ ] MCP / tools
- [ ] Billing / payments
- [ ] Admin console
- [ ] Deployment / Docker / configuration
- [ ] Documentation

## Verification

- `pnpm check` in `frontend` (biome lint + `tsc --noEmit`): pass
- Compared the preview-related props passed by `nav-main.tsx` and `nav-starred.tsx`; both now pass the identical set (`showPreviewPane`, `previewConversationID`, `previewMessages`, `previewLoading`, `previewLoadFailed`, `onPreviewChange`, `onPreviewRetry`)
- Confirmed `filterConversationSearchResults` and `toConversationSearchResult` produce the same `publicID`, so the preview request targets the correct conversation for starred results

Manual check on desktop: star 6+ conversations, open "All conversations" under the starred section, then open the sidebar search; both dialogs should share the same width, two-column layout, and footer.

## Screenshots, API examples, or logs

N/A. UI-only change with no API impact.

## Configuration, migration, and compatibility notes

None. No configuration, schema, API contract, or i18n changes.

## Documentation

- [x] Documentation is not needed for this change.
- [ ] Documentation was updated.
- [ ] Documentation still needs to be updated.

## Security and privacy

- [x] No secrets, tokens, credentials, local config, or personal data are included.
- [x] User data access remains scoped by authenticated user context unless an admin-only path explicitly requires broader access.
- [x] Security-sensitive behavior was reviewed, including authentication, authorization, provider routing, file processing, billing, and admin APIs where relevant.

## Checklist

- [x] I searched existing issues and pull requests.
- [x] Changes are focused and do not include unrelated refactors.
- [x] Tests or static verification were run where practical.
- [x] User-facing behavior, deployment steps, API contracts, or configuration changes are documented.
- [x] Generated artifacts are included only when this project explicitly requires them.
- [x] Caches, build output, `.pyc` files, `.env` files, and local storage data are not committed.